### PR TITLE
fix: not working enforcing lesson sequence when creating a new course

### DIFF
--- a/apps/api/src/courses/course.service.ts
+++ b/apps/api/src/courses/course.service.ts
@@ -44,6 +44,7 @@ import { StatisticsRepository } from "src/statistics/repositories/statistics.rep
 import { StripeService } from "src/stripe/stripe.service";
 import { USER_ROLES } from "src/user/schemas/userRoles";
 import { UserService } from "src/user/user.service";
+import { settingsToJSONBuildObject } from "src/utils/settings-to-json-build-object";
 import { PROGRESS_STATUSES } from "src/utils/types/progress.type";
 
 import { getSortOptions } from "../common/helpers/getSortOptions";
@@ -1020,7 +1021,7 @@ export class CourseService {
           categoryId: createCourseBody.categoryId,
           stripeProductId: productId,
           stripePriceId: priceId,
-          settings,
+          settings: settingsToJSONBuildObject(settings),
         })
         .returning();
 


### PR DESCRIPTION
## Issue(s)
The issue is already closed but switch turned out to not work when testing on the staging environment
Related issue #956 

## Overview 
Applying feedback in attached issue

## Business Value
Admin is actually able to switch sequencing lessons

## Screenshots / Video

https://github.com/user-attachments/assets/5f0f9c88-2502-4412-9362-210060018272


