### PR TITLE
chore: add created_at and updated_at properties

### DIFF
--- a/apps/admin/src/AdminResourceOptions/files.ts
+++ b/apps/admin/src/AdminResourceOptions/files.ts
@@ -2,4 +2,25 @@ import { ResourceOptions } from "adminjs";
 
 export const filesConfigOptions: ResourceOptions = {
   parent: "lesson-items",
+  properties: {
+    created_at: {
+      position: 7,
+      isVisible: {
+        edit: false,
+        list: true,
+        show: true,
+        filter: false,
+      },
+      isSortable: false,
+    },
+    updated_at: {
+      position: 8,
+      isVisible: {
+        edit: false,
+        list: false,
+        show: true,
+        filter: false,
+      },
+    },
+  },
 };

--- a/apps/admin/src/AdminResourceOptions/lessons.ts
+++ b/apps/admin/src/AdminResourceOptions/lessons.ts
@@ -7,5 +7,24 @@ export const lessonsConfigOptions: ResourceOptions = {
     description: {
       type: "richtext",
     },
+    created_at: {
+      position: 7,
+      isVisible: {
+        edit: false,
+        list: true,
+        show: true,
+        filter: false,
+      },
+      isSortable: false,
+    },
+    updated_at: {
+      position: 8,
+      isVisible: {
+        edit: false,
+        list: false,
+        show: true,
+        filter: false,
+      },
+    },
   },
 };

--- a/apps/admin/src/AdminResourceOptions/questions.ts
+++ b/apps/admin/src/AdminResourceOptions/questions.ts
@@ -2,4 +2,25 @@ import { ResourceOptions } from "adminjs";
 
 export const questionsConfigOptions: ResourceOptions = {
   parent: "lesson-items",
+  properties: {
+    created_at: {
+      position: 7,
+      isVisible: {
+        edit: false,
+        list: true,
+        show: true,
+        filter: false,
+      },
+      isSortable: false,
+    },
+    updated_at: {
+      position: 8,
+      isVisible: {
+        edit: false,
+        list: false,
+        show: true,
+        filter: false,
+      },
+    },
+  },
 };

--- a/apps/admin/src/AdminResourceOptions/text-blocks.ts
+++ b/apps/admin/src/AdminResourceOptions/text-blocks.ts
@@ -3,8 +3,27 @@ import { ResourceOptions } from "adminjs";
 export const textBlocksConfigOptions: ResourceOptions = {
   parent: "lesson-items",
   properties: {
-    description: {
+    body: {
       type: "richtext",
+    },
+    created_at: {
+      position: 7,
+      isVisible: {
+        edit: false,
+        list: true,
+        show: true,
+        filter: false,
+      },
+      isSortable: false,
+    },
+    updated_at: {
+      position: 8,
+      isVisible: {
+        edit: false,
+        list: false,
+        show: true,
+        filter: false,
+      },
     },
   },
 };


### PR DESCRIPTION
## Overview

- removed `created_at` and `updated_at` fields from create/update views