### PR TITLE
fix(900): make admin not get email notification about their own registration

### DIFF
--- a/apps/api/src/user/handlers/notify-admins.handler.ts
+++ b/apps/api/src/user/handlers/notify-admins.handler.ts
@@ -2,10 +2,8 @@ import { EventsHandler } from "@nestjs/cqrs";
 import { FinishedCourseEmail, NewUserEmail } from "@repo/email-templates";
 
 import { EmailService } from "src/common/emails/emails.service";
-import { CourseCompletedEvent } from "src/events";
+import { CourseCompletedEvent, UserPasswordCreatedEvent, UserRegisteredEvent } from "src/events";
 
-import { UserPasswordCreatedEvent } from "../../events/user/user-password-created.event";
-import { UserRegisteredEvent } from "../../events/user/user-registered.event";
 import { UserService } from "../user.service";
 
 import type { IEventHandler } from "@nestjs/cqrs";
@@ -45,7 +43,7 @@ export class NotifyAdminsHandler implements IEventHandler<EventType> {
       email: email,
     });
 
-    const adminsEmailsToNotify = await this.userService.getAdminsToNotifyAboutNewUser();
+    const adminsEmailsToNotify = await this.userService.getAdminsToNotifyAboutNewUser(email);
 
     await Promise.all(
       adminsEmailsToNotify.map((adminsEmail) => {

--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -9,7 +9,7 @@ import {
 import { CreatePasswordEmail } from "@repo/email-templates";
 import { OnboardingPages } from "@repo/shared";
 import * as bcrypt from "bcryptjs";
-import { and, count, eq, getTableColumns, ilike, inArray, or, sql } from "drizzle-orm";
+import { and, count, eq, getTableColumns, ilike, inArray, not, or, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
 
 import { CreatePasswordService } from "src/auth/create-password.service";
@@ -443,7 +443,7 @@ export class UserService {
     return await this.s3Service.getSignedUrl(avatarReference);
   };
 
-  public async getAdminsToNotifyAboutNewUser(): Promise<string[]> {
+  public async getAdminsToNotifyAboutNewUser(emailToExclude: string): Promise<string[]> {
     const adminEmails = await this.db
       .select({
         email: users.email,
@@ -454,6 +454,7 @@ export class UserService {
         and(
           eq(users.role, USER_ROLES.ADMIN),
           sql`${settings.settings}->>'adminNewUserNotification' = 'true'`,
+          not(eq(users.email, emailToExclude)),
         ),
       );
 


### PR DESCRIPTION
<!--
 1. Make sure you have correct branch name i.e. `ab_PROJ-123_task_name`, where `LC-123` is a Jira issue ID, and `ab` is an author
 2. Make sure you have meaningful title related to task with correct prefix: feat/fix/chore/style/docs/refactor
 3. Reference multiple Jira issues in one PR by listing them in the Jira issue section
 4. Make sure all necessary sections are filled, remove obsolete sections
 5. Do a self review first
 6. Check if your PR includes only code related to your task
 7. `Notes` is used for additional info but also to notify if any action is required
-->

## Jira issue(s)
[900](https://github.com/Selleo/mentingo/issues/900)

## Overview
- Added condition to exclude own email in `getAdminsToNotifyAboutNewUser`, so that once you add an admin, he won't be sent an email about his own registration
