### PR TITLE
fix: ensure release process runs correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ release:
 			echo "Warning: TAG does not start with 'v', skipping staging to main promotion"; \
 			exit 0 \
 			;; \
-	esac; \
+	esac;
 
 .PHONY: dry-release
 dry-release:


### PR DESCRIPTION
## Overview
Remove an unnecessary trailing backslash in the Makefile release target to avoid a redundant line continuation.

## Business Value
Keeps the release script clean and reduces the chance of subtle shell parsing issues during release automation.

