### PR TITLE
chore: restore staging seed script

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -27,6 +27,7 @@
     "db:migrate": "drizzle-kit migrate",
     "db:generate": "drizzle-kit generate",
     "db:seed": "tsx ./src/seed/seed.ts",
+    "db:seed-staging": "node dist/src/seed/seed.js",
     "db:seed-prod": "tsx ./src/seed/seed-prod.ts",
     "db:seed-bulk": "tsx ./src/seed/bulk-users-seed.ts",
     "db:truncate-tables": "tsx ./src/seed/truncateTables.ts"


### PR DESCRIPTION
## Overview
- Restore the `db:seed-staging` npm script in `apps/api/package.json` so the staging ECS one-off seed task calls the compiled seed entrypoint (`dist/src/seed/seed.js`).

## Business Value
- Unblocks staging deployments by ensuring the automated seed step invoked by the workflow succeeds instead of failing due to a missing script.
