### PR TITLE
fix: ensure content creators can edit only their own courses

### DIFF
--- a/apps/api/src/chapter/chapter.controller.ts
+++ b/apps/api/src/chapter/chapter.controller.ts
@@ -58,8 +58,13 @@ export class ChapterController {
   async betaCreateChapter(
     @Body() createChapterBody: CreateChapterBody,
     @CurrentUser("userId") userId: UUIDType,
+    @CurrentUser("role") role: UserRole,
   ): Promise<BaseResponse<{ id: UUIDType; message: string }>> {
-    const { id } = await this.adminChapterService.createChapterForCourse(createChapterBody, userId);
+    const { id } = await this.adminChapterService.createChapterForCourse(
+      createChapterBody,
+      userId,
+      role,
+    );
 
     return new BaseResponse({ id, message: "Chapter created successfully" });
   }
@@ -83,8 +88,10 @@ export class ChapterController {
   async updateChapter(
     @Query("id") id: UUIDType,
     @Body() updateChapterBody: UpdateChapterBody,
+    @CurrentUser("userId") userId: UUIDType,
+    @CurrentUser("role") role: UserRole,
   ): Promise<BaseResponse<{ message: string }>> {
-    await this.adminChapterService.updateChapter(id, updateChapterBody);
+    await this.adminChapterService.updateChapter(id, updateChapterBody, userId, role);
 
     return new BaseResponse({ message: "Chapter updated successfully" });
   }
@@ -110,8 +117,14 @@ export class ChapterController {
       chapterId: UUIDType;
       displayOrder: number;
     },
+    @CurrentUser("userId") userId: UUIDType,
+    @CurrentUser("role") role: UserRole,
   ): Promise<BaseResponse<{ message: string }>> {
-    await this.adminChapterService.updateChapterDisplayOrder(body);
+    await this.adminChapterService.updateChapterDisplayOrder({
+      ...body,
+      currentUserRole: role,
+      currentUserId: userId,
+    });
 
     return new BaseResponse({
       message: "Chapter display order updated successfully",
@@ -126,8 +139,10 @@ export class ChapterController {
   })
   async removeChapter(
     @Query("chapterId") chapterId: UUIDType,
+    @CurrentUser("role") role: UserRole,
+    @CurrentUser("userId") userId: UUIDType,
   ): Promise<BaseResponse<{ message: string }>> {
-    await this.adminChapterService.removeChapter(chapterId);
+    await this.adminChapterService.removeChapter(chapterId, userId, role);
     return new BaseResponse({
       message: "Lesson removed from course successfully",
     });
@@ -154,8 +169,10 @@ export class ChapterController {
   async updateFreemiumStatus(
     @Query("chapterId") chapterId: UUIDType,
     @Body() body: { isFreemium: boolean },
+    @CurrentUser("userId") userId: UUIDType,
+    @CurrentUser("role") role: UserRole,
   ): Promise<BaseResponse<{ message: string }>> {
-    await this.adminChapterService.updateFreemiumStatus(chapterId, body.isFreemium);
+    await this.adminChapterService.updateFreemiumStatus(chapterId, body.isFreemium, userId, role);
     return new BaseResponse({
       message: "Course lesson free status updated successfully",
     });

--- a/apps/api/src/lesson/lesson.controller.ts
+++ b/apps/api/src/lesson/lesson.controller.ts
@@ -117,8 +117,14 @@ export class LessonController {
   })
   async betaCreateLesson(
     @Body() createLessonBody: CreateLessonBody,
+    @CurrentUser("userId") userId: UUIDType,
+    @CurrentUser("role") role: UserRole,
   ): Promise<BaseResponse<{ id: UUIDType; message: string }>> {
-    const id = await this.adminLessonsService.createLessonForChapter(createLessonBody);
+    const id = await this.adminLessonsService.createLessonForChapter(
+      createLessonBody,
+      userId,
+      role,
+    );
 
     return new BaseResponse({ id, message: "Lesson created successfully" });
   }
@@ -137,8 +143,14 @@ export class LessonController {
   })
   async betaCreateAiMentorLesson(
     @Body() createAiMentorLessonBody: CreateAiMentorLessonBody,
+    @CurrentUser("userId") userId: UUIDType,
+    @CurrentUser("role") role: UserRole,
   ): Promise<BaseResponse<{ id: UUIDType; message: string }>> {
-    const id = await this.adminLessonsService.createAiMentorLesson(createAiMentorLessonBody);
+    const id = await this.adminLessonsService.createAiMentorLesson(
+      createAiMentorLessonBody,
+      userId,
+      role,
+    );
     return new BaseResponse({ id, message: "AI Mentor lesson created successfully" });
   }
 
@@ -163,8 +175,9 @@ export class LessonController {
     @Query("id") id: UUIDType,
     @Body() data: UpdateAiMentorLessonBody,
     @CurrentUser("userId") userId: UUIDType,
+    @CurrentUser("role") role: UserRole,
   ): Promise<BaseResponse<{ message: string }>> {
-    await this.adminLessonsService.updateAiMentorLesson(id, data, userId);
+    await this.adminLessonsService.updateAiMentorLesson(id, data, userId, role);
     return new BaseResponse({ message: "AI Mentor lesson updated successfully" });
   }
 
@@ -183,8 +196,9 @@ export class LessonController {
   async betaCreateQuizLesson(
     @Body() createQuizLessonBody: CreateQuizLessonBody,
     @CurrentUser("userId") userId: UUIDType,
+    @CurrentUser("role") role: UserRole,
   ): Promise<BaseResponse<{ id: UUIDType; message: string }>> {
-    const id = await this.adminLessonsService.createQuizLesson(createQuizLessonBody, userId);
+    const id = await this.adminLessonsService.createQuizLesson(createQuizLessonBody, userId, role);
 
     return new BaseResponse({ id, message: "Quiz created successfully" }) as any;
   }
@@ -210,8 +224,9 @@ export class LessonController {
     @Query("id") id: UUIDType,
     @Body() data: UpdateQuizLessonBody,
     @CurrentUser("userId") userId: UUIDType,
+    @CurrentUser("role") role: UserRole,
   ): Promise<BaseResponse<{ message: string }>> {
-    await this.adminLessonsService.updateQuizLesson(id, data, userId);
+    await this.adminLessonsService.updateQuizLesson(id, data, userId, role);
     return new BaseResponse({ message: "Quiz updated successfully" });
   }
 
@@ -234,8 +249,10 @@ export class LessonController {
   async betaUpdateLesson(
     @Query("id") id: UUIDType,
     @Body() data: UpdateLessonBody,
+    @CurrentUser("role") role: UserRole,
+    @CurrentUser("userId") userId: UUIDType,
   ): Promise<BaseResponse<{ message: string }>> {
-    await this.adminLessonsService.updateLesson(id, data);
+    await this.adminLessonsService.updateLesson(id, data, userId, role);
     return new BaseResponse({ message: "Text block updated successfully" });
   }
 
@@ -247,8 +264,10 @@ export class LessonController {
   })
   async removeLesson(
     @Query("lessonId") lessonId: UUIDType,
+    @CurrentUser("role") role: UserRole,
+    @CurrentUser("userId") userId: UUIDType,
   ): Promise<BaseResponse<{ message: string }>> {
-    await this.adminLessonsService.removeLesson(lessonId);
+    await this.adminLessonsService.removeLesson(lessonId, userId, role);
 
     return new BaseResponse({
       message: "Lesson removed from course successfully",
@@ -316,9 +335,11 @@ export class LessonController {
   })
   async uploadImageToLesson(
     @Body("lessonId") lessonId: UUIDType,
+    @CurrentUser("userId") userId: UUIDType,
+    @CurrentUser("role") role: UserRole,
     @UploadedFile() file: Express.Multer.File,
   ) {
-    return this.adminLessonsService.uploadFileToLesson(lessonId, file);
+    return this.adminLessonsService.uploadFileToLesson(lessonId, userId, role, file);
   }
 
   @Delete("delete-student-quiz-answers")
@@ -343,8 +364,10 @@ export class LessonController {
   })
   async createEmbedLesson(
     @Body() data: CreateEmbedLessonBody,
+    @CurrentUser("userId") userId: UUIDType,
+    @CurrentUser("role") role: UserRole,
   ): Promise<BaseResponse<{ message: string }>> {
-    await this.adminLessonsService.createEmbedLesson(data);
+    await this.adminLessonsService.createEmbedLesson(data, userId, role);
     return new BaseResponse({ message: "Embed lesson created successfully" });
   }
 
@@ -360,8 +383,10 @@ export class LessonController {
   async updateEmbedLesson(
     @Param("id") id: UUIDType,
     @Body() data: UpdateEmbedLessonBody,
+    @CurrentUser("userId") userId: UUIDType,
+    @CurrentUser("role") role: UserRole,
   ): Promise<BaseResponse<{ message: string }>> {
-    await this.adminLessonsService.updateEmbedLesson(id, data);
+    await this.adminLessonsService.updateEmbedLesson(id, userId, role, data);
     return new BaseResponse({ message: "Embed lesson updated successfully" });
   }
 
@@ -424,8 +449,14 @@ export class LessonController {
       lessonId: UUIDType;
       displayOrder: number;
     },
+    @CurrentUser("userId") userId: UUIDType,
+    @CurrentUser("role") role: UserRole,
   ): Promise<BaseResponse<{ message: string }>> {
-    await this.adminLessonsService.updateLessonDisplayOrder(body);
+    await this.adminLessonsService.updateLessonDisplayOrder({
+      ...body,
+      currentUserId: userId,
+      currentUserRole: role,
+    });
 
     return new BaseResponse({
       message: "Lesson display order updated successfully",

--- a/apps/api/src/lesson/repositories/adminLesson.repository.ts
+++ b/apps/api/src/lesson/repositories/adminLesson.repository.ts
@@ -5,6 +5,7 @@ import { DatabasePg, type UUIDType } from "src/common";
 import {
   aiMentorLessons,
   chapters,
+  courses,
   lessonResources,
   lessons,
   questionAnswerOptions,
@@ -443,5 +444,26 @@ export class AdminLessonRepository {
         },
       })
       .returning();
+  }
+
+  async getCourseByLesson(lessonId: UUIDType) {
+    return this.db
+      .select({ ...getTableColumns(courses) })
+      .from(lessons)
+      .innerJoin(chapters, eq(chapters.id, lessons.chapterId))
+      .innerJoin(courses, eq(chapters.courseId, courses.id))
+      .where(eq(lessons.id, lessonId));
+  }
+
+  async getCourseByChapter(chapterId: UUIDType) {
+    return this.db
+      .select({ ...getTableColumns(courses) })
+      .from(chapters)
+      .innerJoin(courses, eq(chapters.courseId, courses.id))
+      .where(eq(chapters.id, chapterId));
+  }
+
+  async getCourse(courseId: UUIDType) {
+    return this.db.select().from(courses).where(eq(courses.id, courseId));
   }
 }

--- a/apps/api/src/scorm/scorm.controller.ts
+++ b/apps/api/src/scorm/scorm.controller.ts
@@ -21,7 +21,7 @@ import { baseResponse, BaseResponse, UUIDSchema, UUIDType } from "src/common";
 import { Roles } from "src/common/decorators/roles.decorator";
 import { CurrentUser } from "src/common/decorators/user.decorator";
 import { RolesGuard } from "src/common/guards/roles.guard";
-import { USER_ROLES } from "src/user/schemas/userRoles";
+import { USER_ROLES, UserRole } from "src/user/schemas/userRoles";
 
 import { scormMetadataSchema, scormUploadResponseSchema } from "./schemas/scorm.schema";
 import { ScormService } from "./services/scorm.service";
@@ -57,6 +57,7 @@ export class ScormController {
     @UploadedFile() file: Express.Multer.File,
     @Query("courseId") courseId: UUIDType,
     @CurrentUser("userId") userId: UUIDType,
+    @CurrentUser("role") role: UserRole,
   ) {
     if (!courseId) {
       throw new BadRequestException("courseId is required");
@@ -66,7 +67,7 @@ export class ScormController {
       throw new BadRequestException("file is required");
     }
 
-    const metadata = await this.scormService.processScormPackage(file, courseId, userId);
+    const metadata = await this.scormService.processScormPackage(file, courseId, userId, role);
 
     return new BaseResponse({
       message: "SCORM package uploaded successfully",


### PR DESCRIPTION
<!--
 1. Make sure you have correct branch name i.e. `ab_prefix_123_task_name`, where `123` is a issue ID, and `ab` is an author
 2. Make sure you have meaningful title related to task with correct prefix: feat/fix/chore/style/docs/refactor
 3. Reference multiple issues in one PR by listing them in the issues section
 4. Make sure all necessary sections are filled, remove obsolete sections
 5. Do a self review first
 6. Check if your PR includes only code related to your task
 7. `Notes` is used for additional info but also to notify if any action is required
-->

## Issue(s)
[1000](https://github.com/Selleo/mentingo/issues/1000)

## Overview 
<!--
General description what it does
-->
Previously a content creator could update a course that didn't belong to him through API. Now there is a guard that runs before each attempt that evaluates, whether the user can update it.

## Business Value
<!--
Why are we doing this from a business perspective? What value does this bring to the project from end-users perspective?
-->
The user is safe and doesn't have to worry about anyone else modifying his course.

## Screenshots / Video

https://github.com/user-attachments/assets/53e9cf51-e644-4028-aa5b-77fc0dc17707

## Notes
The translations for the noAccess message are included in #1003

