### PR TITLE
fix(SCS-596): added possibility to play chapter in freemium lesson and various bugfixes

### DIFF
--- a/apps/web/app/api/mutations/useEnrollCourse.ts
+++ b/apps/web/app/api/mutations/useEnrollCourse.ts
@@ -1,5 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 import { AxiosError } from "axios";
+import { useTranslation } from "react-i18next";
 
 import { useToast } from "~/components/ui/use-toast";
 
@@ -11,6 +12,7 @@ type EnrollCourseOptions = {
 
 export function useEnrollCourse() {
   const { toast } = useToast();
+  const { t } = useTranslation();
 
   return useMutation({
     mutationFn: async (options: EnrollCourseOptions) => {
@@ -20,10 +22,10 @@ export function useEnrollCourse() {
 
       return response.data;
     },
-    onSuccess: ({ data }) => {
+    onSuccess: () => {
       toast({
         variant: "default",
-        description: data.message,
+        description: t("studentCoursesView.other.successfullyEnrolledToCourse"),
       });
     },
     onError: (error) => {

--- a/apps/web/app/locales/en/translation.json
+++ b/apps/web/app/locales/en/translation.json
@@ -998,13 +998,15 @@
     "other": {
       "cannotFindCourses": "We could not find any courses",
       "changeSearchCriteria": "Please change the search criteria or try again later",
-      "freeLessons": "Free Lessons!"
+      "freeLessons": "Free Lessons!",
+      "successfullyEnrolledToCourse": "Successfully enrolled in the course"
     },
     "button": {
       "continue": "Continue",
       "enroll": "Enroll",
       "view": "View",
-      "readMore": "Read More"
+      "readMore": "Read More",
+      "playChapter": "Play chapter"
     },
     "enrolledCourses": {
       "header": "Your Courses",

--- a/apps/web/app/locales/pl/translation.json
+++ b/apps/web/app/locales/pl/translation.json
@@ -1003,13 +1003,15 @@
     "other": {
       "cannotFindCourses": "Nie znaleziono żadnych kursów",
       "changeSearchCriteria": "Zmień kryteria wyszukiwania lub spróbuj ponownie później",
-      "freeLessons": "Darmowe lekcje!"
+      "freeLessons": "Darmowe lekcje!",
+      "successfullyEnrolledToCourse": "Pomyślnie zapisano na kurs"
     },
     "button": {
       "continue": "Kontynuuj",
       "enroll": "Zapisz się",
       "view": "Zobacz",
-      "readMore": "Czytaj więcej"
+      "readMore": "Czytaj więcej",
+      "playChapter": "Rozpocznij rozdział"
     },
     "enrolledCourses": {
       "header": "Twoje kursy",

--- a/apps/web/app/modules/Admin/EditCourse/CourseEnrolled/CourseEnrolled.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/CourseEnrolled/CourseEnrolled.tsx
@@ -193,6 +193,8 @@ export const CourseEnrolled = (): ReactElement => {
     setRowSelection({});
   };
 
+  const isDisabled = Object.values(rowSelection).length === 0;
+
   return (
     <div className="flex flex-col">
       <div className="flex items-center justify-between gap-2">
@@ -204,10 +206,10 @@ export const CourseEnrolled = (): ReactElement => {
         />
 
         <Dialog>
-          <DialogTrigger>
+          <DialogTrigger disabled={isDisabled}>
             <Button
               className="border border-primary-500 bg-transparent text-primary-700"
-              disabled={Object.values(rowSelection).length === 0}
+              disabled={isDisabled}
             >
               {t("adminCourseView.enrolled.enrollSelected")}
             </Button>

--- a/apps/web/app/modules/Courses/CourseView/CourseChapter.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseChapter.tsx
@@ -1,3 +1,5 @@
+import { useNavigate } from "@remix-run/react";
+import { find } from "lodash-es";
 import { useTranslation } from "react-i18next";
 
 import { CardBadge } from "~/components/CardBadge";
@@ -8,6 +10,7 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "~/components/ui/accordion";
+import { Button } from "~/components/ui/button";
 import { formatWithPlural } from "~/lib/utils";
 import { ChapterCounter } from "~/modules/Courses/CourseView/components/ChapterCounter";
 import { CourseChapterLesson } from "~/modules/Courses/CourseView/CourseChapterLesson";
@@ -31,6 +34,18 @@ export const CourseChapter = ({ chapter }: CourseChapterProps) => {
     t("courseChapterView.other.quiz"),
     t("courseChapterView.other.quizzes"),
   );
+
+  const navigate = useNavigate();
+
+  const playChapter = (chapter: CourseChapterProps["chapter"]) => {
+    const firstNotStartedLesson = find(
+      chapter.lessons,
+      (lesson) => lesson.status === "not_started",
+    )?.id;
+    const lessonToPlay = firstNotStartedLesson ?? chapter.lessons[0].id;
+
+    return navigate(`lesson/${lessonToPlay}`);
+  };
 
   return (
     <Accordion type="single" collapsible>
@@ -92,6 +107,16 @@ export const CourseChapter = ({ chapter }: CourseChapterProps) => {
 
                   return <CourseChapterLesson key={lesson.id} lesson={lesson} />;
                 })}
+                {chapter.isFreemium && (
+                  <Button
+                    variant="primary"
+                    className="mt-4 gap-2"
+                    onClick={() => playChapter(chapter)}
+                  >
+                    <Icon name="Play" className="size-4" />
+                    {t("studentCoursesView.button.playChapter")}
+                  </Button>
+                )}
               </div>
             </AccordionContent>
           </div>

--- a/apps/web/app/modules/Courses/Lesson/Lesson.page.tsx
+++ b/apps/web/app/modules/Courses/Lesson/Lesson.page.tsx
@@ -1,5 +1,6 @@
 import { useNavigate, useParams } from "@remix-run/react";
 import { first, get, last, orderBy } from "lodash-es";
+import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 
 import { useCourse, useLesson } from "~/api/queries";
@@ -32,11 +33,19 @@ export default function LessonPage() {
   const { courseId = "", lessonId = "" } = useParams();
   const { language } = useLanguageStore();
 
-  const { data: lesson, isFetching: lessonLoading } = useLesson(lessonId, language);
+  const {
+    data: lesson,
+    isFetching: lessonLoading,
+    isError: lessonError,
+  } = useLesson(lessonId, language);
   const { data: course } = useCourse(courseId);
   const { isStudent } = useUserRole();
   const navigate = useNavigate();
   const { t } = useTranslation();
+
+  useEffect(() => {
+    if (lessonError) navigate(`/course/${courseId}`);
+  }, [lessonError, navigate, courseId]);
 
   if (!lesson || !course)
     return (


### PR DESCRIPTION
## Jira issue(s)
[SCS-596](https://github.com/Selleo/mentingo/issues/596)

## Overview
Enabled freemium lessons to be accessed via the `Play Chapter` button. Updated flow so that when an unregistered user tries to enroll in a paid course, they’re redirected to the signup page. Added a toast message that shows in the correct language when enrolling in a course. Fixed the `Enroll` button so it’s properly disabled when no students are selected.
