### PR TITLE
fix: course category select

### DIFF
--- a/apps/web/app/modules/common/SearchFilter/SearchFilter.tsx
+++ b/apps/web/app/modules/common/SearchFilter/SearchFilter.tsx
@@ -43,7 +43,7 @@ const SearchFilter: React.FC<SearchFilterProps> = ({
   };
 
   const handleCategoryChange = (value: string) => {
-    onCategoryChange(value);
+    onCategoryChange(value === "all" ? undefined : value);
   };
 
   const handleSortChange = (value: string) => {
@@ -75,7 +75,7 @@ const SearchFilter: React.FC<SearchFilterProps> = ({
       </div>
 
       <Select
-        value={categoryValue}
+        value={categoryValue ?? "all"}
         onValueChange={handleCategoryChange}
         disabled={isLoading}
       >


### PR DESCRIPTION
## Overview
- Fixed a bug where clicking on ‘All categories’ did not change the label in the category selection.
## Screenshots
https://github.com/user-attachments/assets/a9cb9087-456c-4958-8629-7c5fd9d38af0

