### PR TITLE
feat: update lesson sidebar links to handle completed and not started statuses

### DIFF
--- a/apps/web/app/modules/Courses/Lesson/LessonSidebar.tsx
+++ b/apps/web/app/modules/Courses/Lesson/LessonSidebar.tsx
@@ -63,10 +63,11 @@ export const LessonSidebar = ({ course, courseId }: LessonSidebarProps) => {
                         return (
                           <Link
                             key={id}
-                            to={`/course/${courseId}/lesson/${id}`}
+                            to={status === "completed" ? `/course/${courseId}/lesson/${id}` : "#"}
                             className={cn("flex gap-x-4 py-2 px-6 border-x hover:bg-neutral-50", {
                               "bg-primary-50 border-l-2 border-l-primary-600":
                                 status === "completed",
+                              "cursor-not-allowed": status === "not_started",
                             })}
                           >
                             <Badge


### PR DESCRIPTION
## Jira issue(s)
[LC-525](https://selleolabs.atlassian.net/browse/LC-525)

## Overview
- now in chapters summary user can navigate only to the completed lessons

[LC-525]: https://selleolabs.atlassian.net/browse/LC-525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ