### PR TITLE
fix: update AddCourse form to use fileUrl and thumbnailS3Key instead of imageUrl

### DIFF
--- a/apps/web/app/modules/Admin/AddCourse/AddCourse.tsx
+++ b/apps/web/app/modules/Admin/AddCourse/AddCourse.tsx
@@ -26,8 +26,8 @@ const AddCourse = () => {
   const [isUploading, setIsUploading] = useState(false);
   const { mutateAsync: uploadFile } = useUploadFile();
   const { isValid: isFormValid } = form.formState;
-  const watchedImageUrl = form.watch("fileUrl");
-  const fileUrl = form.getValues("fileUrl");
+  const watchedImageUrl = form.watch("thumbnailUrl");
+  const thumbnailUrl = form.getValues("thumbnailUrl");
   const maxDescriptionFieldLength = 800;
 
   const watchedDescriptionLength = form.watch("description").length;
@@ -39,7 +39,7 @@ const AddCourse = () => {
       try {
         const result = await uploadFile({ file, resource: "course" });
         form.setValue("thumbnailS3Key", result.fileKey, { shouldValidate: true });
-        form.setValue("fileUrl", result.fileUrl, { shouldValidate: true });
+        form.setValue("thumbnailUrl", result.fileUrl, { shouldValidate: true });
       } catch (error) {
         console.error("Error uploading image:", error);
       } finally {
@@ -151,7 +151,7 @@ const AddCourse = () => {
 
             <FormField
               control={form.control}
-              name="fileUrl"
+              name="thumbnailUrl"
               render={({ field }) => (
                 <FormItem className="mt-5">
                   <Label htmlFor="fileUrl">Thumbnail</Label>
@@ -160,7 +160,7 @@ const AddCourse = () => {
                       field={field}
                       handleImageUpload={handleImageUpload}
                       isUploading={isUploading}
-                      imageUrl={fileUrl}
+                      imageUrl={thumbnailUrl}
                     />
                   </FormControl>
 
@@ -171,7 +171,7 @@ const AddCourse = () => {
             />
             {watchedImageUrl && (
               <Button
-                onClick={() => form.setValue("fileUrl", "")}
+                onClick={() => form.setValue("thumbnailUrl", "")}
                 className="bg-red-500 text-white py-2 px-6 rounded mb-4 mt-4"
               >
                 <Icon name="TrashIcon" className="mr-2" />

--- a/apps/web/app/modules/Admin/AddCourse/AddCourse.tsx
+++ b/apps/web/app/modules/Admin/AddCourse/AddCourse.tsx
@@ -26,8 +26,8 @@ const AddCourse = () => {
   const [isUploading, setIsUploading] = useState(false);
   const { mutateAsync: uploadFile } = useUploadFile();
   const { isValid: isFormValid } = form.formState;
-  const watchedImageUrl = form.watch("imageUrl");
-  const imageUrl = form.getValues("imageUrl");
+  const watchedImageUrl = form.watch("fileUrl");
+  const fileUrl = form.getValues("fileUrl");
   const maxDescriptionFieldLength = 800;
 
   const watchedDescriptionLength = form.watch("description").length;
@@ -38,7 +38,8 @@ const AddCourse = () => {
       setIsUploading(true);
       try {
         const result = await uploadFile({ file, resource: "course" });
-        form.setValue("imageUrl", result.fileUrl, { shouldValidate: true });
+        form.setValue("thumbnailS3Key", result.fileKey, { shouldValidate: true });
+        form.setValue("fileUrl", result.fileUrl, { shouldValidate: true });
       } catch (error) {
         console.error("Error uploading image:", error);
       } finally {
@@ -150,16 +151,16 @@ const AddCourse = () => {
 
             <FormField
               control={form.control}
-              name="imageUrl"
+              name="fileUrl"
               render={({ field }) => (
                 <FormItem className="mt-5">
-                  <Label htmlFor="imageUrl">Thumbnail</Label>
+                  <Label htmlFor="fileUrl">Thumbnail</Label>
                   <FormControl>
                     <ImageUploadInput
                       field={field}
                       handleImageUpload={handleImageUpload}
                       isUploading={isUploading}
-                      imageUrl={imageUrl}
+                      imageUrl={fileUrl}
                     />
                   </FormControl>
 
@@ -170,7 +171,7 @@ const AddCourse = () => {
             />
             {watchedImageUrl && (
               <Button
-                onClick={() => form.setValue("imageUrl", "")}
+                onClick={() => form.setValue("fileUrl", "")}
                 className="bg-red-500 text-white py-2 px-6 rounded mb-4 mt-4"
               >
                 <Icon name="TrashIcon" className="mr-2" />

--- a/apps/web/app/modules/Admin/AddCourse/hooks/useAddCourseForm.tsx
+++ b/apps/web/app/modules/Admin/AddCourse/hooks/useAddCourseForm.tsx
@@ -18,13 +18,15 @@ export const useAddCourseForm = () => {
       title: "",
       description: "",
       categoryId: "",
-      imageUrl: "",
+      thumbnailS3Key: "",
+      fileUrl: "",
     },
   });
 
   const onSubmit = (values: AddCourseFormValues) => {
+    const { fileUrl: _, ...rest } = values;
     createCourse({
-      data: { ...values, state: "draft" },
+      data: { ...rest, state: "draft" },
     }).then(({ data }) => {
       queryClient.invalidateQueries({ queryKey: ALL_COURSES_QUERY_KEY });
       navigate(`/admin/beta-courses/${data.id}`);

--- a/apps/web/app/modules/Admin/AddCourse/hooks/useAddCourseForm.tsx
+++ b/apps/web/app/modules/Admin/AddCourse/hooks/useAddCourseForm.tsx
@@ -19,12 +19,12 @@ export const useAddCourseForm = () => {
       description: "",
       categoryId: "",
       thumbnailS3Key: "",
-      fileUrl: "",
+      thumbnailUrl: "",
     },
   });
 
   const onSubmit = (values: AddCourseFormValues) => {
-    const { fileUrl: _, ...rest } = values;
+    const { thumbnailUrl: _, ...rest } = values;
     createCourse({
       data: { ...rest, state: "draft" },
     }).then(({ data }) => {

--- a/apps/web/app/modules/Admin/AddCourse/validators/addCourseFormSchema.ts
+++ b/apps/web/app/modules/Admin/AddCourse/validators/addCourseFormSchema.ts
@@ -4,7 +4,8 @@ export const addCourseFormSchema = z.object({
   title: z.string().min(2, "Title must be at least 2 characters."),
   description: z.string().min(2, "Description must be at least 2 characters.").max(800),
   categoryId: z.string().min(1, "Category is required"),
-  imageUrl: z.union([z.string().url("Invalid image URL"), z.string().length(0)]).optional(),
+  fileUrl: z.union([z.string().url("Invalid image URL"), z.string().length(0)]).optional(),
+  thumbnailS3Key: z.string().optional(),
 });
 
 export type AddCourseFormValues = z.infer<typeof addCourseFormSchema>;

--- a/apps/web/app/modules/Admin/AddCourse/validators/addCourseFormSchema.ts
+++ b/apps/web/app/modules/Admin/AddCourse/validators/addCourseFormSchema.ts
@@ -4,7 +4,7 @@ export const addCourseFormSchema = z.object({
   title: z.string().min(2, "Title must be at least 2 characters."),
   description: z.string().min(2, "Description must be at least 2 characters.").max(800),
   categoryId: z.string().min(1, "Category is required"),
-  fileUrl: z.union([z.string().url("Invalid image URL"), z.string().length(0)]).optional(),
+  thumbnailUrl: z.union([z.string().url("Invalid image URL"), z.string().length(0)]).optional(),
   thumbnailS3Key: z.string().optional(),
 });
 


### PR DESCRIPTION
## Jira issue(s)
[LC-546](https://selleolabs.atlassian.net/browse/LC-546)

## Overview
- fixed a bug that resulted in course thumbnails being sent to the course form with the wrong key
- fixed a bug that resulted in an image signed with a url being saved instead of the s3 key


[LC-546]: https://selleolabs.atlassian.net/browse/LC-546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ