### PR TITLE
feat(SCS-546): Created AI Mentor Lesson Preview Mode

### DIFF
--- a/apps/api/src/ai/ai.controller.ts
+++ b/apps/api/src/ai/ai.controller.ts
@@ -20,7 +20,7 @@ import { type BaseResponse, baseResponse, UUIDSchema, UUIDType } from "src/commo
 import { Roles } from "src/common/decorators/roles.decorator";
 import { CurrentUser } from "src/common/decorators/user.decorator";
 import { RolesGuard } from "src/common/guards/roles.guard";
-import { USER_ROLES } from "src/user/schemas/userRoles";
+import { USER_ROLES, UserRole } from "src/user/schemas/userRoles";
 
 @Controller("ai")
 @UseGuards(RolesGuard)
@@ -31,7 +31,7 @@ export class AiController {
   ) {}
 
   @Get("thread")
-  @Roles(USER_ROLES.STUDENT)
+  @Roles(...Object.values(USER_ROLES))
   @Validate({
     request: [{ type: "query" as const, name: "thread", schema: UUIDSchema }],
     response: baseResponse(responseThreadSchema),
@@ -44,7 +44,7 @@ export class AiController {
   }
 
   @Get("thread/messages")
-  @Roles(USER_ROLES.STUDENT)
+  @Roles(...Object.values(USER_ROLES))
   @Validate({
     request: [{ type: "query" as const, name: "thread", schema: UUIDSchema }],
     response: baseResponse(Type.Array(responseThreadMessageSchema)),
@@ -57,7 +57,7 @@ export class AiController {
   }
 
   @Post("chat")
-  @Roles(USER_ROLES.STUDENT)
+  @Roles(...Object.values(USER_ROLES))
   @Validate({
     request: [{ type: "body", schema: streamChatSchema }],
   })
@@ -72,7 +72,7 @@ export class AiController {
   }
 
   @Post("judge/:threadId")
-  @Roles(USER_ROLES.STUDENT)
+  @Roles(...Object.values(USER_ROLES))
   @Validate({
     request: [{ type: "param", name: "threadId", schema: UUIDSchema }],
     response: baseResponse(responseJudgeSchema),
@@ -80,19 +80,21 @@ export class AiController {
   async judgeThread(
     @Param("threadId") threadId: UUIDType,
     @CurrentUser("userId") userId: UUIDType,
+    @CurrentUser("role") userRole: UserRole,
   ): Promise<BaseResponse<ResponseJudgeBody>> {
-    return await this.aiService.runJudge({ threadId, userId });
+    return await this.aiService.runJudge({ threadId, userId }, userRole);
   }
 
   @Post("retake/:lessonId")
-  @Roles(USER_ROLES.STUDENT)
+  @Roles(...Object.values(USER_ROLES))
   @Validate({
     request: [{ type: "param", name: "lessonId", schema: UUIDSchema }],
   })
   async retakeLesson(
     @Param("lessonId") lessonId: UUIDType,
     @CurrentUser("userId") userId: UUIDType,
+    @CurrentUser("role") userRole: UserRole,
   ) {
-    await this.aiService.retakeLesson(lessonId, userId);
+    await this.aiService.retakeLesson(lessonId, userId, userRole);
   }
 }

--- a/apps/api/src/ai/ai.module.ts
+++ b/apps/api/src/ai/ai.module.ts
@@ -26,6 +26,6 @@ import { StudentLessonProgressModule } from "src/studentLessonProgress/studentLe
     JudgeService,
     SummaryService,
   ],
-  exports: [AiService],
+  exports: [AiService, AiRepository],
 })
 export class AiModule {}

--- a/apps/api/src/ai/services/ai.service.ts
+++ b/apps/api/src/ai/services/ai.service.ts
@@ -126,11 +126,11 @@ export class AiService {
     });
   }
 
-  async runJudge(data: ThreadOwnershipBody) {
+  async runJudge(data: ThreadOwnershipBody, userRole: UserRole = USER_ROLES.STUDENT) {
     const judged = await this.judgeService.runJudge(data);
     const { lessonId } = await this.aiRepository.findLessonIdByThreadId(data.threadId);
 
-    await this.markAsCompletedIfJudge(lessonId, data.userId, USER_ROLES.STUDENT, judged.data, true);
+    await this.markAsCompletedIfJudge(lessonId, data.userId, userRole, judged.data, true);
 
     const tokenCount = this.tokenService.countTokens(OPENAI_MODELS.BASIC, judged.data.summary);
 
@@ -176,10 +176,10 @@ export class AiService {
     });
   }
 
-  async retakeLesson(lessonId: UUIDType, userId: UUIDType) {
+  async retakeLesson(lessonId: UUIDType, userId: UUIDType, userRole: UserRole) {
     const [lesson] = await this.aiRepository.checkLessonAssignment(lessonId, userId);
 
-    if (!lesson.isAssigned && !lesson.isFreemium)
+    if (userRole === USER_ROLES.STUDENT && !lesson.isAssigned && !lesson.isFreemium)
       throw new UnauthorizedException("You are not assigned to this lesson");
 
     await this.db.transaction(async (trx) => {

--- a/apps/api/src/ai/services/prompt.service.ts
+++ b/apps/api/src/ai/services/prompt.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { BadRequestException, Injectable } from "@nestjs/common";
 import { eq } from "drizzle-orm";
 
 import { AiRepository } from "src/ai/repositories/ai.repository";
@@ -82,7 +82,7 @@ export class PromptService {
 
   async isNotEmpty(prompt: string) {
     if (!prompt?.trim()) {
-      throw new Error("Prompt cannot be empty");
+      throw new BadRequestException("At least one message required");
     }
   }
 }

--- a/apps/api/src/lesson/lesson.controller.ts
+++ b/apps/api/src/lesson/lesson.controller.ts
@@ -140,8 +140,9 @@ export class LessonController {
   async betaUpdateAiMentorLesson(
     @Query("id") id: UUIDType,
     @Body() data: UpdateAiMentorLessonBody,
+    @CurrentUser("userId") userId: UUIDType,
   ): Promise<BaseResponse<{ message: string }>> {
-    await this.adminLessonsService.updateAiMentorLesson(id, data);
+    await this.adminLessonsService.updateAiMentorLesson(id, data, userId);
     return new BaseResponse({ message: "AI Mentor lesson updated successfully" });
   }
   @Post("beta-create-lesson/quiz")

--- a/apps/web/app/locales/en/translation.json
+++ b/apps/web/app/locales/en/translation.json
@@ -546,7 +546,8 @@
       "status": "Status",
       "pricing": "Pricing",
       "preview": "Preview",
-      "enrolledStudents": "Enrolled students"
+      "enrolledStudents": "Enrolled students",
+      "testAiMentor": "Test AI Mentor"
     },
     "toast": {
       "createCourseSuccessfully": "Course created successfully",

--- a/apps/web/app/locales/pl/translation.json
+++ b/apps/web/app/locales/pl/translation.json
@@ -547,7 +547,8 @@
       "status": "Status",
       "pricing": "Cennik",
       "preview": "Podgląd",
-      "enrolledStudents": "Zapisani studenci"
+      "enrolledStudents": "Zapisani studenci",
+      "testAiMentor": "Przetestuj AI Mentora"
     },
     "toast": {
       "createCourseSuccessfully": "Kurs utworzony pomyślnie",

--- a/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/AiMentorLessonForm/AiMentorLessonForm.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/AiMentorLessonForm/AiMentorLessonForm.tsx
@@ -23,6 +23,7 @@ import {
   TooltipArrow,
 } from "~/components/ui/tooltip";
 import DeleteConfirmationModal from "~/modules/Admin/components/DeleteConfirmationModal";
+import AiMentorLessonPreview from "~/modules/Admin/EditCourse/CourseLessons/NewLesson/AiMentorLessonForm/hooks/AiMentorLessonPreview";
 import { SuggestionExamples } from "~/modules/Admin/EditCourse/CourseLessons/NewLesson/AiMentorLessonForm/utils/AiMentor.constants";
 
 import { DeleteContentType } from "../../../EditCourse.types";
@@ -72,209 +73,226 @@ const AiMentorLessonForm = ({
     setIsModalOpen(true);
   };
 
+  const onOpenPreview = () => setPreviewOpen(true);
+  const onClosePreview = () => setPreviewOpen(false);
+
+  const [previewOpen, setPreviewOpen] = useState(false);
+
   return (
-    <TooltipProvider delayDuration={0}>
-      <div className="flex flex-col gap-y-6 rounded-lg bg-white p-8">
-        <div className="flex flex-col gap-y-1">
-          {!lessonToEdit && (
-            <Breadcrumb
-              lessonLabel="AI Mentor"
-              setContentTypeToDisplay={setContentTypeToDisplay}
-              setSelectedLesson={setSelectedLesson}
-            />
-          )}
-          <div className="h5 text-neutral-950">
-            {lessonToEdit ? (
-              <>
-                <span className="text-neutral-600">
-                  {t("adminCourseView.curriculum.other.edit")}:{" "}
-                </span>
-                <span className="font-bold">{lessonToEdit.title}</span>
-              </>
-            ) : (
-              t("common.button.create")
+    <>
+      {lessonToEdit && previewOpen && (
+        <AiMentorLessonPreview lesson={lessonToEdit} onClose={onClosePreview} />
+      )}
+      <TooltipProvider delayDuration={0}>
+        <div className="flex flex-col gap-y-6 rounded-lg bg-white p-8">
+          <div className="flex flex-col gap-y-1">
+            {!lessonToEdit && (
+              <Breadcrumb
+                lessonLabel="AI Mentor"
+                setContentTypeToDisplay={setContentTypeToDisplay}
+                setSelectedLesson={setSelectedLesson}
+              />
             )}
-          </div>
-        </div>
-        <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className="flex grow flex-col">
-            <div className="flex items-center">
-              <span className="mr-1 text-red-500">*</span>
-              <Label htmlFor="title" className="mr-2">
-                {t("adminCourseView.curriculum.lesson.field.title")}
-              </Label>
-            </div>
-            <FormTextField
-              control={form.control}
-              name="title"
-              id="title"
-              placeholder={t("adminCourseView.curriculum.lesson.placeholder.title")}
-              className="mb-4"
-            />
-            <div className="mb-4 grid grid-cols-1 lg:grid-cols-2">
-              <div>
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-2">
-                    <Label htmlFor="aiMentorInstructions" className="mb-2 block">
-                      <span className="mr-1 text-red-500">*</span>
-                      {t("adminCourseView.curriculum.lesson.field.aiMentorInstructions")}
-                    </Label>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span>
-                          <Icon
-                            name="Info"
-                            className="h-auto w-6 cursor-default text-neutral-800"
-                          />
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent
-                        side="top"
-                        align="center"
-                        className="max-w-xs whitespace-pre-line break-words rounded bg-black px-2 py-1 text-sm text-white shadow-md"
-                      >
-                        {t("adminCourseView.curriculum.lesson.other.aiMentorInstructionsTooltip")}
-                        <TooltipArrow className="fill-black" />
-                      </TooltipContent>
-                    </Tooltip>
-                  </div>
-                </div>
-                <FormField
-                  control={form.control}
-                  name="aiMentorInstructions"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormControl>
-                        <Editor
-                          content={field.value}
-                          placeholder={t(
-                            "adminCourseView.curriculum.lesson.placeholder.aiMentorInstructions",
-                          )}
-                          className="h-48 grow resize-none overflow-y-auto"
-                          parentClassName="lg:rounded-r-none"
-                          {...field}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
-
-              <div>
-                <div className="mt-4 flex items-center justify-between lg:mt-0">
-                  <div className="flex items-center gap-2">
-                    <Label htmlFor="completionConditions" className="mb-2 block">
-                      <span className="mr-1 text-red-500">*</span>
-                      {t("adminCourseView.curriculum.lesson.field.completionConditions")}
-                    </Label>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span>
-                          <Icon
-                            name="Info"
-                            className="h-auto w-6 cursor-default text-neutral-800"
-                          />
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent
-                        side="top"
-                        align="center"
-                        className="max-w-xs whitespace-pre-line break-words rounded bg-black px-2 py-1 text-sm text-white shadow-md"
-                      >
-                        {t("adminCourseView.curriculum.lesson.other.completionConditionsTooltip")}
-                        <TooltipArrow className="fill-black" />
-                      </TooltipContent>
-                    </Tooltip>
-                  </div>
-                </div>
-                <FormField
-                  control={form.control}
-                  name="completionConditions"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormControl>
-                        <Editor
-                          content={field.value}
-                          placeholder={t(
-                            "adminCourseView.curriculum.lesson.placeholder.completionConditions",
-                          )}
-                          className="h-48 grow resize-none overflow-y-auto"
-                          parentClassName={"lg:rounded-l-none lg:border-l-0"}
-                          {...field}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
-            </div>
-
-            <div className="mb-6 rounded-lg bg-neutral-50 p-4">
-              <h3 className="mb-3 text-sm font-semibold text-neutral-900">
-                {t("adminCourseView.curriculum.lesson.other.suggestedExamples")}
-              </h3>
-              <div className="grid min-w-0 max-w-full grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-4">
-                {SuggestionExamples.map(({ onClick, translationKey }) => (
-                  <Button
-                    key={onClick}
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    className="box-border min-w-0 justify-center px-4 text-center"
-                    onClick={() => handleSuggestionClick(onClick)}
-                  >
-                    <span className="block w-full truncate">{t(translationKey)}</span>
-                  </Button>
-                ))}
-              </div>
-            </div>
-
-            <div className="flex gap-x-4">
-              <Button type="submit" className="bg-primary-700">
-                {t("common.button.save")}
-              </Button>
-              {lessonToEdit && (
-                <Button
-                  type="button"
-                  onClick={onClickDelete}
-                  className="bg-color-white border border-neutral-300 text-error-700"
-                >
-                  {t("common.button.delete")}
-                </Button>
+            <div className="h5 text-neutral-950">
+              {lessonToEdit ? (
+                <>
+                  <span className="text-neutral-600">
+                    {t("adminCourseView.curriculum.other.edit")}:{" "}
+                  </span>
+                  <span className="font-bold">{lessonToEdit.title}</span>
+                </>
+              ) : (
+                t("common.button.create")
               )}
             </div>
-          </form>
-        </Form>
-        <DeleteConfirmationModal
-          open={isModalOpen}
-          onClose={onCloseModal}
-          onDelete={onDelete}
-          contentType={DeleteContentType.AI_MENTOR}
-        />
-        <Dialog open={isConfirmDialogOpen} onOpenChange={setIsConfirmDialogOpen}>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>
-                {t("adminCourseView.curriculum.lesson.other.overwriteContent")}
-              </DialogTitle>
-              <DialogDescription>
-                {t("adminCourseView.curriculum.lesson.other.overwriteContentDescription")}
-              </DialogDescription>
-            </DialogHeader>
-            <DialogFooter>
-              <Button variant="outline" onClick={onCancelOverwrite}>
-                {t("common.button.cancel")}
-              </Button>
-              <Button onClick={onConfirmOverwrite} className="bg-primary-700">
-                {t("clientStatisticsView.button.continue")}
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
-      </div>
-    </TooltipProvider>
+          </div>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="flex grow flex-col">
+              <div className="flex items-center">
+                <span className="mr-1 text-red-500">*</span>
+                <Label htmlFor="title" className="mr-2">
+                  {t("adminCourseView.curriculum.lesson.field.title")}
+                </Label>
+              </div>
+              <FormTextField
+                control={form.control}
+                name="title"
+                id="title"
+                placeholder={t("adminCourseView.curriculum.lesson.placeholder.title")}
+                className="mb-4"
+              />
+              <div className="mb-4 grid grid-cols-1 lg:grid-cols-2">
+                <div>
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      <Label htmlFor="aiMentorInstructions" className="mb-2 block">
+                        <span className="mr-1 text-red-500">*</span>
+                        {t("adminCourseView.curriculum.lesson.field.aiMentorInstructions")}
+                      </Label>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span>
+                            <Icon
+                              name="Info"
+                              className="h-auto w-6 cursor-default text-neutral-800"
+                            />
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent
+                          side="top"
+                          align="center"
+                          className="max-w-xs whitespace-pre-line break-words rounded bg-black px-2 py-1 text-sm text-white shadow-md"
+                        >
+                          {t("adminCourseView.curriculum.lesson.other.aiMentorInstructionsTooltip")}
+                          <TooltipArrow className="fill-black" />
+                        </TooltipContent>
+                      </Tooltip>
+                    </div>
+                  </div>
+                  <FormField
+                    control={form.control}
+                    name="aiMentorInstructions"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormControl>
+                          <Editor
+                            content={field.value}
+                            placeholder={t(
+                              "adminCourseView.curriculum.lesson.placeholder.aiMentorInstructions",
+                            )}
+                            className="h-48 grow resize-none overflow-y-auto"
+                            parentClassName="lg:rounded-r-none"
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+
+                <div>
+                  <div className="mt-4 flex items-center justify-between lg:mt-0">
+                    <div className="flex items-center gap-2">
+                      <Label htmlFor="completionConditions" className="mb-2 block">
+                        <span className="mr-1 text-red-500">*</span>
+                        {t("adminCourseView.curriculum.lesson.field.completionConditions")}
+                      </Label>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span>
+                            <Icon
+                              name="Info"
+                              className="h-auto w-6 cursor-default text-neutral-800"
+                            />
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent
+                          side="top"
+                          align="center"
+                          className="max-w-xs whitespace-pre-line break-words rounded bg-black px-2 py-1 text-sm text-white shadow-md"
+                        >
+                          {t("adminCourseView.curriculum.lesson.other.completionConditionsTooltip")}
+                          <TooltipArrow className="fill-black" />
+                        </TooltipContent>
+                      </Tooltip>
+                    </div>
+                  </div>
+                  <FormField
+                    control={form.control}
+                    name="completionConditions"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormControl>
+                          <Editor
+                            content={field.value}
+                            placeholder={t(
+                              "adminCourseView.curriculum.lesson.placeholder.completionConditions",
+                            )}
+                            className="h-48 grow resize-none overflow-y-auto"
+                            parentClassName={"lg:rounded-l-none lg:border-l-0"}
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+              </div>
+
+              <div className="mb-6 rounded-lg bg-neutral-50 p-4">
+                <h3 className="mb-3 text-sm font-semibold text-neutral-900">
+                  {t("adminCourseView.curriculum.lesson.other.suggestedExamples")}
+                </h3>
+                <div className="grid min-w-0 max-w-full grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-4">
+                  {SuggestionExamples.map(({ onClick, translationKey }) => (
+                    <Button
+                      key={onClick}
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="box-border min-w-0 justify-center px-4 text-center"
+                      onClick={() => handleSuggestionClick(onClick)}
+                    >
+                      <span className="block w-full truncate">{t(translationKey)}</span>
+                    </Button>
+                  ))}
+                </div>
+              </div>
+
+              <div className="flex justify-between">
+                <div className="flex gap-x-4">
+                  <Button type="submit" className="bg-primary-700">
+                    {t("common.button.save")}
+                  </Button>
+                  {lessonToEdit && (
+                    <Button
+                      type="button"
+                      onClick={onClickDelete}
+                      className="bg-color-white border border-neutral-300 text-error-700"
+                    >
+                      {t("common.button.delete")}
+                    </Button>
+                  )}
+                </div>
+                {lessonToEdit && (
+                  <Button type="button" onClick={onOpenPreview} variant="primary">
+                    {t("adminCourseView.common.testAiMentor")}
+                  </Button>
+                )}
+              </div>
+            </form>
+          </Form>
+          <DeleteConfirmationModal
+            open={isModalOpen}
+            onClose={onCloseModal}
+            onDelete={onDelete}
+            contentType={DeleteContentType.AI_MENTOR}
+          />
+          <Dialog open={isConfirmDialogOpen} onOpenChange={setIsConfirmDialogOpen}>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>
+                  {t("adminCourseView.curriculum.lesson.other.overwriteContent")}
+                </DialogTitle>
+                <DialogDescription>
+                  {t("adminCourseView.curriculum.lesson.other.overwriteContentDescription")}
+                </DialogDescription>
+              </DialogHeader>
+              <DialogFooter>
+                <Button variant="outline" onClick={onCancelOverwrite}>
+                  {t("common.button.cancel")}
+                </Button>
+                <Button onClick={onConfirmOverwrite} className="bg-primary-700">
+                  {t("clientStatisticsView.button.continue")}
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        </div>
+      </TooltipProvider>
+    </>
   );
 };
 

--- a/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/AiMentorLessonForm/hooks/AiMentorLessonPreview.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/AiMentorLessonForm/hooks/AiMentorLessonPreview.tsx
@@ -1,0 +1,46 @@
+import { X } from "lucide-react";
+
+import { useLesson } from "~/api/queries";
+import { Button } from "~/components/ui/button";
+import AiMentorLesson from "~/modules/Courses/Lesson/AiMentorLesson/AiMentorLesson";
+import { useLanguageStore } from "~/modules/Dashboard/Settings/Language/LanguageStore";
+
+import type { Lesson } from "~/modules/Admin/EditCourse/EditCourse.types";
+
+interface AiMentorPreviewProps {
+  onClose: () => void;
+  lesson: Lesson;
+}
+
+const AiMentorLessonPreview = ({ onClose, lesson }: AiMentorPreviewProps) => {
+  const { language } = useLanguageStore();
+  const { data: lessonData, isFetching: lessonLoading } = useLesson(lesson.id, language);
+
+  return (
+    <div className="fixed left-0 top-0 z-[100] box-border flex size-full max-h-dvh justify-center bg-gray-900/50 p-4">
+      <div className="flex w-full max-w-6xl flex-col">
+        <div className="flex items-center justify-between rounded-t-lg bg-white p-4">
+          <div>
+            <h2 className="font-medium text-blue-800">{lesson.title}</h2>
+            <h2 className="text-sm text-gray-400">AI Mentor</h2>
+          </div>
+
+          <div className="flex gap-3">
+            <Button
+              onClick={onClose}
+              variant="outline"
+              className="flex h-8 w-8 items-center justify-center p-0 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700"
+            >
+              <X className="size-5" />
+            </Button>
+          </div>
+        </div>
+        <div className="box-border flex flex-1 rounded-b-lg bg-neutral-50 p-4">
+          {lessonData && <AiMentorLesson lesson={lessonData} lessonLoading={lessonLoading} />}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AiMentorLessonPreview;

--- a/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/AiMentorLessonForm/hooks/useAiMentorLessonForm.ts
+++ b/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/AiMentorLessonForm/hooks/useAiMentorLessonForm.ts
@@ -117,6 +117,10 @@ export const useAiMentorLessonForm = ({
 
       setContentTypeToDisplay(ContentTypes.EMPTY);
       await queryClient.invalidateQueries({ queryKey: [COURSE_QUERY_KEY, { id: courseId }] });
+      await queryClient.invalidateQueries({ queryKey: ["lesson", lessonToEdit?.id] });
+      await queryClient.invalidateQueries({
+        queryKey: ["threadMessages", { lessonId: lessonToEdit?.id }],
+      });
     } catch (error) {
       console.error("Error creating/updating AI Mentor lesson:", error);
     }

--- a/apps/web/app/modules/Admin/EditCourse/EditCourse.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/EditCourse.tsx
@@ -45,7 +45,7 @@ const EditCourse = () => {
     );
   }
 
-  if (error) return <Navigate to={"/"} />;
+  if (error) return <Navigate to="/" />;
 
   const breadcrumbs = [
     { title: t("adminCourseView.breadcrumbs.myCourses"), href: "/admin/courses" },

--- a/apps/web/app/modules/Courses/Lesson/AiMentorLesson/AiMentorLesson.tsx
+++ b/apps/web/app/modules/Courses/Lesson/AiMentorLesson/AiMentorLesson.tsx
@@ -23,16 +23,16 @@ interface AiMentorLessonProps {
 
 const AiMentorLesson = ({ lesson, lessonLoading }: AiMentorLessonProps) => {
   const { t } = useTranslation();
-  const { lessonId = "", courseId = "" } = useParams();
+  const { courseId = "" } = useParams();
 
   const { mutateAsync: judgeLesson, isPending: isJudgePending } = useJudgeLesson(
-    lessonId,
+    lesson.id,
     courseId,
   );
-  const { mutateAsync: retakeLesson } = useRetakeLesson(lessonId, courseId);
+  const { mutateAsync: retakeLesson } = useRetakeLesson(lesson.id, courseId);
 
   const { data: currentThreadMessages } = useCurrentThreadMessages(
-    lessonId,
+    lesson.id,
     lessonLoading,
     lesson.threadId,
   );
@@ -70,7 +70,7 @@ const AiMentorLesson = ({ lesson, lessonLoading }: AiMentorLessonProps) => {
 
     setShowRetakeModal(false);
 
-    await retakeLesson({ lessonId });
+    await retakeLesson({ lessonId: lesson.id });
   };
 
   const isSubmitted = status === "submitted";
@@ -83,7 +83,7 @@ const AiMentorLesson = ({ lesson, lessonLoading }: AiMentorLessonProps) => {
   }, [messages]);
 
   return (
-    <div className="mx-auto flex size-full max-h-[70vh] w-full flex-col items-center py-4">
+    <div className="mx-auto flex size-full max-h-[85vh] flex-col items-center overflow-y-scroll py-4">
       <RetakeModal
         open={showRetakeModal}
         onOpenChange={setShowRetakeModal}

--- a/apps/web/app/modules/Courses/Lesson/AiMentorLesson/components/RetakeModal.tsx
+++ b/apps/web/app/modules/Courses/Lesson/AiMentorLesson/components/RetakeModal.tsx
@@ -8,6 +8,7 @@ import {
   DialogTitle,
   DialogDescription,
   DialogFooter,
+  DialogOverlay,
 } from "~/components/ui/dialog";
 
 import type React from "react";
@@ -24,7 +25,8 @@ const RetakeModal: React.FC<RetakeModalProps> = ({ open, onOpenChange, onConfirm
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
+      <DialogOverlay className="z-[110]" />
+      <DialogContent className="z-[120]">
         <DialogHeader>
           <DialogTitle>{t("studentCourseView.lesson.aiMentorLesson.retakeModalTitle")}</DialogTitle>
           <DialogDescription>


### PR DESCRIPTION
## Jira issue(s)
[SCS-546](https://github.com/Selleo/mentingo/issues/546)

## Overview
Added Preview Mode for AI Mentor. Now admin or content creator can test the system instructions for the mentor. After each change in system instructions the thread is archived, which forces generation of new one, so that the preview is always up to date. Writing with the AI Mentor is possible in both the modal and the normal lesson overview, but it doesn't have any effect on the lesson progress as the `markLessonAsCompleted()` method exits early.

## Screenshots
<img width="1512" height="791" alt="image" src="https://github.com/user-attachments/assets/3e23cd8e-e35c-448b-90ae-667b3ef5c5fc" />
<img width="1512" height="791" alt="image" src="https://github.com/user-attachments/assets/c27d494b-53cd-4d5f-b35b-74fdfbf6c4a0" />
<img width="1512" height="791" alt="image" src="https://github.com/user-attachments/assets/b05c2495-afc8-45cf-a517-c3d1bbd1ff3a" />

