### PR TITLE
chore: keep lesson editor visible while editing a course

### DIFF
--- a/apps/web/app/modules/Admin/EditCourse/CourseLessons/CourseLessons.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/CourseLessons/CourseLessons.tsx
@@ -200,7 +200,7 @@ const CourseLessons = ({
           </Button>
         )}
       </div>
-      <div className="size-full md:sticky md:top-4 self-start">{renderContent}</div>
+      <div className="size-full md:sticky md:top-8 self-start">{renderContent}</div>
     </div>
   );
 };

--- a/apps/web/app/modules/Admin/EditCourse/EditCourse.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/EditCourse.tsx
@@ -252,7 +252,7 @@ const EditCourse = () => {
             courseLanguage={courseLanguage}
           />
         </TabsContent>
-        <TabsContent value="Curriculum" className="h-full overflow-hidden">
+        <TabsContent value="Curriculum" className="h-full">
           <LeaveModalProvider>
             <CourseLessons
               chapters={course?.chapters as Chapter[]}


### PR DESCRIPTION
## Issue(s)
- #1239 

## Overview
- Increase sticky lesson content offset to `md:top-8` so the panel clears the admin header in `apps/web/app/modules/Admin/EditCourse/CourseLessons/CourseLessons.tsx`.
- Remove `overflow-hidden` from the Curriculum tab so nested curriculum content and sticky elements can render/scroll fully in `apps/web/app/modules/Admin/EditCourse/EditCourse.tsx`.

## Business Value
- Prevents the lesson panel from being partially obscured, improving readability while editing courses.
- Ensures curriculum content and dialogs are not clipped, reducing friction for admins managing chapters and lessons.

## Screenshots / Video
<img width="2905" height="2028" alt="image" src="https://github.com/user-attachments/assets/4d810858-d734-4b05-8b85-49e079e955e9" />


### Notes
- [ ] Fired up e2e tests and got a positive result
