### PR TITLE
refactor: update SCORM schemas and improve metadata handling in API responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ After starting the development environment, you can access:
 | Service | URL                           | Description             |
 | ------- | ----------------------------- | ----------------------- |
 | Web App | https://app.lms.localhost     | Frontend application    |
-| API     | https://api.lms.localhost     | Backend API             |
+| API     | https://app.lms.localhost/api | Backend API url         |
 | Swagger | https://api.lms.localhost/api | API documentation       |
 | Mailhog | https://mailbox.lms.localhost | Email testing interface |
 

--- a/apps/api/src/scorm/schemas/scorm.schema.ts
+++ b/apps/api/src/scorm/schemas/scorm.schema.ts
@@ -1,35 +1,24 @@
-import { ApiProperty } from "@nestjs/swagger";
+import { Type } from "@sinclair/typebox";
 
-export class ScormMetadata {
-  @ApiProperty()
-  id: string;
+import { UUIDSchema } from "src/common";
 
-  @ApiProperty()
-  createdAt: string;
+import type { Static } from "@sinclair/typebox";
 
-  @ApiProperty()
-  updatedAt: string;
+export const scormMetadataSchema = Type.Object({
+  id: UUIDSchema,
+  createdAt: Type.String(),
+  updatedAt: Type.String(),
+  courseId: UUIDSchema,
+  fileId: UUIDSchema,
+  version: Type.String(),
+  entryPoint: Type.String(),
+  s3Key: Type.String(),
+});
 
-  @ApiProperty()
-  courseId: string;
+export const scormUploadResponseSchema = Type.Object({
+  message: Type.String(),
+  metadata: scormMetadataSchema,
+});
 
-  @ApiProperty()
-  fileId: string;
-
-  @ApiProperty()
-  version: string;
-
-  @ApiProperty()
-  entryPoint: string;
-
-  @ApiProperty()
-  s3Key: string;
-}
-
-export class ScormUploadResponse {
-  @ApiProperty()
-  message: string;
-
-  @ApiProperty()
-  metadata: ScormMetadata;
-}
+export type ScormMetadata = Static<typeof scormMetadataSchema>;
+export type ScormUploadResponse = Static<typeof scormUploadResponseSchema>;

--- a/apps/api/src/seed/nice-data-seeds.ts
+++ b/apps/api/src/seed/nice-data-seeds.ts
@@ -2,7 +2,6 @@ import { faker } from "@faker-js/faker";
 
 import { LESSON_TYPES, QuestionType } from "src/lesson/lesson.type";
 
-
 import type { NiceCourseData } from "src/utils/types/test-types";
 
 export const niceCourses: NiceCourseData[] = [

--- a/apps/api/src/swagger/api-schema.json
+++ b/apps/api/src/swagger/api-schema.json
@@ -1991,12 +1991,11 @@
           }
         },
         "responses": {
-          "201": {
-            "description": "File uploaded successfully",
+          "200": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ScormUploadResponse"
+                  "$ref": "#/components/schemas/UploadScormPackageResponse"
                 }
               }
             }
@@ -2041,17 +2040,17 @@
             "required": true,
             "in": "path",
             "schema": {
+              "format": "uuid",
               "type": "string"
             }
           }
         ],
         "responses": {
           "200": {
-            "description": "Returns SCORM metadata including entry point path",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ScormMetadata"
+                  "$ref": "#/components/schemas/GetScormMetadataResponse"
                 }
               }
             }
@@ -4976,58 +4975,116 @@
           "data"
         ]
       },
-      "ScormMetadata": {
+      "UploadScormPackageResponse": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "createdAt": {
-            "type": "string"
-          },
-          "updatedAt": {
-            "type": "string"
-          },
-          "courseId": {
-            "type": "string"
-          },
-          "fileId": {
-            "type": "string"
-          },
-          "version": {
-            "type": "string"
-          },
-          "entryPoint": {
-            "type": "string"
-          },
-          "s3Key": {
-            "type": "string"
+          "data": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string"
+              },
+              "metadata": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "createdAt": {
+                    "type": "string"
+                  },
+                  "updatedAt": {
+                    "type": "string"
+                  },
+                  "courseId": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "fileId": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "version": {
+                    "type": "string"
+                  },
+                  "entryPoint": {
+                    "type": "string"
+                  },
+                  "s3Key": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "createdAt",
+                  "updatedAt",
+                  "courseId",
+                  "fileId",
+                  "version",
+                  "entryPoint",
+                  "s3Key"
+                ]
+              }
+            },
+            "required": [
+              "message",
+              "metadata"
+            ]
           }
         },
         "required": [
-          "id",
-          "createdAt",
-          "updatedAt",
-          "courseId",
-          "fileId",
-          "version",
-          "entryPoint",
-          "s3Key"
+          "data"
         ]
       },
-      "ScormUploadResponse": {
+      "GetScormMetadataResponse": {
         "type": "object",
         "properties": {
-          "message": {
-            "type": "string"
-          },
-          "metadata": {
-            "$ref": "#/components/schemas/ScormMetadata"
+          "data": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "format": "uuid",
+                "type": "string"
+              },
+              "createdAt": {
+                "type": "string"
+              },
+              "updatedAt": {
+                "type": "string"
+              },
+              "courseId": {
+                "format": "uuid",
+                "type": "string"
+              },
+              "fileId": {
+                "format": "uuid",
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              },
+              "entryPoint": {
+                "type": "string"
+              },
+              "s3Key": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "createdAt",
+              "updatedAt",
+              "courseId",
+              "fileId",
+              "version",
+              "entryPoint",
+              "s3Key"
+            ]
           }
         },
         "required": [
-          "message",
-          "metadata"
+          "data"
         ]
       }
     }

--- a/apps/reverse-proxy/Caddyfile
+++ b/apps/reverse-proxy/Caddyfile
@@ -1,9 +1,11 @@
-api.lms.localhost {
-	reverse_proxy localhost:3000
-}
-
 app.lms.localhost {
-	reverse_proxy localhost:5173
+    handle_path /api/* {
+        reverse_proxy localhost:3000
+    }
+
+    handle {
+        reverse_proxy localhost:5173
+    }
 }
 
 mailbox.lms.localhost {

--- a/apps/web/app/api/api-client.ts
+++ b/apps/web/app/api/api-client.ts
@@ -11,7 +11,7 @@ export const requestManager = {
 };
 
 export const ApiClient = new API({
-  baseURL: import.meta.env.VITE_API_URL,
+  baseURL: import.meta.env.VITE_APP_URL,
   secure: true,
   withCredentials: true,
 });

--- a/apps/web/app/api/generated-api.ts
+++ b/apps/web/app/api/generated-api.ts
@@ -145,8 +145,6 @@ export interface GetUserByIdResponse {
 
 export interface GetUserDetailsResponse {
   data: {
-    firstName: string | null;
-    lastName: string | null;
     /** @format uuid */
     id: string;
     description: string | null;
@@ -607,6 +605,7 @@ export interface FileUploadResponse {
 }
 
 export type BetaCreateLessonBody = {
+  updatedAt?: string;
   title: string;
   type: string;
   description: string;
@@ -734,6 +733,7 @@ export interface BetaUpdateQuizLessonResponse {
 }
 
 export type BetaUpdateLessonBody = {
+  updatedAt?: string;
   title?: string;
   type?: string;
   description?: string;
@@ -854,20 +854,39 @@ export interface CreatePaymentIntentResponse {
   };
 }
 
-export interface ScormMetadata {
-  id: string;
-  createdAt: string;
-  updatedAt: string;
-  courseId: string;
-  fileId: string;
-  version: string;
-  entryPoint: string;
-  s3Key: string;
+export interface UploadScormPackageResponse {
+  data: {
+    message: string;
+    metadata: {
+      /** @format uuid */
+      id: string;
+      createdAt: string;
+      updatedAt: string;
+      /** @format uuid */
+      courseId: string;
+      /** @format uuid */
+      fileId: string;
+      version: string;
+      entryPoint: string;
+      s3Key: string;
+    };
+  };
 }
 
-export interface ScormUploadResponse {
-  message: string;
-  metadata: ScormMetadata;
+export interface GetScormMetadataResponse {
+  data: {
+    /** @format uuid */
+    id: string;
+    createdAt: string;
+    updatedAt: string;
+    /** @format uuid */
+    courseId: string;
+    /** @format uuid */
+    fileId: string;
+    version: string;
+    entryPoint: string;
+    s3Key: string;
+  };
 }
 
 import type {
@@ -2139,7 +2158,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       },
       params: RequestParams = {},
     ) =>
-      this.request<ScormUploadResponse, any>({
+      this.request<UploadScormPackageResponse, any>({
         path: `/api/scorm/upload`,
         method: "POST",
         query: query,
@@ -2176,7 +2195,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request GET:/api/scorm/{courseId}/metadata
      */
     scormControllerGetScormMetadata: (courseId: string, params: RequestParams = {}) =>
-      this.request<ScormMetadata, any>({
+      this.request<GetScormMetadataResponse, any>({
         path: `/api/scorm/${courseId}/metadata`,
         method: "GET",
         format: "json",

--- a/apps/web/app/api/queries/admin/useScormMetaData.ts
+++ b/apps/web/app/api/queries/admin/useScormMetaData.ts
@@ -1,0 +1,29 @@
+import { queryOptions, useQuery, useSuspenseQuery } from "@tanstack/react-query";
+
+import { ApiClient } from "../../api-client";
+
+import type { GetScormMetadataResponse } from "~/api/generated-api";
+
+type ScormMetadataQueryOptions = {
+  id: string;
+  isScorm?: boolean;
+};
+
+export const scormMetadataQueryOptions = ({ id, isScorm = false }: ScormMetadataQueryOptions) =>
+  queryOptions({
+    enabled: isScorm,
+    queryKey: ["scorm-meta", "admin", { id }],
+    queryFn: async () => {
+      const response = await ApiClient.api.scormControllerGetScormMetadata(id);
+      return response.data;
+    },
+    select: (data: GetScormMetadataResponse) => data.data,
+  });
+
+export function useScormMetadata({ id, isScorm }: ScormMetadataQueryOptions) {
+  return useQuery(scormMetadataQueryOptions({ id, isScorm }));
+}
+
+export function useScormMetadataSuspense({ id, isScorm }: ScormMetadataQueryOptions) {
+  return useSuspenseQuery(scormMetadataQueryOptions({ id, isScorm }));
+}

--- a/apps/web/app/modules/Courses/CourseView/CourseView.page.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseView.page.tsx
@@ -6,6 +6,7 @@ import {
 } from "@remix-run/react";
 
 import { courseQueryOptions, useCourseSuspense } from "~/api/queries";
+import { useScormMetadata } from "~/api/queries/admin/useScormMetaData";
 import { queryClient } from "~/api/queryClient";
 import { PageWrapper } from "~/components/PageWrapper";
 import {
@@ -39,6 +40,10 @@ export default function CoursesViewPage() {
   const { id } = useParams<{ id: string }>();
 
   const { data: course } = useCourseSuspense(id ?? "");
+  const { data: scormMetadata } = useScormMetadata({
+    id: id ?? "",
+    isScorm: course?.isScorm,
+  });
 
   if (!id) {
     throw new Error("No course ID provided");
@@ -66,8 +71,8 @@ export default function CoursesViewPage() {
       <div className="flex flex-col md:flex-row h-full gap-6">
         {course.isScorm ? (
           <iframe
-            title="Playing"
-            src="https://api.lms.localhost/api/scorm/dd284185-2e3b-4a06-8736-403a421a32a5/content?path=Playing/Playing.html"
+            title={scormMetadata?.entryPoint}
+            src={`/api/scorm/${id}/content?path=${scormMetadata?.entryPoint}`}
             width="100%"
             height="100%"
             className="w-full h-full"

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -53,6 +53,12 @@ export default defineConfig(({ mode }) => {
       warmup: {
         clientFiles: ["./app/**/*.tsx"],
       },
+      proxy: {
+        "/api": {
+          target: "http://localhost:3000",
+          changeOrigin: true,
+        },
+      },
     },
     resolve: {
       alias: {


### PR DESCRIPTION
## Jira issue(s)

https://selleolabs.atlassian.net/browse/LC-481

## Overview
- fixed scorm course view
- the `CourseView.page.tsx` will change as soon as the scorm will generate proper chapters for each resource

### Notes
> [!WARNING]
> - changed Caddy reverse proxy to match our non-local reverse proxy (we need that to allow scorm api to connect with with `window` through iframe which requires the same origin)
>    - `https://app.lms.localhost` -> frontend
>    - `https://app.lms.localhost/api` -> backend
>
> You will need to update your Postman/Insomnia etc base url