### PR TITLE
feat: include generator metadata for better platform identification

### DIFF
--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -8,6 +8,8 @@ import {
   useRouteError,
 } from "@remix-run/react";
 
+import { version } from "~/../version.json";
+
 import { PlatformFavicon } from "./components/PlatformFavicon";
 import { Toaster } from "./components/ui/toaster";
 import { useNavigationTracker } from "./hooks/useNavigationTracker";
@@ -33,6 +35,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="generator" content={`Mentingo LMS ${version}`} />
         <Meta />
         <Links />
       </head>


### PR DESCRIPTION
## Issue(s)
- #1103 

## Overview
Add a generator meta tag that includes the Mentingo LMS version from `version.json`.

## Business Value
Expose build/version information in page metadata to aid diagnostics and tooling that read the generator tag.

## Screenshots / Video
<img width="906" height="102" alt="image" src="https://github.com/user-attachments/assets/2cb83065-53ad-4947-9b4b-fa0b7e975b8a" />
Note: screenshot has been taken on local environment, on deployed versions it will be different based on the version on Github
