### PR TITLE
fix: improve account security by consistently enforcing MFA

### DIFF
--- a/apps/web/app/Guards/MFAGuard.tsx
+++ b/apps/web/app/Guards/MFAGuard.tsx
@@ -1,0 +1,62 @@
+import { Navigate, useLocation } from "@remix-run/react";
+import { match } from "ts-pattern";
+
+import { useCurrentUser } from "~/api/queries/useCurrentUser";
+import { LOGIN_REDIRECT_URL } from "~/modules/Auth/constants";
+import { useCurrentUserStore } from "~/modules/common/store/useCurrentUserStore";
+
+import type React from "react";
+
+type MFAGuardProps = {
+  children: React.ReactElement;
+  mode: "auth" | "app" | "public";
+};
+
+export const MFAGuard = ({ children, mode }: MFAGuardProps) => {
+  const location = useLocation();
+  const { data: currentUser, isLoading } = useCurrentUser();
+  const hasVerifiedMFA = useCurrentUserStore((state) => state.hasVerifiedMFA);
+
+  if (isLoading) {
+    return null;
+  }
+
+  const shouldVerifyMFA = Boolean(currentUser?.shouldVerifyMFA);
+  const isMFAComplete = !shouldVerifyMFA || hasVerifiedMFA;
+
+  return match(mode)
+    .with("auth", () => {
+      if (!currentUser) {
+        return children;
+      }
+
+      if (shouldVerifyMFA && location.pathname !== "/auth/mfa") {
+        return <Navigate to="/auth/mfa" />;
+      }
+
+      if (!shouldVerifyMFA) {
+        return <Navigate to={LOGIN_REDIRECT_URL} />;
+      }
+
+      return children;
+    })
+    .with("public", () => {
+      if (shouldVerifyMFA && !hasVerifiedMFA) {
+        return <Navigate to="/auth/mfa" />;
+      }
+
+      return children;
+    })
+    .with("app", () => {
+      if (!currentUser) {
+        return <Navigate to="/auth/login" />;
+      }
+
+      if (!isMFAComplete) {
+        return <Navigate to="/auth/mfa" />;
+      }
+
+      return children;
+    })
+    .exhaustive();
+};

--- a/apps/web/app/modules/Auth/Auth.layout.tsx
+++ b/apps/web/app/modules/Auth/Auth.layout.tsx
@@ -1,25 +1,16 @@
-import { Outlet, redirect } from "@remix-run/react";
+import { Outlet } from "@remix-run/react";
 
 import { currentUserQueryOptions } from "~/api/queries";
 import { queryClient } from "~/api/queryClient";
+import { MFAGuard } from "~/Guards/MFAGuard";
 
 import { useCurrentUserStore } from "../common/store/useCurrentUserStore";
 
-import { LOGIN_REDIRECT_URL } from "./constants";
-
-import type { CurrentUserResponse } from "~/api/generated-api";
-
 export const clientLoader = async () => {
-  let user: CurrentUserResponse | null = null;
-
   try {
-    user = await queryClient.ensureQueryData(currentUserQueryOptions);
+    await queryClient.ensureQueryData(currentUserQueryOptions);
   } catch {
     return null;
-  }
-
-  if (user) {
-    throw redirect(LOGIN_REDIRECT_URL);
   }
 
   return null;
@@ -32,7 +23,9 @@ export default function AuthLayout() {
 
   return (
     <main className="flex h-screen w-screen items-center justify-center">
-      <Outlet />
+      <MFAGuard mode="auth">
+        <Outlet />
+      </MFAGuard>
     </main>
   );
 }

--- a/apps/web/app/modules/Dashboard/UserDashboard.layout.tsx
+++ b/apps/web/app/modules/Dashboard/UserDashboard.layout.tsx
@@ -3,6 +3,7 @@ import { useMemo } from "react";
 
 import { currentUserQueryOptions, useCurrentUser } from "~/api/queries/useCurrentUser";
 import { queryClient } from "~/api/queryClient";
+import { MFAGuard } from "~/Guards/MFAGuard";
 import { useNavigationHistoryStore } from "~/lib/stores/navigationHistory";
 import { Dashboard } from "~/modules/Dashboard/Dashboard";
 import { saveEntryToNavigationHistory } from "~/utils/saveEntryToNavigationHistory";
@@ -45,17 +46,17 @@ export default function UserDashboardLayout() {
 
   useSyncUserAfterLogin(user);
 
-  if (!hasVerifiedMFA) {
-    return <Navigate to="/auth/mfa" />;
-  }
-
   if (lastEntry && lastEntry.pathname !== location.pathname) {
     clearHistory();
 
     return <Navigate to={lastEntry.pathname || LOGIN_REDIRECT_URL} />;
   }
 
-  const isAuthenticated = Boolean(user && hasVerifiedMFA);
+  const isAuthenticated = Boolean(user && (!user.shouldVerifyMFA || hasVerifiedMFA));
 
-  return <Dashboard isAuthenticated={isAuthenticated} />;
+  return (
+    <MFAGuard mode="app">
+      <Dashboard isAuthenticated={isAuthenticated} />
+    </MFAGuard>
+  );
 }

--- a/apps/web/app/modules/Navigation/NavigationWrapper.tsx
+++ b/apps/web/app/modules/Navigation/NavigationWrapper.tsx
@@ -1,13 +1,16 @@
 import { Outlet } from "@remix-run/react";
 
 import { Navigation } from "~/components/Navigation/Navigation";
+import { MFAGuard } from "~/Guards/MFAGuard";
 
 export default function NavigationWrapper() {
   return (
     <div className="flex h-screen flex-col">
       <div className="flex flex-1 flex-col overflow-hidden 2xl:flex-row">
         <Navigation />
-        <Outlet />
+        <MFAGuard mode="public">
+          <Outlet />
+        </MFAGuard>
       </div>
     </div>
   );


### PR DESCRIPTION
## Overview
Centralize MFA routing rules in a shared guard and apply them across auth, public, and app layouts to prevent redirect loops and ensure MFA enforcement on public routes for logged-in users.

## Business Value
Users who require MFA now reliably land on the verification flow and cannot bypass it by navigating to public routes, reducing login friction and improving account security.

## Screenshots / Video

https://github.com/user-attachments/assets/4ead87d5-4066-4cbb-bfb5-5b7f37d5e0eb

