### PR TITLE
fix(870): hide empty sections in content creator and admin profile

### DIFF
--- a/apps/web/app/modules/Courses/CourseView/CourseViewSidebar/CourseViewSidebar.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseViewSidebar/CourseViewSidebar.tsx
@@ -42,26 +42,32 @@ export const CourseViewSidebar = ({ course }: CourseViewSidebar) => {
             {userDetails?.firstName} {userDetails?.lastName}
           </h2>
           <div className="flex flex-col gap-y-1">
-            <p className="body-sm">
-              <span className="text-neutral-900">
-                {t("studentCourseView.sideSection.other.title")}:
-              </span>{" "}
-              <span className="body-sm-md text-neutral-950">{userDetails?.jobTitle}</span>
-            </p>
+            {userDetails?.jobTitle && (
+              <p className="body-sm">
+                <span className="text-neutral-900">
+                  {t("studentCourseView.sideSection.other.title")}:
+                </span>{" "}
+                <span className="body-sm-md text-neutral-950">{userDetails?.jobTitle}</span>
+              </p>
+            )}
           </div>
         </div>
       </div>
-      <div className="flex flex-col gap-y-2">
-        <div className="flex items-center gap-x-3">
-          <span className="text-neutral-900">{t("studentCourseView.sideSection.other.about")}</span>
-          <div className="h-px w-full bg-primary-200" />
+      {userDetails?.description && (
+        <div className="flex flex-col gap-y-2">
+          <div className="flex items-center gap-x-3">
+            <span className="text-neutral-900">
+              {t("studentCourseView.sideSection.other.about")}
+            </span>
+            <div className="h-px w-full bg-primary-200" />
+          </div>
+          <p className="body-sm mt-2 text-neutral-950">{userDetails?.description}</p>
         </div>
-        <p className="body-sm mt-2 text-neutral-950">{userDetails?.description}</p>
-      </div>
+      )}
       <Button variant="outline" className="sr-only">
         <span>{t("studentCourseView.sideSection.other.collapse")}</span>
       </Button>
-      <Button variant="outline">
+      <Button variant="outline" asChild>
         <Link to={`/profile/${course?.authorId}`}>
           <span>{t("studentCourseView.sideSection.button.goToContentCreatorPage")}</span>
         </Link>

--- a/apps/web/app/modules/Profile/components/ProfileCard.tsx
+++ b/apps/web/app/modules/Profile/components/ProfileCard.tsx
@@ -30,7 +30,7 @@ export const ProfileCard = ({ isAdminLike, userDetails }: ProfileCardProps) => {
             <h2 className="h6 md:h4 text-neutral-950" data-testid="username">
               {userDetails?.firstName} {userDetails?.lastName}
             </h2>
-            {isAdminLike && (
+            {isAdminLike && userDetails?.jobTitle && (
               <div className="body-sm">
                 <span className="text-neutral-900 body-base-md">
                   {t("contentCreatorView.other.title")}:
@@ -43,25 +43,29 @@ export const ProfileCard = ({ isAdminLike, userDetails }: ProfileCardProps) => {
           </div>
           {isAdminLike && (
             <div className="flex w-full flex-col gap-3 *:w-full md:flex-row md:*:w-fit">
-              <a
-                href={`tel:${userDetails?.contactPhone}`}
-                className="body-sm-md md:body-base-md flex items-center justify-center gap-x-2 rounded-lg bg-primary-50 px-3 py-2 text-accent-foreground md:justify-start"
-              >
-                <Icon name="Phone" className="size-5 text-neutral-900" />
-                <span data-testid="contactPhone">{userDetails?.contactPhone}</span>
-              </a>
-              <a
-                href={`mailto:${userDetails?.contactEmail}`}
-                className="body-sm-md md:body-base-md flex items-center justify-center gap-x-2 rounded-lg bg-primary-50 px-2 py-1 text-accent-foreground md:justify-start"
-              >
-                <Icon name="Email" className="size-5 text-neutral-900" />
-                <span data-testid="contactEmail">{userDetails?.contactEmail}</span>
-              </a>
+              {userDetails?.contactPhone && (
+                <a
+                  href={`tel:${userDetails?.contactPhone}`}
+                  className="body-sm-md md:body-base-md flex items-center justify-center gap-x-2 rounded-lg bg-primary-50 px-3 py-2 text-accent-foreground md:justify-start"
+                >
+                  <Icon name="Phone" className="size-5 text-neutral-900" />
+                  <span data-testid="contactPhone">{userDetails?.contactPhone}</span>
+                </a>
+              )}
+              {userDetails?.contactEmail && (
+                <a
+                  href={`mailto:${userDetails?.contactEmail}`}
+                  className="body-sm-md md:body-base-md flex items-center justify-center gap-x-2 rounded-lg bg-primary-50 px-2 py-1 text-accent-foreground md:justify-start"
+                >
+                  <Icon name="Email" className="size-5 text-neutral-900" />
+                  <span data-testid="contactEmail">{userDetails?.contactEmail}</span>
+                </a>
+              )}
             </div>
           )}
         </div>
       </div>
-      {isAdminLike && (
+      {isAdminLike && userDetails?.description && (
         <div className="flex flex-col gap-y-2">
           <div className="flex items-center gap-x-3">
             <span className="min-w-fit body-base-md md:body-lg-md text-neutral-900">


### PR DESCRIPTION
<!--
 1. Make sure you have correct branch name i.e. `ab_PROJ-123_task_name`, where `LC-123` is a Jira issue ID, and `ab` is an author
 2. Make sure you have meaningful title related to task with correct prefix: feat/fix/chore/style/docs/refactor
 3. Reference multiple Jira issues in one PR by listing them in the Jira issue section
 4. Make sure all necessary sections are filled, remove obsolete sections
 5. Do a self review first
 6. Check if your PR includes only code related to your task
 7. `Notes` is used for additional info but also to notify if any action is required
-->

## Jira issue(s)
[870](https://github.com/Selleo/mentingo/issues/870)

## Overview
- Added conditional rendering for admin details fields
- Fixed `Go to content creator page` button. Now you don't have to click the text for it to redirect,  you can press the entire button.

## Screenshots
https://github.com/user-attachments/assets/60da5ce8-3380-4b2b-9b46-da2c158dc881


