### PR TITLE
feat: improve news navigation and summary readability

### DIFF
--- a/apps/web/app/locales/pl/translation.json
+++ b/apps/web/app/locales/pl/translation.json
@@ -162,6 +162,8 @@
   "newsView": {
     "header": "Aktualności",
     "notFound": "Nie znaleziono aktualności.",
+    "previousNews": "Poprzednia aktualność",
+    "nextNews": "Następna aktualność",
     "previousArticle": "Poprzedni artykuł",
     "nextArticle": "Następny artykuł",
     "prompt": {

--- a/apps/web/app/modules/News/NewsDetails.page.tsx
+++ b/apps/web/app/modules/News/NewsDetails.page.tsx
@@ -102,7 +102,7 @@ export default function NewsDetailsPage() {
         </div>
       )}
 
-      <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 bg-white rounded-3xl">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 bg-white rounded-3xl mb-8">
         {headerImageUrl ? (
           <div className="overflow-hidden bg-white rounded-t-3xl px-10 pt-10 pb-6">
             <img

--- a/apps/web/app/modules/News/NewsItem.tsx
+++ b/apps/web/app/modules/News/NewsItem.tsx
@@ -49,18 +49,20 @@ function NewsItem({
         <h3 className="text-xl font-gothic font-bold leading-6 text-white transition-all duration-300 group-hover:text-primary-500 text-left">
           {title}
         </h3>
-        <p className="text-base font-normal leading-7 text-white opacity-95 text-left">{summary}</p>
+        <p className="text-base font-normal leading-7 text-white opacity-95 text-left overflow-hidden max-h-[7rem] [display:-webkit-box] [-webkit-box-orient:vertical] [-webkit-line-clamp:4]">
+          {summary}
+        </p>
         <div className="flex items-center gap-6">
           {date ? (
             <div className="flex items-center gap-2">
-              <Icon name="Calendar" />
+              <Icon name="Calendar" className="text-white" />
               <p className="text-sm font-normal leading-5 text-white opacity-80">
                 {formatDate(new Date(date), "d MMMM yyyy")}
               </p>
             </div>
           ) : null}
           <div className="flex items-center gap-2">
-            <Icon name="User" className="size-4" />
+            <Icon name="User" className="size-4 text-white" />
             <p className="text-sm font-normal leading-5 text-white opacity-80">{authorName}</p>
           </div>
         </div>


### PR DESCRIPTION
## Issue(s)
- #1115

## Overview 
- Improves News UI readability by clamping the news card summary to 4 lines.
- Aligns News card metadata icons with dark backgrounds (sets Calendar/User icon color to white).
- Adds bottom spacing on the News details container to prevent the content from feeling cramped.
- Adds missing Polish translations for the News details navigation buttons (Previous/Next).

## Business Value
- Makes the News list easier to scan by keeping cards visually consistent.
- Improves legibility of metadata on image-based cards.
- Prevents missing-translation fallbacks in PL, keeping navigation clear for Polish users.

## Screenshots / Video

<img width="770" height="617" alt="image" src="https://github.com/user-attachments/assets/093300c4-0c88-487f-8bae-92424f6fbc5d" />

<img width="2018" height="497" alt="image" src="https://github.com/user-attachments/assets/778835a2-ad56-4319-81cb-f30d41ab3cda" />
