### PR TITLE
chore: ensure PR preview environments are cleaned up correctly

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -266,3 +266,15 @@ jobs:
           # remove services and volumes
           echo "$services" | xargs -r uc --connect "ssh+cli://${{ secrets.UNCLOUD_CONNECT }}" rm || true
           echo "$volumes" | xargs -r uc --connect "ssh+cli://${{ secrets.UNCLOUD_CONNECT }}" volume rm -y || true
+
+      - name: Prune unused Docker images
+        shell: bash
+        env:
+          UNCLOUD_CONNECT: ${{ secrets.UNCLOUD_CONNECT }}
+        run: |
+          set -euo pipefail
+
+          # Extract user@host from UNCLOUD_CONNECT
+          ssh_target="$(echo "${{ secrets.UNCLOUD_CONNECT }}" | sed -E 's#^ssh(\+cli)?://##; s#:/.*##')"
+
+          ssh -i ~/.ssh/id_ecdsa "$ssh_target" "docker image prune -f -a"


### PR DESCRIPTION
## Issue(s)
[1088](https://github.com/Selleo/mentingo/issues/1088)

## Overview
Fixes PR preview cleanup job by adding missing `Checkout` step. Without it, the `docker-compose.preview.tpl.yml` file was not available during cleanup, causing the workflow to fail.

## Changes
- Added `actions/checkout@v4` step to `cleanup-pr-preview` job