### PR TITLE
fix: certificate generation no longer ignores settings

### DIFF
--- a/apps/api/src/courses/course.service.ts
+++ b/apps/api/src/courses/course.service.ts
@@ -2129,13 +2129,13 @@ export class CourseService {
     };
   }
 
-  async getCourseName(courseId: UUIDType) {
-    const [{ courseName }] = await this.db
-      .select({ courseName: courses.title })
+  async getCourseEmailData(courseId: UUIDType) {
+    const [courseData] = await this.db
+      .select({ courseName: courses.title, hasCertificate: courses.hasCertificate })
       .from(courses)
       .where(eq(courses.id, courseId));
 
-    return courseName;
+    return courseData;
   }
 
   async getChapterName(chapterId: UUIDType) {

--- a/apps/api/src/user/handlers/notify-users.handler.ts
+++ b/apps/api/src/user/handlers/notify-users.handler.ts
@@ -150,7 +150,7 @@ export class NotifyUsersHandler implements IEventHandler {
     const { courseId, studentIds } = usersAssignedToCourse;
 
     const courseLink = `${process.env.CORS_ORIGIN}/course/${courseId}`;
-    const courseName = await this.courseService.getCourseName(courseId);
+    const { courseName } = await this.courseService.getCourseEmailData(courseId);
 
     const studentContacts = await this.userService.getStudentEmailsByIds(studentIds);
 
@@ -244,7 +244,9 @@ export class NotifyUsersHandler implements IEventHandler {
 
     const user = await this.userService.getUserById(chapterFinishedData.userId);
     const chapterName = await this.courseService.getChapterName(chapterFinishedData.chapterId);
-    const courseName = await this.courseService.getCourseName(chapterFinishedData.courseId);
+    const { courseName } = await this.courseService.getCourseEmailData(
+      chapterFinishedData.courseId,
+    );
 
     const courseLink = `${process.env.CORS_ORIGIN}/course/${chapterFinishedData.courseId}`;
 
@@ -271,16 +273,21 @@ export class NotifyUsersHandler implements IEventHandler {
     const { courseFinishedData } = event;
 
     const user = await this.userService.getUserById(courseFinishedData.userId);
-    const courseName = await this.courseService.getCourseName(courseFinishedData.courseId);
+    const { courseName, hasCertificate } = await this.courseService.getCourseEmailData(
+      courseFinishedData.courseId,
+    );
 
-    const certificateDownloadLink = `${process.env.CORS_ORIGIN}/profile/${user.id}`;
+    const buttonLink = hasCertificate
+      ? `${process.env.CORS_ORIGIN}/profile/${user.id}`
+      : `${process.env.CORS_ORIGIN}/courses`;
 
     const defaultEmailSettings = await this.emailService.getDefaultEmailProperties(user.id);
 
     const { text, html } = new UserFinishedCourseEmail({
-      certificateDownloadLink,
+      buttonLink,
       courseName,
       ...defaultEmailSettings,
+      hasCertificate,
     });
 
     await this.emailService.sendEmailWithLogo({

--- a/apps/web/app/modules/Courses/CourseView/CourseCertificate.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseCertificate.tsx
@@ -53,7 +53,7 @@ const CourseCertificate = () => {
 
   return (
     <div>
-      {hasFinishedCourse && (
+      {certificate && hasFinishedCourse && (
         <Card className="p-4 md:px-8 flex items-center gap-4 bg-success-50">
           <div className="bg-success-50 aspect-square size-10 rounded-full grid place-items-center">
             <Icon name="InputRoundedMarkerSuccess" className="size-4" />
@@ -68,7 +68,7 @@ const CourseCertificate = () => {
         </Card>
       )}
 
-      {isCertificatePreviewOpen && isStudent && (
+      {certificate && isCertificatePreviewOpen && isStudent && (
         <button
           className="fixed inset-0 z-50 flex items-center justify-center bg-gray-900/50"
           onClick={handleCloseCertificatePreview}

--- a/packages/email-templates/src/templates/UserFinishedCourseEmail.tsx
+++ b/packages/email-templates/src/templates/UserFinishedCourseEmail.tsx
@@ -6,25 +6,28 @@ import { DefaultEmailSettings } from "types";
 
 export type UserFinishedCourseProps = {
   courseName: string;
-  certificateDownloadLink: string;
+  buttonLink: string;
+  hasCertificate: boolean;
 } & DefaultEmailSettings;
 
 export const UserFinishedCourseEmail = ({
   courseName,
-  certificateDownloadLink,
+  buttonLink,
   primaryColor,
   language = "en",
+  hasCertificate,
 }: UserFinishedCourseProps) => {
   const { heading, paragraphs, buttonText } = getUserFinishedCourseEmailTranslations(
     language,
     courseName,
+    hasCertificate,
   );
 
   return BaseEmailTemplate({
     heading,
     paragraphs,
     buttonText,
-    buttonLink: certificateDownloadLink,
+    buttonLink,
     primaryColor,
   });
 };

--- a/packages/email-templates/src/translations/userFinishedCourse.ts
+++ b/packages/email-templates/src/translations/userFinishedCourse.ts
@@ -1,22 +1,26 @@
 import { EmailContent, Language } from "types";
 
-export const getUserFinishedCourseEmailTranslations = (language: Language, courseName: string) => {
+export const getUserFinishedCourseEmailTranslations = (
+  language: Language,
+  courseName: string,
+  hasCertificate: boolean,
+) => {
   const emailContent: Record<Language, EmailContent> = {
     en: {
       heading: "Course completed",
       paragraphs: [
         "Congratulations! 🏁",
-        `You've completed ${courseName}. Your certificate is ready to download; check the recommended next steps.`,
+        `You've completed ${courseName}. ${hasCertificate ? "Your certificate is ready to download; check the recommended next steps." : ""}`,
       ],
-      buttonText: "DOWNLOAD CERTIFICATE",
+      buttonText: hasCertificate ? "DOWNLOAD CERTIFICATE" : "CONTINUE LEARNING",
     },
     pl: {
       heading: "Kurs ukończony",
       paragraphs: [
         "Gratulacje! 🏁",
-        `Ukończyłeś(-aś) ${courseName}. Certyfikat jest gotowy do pobrania; sprawdź też proponowane ścieżki dalszej nauki.`,
+        `Ukończyłeś(-aś) ${courseName}. ${hasCertificate ? "Certyfikat jest gotowy do pobrania; sprawdź też proponowane ścieżki dalszej nauki." : ""}`,
       ],
-      buttonText: "POBIERZ CERTYFIKAT",
+      buttonText: hasCertificate ? "POBIERZ CERTYFIKAT" : "KONTYNUUJ SWOJĄ NAUKĘ",
     },
   };
 


### PR DESCRIPTION
<!--
 1. Make sure you have correct branch name i.e. `ab_prefix_123_task_name`, where `123` is a issue ID, and `ab` is an author
 2. Make sure you have meaningful title related to task with correct prefix: feat/fix/chore/style/docs/refactor
 3. Reference multiple issues in one PR by listing them in the issues section
 4. Make sure all necessary sections are filled, remove obsolete sections
 5. Do a self review first
 6. Check if your PR includes only code related to your task
 7. `Notes` is used for additional info but also to notify if any action is required
-->

## Issue(s)
[1005](https://github.com/Selleo/mentingo/issues/1005)

## Overview 
<!--
General description what it does
-->
- Previously, if you finished a course, you would be able to see a certificate on the course page, even if the course didn't include any certificates. Now you will only see a certificate if a course has certificates enabled. Also the course completion template now varies based on if the course had certificates on time of completion or not.

## Business Value
<!--
Why are we doing this from a business perspective? What value does this bring to the project from end-users perspective?
-->

- It improves UX, because now it doesn't say that you have a certificate, when you don't have it.

## Screenshots / Video
<img width="1512" height="788" alt="image" src="https://github.com/user-attachments/assets/fd891f1b-89ea-4b86-92c7-3dfa55030132" />
<img width="1512" height="787" alt="image" src="https://github.com/user-attachments/assets/127a46cc-23cb-4669-9f21-2f84307737d7" />
<img width="1512" height="788" alt="image" src="https://github.com/user-attachments/assets/46dffea0-793f-4031-b835-147358a168d1" />
<img width="1251" height="670" alt="image" src="https://github.com/user-attachments/assets/4307adac-fe17-4aad-865a-88b387465b0d" />
<img width="1251" height="699" alt="image" src="https://github.com/user-attachments/assets/08e6f809-33be-43c6-abae-4de1ee2e7f2a" />
