### PR TITLE
fix: incorrect display of course description in continue learning section

### DIFF
--- a/apps/web/app/modules/Statistics/Client/components/ContinueLearningCard.tsx
+++ b/apps/web/app/modules/Statistics/Client/components/ContinueLearningCard.tsx
@@ -60,7 +60,7 @@ export const ContinueLearningCard = ({ isLoading = false, lesson }: ContinueLear
         <a href={`/course/${lesson?.courseId}`} className="body-sm-md text-primary-700 underline">
           {lesson?.courseTitle}
         </a>
-        <p className="md:body-base sr-only md:not-sr-only md:mt-6 md:text-neutral-800 2xl:sr-only">
+        <p className="sr-only md:not-sr-only md:mt-6 2xl:sr-only">
           <Viewer content={lesson?.courseDescription} variant="lesson" />
         </p>
       </div>


### PR DESCRIPTION
<!--
 1. Make sure you have correct branch name i.e. `ab_PROJ-123_task_name`, where `LC-123` is a Jira issue ID, and `ab` is an author
 2. Make sure you have meaningful title related to task with correct prefix: feat/fix/chore/style/docs/refactor
 3. Reference multiple Jira issues in one PR by listing them in the Jira issue section
 4. Make sure all necessary sections are filled, remove obsolete sections
 5. Do a self review first
 6. Check if your PR includes only code related to your task
 7. `Notes` is used for additional info but also to notify if any action is required
-->

## Issue
[891](https://github.com/Selleo/mentingo/issues/891)

## Overview
Fixed display of course description in continue learning card.

## Screenshots

### Before
<img width="1962" height="828" alt="image" src="https://github.com/user-attachments/assets/60c5eccf-b9ee-40f1-8dd7-ae7cc6b42b41" />


### After
<img width="1962" height="828" alt="image" src="https://github.com/user-attachments/assets/940c1ddf-3290-4cdd-b4cc-bd572754444c" />

### Notes 

Screenshot kinda bolds the text, so in reality it's kinda narrower.

- [x] Fired up e2e tests and got a positive result
