### PR TITLE
chroe: add tooltip for disabled scorm upload button

### DIFF
--- a/apps/web/app/locales/en/translation.json
+++ b/apps/web/app/locales/en/translation.json
@@ -15,6 +15,9 @@
       "clearAll": "Clear All",
       "validate": "Validate"
     },
+    "tooltip": {
+      "soon": "Cooming soon"
+    },
     "roles": {
       "admin": "Admin",
       "teacher": "Teacher",

--- a/apps/web/app/locales/pl/translation.json
+++ b/apps/web/app/locales/pl/translation.json
@@ -15,6 +15,9 @@
       "ignore": "Ignoruj",
       "validate": "Waliduj"
     },
+    "tooltip": {
+      "soon": "Dostępne wkrótce"
+    },
     "roles": {
       "admin": "Administrator",
       "teacher": "Nauczyciel",

--- a/apps/web/app/modules/Admin/Courses/Courses.page.tsx
+++ b/apps/web/app/modules/Admin/Courses/Courses.page.tsx
@@ -17,6 +17,7 @@ import { useTranslation } from "react-i18next";
 import { categoriesQueryOptions } from "~/api/queries";
 import { ALL_COURSES_QUERY_KEY, useCoursesSuspense } from "~/api/queries/useCourses";
 import { queryClient } from "~/api/queryClient";
+import { Icon } from "~/components/Icon";
 import SortButton from "~/components/TableSortButton/TableSortButton";
 import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
@@ -29,6 +30,13 @@ import {
   TableHeader,
   TableRow,
 } from "~/components/ui/table";
+import {
+  Tooltip,
+  TooltipArrow,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "~/components/ui/tooltip";
 import { formatHtmlString } from "~/lib/formatters/formatHtmlString";
 import { formatPrice } from "~/lib/formatters/priceFormatter";
 import { cn } from "~/lib/utils";
@@ -205,9 +213,23 @@ const Courses = () => {
   return (
     <div className="flex flex-col">
       <div className="flex gap-3 ml-auto">
-        <Link to="new-scorm">
-          <Button variant="outline">{t("adminCoursesView.button.uploadScorm")}</Button>
-        </Link>
+        <TooltipProvider delayDuration={0}>
+          <Tooltip>
+            <TooltipTrigger>
+              <Button variant="outline" disabled>
+                {t("adminCoursesView.button.uploadScorm")}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent
+              side="top"
+              align="center"
+              className="bg-black text-white text-sm px-2 py-1 rounded shadow-md"
+            >
+              {t("common.tooltip.soon")}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+
         <Link to="/admin/beta-courses/new">
           <Button variant="outline">{t("adminCoursesView.button.createNew")}</Button>
         </Link>


### PR DESCRIPTION
## Overview
- turned off the 'upload scorm' button 

## Screenshots
<img width="470" alt="image" src="https://github.com/user-attachments/assets/2dd06d43-12b6-42f4-8eb2-e09ac3b580bd" />

