### PR TITLE
remove unused migration file

### DIFF
--- a/apps/api/src/storage/migrations/0011_change_archived_type_to_boolean.sql
+++ b/apps/api/src/storage/migrations/0011_change_archived_type_to_boolean.sql
@@ -1,5 +1,0 @@
-ALTER TABLE "categories" RENAME COLUMN "archived_at" TO "archived";--> statement-breakpoint
-ALTER TABLE "categories" ALTER COLUMN "archived" SET DATA TYPE boolean;--> statement-breakpoint
-ALTER TABLE "categories" ALTER COLUMN "archived" SET DEFAULT false;--> statement-breakpoint
-ALTER TABLE "categories" ALTER COLUMN "archived" SET NOT NULL;--> statement-breakpoint
-ALTER TABLE "users" ALTER COLUMN "role" SET DATA TYPE text;


### PR DESCRIPTION
## Overview

- removed unused migration file

## Notes 
The same functionality is in `0011_categories_title_unique_archived_boolean.sql` migration