### PR TITLE
refactor(875): resize AI mentor input based on content to display the whole input

### DIFF
--- a/apps/web/app/index.css
+++ b/apps/web/app/index.css
@@ -281,6 +281,15 @@ html {
   display: none;
 }
 
+/* Only supported by Chrome */
+/* noinspection CssUnknownProperty */
+@supports (field-sizing: content) {
+  .field-sizing-content {
+    field-sizing: content;
+  }
+}
+
+
 @supports (scrollbar-width: thin) {
   .scrollbar-thin {
     scrollbar-width: thin;

--- a/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/AiMentorLessonForm/AiMentorLessonForm.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/AiMentorLessonForm/AiMentorLessonForm.tsx
@@ -281,7 +281,7 @@ const AiMentorLessonForm = ({
                               "adminCourseView.curriculum.lesson.placeholder.completionConditions",
                             )}
                             className="h-48 grow resize-none overflow-y-auto"
-                            parentClassName={"lg:rounded-l-none lg:border-l-0"}
+                            parentClassName="lg:rounded-l-none lg:border-l-0"
                             {...field}
                           />
                         </FormControl>

--- a/apps/web/app/modules/Courses/Lesson/AiMentorLesson/components/LessonForm.tsx
+++ b/apps/web/app/modules/Courses/Lesson/AiMentorLesson/components/LessonForm.tsx
@@ -1,8 +1,8 @@
+import { useRef, useLayoutEffect } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Icon } from "~/components/Icon";
 import { Button } from "~/components/ui/button";
-import { Input } from "~/components/ui/input";
 
 import type { ChangeEvent } from "react";
 
@@ -15,39 +15,59 @@ interface LessonFormProps {
 export const LessonForm = ({ handleSubmit, input, handleInputChange }: LessonFormProps) => {
   const { t } = useTranslation();
 
+  const ref = useRef<HTMLTextAreaElement | null>(null);
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const resize = () => {
+      el.style.height = "auto";
+      el.style.height = `${el.scrollHeight}px`;
+    };
+
+    resize();
+
+    el.addEventListener("input", resize);
+
+    return () => {
+      el.removeEventListener("input", resize);
+    };
+  }, [ref.current?.value, handleSubmit]);
+
   return (
     <div className="mt-8 w-full">
       <form onSubmit={handleSubmit}>
         <div className="flex w-full flex-col gap-y-4 rounded-2xl border border-[#E4E6EB] bg-[#F5F6F7] px-6 py-4">
           <div className="flex w-full items-end">
-            <div className="flex grow flex-col">
-              <Input
-                type="text"
+            <div className="flex grow flex-col max-h-64">
+              <textarea
+                ref={ref}
                 value={input}
                 onChange={handleInputChange}
                 placeholder={t("studentCourseView.lesson.aiMentorLesson.sendMessage")}
-                className="w-full border-none bg-transparent py-2 text-base font-normal text-gray-500 shadow-none focus:outline-none focus:ring-0 disabled:opacity-50"
+                className="w-full border-none bg-transparent py-2 text-base font-normal max-w-full overflow-x-hidden resize-none max-h-48 h-auto text-gray-500 shadow-none focus:outline-none focus:ring-0 disabled:opacity-50"
               />
-              <div className="mt-5 flex items-center gap-x-2">
-                <Button className="flex size-8 items-center justify-center rounded-full border-none bg-white p-0 shadow-sm disabled:opacity-50">
-                  <Icon name="Plus" className="size-5 text-gray-700" />
-                </Button>
-                <Button className="flex size-8 items-center justify-center rounded-full border-none bg-white p-0 shadow-sm disabled:opacity-50">
-                  <Icon name="Smile" className="size-5 text-gray-700" />
+              <div className="flex items-center justify-between">
+                <div className="mt-5 flex items-center gap-x-2">
+                  <Button className="flex size-8 items-center justify-center rounded-full border-none bg-white p-0 shadow-sm disabled:opacity-50">
+                    <Icon name="Plus" className="size-5 text-gray-700" />
+                  </Button>
+                  <Button className="flex size-8 items-center justify-center rounded-full border-none bg-white p-0 shadow-sm disabled:opacity-50">
+                    <Icon name="Smile" className="size-5 text-gray-700" />
+                  </Button>
+                </div>
+                <Button
+                  type="submit"
+                  variant="primary"
+                  size="sm"
+                  disabled={!input.trim()}
+                  className="flex items-center gap-x-2 rounded-full px-5 py-2 font-semibold text-white disabled:opacity-50"
+                >
+                  <Icon name="Send" className="size-5" />
+                  {t("studentCourseView.lesson.aiMentorLesson.send")}
                 </Button>
               </div>
-            </div>
-            <div className="ml-4 flex-shrink-0">
-              <Button
-                type="submit"
-                variant="primary"
-                size="sm"
-                disabled={!input.trim()}
-                className="flex items-center gap-x-2 rounded-full px-5 py-2 font-semibold text-white disabled:opacity-50"
-              >
-                <Icon name="Send" className="size-5" />
-                {t("studentCourseView.lesson.aiMentorLesson.send")}
-              </Button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
<!--
 1. Make sure you have correct branch name i.e. `ab_PROJ-123_task_name`, where `LC-123` is a Jira issue ID, and `ab` is an author
 2. Make sure you have meaningful title related to task with correct prefix: feat/fix/chore/style/docs/refactor
 3. Reference multiple Jira issues in one PR by listing them in the Jira issue section
 4. Make sure all necessary sections are filled, remove obsolete sections
 5. Do a self review first
 6. Check if your PR includes only code related to your task
 7. `Notes` is used for additional info but also to notify if any action is required
-->

## Jira issue(s)
[875](https://github.com/Selleo/mentingo/issues/875)

## Overview
- Added content resizable input field for ai mentor lesson

## Screenshots
https://github.com/user-attachments/assets/6c24bd4c-a960-4cc8-92de-5528e352288f

## Notes
- We could just use field-sizing: content css property, but it's only available on new chromium browsers, so I stuck with a classic useLayoutEffect approach

