### PR TITLE
fix: make drag-and-drop in quizzes work properly on mobile

### DIFF
--- a/apps/web/app/modules/Courses/Lesson/Question/FillInTheBlanks/dnd/FillInTheBlanksDnd.tsx
+++ b/apps/web/app/modules/Courses/Lesson/Question/FillInTheBlanks/dnd/FillInTheBlanksDnd.tsx
@@ -7,7 +7,6 @@ import {
   type DragStartEvent,
   KeyboardSensor,
   PointerSensor,
-  TouchSensor,
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
@@ -69,11 +68,6 @@ export const FillInTheBlanksDnd: FC<FillInTheBlanksDndProps> = ({ question, isCo
       activationConstraint: {
         distance: isCompleted ? Infinity : 0,
       },
-    }),
-    useSensor(TouchSensor, {
-      activationConstraint: isCompleted
-        ? { delay: 999999, tolerance: 0 }
-        : { delay: 150, tolerance: 8 },
     }),
     useSensor(KeyboardSensor, {
       coordinateGetter: sortableKeyboardCoordinates,


### PR DESCRIPTION
## Issue(s)
https://github.com/Selleo/mentingo/issues/964

## Overview 
As in task

## Business Value
Without this feature, user won't be able to complete "fill in the blanks dnd" type of lesson on mobile, it's crucial if mobile users are also part of the target for our LMS

## Screenshots / Video

https://github.com/user-attachments/assets/c8ba81f5-16d6-4b57-86d2-0cb4cf60a327

### Notes 
When testing, please take a look if you can select a checkbox, I've a weird issue locally that I cannot use the checkbox
