### PR TITLE
fix: ensure lesson and course progress update correctly after lesson deletion

### DIFF
--- a/apps/api/src/lesson/services/adminLesson.service.ts
+++ b/apps/api/src/lesson/services/adminLesson.service.ts
@@ -27,6 +27,7 @@ import { LocalizationService } from "src/localization/localization.service";
 import { ENTITY_TYPE } from "src/localization/localization.types";
 import { OutboxPublisher } from "src/outbox/outbox.publisher";
 import { questionAnswerOptions, questions } from "src/storage/schema";
+import { StudentLessonProgressService } from "src/studentLessonProgress/studentLessonProgress.service";
 import { USER_ROLES } from "src/user/schemas/userRoles";
 import { isRichTextEmpty } from "src/utils/isRichTextEmpty";
 
@@ -64,6 +65,7 @@ export class AdminLessonService {
     private localizationService: LocalizationService,
     private readonly outboxPublisher: OutboxPublisher,
     private lessonService: LessonService,
+    private readonly studentLessonProgressService: StudentLessonProgressService,
     private readonly masterCourseService: MasterCourseService,
     @Inject("CACHE_MANAGER") private readonly cache: CacheManagerStore,
   ) {}
@@ -380,6 +382,12 @@ export class AdminLessonService {
       await this.adminLessonRepository.removeLesson(lessonId, trx);
       await this.adminLessonRepository.updateLessonDisplayOrderAfterRemove(lesson.chapterId, trx);
       await this.adminLessonRepository.updateLessonCountForChapter(lesson.chapterId, trx);
+      await this.studentLessonProgressService.recalculateProgressAfterLessonDeletion(
+        lesson.courseId,
+        lesson.chapterId,
+        currentUser,
+        trx,
+      );
     });
 
     await this.outboxPublisher.publish(

--- a/apps/api/src/studentLessonProgress/studentLessonProgress.service.ts
+++ b/apps/api/src/studentLessonProgress/studentLessonProgress.service.ts
@@ -290,6 +290,61 @@ export class StudentLessonProgressService {
     }
   }
 
+  async recalculateProgressAfterLessonDeletion(
+    courseId: UUIDType,
+    chapterId: UUIDType,
+    actor: ActorUserType,
+    dbInstance: PostgresJsDatabase<typeof schema> = this.db,
+  ) {
+    const [chapter] = await dbInstance
+      .select({ lessonCount: chapters.lessonCount })
+      .from(chapters)
+      .where(and(eq(chapters.id, chapterId), eq(chapters.courseId, courseId)))
+      .limit(1);
+
+    if (!chapter) return;
+
+    const studentsToRecalculate = await dbInstance
+      .selectDistinct({ studentId: studentCourses.studentId })
+      .from(studentCourses)
+      .leftJoin(
+        studentChapterProgress,
+        and(
+          eq(studentChapterProgress.studentId, studentCourses.studentId),
+          eq(studentChapterProgress.courseId, studentCourses.courseId),
+          eq(studentChapterProgress.chapterId, chapterId),
+        ),
+      )
+      .leftJoin(
+        studentLessonProgress,
+        and(
+          eq(studentLessonProgress.studentId, studentCourses.studentId),
+          eq(studentLessonProgress.chapterId, chapterId),
+        ),
+      )
+      .where(
+        and(
+          eq(studentCourses.courseId, courseId),
+          eq(studentCourses.status, COURSE_ENROLLMENT.ENROLLED),
+          sql<boolean>`${studentChapterProgress.id} IS NOT NULL OR ${studentLessonProgress.id} IS NOT NULL`,
+        ),
+      );
+
+    for (const { studentId } of studentsToRecalculate) {
+      await this.updateChapterProgress(
+        courseId,
+        chapterId,
+        studentId,
+        chapter.lessonCount,
+        false,
+        actor,
+        dbInstance,
+      );
+
+      await this.checkCourseIsCompletedForUser(courseId, studentId, actor, dbInstance);
+    }
+  }
+
   async updateQuizProgress(
     chapterId: UUIDType,
     lessonId: UUIDType,


### PR DESCRIPTION
## Issue(s)
- #1128 

## Overview
This fix recalculates student chapter and course progress when an admin deletes a lesson.

The change introduces a synchronous recalculation flow during lesson deletion:
- `AdminLessonService.removeLesson` now calls `StudentLessonProgressService.recalculateProgressAfterLessonDeletion(...)` inside the same DB transaction.

This keeps progress state consistent immediately after lesson deletion.

## Business Value
This prevents students from getting stuck in incomplete chapters/courses after content changes made by admins.

## Screenshots / Video

https://github.com/user-attachments/assets/6fb5be0c-b397-4bbf-9af0-511ebf3cb43b
