### PR TITLE
fix: allow saving lesson without selecting a chapter

### DIFF
--- a/apps/web/app/modules/Admin/EditCourse/CourseLessons/components/ChaptersList.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/CourseLessons/components/ChaptersList.tsx
@@ -206,6 +206,8 @@ const ChapterCard = ({
                 setSelectedLesson={setSelectedLesson}
                 setContentTypeToDisplay={setContentTypeToDisplay}
                 language={language}
+                setSelectedChapter={setSelectedChapter}
+                chapter={chapter}
               />
             </AccordionContent>
             <div className="mt-3 flex items-center justify-between">

--- a/apps/web/app/modules/Admin/EditCourse/CourseLessons/components/LessonCardList.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/CourseLessons/components/LessonCardList.tsx
@@ -14,11 +14,13 @@ import { ContentTypes } from "~/modules/Admin/EditCourse/EditCourse.types";
 
 import type { SupportedLanguages } from "@repo/shared";
 import type { Sortable } from "~/components/SortableList/SortableList";
-import type { Lesson } from "~/modules/Admin/EditCourse/EditCourse.types";
+import type { Chapter, Lesson } from "~/modules/Admin/EditCourse/EditCourse.types";
 
 type LessonCardListProps = {
   setSelectedLesson: (lesson: Lesson) => void;
   setContentTypeToDisplay: (contentType: string) => void;
+  setSelectedChapter?: (chapter: Chapter | null) => void;
+  chapter?: Chapter;
   lessons: Sortable<Lesson>[];
   selectedLesson: Lesson | null;
   language: SupportedLanguages;
@@ -28,6 +30,8 @@ export const LessonCardList = ({
   lessons,
   setSelectedLesson,
   setContentTypeToDisplay,
+  setSelectedChapter,
+  chapter,
   selectedLesson,
   language,
 }: LessonCardListProps) => {
@@ -49,6 +53,10 @@ export const LessonCardList = ({
         setIsLeavingContent(true);
         openLeaveModal();
         return;
+      }
+
+      if (setSelectedChapter && chapter) {
+        setSelectedChapter(chapter);
       }
 
       setSelectedLesson(lesson);
@@ -73,6 +81,8 @@ export const LessonCardList = ({
       isCurrentFormDirty,
       setContentTypeToDisplay,
       setSelectedLesson,
+      setSelectedChapter,
+      chapter,
       openLeaveModal,
       setIsLeavingContent,
     ],


### PR DESCRIPTION
## Issue(s)
- #1244 

## Overview
- Pass chapter data into `LessonCardList` so lesson clicks can also set the selected chapter.
- When a lesson is clicked, its parent chapter is selected to keep curriculum selection in sync.

## Business Value
- Prevents editors from editing the wrong chapter by ensuring the chapter context follows the selected lesson.
