### PR TITLE
fix: lc-566 paid course price input

### DIFF
--- a/apps/web/app/components/PriceInput/PriceInput.test.tsx
+++ b/apps/web/app/components/PriceInput/PriceInput.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { PriceInput } from "./PriceInput";
+
+describe("PriceInput", () => {
+  const defaultProps = {
+    onChange: vi.fn(),
+    "aria-label": "Price input",
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("renders without crashing", () => {
+    render(<PriceInput {...defaultProps} />);
+    expect(screen.getByLabelText("Price input")).toBeInTheDocument();
+  });
+
+  it("displays initial value correctly", () => {
+    render(<PriceInput {...defaultProps} value={1050} />);
+    expect(screen.getByLabelText("Price input")).toHaveValue("10.50");
+  });
+
+  it("displays currency when provided", () => {
+    render(<PriceInput {...defaultProps} currency="PLN" />);
+    expect(screen.getByText("PLN")).toBeInTheDocument();
+  });
+
+  it("handles comma input correctly", async () => {
+    const onChange = vi.fn();
+    render(<PriceInput {...defaultProps} onChange={onChange} />);
+
+    const input = screen.getByLabelText("Price input");
+    const user = userEvent.setup();
+
+    await user.type(input, "10,50");
+    expect(input).toHaveValue("10.50");
+    expect(onChange).toHaveBeenLastCalledWith(1050);
+  });
+
+  it("handles dot input correctly", async () => {
+    const onChange = vi.fn();
+    render(<PriceInput {...defaultProps} onChange={onChange} />);
+
+    const input = screen.getByLabelText("Price input");
+    const user = userEvent.setup();
+
+    await user.type(input, "10.50");
+    expect(input).toHaveValue("10.50");
+    expect(onChange).toHaveBeenLastCalledWith(1050);
+  });
+
+  it("limits decimal places to 2", async () => {
+    const onChange = vi.fn();
+    render(<PriceInput {...defaultProps} onChange={onChange} />);
+
+    const input = screen.getByLabelText("Price input");
+    const user = userEvent.setup();
+
+    await user.type(input, "10.555");
+    expect(input).toHaveValue("10.55");
+    expect(onChange).toHaveBeenLastCalledWith(1055);
+  });
+
+  it("handles max value correctly", async () => {
+    const onChange = vi.fn();
+    render(<PriceInput {...defaultProps} onChange={onChange} max={100} />);
+
+    const input = screen.getByLabelText("Price input");
+    const user = userEvent.setup();
+
+    await user.type(input, "150.00");
+    expect(input).toHaveValue("100.00");
+    expect(onChange).toHaveBeenLastCalledWith(10000);
+  });
+
+  it("handles empty input correctly", async () => {
+    const onChange = vi.fn();
+    render(<PriceInput {...defaultProps} onChange={onChange} />);
+
+    const input = screen.getByLabelText("Price input");
+    const user = userEvent.setup();
+
+    await user.type(input, "10");
+    expect(onChange).toHaveBeenCalledWith(1000);
+
+    await user.clear(input);
+    fireEvent.change(input, { target: { value: "" } });
+
+    expect(input).toHaveValue("");
+    expect(onChange).toHaveBeenLastCalledWith(0);
+  });
+
+  it("handles multiple dots/commas correctly", async () => {
+    const onChange = vi.fn();
+    render(<PriceInput {...defaultProps} onChange={onChange} />);
+
+    const input = screen.getByLabelText("Price input");
+    const user = userEvent.setup();
+
+    await user.type(input, "10..50");
+    expect(input).toHaveValue("10.50");
+    expect(onChange).toHaveBeenLastCalledWith(1050);
+  });
+
+  it("passes through additional HTML input props", () => {
+    render(
+      <PriceInput
+        {...defaultProps}
+        id="price-test"
+        data-testid="price-input"
+        placeholder="Enter price"
+      />,
+    );
+
+    const input = screen.getByLabelText("Price input");
+    expect(input).toHaveAttribute("id", "price-test");
+    expect(input).toHaveAttribute("data-testid", "price-input");
+    expect(input).toHaveAttribute("placeholder", "Enter price");
+  });
+});

--- a/apps/web/app/components/PriceInput/PriceInput.tsx
+++ b/apps/web/app/components/PriceInput/PriceInput.tsx
@@ -1,34 +1,39 @@
 import { Input } from "~/components/ui/input";
+import { formatPrice, type CurrencyCode } from "~/lib/formatters/priceFormatter";
 
 import type { ChangeEvent, InputHTMLAttributes } from "react";
 
 type PriceInputProps = Omit<InputHTMLAttributes<HTMLInputElement>, "onChange" | "value"> & {
   value?: number;
   onChange: (value: number) => void;
-  currency?: string;
+  currency?: CurrencyCode;
   max?: number;
+  locale?: string;
 };
 
 /**
  * Input component for handling price entries with automatic formatting
+ * @component
  * @param {Object} props - Component props
- * @param {number} [props.value] - Value in cents (e.g., 1000 for 10.00)
- * @param {(value: number) => void} props.onChange - Callback triggered on value change, returns value in cents
- * @param {string} [props.currency] - Currency symbol displayed on the right side of input
- * @param {number} [props.max=999999.99] - Maximum allowed value in units (not cents)
- * @param {string} [props.className] - Additional CSS classes
+ * @param {number} [props.value] - Value in minor units (e.g., cents)
+ * @param {(value: number) => void} props.onChange - Callback triggered on value change, returns value in minor units
+ * @param {CurrencyCode} [props.currency] - Currency code (e.g., 'USD', 'EUR')
+ * @param {number} [props.max=999999.99] - Maximum allowed value in major units
+ * @param {string} [props.locale] - Locale for number formatting
  *
  * @example
  * <PriceInput
- *   value={1000} // 10.00
- *   onChange={(value) => console.log(value)} // value will be in cents
- *   currency="PLN"
+ *   value={1000} // $10.00
+ *   onChange={(value) => console.log(value)}
+ *   currency="USD"
+ *   locale="en-US"
  * />
  */
 export const PriceInput = ({
   value,
   onChange,
-  currency,
+  currency = "USD",
+  locale = "en-US",
   max = 999999.99,
   className,
   ...props
@@ -72,15 +77,10 @@ export const PriceInput = ({
       return;
     }
 
-    const priceInCents = Math.round(parseFloat(normalizedValue) * 100);
-    if (!isNaN(priceInCents) && priceInCents >= 0) {
-      onChange(priceInCents);
+    const priceInMinorUnits = Math.round(parseFloat(normalizedValue) * 100);
+    if (!isNaN(priceInMinorUnits) && priceInMinorUnits >= 0) {
+      onChange(priceInMinorUnits);
     }
-  };
-
-  const formatPrice = (cents?: number): string => {
-    if (!cents) return "";
-    return (cents / 100).toFixed(2);
   };
 
   return (
@@ -89,7 +89,7 @@ export const PriceInput = ({
         type="text"
         inputMode="decimal"
         onChange={handleChange}
-        defaultValue={formatPrice(value)}
+        defaultValue={value ? formatPrice(value, currency, locale, { withCurrency: false }) : ""}
         className={className}
         {...props}
       />

--- a/apps/web/app/components/PriceInput/PriceInput.tsx
+++ b/apps/web/app/components/PriceInput/PriceInput.tsx
@@ -1,0 +1,77 @@
+import { Input } from "~/components/ui/input";
+
+import type { ChangeEvent, InputHTMLAttributes } from "react";
+
+type PriceInputProps = InputHTMLAttributes<HTMLInputElement> & {
+  value?: number;
+  onChange: (value: number) => void;
+  currency?: string;
+  max?: number;
+};
+
+export const PriceInput = ({
+  value,
+  onChange,
+  currency,
+  max = 999999.99,
+  className,
+  ...props
+}: PriceInputProps) => {
+  const normalizePrice = (value: string) => {
+    const normalized = value.replace(/[.,]/g, (match, index, string) => {
+      return index === string.lastIndexOf(match) ? "." : "";
+    });
+
+    const cleaned = normalized.replace(/[^\d.]/g, "");
+    const [whole, decimal] = cleaned.split(".");
+
+    if (!decimal) return cleaned;
+    return `${whole}.${decimal.slice(0, 2)}`;
+  };
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const normalizedValue = normalizePrice(event.target.value);
+    const numericValue = parseFloat(normalizedValue);
+
+    if (numericValue > max) {
+      event.target.value = max.toFixed(2);
+      onChange(max * 100);
+      return;
+    }
+
+    event.target.value = normalizedValue;
+
+    if (!normalizedValue) {
+      onChange(0);
+      return;
+    }
+
+    const priceInCents = Math.round(parseFloat(normalizedValue) * 100);
+    if (!isNaN(priceInCents) && priceInCents >= 0) {
+      onChange(priceInCents);
+    }
+  };
+
+  const formatPrice = (cents?: number): string => {
+    if (!cents) return "";
+    return (cents / 100).toFixed(2);
+  };
+
+  return (
+    <div className="relative">
+      <Input
+        type="text"
+        inputMode="decimal"
+        onChange={handleChange}
+        defaultValue={formatPrice(value)}
+        className={className}
+        {...props}
+      />
+      {currency && (
+        <span className="absolute right-0 top-1/2 -translate-x-4 -translate-y-1/2 cursor-default uppercase">
+          {currency}
+        </span>
+      )}
+    </div>
+  );
+};

--- a/apps/web/app/components/PriceInput/PriceInput.tsx
+++ b/apps/web/app/components/PriceInput/PriceInput.tsx
@@ -1,7 +1,7 @@
 import { Input } from "~/components/ui/input";
 import { formatPrice, type CurrencyCode } from "~/lib/formatters/priceFormatter";
 
-import type { ChangeEvent, InputHTMLAttributes } from "react";
+import type { ChangeEvent, InputHTMLAttributes, FocusEvent } from "react";
 
 type PriceInputProps = Omit<InputHTMLAttributes<HTMLInputElement>, "onChange" | "value"> & {
   value?: number;
@@ -32,6 +32,7 @@ type PriceInputProps = Omit<InputHTMLAttributes<HTMLInputElement>, "onChange" | 
 export const PriceInput = ({
   value,
   onChange,
+  onBlur,
   currency = "USD",
   locale = "en-US",
   max = 999999.99,
@@ -83,12 +84,28 @@ export const PriceInput = ({
     }
   };
 
+  const handleBlur = (event: FocusEvent<HTMLInputElement>) => {
+    onBlur?.(event);
+
+    const value = event.target.value;
+    const numericValue = parseFloat(value);
+
+    /*
+     *  for values like 0, 0.00, 0.000, 00 etc. clear the input
+     */
+    if (numericValue === 0 || value.match(/^0[.,]?0*$/)) {
+      event.target.value = "";
+      onChange(0);
+    }
+  };
+
   return (
     <div className="relative">
       <Input
         type="text"
         inputMode="decimal"
         onChange={handleChange}
+        onBlur={handleBlur}
         defaultValue={value ? formatPrice(value, currency, locale, { withCurrency: false }) : ""}
         className={className}
         {...props}

--- a/apps/web/app/components/PriceInput/PriceInput.tsx
+++ b/apps/web/app/components/PriceInput/PriceInput.tsx
@@ -2,13 +2,29 @@ import { Input } from "~/components/ui/input";
 
 import type { ChangeEvent, InputHTMLAttributes } from "react";
 
-type PriceInputProps = InputHTMLAttributes<HTMLInputElement> & {
+type PriceInputProps = Omit<InputHTMLAttributes<HTMLInputElement>, "onChange" | "value"> & {
   value?: number;
   onChange: (value: number) => void;
   currency?: string;
   max?: number;
 };
 
+/**
+ * Input component for handling price entries with automatic formatting
+ * @param {Object} props - Component props
+ * @param {number} [props.value] - Value in cents (e.g., 1000 for 10.00)
+ * @param {(value: number) => void} props.onChange - Callback triggered on value change, returns value in cents
+ * @param {string} [props.currency] - Currency symbol displayed on the right side of input
+ * @param {number} [props.max=999999.99] - Maximum allowed value in units (not cents)
+ * @param {string} [props.className] - Additional CSS classes
+ *
+ * @example
+ * <PriceInput
+ *   value={1000} // 10.00
+ *   onChange={(value) => console.log(value)} // value will be in cents
+ *   currency="PLN"
+ * />
+ */
 export const PriceInput = ({
   value,
   onChange,
@@ -17,6 +33,16 @@ export const PriceInput = ({
   className,
   ...props
 }: PriceInputProps) => {
+  /**
+   * Formats the input text by normalizing decimal separators and cleaning input
+   * @param {string} value - Raw input value
+   * @returns {string} Normalized price string with proper decimal formatting
+   *
+   * @example
+   * normalizePrice("1,000.23") // "1000.23"
+   * normalizePrice("1.000,23") // "1000.23"
+   * normalizePrice("1000.234") // "1000.23"
+   */
   const normalizePrice = (value: string) => {
     const normalized = value.replace(/[.,]/g, (match, index, string) => {
       return index === string.lastIndexOf(match) ? "." : "";

--- a/apps/web/app/lib/formatters/priceFormatter.ts
+++ b/apps/web/app/lib/formatters/priceFormatter.ts
@@ -1,25 +1,28 @@
 /**
  * Supported currency codes.
  */
-type CurrencyCode = "USD" | "EUR" | "GBP" | "JPY" | "KRW" | "BHD" | string;
+export type CurrencyCode = "USD" | "EUR" | "GBP" | "JPY" | "KRW" | "BHD" | string;
 
 /**
  * Formats a price in minor units to a localized string representation.
  * @param amount - The price amount in minor units (e.g., cents).
  * @optional currency - The currency code (e.g., 'USD', 'EUR', 'JPY'). Case-insensitive. Default is 'USD'.
  * @param locale - The locale to use for formatting.
+ * @param options - Additional formatting options
+ * @param options.withCurrency - Whether to include the currency symbol. Default is true.
  * @returns The formatted price string.
  */
 export function formatPrice(
   amount: number,
   currency: CurrencyCode = "USD",
   locale: string = "en-US",
+  options: { withCurrency?: boolean } = { withCurrency: true },
 ): string {
   const upperCaseCurrency = currency.toUpperCase() as CurrencyCode;
   const majorUnits = convertToMajorUnits(amount, upperCaseCurrency);
 
   const formatter = new Intl.NumberFormat(locale, {
-    style: "currency",
+    style: options.withCurrency ? "currency" : "decimal",
     currency: upperCaseCurrency,
     minimumFractionDigits: getMinimumFractionDigits(upperCaseCurrency),
     maximumFractionDigits: getMaximumFractionDigits(upperCaseCurrency),

--- a/apps/web/app/locales/en/translation.json
+++ b/apps/web/app/locales/en/translation.json
@@ -579,6 +579,9 @@
       },
       "placeholder": {
         "amount": "Amount"
+      },
+      "validation": {
+        "priceInCents": "Price must be at least 2.00 or free"
       }
     }
   },

--- a/apps/web/app/locales/pl/translation.json
+++ b/apps/web/app/locales/pl/translation.json
@@ -579,6 +579,9 @@
       },
       "placeholder": {
         "amount": "Kwota"
+      },
+      "validation": {
+        "priceInCents": "Kurs musi kosztować co najmniej 2.00 lub być darmowy"
       }
     }
   },

--- a/apps/web/app/modules/Admin/EditCourse/CoursePricing/CoursePricing.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/CoursePricing/CoursePricing.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next";
 
+import { PriceInput } from "~/components/PriceInput/PriceInput";
 import { Button } from "~/components/ui/button";
 import { Card } from "~/components/ui/card";
 import { Form } from "~/components/ui/form";
@@ -17,7 +18,7 @@ type CoursePricingProps = {
 
 const CoursePricing = ({ courseId, priceInCents, currency }: CoursePricingProps) => {
   const { form, onSubmit } = useCoursePricingForm({ courseId, priceInCents, currency });
-  const { setValue, register, watch } = form;
+  const { setValue, watch } = form;
   const { t } = useTranslation();
 
   const isFree = watch("isFree");
@@ -105,31 +106,16 @@ const CoursePricing = ({ courseId, priceInCents, currency }: CoursePricingProps)
                         {t("adminCourseView.pricing.field.price")}
                       </Label>
                     </div>
-                    <div className="relative mb-2">
-                      <Input
-                        id="priceInCents"
-                        {...register("priceInCents", {
-                          valueAsNumber: true,
-                          onChange: (e) => {
-                            const value = e.target.value;
-                            if (Number(value) <= 0) {
-                              e.target.value = "";
-                            }
-                          },
-                        })}
+                    <div className="mb-2">
+                      <PriceInput
+                        value={form.getValues("priceInCents")}
+                        // @ts-expect-error test
+                        onChange={(value) => setValue("priceInCents", value)}
+                        currency={currency}
                         placeholder={t("adminCourseView.pricing.placeholder.amount")}
-                        type="number"
                         className="[&::-moz-appearance]:textfield appearance-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-                        onInput={(e) => {
-                          const input = e.target as HTMLInputElement;
-                          if (Number(input.value) <= 0) {
-                            input.value = "";
-                          }
-                        }}
+                        aria-label={t("adminCourseView.pricing.field.price")}
                       />
-                      <span className="absolute right-0 top-1/2 -translate-x-4 -translate-y-1/2 cursor-default uppercase">
-                        {currency}
-                      </span>
                     </div>
                   </>
                 )}

--- a/apps/web/app/modules/Admin/EditCourse/CoursePricing/CoursePricing.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/CoursePricing/CoursePricing.tsx
@@ -109,7 +109,6 @@ const CoursePricing = ({ courseId, priceInCents, currency }: CoursePricingProps)
                     <div className="mb-2">
                       <PriceInput
                         value={form.getValues("priceInCents")}
-                        // @ts-expect-error test
                         onChange={(value) => setValue("priceInCents", value)}
                         currency={currency}
                         placeholder={t("adminCourseView.pricing.placeholder.amount")}

--- a/apps/web/app/modules/Admin/EditCourse/CoursePricing/CoursePricing.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/CoursePricing/CoursePricing.tsx
@@ -112,9 +112,19 @@ const CoursePricing = ({ courseId, priceInCents, currency }: CoursePricingProps)
                         onChange={(value) => setValue("priceInCents", value)}
                         currency={currency}
                         placeholder={t("adminCourseView.pricing.placeholder.amount")}
-                        className="[&::-moz-appearance]:textfield appearance-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                        className={cn(
+                          "[&::-moz-appearance]:textfield appearance-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none",
+                          {
+                            "border-error-600": form.formState.errors.priceInCents,
+                          },
+                        )}
                         aria-label={t("adminCourseView.pricing.field.price")}
                       />
+                      {form.formState.errors.priceInCents && (
+                        <p className="text-error-600 text-xs">
+                          {form.formState.errors.priceInCents.message}
+                        </p>
+                      )}
                     </div>
                   </>
                 )}

--- a/apps/web/app/modules/Admin/EditCourse/CoursePricing/hooks/useCoursePricingForm.ts
+++ b/apps/web/app/modules/Admin/EditCourse/CoursePricing/hooks/useCoursePricingForm.ts
@@ -1,5 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 
 import { useUpdateCourse } from "~/api/mutations/admin/useUpdateCourse";
 import { courseQueryOptions } from "~/api/queries/admin/useBetaCourse";
@@ -20,9 +21,10 @@ export const useCoursePricingForm = ({
   priceInCents,
   currency,
 }: UseCoursePricingFormProps) => {
+  const { t } = useTranslation();
   const { mutateAsync: updateCourse } = useUpdateCourse();
   const form = useForm<CoursePricingFormValues>({
-    resolver: zodResolver(coursePricingFormSchema),
+    resolver: zodResolver(coursePricingFormSchema(t)),
     defaultValues: {
       priceInCents: priceInCents || undefined,
       currency: currency || "",
@@ -30,8 +32,9 @@ export const useCoursePricingForm = ({
     },
   });
   const onSubmit = async (data: CoursePricingFormValues) => {
+    const { isFree: _, ...rest } = data;
     updateCourse({
-      data,
+      data: { ...rest },
       courseId,
     }).then(() => {
       queryClient.invalidateQueries(courseQueryOptions(courseId));

--- a/apps/web/app/modules/Admin/EditCourse/CoursePricing/validators/coursePricingFormSchema.ts
+++ b/apps/web/app/modules/Admin/EditCourse/CoursePricing/validators/coursePricingFormSchema.ts
@@ -1,9 +1,26 @@
 import { z } from "zod";
 
-export const coursePricingFormSchema = z.object({
-  priceInCents: z.number(),
-  currency: z.string().optional().default("pln"),
-  isFree: z.boolean().default(false),
-});
+import type i18next from "i18next";
 
-export type CoursePricingFormValues = z.infer<typeof coursePricingFormSchema>;
+export const coursePricingFormSchema = (t: typeof i18next.t) =>
+  z
+    .object({
+      priceInCents: z.number().optional(),
+      currency: z.string().optional().default("pln"),
+      isFree: z.boolean().default(false),
+    })
+    .superRefine((data, ctx) => {
+      if (data.isFree) {
+        data.priceInCents = 0;
+      } else {
+        if (!data.priceInCents || data.priceInCents < 200) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: t("adminCourseView.pricing.validation.priceInCents"),
+            path: ["priceInCents"],
+          });
+        }
+      }
+    });
+
+export type CoursePricingFormValues = z.infer<ReturnType<typeof coursePricingFormSchema>>;


### PR DESCRIPTION
## Jira issue(s)
[LC-566](https://selleolabs.atlassian.net/browse/LC-582)

## Overview
- fixed an issue when course price (in dollars) in input was not converted into cents
- created separated price input component with normalization (usage of `,` and `. `) and support for locale
- added test for price input component
## Screenshots
![image](https://github.com/user-attachments/assets/21a3ed48-d531-473e-aad9-88d0707a0b7a)
![image](https://github.com/user-attachments/assets/e4ca8716-6d69-49dd-b7c2-8ad08c4c55e5)


[LC-566]: https://selleolabs.atlassian.net/browse/LC-566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ