### PR TITLE
chore: improve thumbnail performance and quality

### DIFF
--- a/apps/api/src/file/thumbnail.service.ts
+++ b/apps/api/src/file/thumbnail.service.ts
@@ -297,7 +297,7 @@ export class ThumbnailService {
       "-f",
       "mjpeg",
       "-q:v",
-      "2",
+      "1",
       "pipe:1",
     ];
 


### PR DESCRIPTION
## Overview 
<!--
General description what it does
-->
- Thumbnails didn't want to be generated on deployed instances, possibly due to the output pipe closing to early. This should block it from happening
