### PR TITLE
feat: optimize video player import to use lazy loading in Video component

### DIFF
--- a/apps/web/app/modules/Courses/Lesson/LessonItems/File/Video.tsx
+++ b/apps/web/app/modules/Courses/Lesson/LessonItems/File/Video.tsx
@@ -1,5 +1,5 @@
 import { useParams } from "@remix-run/react";
-import ReactPlayer from "react-player";
+import ReactPlayer from "react-player/lazy";
 
 import { useMarkLessonItemAsCompleted } from "~/api/mutations/useMarkLessonItemAsCompleted";
 


### PR DESCRIPTION

## Jira issue(s)

https://selleolabs.atlassian.net/browse/LC-382

## Overview
https://github.com/cookpete/react-player#usage
> If your build system supports import() statements, use react-player/lazy to lazy load the appropriate player for the url you pass in. This adds several reactPlayer chunks to your output, but reduces your main bundle size.


## Screenshots

https://github.com/user-attachments/assets/81421560-c078-48dc-a1a1-892673f6573e




