### PR TITLE
fix: ensure deployed applications function correctly

### DIFF
--- a/apps/web/app/api/api-client.ts
+++ b/apps/web/app/api/api-client.ts
@@ -23,17 +23,15 @@ const baseURL = (() => {
   const processEnvApiUrl =
     get(typeof process !== "undefined" ? process.env : {}, "VITE_API_URL") || undefined;
 
+  const resolvedApiUrl = importEnvApiUrl || windowEnvApiUrl || processEnvApiUrl;
+
   return match({
     importEnvMode,
-    windowEnvApiUrl,
-    importEnvApiUrl,
-    processEnvApiUrl,
+    resolvedApiUrl,
   })
     .with({ importEnvMode: "test" }, () => "http://localhost:3000")
-    .with({ processEnvApiUrl: P.string }, () => processEnvApiUrl)
-    .with({ windowEnvApiUrl: P.string }, () => windowEnvApiUrl)
-    .with({ importEnvApiUrl: P.string }, () => importEnvApiUrl)
-    .otherwise(() => "http://localhost:5173");
+    .with({ resolvedApiUrl: P.string }, () => resolvedApiUrl)
+    .otherwise(() => undefined);
 })();
 
 export const ApiClient = new API({


### PR DESCRIPTION
## Overview
Refine API client base URL resolution to prefer `VITE_API_URL` when provided, while keeping tests pinned to `http://localhost:3000` and otherwise using relative URLs.

## Business Value
Ensures preview deployments can target explicit API hosts via `VITE_API_URL` while preserving predictable test behavior and same-origin setups.