### PR TITLE
chore: optimize caching to ensure reliable updates

### DIFF
--- a/apps/web/nginx.conf
+++ b/apps/web/nginx.conf
@@ -18,7 +18,12 @@ http {
     gzip_proxied expired no-cache no-store private auth;
     gzip_types text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript;
 
+    location /assets/ {
+      add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+
     location / {
+      add_header Cache-Control "no-store, must-revalidate";
       try_files $uri $uri/ /index.html;
     }
   }


### PR DESCRIPTION
## Issue(s)
- #1237 

## Overview
Align Nginx behavior with prod expectations: long-cache hashed assets under `/assets/` and force fresh fetches for the HTML shell via `Cache-Control: no-store, must-revalidate`. This prevents users from seeing stale UI after deployments.

## Business Value
Users now automatically load the latest frontend after each deploy.

## Screenshots
<img width="363" height="199" alt="image" src="https://github.com/user-attachments/assets/a839572c-d7ec-4a63-bfa6-5380799b0a03" />

<img width="554" height="200" alt="image" src="https://github.com/user-attachments/assets/51f25272-9496-4328-bd92-6f6cd0124b3e" />

