### PR TITLE
fix(SCS-506): Fixed checkboxes in filtered lists

### DIFF
--- a/apps/api/src/swagger/api-schema.json
+++ b/apps/api/src/swagger/api-schema.json
@@ -3179,10 +3179,16 @@
               "role": {
                 "anyOf": [
                   {
+                    "const": "admin",
                     "type": "string"
                   },
                   {
-                    "type": "null"
+                    "const": "student",
+                    "type": "string"
+                  },
+                  {
+                    "const": "content_creator",
+                    "type": "string"
                   }
                 ]
               }

--- a/apps/web/app/modules/Admin/Categories/Categories.page.tsx
+++ b/apps/web/app/modules/Admin/Categories/Categories.page.tsx
@@ -149,6 +149,7 @@ const Categories = () => {
   ];
 
   const table = useReactTable({
+    getRowId: (row) => row.id,
     data,
     columns,
     getCoreRowModel: getCoreRowModel(),
@@ -162,7 +163,6 @@ const Categories = () => {
   });
 
   const selectedCategories = table.getSelectedRowModel().rows.map((row) => row.original.id);
-
   const handleDelete = () => {
     try {
       if (selectedCategories.length === 1) {

--- a/apps/web/app/modules/Admin/Courses/Courses.page.tsx
+++ b/apps/web/app/modules/Admin/Courses/Courses.page.tsx
@@ -191,6 +191,7 @@ const Courses = () => {
   ];
 
   const table = useReactTable({
+    getRowId: (row) => row.id,
     data,
     columns,
     getCoreRowModel: getCoreRowModel(),

--- a/apps/web/app/modules/Admin/EditCourse/CourseEnrolled/CourseEnrolled.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/CourseEnrolled/CourseEnrolled.tsx
@@ -136,6 +136,7 @@ export const CourseEnrolled = (): ReactElement => {
   ];
 
   const table = useReactTable({
+    getRowId: (row) => row.id,
     data: usersData,
     columns,
     getCoreRowModel: getCoreRowModel(),

--- a/apps/web/app/modules/Admin/Groups/Groups.page.tsx
+++ b/apps/web/app/modules/Admin/Groups/Groups.page.tsx
@@ -49,6 +49,7 @@ const Groups = (): ReactElement => {
   const { mutateAsync: deleteGroupsMutation } = useBulkDeleteGroups();
 
   const table = useReactTable({
+    getRowId: (row) => row.id,
     data,
     columns,
     getCoreRowModel: getCoreRowModel(),

--- a/apps/web/app/modules/Admin/Users/Users.page.tsx
+++ b/apps/web/app/modules/Admin/Users/Users.page.tsx
@@ -159,6 +159,7 @@ const Users = () => {
   ];
 
   const table = useReactTable({
+    getRowId: (row) => row.id,
     data,
     columns,
     getCoreRowModel: getCoreRowModel(),


### PR DESCRIPTION
## Jira issue(s)
[SCS-506](https://github.com/Selleo/mentingo/issues/506)

## Overview
Checkboxes were getting out of sync when filtering the table. The selection was based on the row index, so after filtering, it was toggling the wrong rows.

I fixed this by overriding the getRowId method in the useReactTable hook to use the actual row id instead of the index. Now checkbox selection works correctly, even after filtering.

## Footage
https://github.com/user-attachments/assets/82c364fc-4be1-4725-a4de-47a3fa08f483



