### PR TITLE
chore: improve admin course preview navigation

### DIFF
--- a/apps/web/app/modules/Courses/CourseView/CourseChapter.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseChapter.tsx
@@ -26,9 +26,15 @@ type CourseChapterProps = {
   chapter: Chapter;
   courseId: string;
   isEnrolled: boolean;
+  isPreviewMode?: boolean;
 };
 
-export const CourseChapter = ({ chapter, courseId, isEnrolled }: CourseChapterProps) => {
+export const CourseChapter = ({
+  chapter,
+  courseId,
+  isEnrolled,
+  isPreviewMode = false,
+}: CourseChapterProps) => {
   const { t } = useTranslation();
   const lessonText = formatWithPlural(
     chapter.lessonCount ?? 0,
@@ -40,7 +46,8 @@ export const CourseChapter = ({ chapter, courseId, isEnrolled }: CourseChapterPr
     t("courseChapterView.other.quiz"),
     t("courseChapterView.other.quizzes"),
   );
-  const hasAccessToChapter = chapter.lessons.some((lesson: Lesson) => lesson.hasAccess);
+  const hasAccessToChapter =
+    isPreviewMode || chapter.lessons.some((lesson: Lesson) => lesson.hasAccess);
   const lessons = useMemo(() => chapter?.lessons || [], [chapter?.lessons]);
 
   const navigate = useNavigate();
@@ -122,12 +129,23 @@ export const CourseChapter = ({ chapter, courseId, isEnrolled }: CourseChapterPr
                 {lessons?.map((lesson: Lesson) => {
                   if (!lesson) return null;
 
-                  return (chapter.isFreemium || isEnrolled) && lesson.hasAccess ? (
-                    <Link key={lesson.id} to={`/course/${courseId}/lesson/${lesson.id}`}>
-                      <CourseChapterLesson lesson={lesson} />
+                  const canOpenLesson =
+                    isPreviewMode || ((chapter.isFreemium || isEnrolled) && lesson.hasAccess);
+
+                  return canOpenLesson ? (
+                    <Link to={`/course/${courseId}/lesson/${lesson.id}`}>
+                      <CourseChapterLesson
+                        key={lesson.id}
+                        lesson={lesson}
+                        isPreviewMode={isPreviewMode}
+                      />
                     </Link>
                   ) : (
-                    <CourseChapterLesson key={lesson.id} lesson={lesson} />
+                    <CourseChapterLesson
+                      key={lesson.id}
+                      lesson={lesson}
+                      isPreviewMode={isPreviewMode}
+                    />
                   );
                 })}
                 {chapter.isFreemium && hasAccessToChapter && (

--- a/apps/web/app/modules/Courses/CourseView/CourseChapterLesson.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseChapterLesson.tsx
@@ -14,15 +14,19 @@ const progressBadge = {
 
 type CourseChapterLessonProps = {
   lesson: Lesson;
+  isPreviewMode?: boolean;
 };
 
-export const CourseChapterLesson = ({ lesson }: CourseChapterLessonProps) => {
-  const hasAccess = lesson.hasAccess;
+export const CourseChapterLesson = ({
+  lesson,
+  isPreviewMode = false,
+}: CourseChapterLessonProps) => {
+  const hasAccess = isPreviewMode || lesson.hasAccess;
 
   const lessonElement = (
     <div
       className={cn("flex w-full gap-x-2 p-2", {
-        "opacity-30": !hasAccess,
+        "opacity-30": !hasAccess && !isPreviewMode,
       })}
     >
       <Icon name={LessonTypesIcons[lesson.type]} className="size-6 text-accent-foreground" />
@@ -40,12 +44,12 @@ export const CourseChapterLesson = ({ lesson }: CourseChapterLessonProps) => {
       </div>
       <ProgressBadge
         progress={progressBadge[hasAccess ? lesson.status : "blocked"]}
-        className="self-center"
+        className={cn("self-center", { invisible: isPreviewMode })}
       />
     </div>
   );
 
-  if (!hasAccess) {
+  if (!hasAccess && !isPreviewMode) {
     return <button className="w-full flex cursor-not-allowed">{lessonElement}</button>;
   }
 

--- a/apps/web/app/modules/Courses/CourseView/CourseView.page.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseView.page.tsx
@@ -90,15 +90,17 @@ export default function CourseViewPage() {
     navigate(`${url.pathname}${url.search ?? ""}`, { replace: true });
   }, [course?.slug, id, navigate]);
 
-  const { isStudent } = useUserRole();
+  const { isStudent, isAdminLike } = useUserRole();
   const { data: currentUser } = useCurrentUser();
+
+  const isPreviewMode = !course?.enrolled && isAdminLike;
 
   const courseViewTabs = useMemo(
     () => [
       {
         title: t("studentCourseView.tabs.chapters"),
         itemCount: course?.chapters?.length,
-        content: <ChapterListOverview course={course} />,
+        content: <ChapterListOverview course={course} isPreviewMode={isPreviewMode} />,
         isForAdminLike: false,
         isForUnregistered: true,
       },
@@ -120,7 +122,7 @@ export default function CourseViewPage() {
         isForUnregistered: false,
       },
     ],
-    [t, course],
+    [t, course, isPreviewMode],
   );
 
   if (!course) return null;

--- a/apps/web/app/modules/Courses/CourseView/components/ChapterListOverview.tsx
+++ b/apps/web/app/modules/Courses/CourseView/components/ChapterListOverview.tsx
@@ -10,16 +10,18 @@ import type { GetCourseResponse } from "~/api/generated-api";
 
 interface ChapterListOverviewProps {
   course?: GetCourseResponse["data"];
+  isPreviewMode?: boolean;
 }
 
-export function ChapterListOverview({ course }: ChapterListOverviewProps) {
+export function ChapterListOverview({ course, isPreviewMode = false }: ChapterListOverviewProps) {
   const { t } = useTranslation();
 
   const { sequenceEnabled } = useLessonsSequence(course?.id);
+  const shouldEnforceSequence = sequenceEnabled && !isPreviewMode;
 
   const chapters = useMemo(
-    () => getChaptersWithAccess(course?.chapters || [], sequenceEnabled),
-    [course?.chapters, sequenceEnabled],
+    () => getChaptersWithAccess(course?.chapters || [], shouldEnforceSequence),
+    [course?.chapters, shouldEnforceSequence],
   );
 
   return (
@@ -36,6 +38,7 @@ export function ChapterListOverview({ course }: ChapterListOverviewProps) {
             chapter={chapter}
             courseId={course!.id}
             isEnrolled={Boolean(course?.enrolled)}
+            isPreviewMode={isPreviewMode}
           />
         );
       })}

--- a/apps/web/app/modules/Courses/Lesson/Lesson.page.tsx
+++ b/apps/web/app/modules/Courses/Lesson/Lesson.page.tsx
@@ -8,6 +8,7 @@ import { queryClient } from "~/api/queryClient";
 import ErrorPage from "~/components/ErrorPage/ErrorPage";
 import { PageWrapper } from "~/components/PageWrapper";
 import { useLearningTimeTracker } from "~/hooks/useLearningTimeTracker";
+import { useUserRole } from "~/hooks/useUserRole";
 import Loader from "~/modules/common/Loader/Loader";
 import { LessonContent } from "~/modules/Courses/Lesson/LessonContent";
 import { LessonSidebar } from "~/modules/Courses/Lesson/LessonSidebar";
@@ -41,6 +42,7 @@ export default function LessonPage() {
 
   const { language } = useLanguageStore();
   const { data: user } = useCurrentUser();
+  const { isAdminLike } = useUserRole();
 
   const [error, setError] = useState(false);
 
@@ -83,6 +85,7 @@ export default function LessonPage() {
   }
 
   const { isFirst, isLast } = checkOverallLessonPosition(course.chapters, lessonId);
+  const isPreviewMode = !course.enrolled && isAdminLike;
 
   const currentChapter = course.chapters.find((chapter) =>
     chapter?.lessons.some((l) => l.id === lessonId),
@@ -190,7 +193,7 @@ export default function LessonPage() {
             lessonLoading={lessonLoading}
           />
         </div>
-        <LessonSidebar course={course} lessonId={lessonId} />
+        <LessonSidebar course={course} lessonId={lessonId} isPreviewMode={isPreviewMode} />
       </div>
     </PageWrapper>
   );

--- a/apps/web/app/modules/Courses/Lesson/LessonSidebar.tsx
+++ b/apps/web/app/modules/Courses/Lesson/LessonSidebar.tsx
@@ -30,6 +30,7 @@ import type { GetCourseResponse } from "~/api/generated-api";
 type LessonSidebarProps = {
   course: GetCourseResponse["data"];
   lessonId: string;
+  isPreviewMode?: boolean;
 };
 
 const progressBadge = {
@@ -39,7 +40,7 @@ const progressBadge = {
   blocked: "Blocked",
 } as const;
 
-export const LessonSidebar = ({ course, lessonId }: LessonSidebarProps) => {
+export const LessonSidebar = ({ course, lessonId, isPreviewMode = false }: LessonSidebarProps) => {
   const { t } = useTranslation();
   const { state } = useLocation();
 
@@ -48,10 +49,11 @@ export const LessonSidebar = ({ course, lessonId }: LessonSidebarProps) => {
   );
 
   const { sequenceEnabled } = useLessonsSequence(course?.id);
+  const shouldEnforceSequence = sequenceEnabled && !isPreviewMode;
 
   const chapters = useMemo(
-    () => getChaptersWithAccess(course?.chapters || [], sequenceEnabled),
-    [course?.chapters, sequenceEnabled],
+    () => getChaptersWithAccess(course?.chapters || [], shouldEnforceSequence),
+    [course?.chapters, shouldEnforceSequence],
   );
 
   useEffect(() => {
@@ -101,7 +103,7 @@ export const LessonSidebar = ({ course, lessonId }: LessonSidebarProps) => {
                     <AccordionItem value={id} key={id}>
                       <AccordionTrigger
                         className={cn(
-                          "flex items-start gap-x-4 border border-neutral-200 px-6 py-4 text-start hover:bg-neutral-50 data-[state=closed]:rounded-none data-[state=open]:rounded-t-lg data-[state=closed]:border-x-transparent data-[state=closed]:border-t-transparent [&[data-state=closed]>svg]:duration-200 [&[data-state=closed]>svg]:ease-out [&[data-state=open]>svg]:rotate-180 [&[data-state=open]>svg]:duration-200 [&[data-state=open]>svg]:ease-out",
+                          "flex items-start gap-x-4 border border-neutral-200 px-6 py-4 text-start hover:bg-neutral-50 data-[state=closed]:rounded-none data-[state=open]:rounded-t-lg data-[state=open]:border-primary-500 data-[state=open]:bg-primary-50 data-[state=closed]:border-x-transparent data-[state=closed]:border-t-transparent [&[data-state=closed]>svg]:duration-200 [&[data-state=closed]>svg]:ease-out [&[data-state=open]>svg]:rotate-180 [&[data-state=open]>svg]:duration-200 [&[data-state=open]>svg]:ease-out",
                           {
                             "data-[state=closed]:border-b-0":
                               last(course?.chapters)?.id === id || activeChapter !== id,
@@ -119,6 +121,7 @@ export const LessonSidebar = ({ course, lessonId }: LessonSidebarProps) => {
                             ]
                           }
                           iconClasses="w-6 h-auto shrink-0"
+                          className={cn({ hidden: isPreviewMode })}
                         />
                         <div className="body-base-md w-full text-start text-neutral-950">
                           {title}
@@ -128,7 +131,8 @@ export const LessonSidebar = ({ course, lessonId }: LessonSidebarProps) => {
                       <AccordionContent className="flex flex-col rounded-b-lg border border-t-0">
                         {lessons?.map(({ id, title, status, type, hasAccess }) => {
                           const isBlocked =
-                            status === LESSON_PROGRESS_STATUSES.BLOCKED || !hasAccess;
+                            !isPreviewMode &&
+                            (status === LESSON_PROGRESS_STATUSES.BLOCKED || !hasAccess);
 
                           return (
                             <Link
@@ -148,6 +152,7 @@ export const LessonSidebar = ({ course, lessonId }: LessonSidebarProps) => {
                                   ]
                                 }
                                 iconClasses="w-6 h-auto shrink-0"
+                                className={cn({ hidden: isPreviewMode })}
                               />{" "}
                               <div className="flex flex-1 flex-col break-words overflow-x-hidden">
                                 <p className="body-sm-md text-neutral-950">{title}</p>


### PR DESCRIPTION
## Issue(s)
- #1058 

## Overview 
- Allow admin/content creator preview mode to bypass access restrictions and sequencing so every lesson link remains clickable.
- Hide progress/status badges in preview while preserving layout to reduce visual noise.
- Propagate preview flag through course overview, chapter list, lesson page, and sidebar components.

## Business Value
- Simplifies QA for course creators by letting them navigate full course flows without enrollment gating or enforced sequencing.
- Reduces confusion in preview by removing status indicators that don't matter for author review.

## Screenshots / Video

https://github.com/user-attachments/assets/a7a64b63-8ff4-46ea-9c65-589f49f1fdc0
