### PR TITLE
fix: video player not working on Firefox

### DIFF
--- a/apps/web/app/components/VideoPlayer/VideoPlayer.tsx
+++ b/apps/web/app/components/VideoPlayer/VideoPlayer.tsx
@@ -18,7 +18,6 @@ import {
   registerMentingoFullscreenControl,
 } from "./VideoJSFullscreenControl";
 import "./videojs-vimeo-tech";
-
 import "./videoPlayer.css";
 
 interface VideoPlayerProps {
@@ -30,43 +29,22 @@ interface VideoPlayerProps {
   getFullscreenTarget?: () => HTMLElement | null;
 }
 
-export type VideoJSType = ReturnType<typeof videojs>;
-type VideoPlayerOptions = {
-  autoplay: boolean;
-  controls: boolean;
-  inactivityTimeout: number;
-  loop: boolean;
-  bigPlayButton: boolean;
-  responsive: boolean;
-  fluid: boolean;
-  fill: boolean;
-  techOrder: string[];
-  getFullscreenTarget?: () => HTMLElement | null;
-};
-
-type PlayerWithControlBar = VideoJSType & {
-  controlBar?: {
-    getChild: (name: string) => unknown;
-    addChild: (name: string, options?: Record<string, unknown>) => unknown;
-    removeChild: (child: unknown) => unknown;
-  };
-};
-type PlayerWithErrorState = VideoJSType & {
-  error: (err?: unknown) => unknown;
-  removeClass?: (name: string) => void;
-};
-type VideoJsSource = {
-  src: string;
-  type?: string;
-};
+type VideoJSType = ReturnType<typeof videojs>;
 
 const replaceFullscreenControl = (player: VideoJSType) => {
-  const playerWithControlBar = player as PlayerWithControlBar;
-  const controlBar = playerWithControlBar.controlBar;
+  const controlBar = (
+    player as VideoJSType & {
+      controlBar?: {
+        getChild: (name: string) => unknown;
+        addChild: (name: string, options?: Record<string, unknown>) => unknown;
+        removeChild: (child: unknown) => unknown;
+      };
+    }
+  ).controlBar;
+
   if (!controlBar) return;
 
-  const existingCustom = controlBar.getChild(MENTINGO_FULLSCREEN_CONTROL_NAME);
-  if (!existingCustom) {
+  if (!controlBar.getChild(MENTINGO_FULLSCREEN_CONTROL_NAME)) {
     controlBar.addChild(MENTINGO_FULLSCREEN_CONTROL_NAME, {});
   }
 
@@ -80,9 +58,19 @@ const getTypeByProvider = (provider: VideoProvider) =>
   match(provider)
     .with(VIDEO_EMBED_PROVIDERS.YOUTUBE, () => "video/youtube")
     .with(VIDEO_EMBED_PROVIDERS.VIMEO, () => "video/vimeo")
-    .with(VIDEO_EMBED_PROVIDERS.BUNNY, () => "application/x-mpegURL")
-    .with(VIDEO_EMBED_PROVIDERS.SELF, () => "video/mp4")
+    .with(VIDEO_EMBED_PROVIDERS.BUNNY, () => "application/vnd.apple.mpegurl")
+    .with(VIDEO_EMBED_PROVIDERS.SELF, () => "")
     .otherwise(() => "");
+
+const getSourceTypes = (url: string, type: string) => {
+  const isInternalLessonResource = /\/api\/lesson\/lesson-resource\//i.test(url);
+
+  return Array.from(
+    new Set(
+      isInternalLessonResource ? [type, "application/vnd.apple.mpegurl", "video/mp4"] : [type],
+    ),
+  ).filter(Boolean) as string[];
+};
 
 export const VideoPlayer = ({
   url,
@@ -92,21 +80,24 @@ export const VideoPlayer = ({
   className,
   getFullscreenTarget,
 }: VideoPlayerProps) => {
-  const resolvedProvider = useMemo(
-    () => (provider === VIDEO_EMBED_PROVIDERS.UNKNOWN ? detectVideoProviderFromUrl(url) : provider),
-    [provider, url],
-  );
-  const type = useMemo(() => getTypeByProvider(resolvedProvider), [resolvedProvider]);
   const videoRef = useRef<HTMLDivElement | null>(null);
   const playerRef = useRef<VideoJSType | null>(null);
-  const onEndedRef = useRef<(() => void) | undefined>(onEnded);
+  const onEndedRef = useRef(onEnded);
+  const lastSourceRef = useRef<string | null>(null);
 
   useEffect(() => {
     onEndedRef.current = onEnded;
   }, [onEnded]);
 
-  const options = useMemo<VideoPlayerOptions>(() => {
-    return {
+  const resolvedProvider = useMemo(
+    () => (provider === VIDEO_EMBED_PROVIDERS.UNKNOWN ? detectVideoProviderFromUrl(url) : provider),
+    [provider, url],
+  );
+
+  const type = useMemo(() => getTypeByProvider(resolvedProvider), [resolvedProvider]);
+
+  const options = useMemo(
+    () => ({
       autoplay: true,
       controls: true,
       inactivityTimeout: 3000,
@@ -117,11 +108,18 @@ export const VideoPlayer = ({
       fill: true,
       getFullscreenTarget,
       techOrder: ["html5", "youtube", "Vimeo"],
-    };
-  }, [getFullscreenTarget]);
+      html5: {
+        vhs: { overrideNative: true },
+        nativeAudioTracks: false,
+        nativeVideoTracks: false,
+      },
+    }),
+    [getFullscreenTarget],
+  );
 
   useEffect(() => {
     if (playerRef.current) return;
+
     registerMentingoFullscreenControl();
 
     const videoElement = document.createElement("video-js");
@@ -129,6 +127,7 @@ export const VideoPlayer = ({
     videoRef.current?.appendChild(videoElement);
 
     const player = (playerRef.current = videojs(videoElement, options));
+
     player.ready(() => {
       replaceFullscreenControl(player);
     });
@@ -140,44 +139,59 @@ export const VideoPlayer = ({
 
   useEffect(() => {
     const player = playerRef.current;
-    if (!player) return;
+    if (!player || !url) return;
 
-    const playerWithErrorState = player as PlayerWithErrorState;
-    playerWithErrorState.error(null);
-    playerWithErrorState.removeClass?.("vjs-error");
+    const sourceTypes = getSourceTypes(url, type);
+    const sourceKey = `${url}::${sourceTypes.join("|")}`;
 
-    const typedSource: VideoJsSource[] = type ? [{ src: url, type }] : [{ src: url }];
-    player.src(typedSource);
+    if (lastSourceRef.current === sourceKey) {
+      return;
+    }
 
-    let retriedWithoutType = false;
+    lastSourceRef.current = sourceKey;
+
+    let attemptIndex = 0;
+
+    const applySource = () => {
+      const currentType = sourceTypes[attemptIndex];
+      const source = currentType ? [{ src: url, type: currentType }] : [{ src: url }];
+
+      player.error(undefined);
+      player.removeClass?.("vjs-error");
+
+      player.src(source);
+      player.load();
+      void player.play()?.catch(() => undefined);
+    };
+
     const onError = () => {
       const mediaError = player.error();
-      if (!mediaError || mediaError.code !== 4 || retriedWithoutType || !type) {
-        return;
-      }
+      if (!mediaError || mediaError.code !== 4) return;
 
-      retriedWithoutType = true;
-      playerWithErrorState.error(null);
-      playerWithErrorState.removeClass?.("vjs-error");
-      player.src([{ src: url }]);
+      attemptIndex += 1;
+      if (attemptIndex >= sourceTypes.length) return;
+
+      applySource();
     };
 
     player.on("error", onError);
+    applySource();
+
     return () => {
       player.off("error", onError);
     };
   }, [url, type]);
 
   useEffect(() => {
-    const player = playerRef.current;
-
     return () => {
-      if (player && !player.isDisposed()) {
-        player.dispose();
+      lastSourceRef.current = null;
+
+      if (playerRef.current && !playerRef.current.isDisposed()) {
+        playerRef.current.dispose();
         playerRef.current = null;
       }
     };
-  }, [playerRef]);
+  }, []);
 
   return (
     <div

--- a/apps/web/app/components/VideoPlayer/VideoPlayerSingleton.tsx
+++ b/apps/web/app/components/VideoPlayer/VideoPlayerSingleton.tsx
@@ -31,8 +31,9 @@ export function VideoPlayerSingleton() {
   const { currentUrl, placeholderElement, provider } = state;
   const rect = usePlaceholderRect(placeholderElement, currentUrl);
   const [showPlayNext, setShowPlayNext] = useState(false);
+  const [lastRect, setLastRect] = useState<DOMRect | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const { isFullscreen } = useFullscreenToggle(containerRef);
+  const { isFullscreen, isAnyFullscreen } = useFullscreenToggle(containerRef);
 
   const { autoplay, autoplaySettings } = useVideoPreferencesStore();
   const { onAutoplay } = useAutoplayAction(
@@ -43,6 +44,10 @@ export function VideoPlayerSingleton() {
   useEffect(() => {
     setShowPlayNext(false);
   }, [currentUrl]);
+
+  useEffect(() => {
+    if (rect) setLastRect(rect);
+  }, [rect]);
 
   const runAutoplay = useCallback(() => {
     setShowPlayNext(false);
@@ -79,18 +84,28 @@ export function VideoPlayerSingleton() {
     );
   }, [autoplay, autoplaySettings]);
 
-  const canRender = !!rect && (currentUrl || showPlayNext);
+  const activeRect = rect ?? lastRect;
+  const canRender = (Boolean(activeRect) || isAnyFullscreen) && (currentUrl || showPlayNext);
 
   if (!canRender) return null;
 
-  const style: React.CSSProperties = {
-    position: "fixed",
-    top: rect.top,
-    left: rect.left,
-    width: rect.width,
-    height: rect.height,
-    zIndex: 10,
-  };
+  const style: React.CSSProperties =
+    !activeRect && isAnyFullscreen
+      ? {
+          position: "fixed",
+          inset: 0,
+          width: "100vw",
+          height: "100vh",
+          zIndex: 10,
+        }
+      : {
+          position: "fixed",
+          top: activeRect?.top ?? 0,
+          left: activeRect?.left ?? 0,
+          width: activeRect?.width ?? 0,
+          height: activeRect?.height ?? 0,
+          zIndex: 10,
+        };
 
   return createPortal(
     <div ref={containerRef} style={style} className="relative bg-black">


### PR DESCRIPTION
## Issue(s)

## Overview
This PR fixes video playback failures in Firefox by improving source-type handling and fallback behavior in the video player. Also made the video player less wobbly.

- Updated provider MIME mapping for HLS to `application/vnd.apple.mpegurl`.
- Added source-type fallback attempts for internal lesson resources (`application/vnd.apple.mpegurl` -> `video/mp4` -> no explicit type) when playback throws media error code `4`.
- Enabled Video.js VHS with `overrideNative` and disabled native track handling for more consistent cross-browser behavior.
- Prevented redundant source re-initialization by tracking the last applied source signature.
- Improved singleton player rendering/positioning by preserving the last known placeholder rect and supporting fullscreen rendering even when rect is temporarily unavailable.

## Business Value
- Restores reliable lesson video playback for Firefox users.

## Screenshots / Video


https://github.com/user-attachments/assets/9c95b650-5339-4096-97bb-4c608f9b9d03



