### PR TITLE
chore: update email footers to show the correct company name

### DIFF
--- a/apps/api/src/common/emails/emails.service.ts
+++ b/apps/api/src/common/emails/emails.service.ts
@@ -87,9 +87,11 @@ export class EmailService {
   ): Promise<DefaultEmailSettings> {
     return this.tenantRunner.runWithTenant(tenantId, async () => {
       const globalSettings = await this.settingsService.getGlobalSettings();
+      const companyName = globalSettings.companyInformation?.companyName || "Mentingo.com";
 
       return {
         primaryColor: globalSettings.primaryColor || "#4796FD",
+        companyName,
         language:
           language ?? (userId ? await this.getFinalLanguage(userId) : SUPPORTED_LANGUAGES.EN),
       };

--- a/apps/api/src/events/types.ts
+++ b/apps/api/src/events/types.ts
@@ -2,5 +2,6 @@ import type { SupportedLanguages } from "@repo/shared";
 
 export type DefaultEmailSettings = {
   primaryColor: string;
+  companyName: string;
   language: SupportedLanguages;
 };

--- a/packages/email-templates/src/templates/BaseEmailTemplate.tsx
+++ b/packages/email-templates/src/templates/BaseEmailTemplate.tsx
@@ -27,6 +27,7 @@ export const BaseEmailTemplate = ({
   buttonText,
   buttonLink,
   primaryColor,
+  companyName,
 }: BaseEmailTemplateProps) => {
   const styles = getBaseEmailStyles(primaryColor);
 
@@ -96,7 +97,7 @@ export const BaseEmailTemplate = ({
         </Section>
         <Section style={styles.footerSection}>
           <Text style={styles.footerText} className="footer-text">
-            Powered by &copy;{new Date().getFullYear()} Mentingo.com
+            Powered by {companyName}
           </Text>
         </Section>
       </Body>

--- a/packages/email-templates/src/templates/CreatePasswordReminderEmail.tsx
+++ b/packages/email-templates/src/templates/CreatePasswordReminderEmail.tsx
@@ -10,6 +10,7 @@ export type CreatePasswordReminderEmailProps = {
 export const CreatePasswordReminderEmail = ({
   createPasswordLink,
   primaryColor,
+  companyName,
   language = "en",
 }: CreatePasswordReminderEmailProps) => {
   const { heading, paragraphs, buttonText } = getCreatePasswordReminderEmailTranslations(language);
@@ -20,6 +21,7 @@ export const CreatePasswordReminderEmail = ({
     buttonText,
     buttonLink: createPasswordLink,
     primaryColor,
+    companyName,
   });
 };
 

--- a/packages/email-templates/src/templates/FinishedCourseEmail.tsx
+++ b/packages/email-templates/src/templates/FinishedCourseEmail.tsx
@@ -15,6 +15,7 @@ export const FinishedCourseEmail = ({
   courseName,
   progressLink,
   primaryColor,
+  companyName,
   language = "en",
 }: FinishedCourseEmailProps) => {
   const { heading, paragraphs, buttonText } = getFinishedCourseEmailTranslations(
@@ -29,6 +30,7 @@ export const FinishedCourseEmail = ({
     buttonText,
     buttonLink: progressLink,
     primaryColor,
+    companyName,
   });
 };
 

--- a/packages/email-templates/src/templates/MagicLinkEmail.tsx
+++ b/packages/email-templates/src/templates/MagicLinkEmail.tsx
@@ -10,6 +10,7 @@ export type MagicLinkEmailProps = {
 export const MagicLinkEmail = ({
   magicLink,
   primaryColor,
+  companyName,
   language = "en",
 }: MagicLinkEmailProps) => {
   const { heading, paragraphs, buttonText } = getMagicLinkEmailTranslations(language);
@@ -20,6 +21,7 @@ export const MagicLinkEmail = ({
     buttonText,
     buttonLink: magicLink,
     primaryColor,
+    companyName,
   });
 };
 

--- a/packages/email-templates/src/templates/NewUserEmail.tsx
+++ b/packages/email-templates/src/templates/NewUserEmail.tsx
@@ -13,6 +13,7 @@ export const NewUserEmail = ({
   userName,
   profileLink,
   primaryColor,
+  companyName,
   language = "en",
 }: NewUserEmailProps) => {
   const { heading, paragraphs, buttonText } = getNewUserEmailTranslations(language, userName);
@@ -23,6 +24,7 @@ export const NewUserEmail = ({
     buttonText,
     buttonLink: profileLink,
     primaryColor,
+    companyName,
   });
 };
 

--- a/packages/email-templates/src/templates/PasswordRecoveryEmail.tsx
+++ b/packages/email-templates/src/templates/PasswordRecoveryEmail.tsx
@@ -12,6 +12,7 @@ export const PasswordRecoveryEmail = ({
   name,
   resetLink,
   primaryColor,
+  companyName,
   language = "en",
 }: PasswordRecoveryEmailProps) => {
   const { heading, paragraphs, buttonText } = getPasswordRecoveryEmailTranslations(language, name);
@@ -22,6 +23,7 @@ export const PasswordRecoveryEmail = ({
     buttonText,
     buttonLink: resetLink,
     primaryColor,
+    companyName,
   });
 };
 

--- a/packages/email-templates/src/templates/UserAssignedToCourseEmail.tsx
+++ b/packages/email-templates/src/templates/UserAssignedToCourseEmail.tsx
@@ -15,6 +15,7 @@ export const UserAssignedToCourse = ({
   courseName,
   formatedCourseDueDate,
   primaryColor,
+  companyName,
   language = "en",
 }: UserAssignedToCourseProps) => {
   const { heading, paragraphs, buttonText } = getUserAssignedToCourseEmailTranslations(
@@ -29,6 +30,7 @@ export const UserAssignedToCourse = ({
     buttonText,
     buttonLink: courseLink,
     primaryColor,
+    companyName,
   });
 };
 

--- a/packages/email-templates/src/templates/UserFinishedChapterEmail.tsx
+++ b/packages/email-templates/src/templates/UserFinishedChapterEmail.tsx
@@ -15,6 +15,7 @@ export const UserFinishedChapterEmail = ({
   courseLink,
   courseName,
   primaryColor,
+  companyName,
   language = "en",
 }: UserFinishedChapterProps) => {
   const { heading, paragraphs, buttonText } = getUserFinishedChapterEmailTranslations(
@@ -29,6 +30,7 @@ export const UserFinishedChapterEmail = ({
     buttonText,
     buttonLink: courseLink,
     primaryColor,
+    companyName,
   });
 };
 

--- a/packages/email-templates/src/templates/UserFinishedCourseEmail.tsx
+++ b/packages/email-templates/src/templates/UserFinishedCourseEmail.tsx
@@ -14,6 +14,7 @@ export const UserFinishedCourseEmail = ({
   courseName,
   buttonLink,
   primaryColor,
+  companyName,
   language = "en",
   hasCertificate,
 }: UserFinishedCourseProps) => {
@@ -29,6 +30,7 @@ export const UserFinishedCourseEmail = ({
     buttonText,
     buttonLink,
     primaryColor,
+    companyName,
   });
 };
 

--- a/packages/email-templates/src/templates/UserFirstLoginEmail.tsx
+++ b/packages/email-templates/src/templates/UserFirstLoginEmail.tsx
@@ -13,6 +13,7 @@ export const UserFirstLoginEmail = ({
   name,
   coursesUrl,
   primaryColor,
+  companyName,
   language = "en",
 }: UserFirstLoginEmailProps) => {
   const { heading, paragraphs, buttonText } = getUserFirstLoginEmailTranslations(language, name);
@@ -23,6 +24,7 @@ export const UserFirstLoginEmail = ({
     buttonText,
     buttonLink: coursesUrl,
     primaryColor,
+    companyName,
   });
 };
 

--- a/packages/email-templates/src/templates/UserInviteEmail.tsx
+++ b/packages/email-templates/src/templates/UserInviteEmail.tsx
@@ -13,6 +13,7 @@ export const UserInviteEmail = ({
   invitedByUserName,
   createPasswordLink,
   primaryColor,
+  companyName,
   language = "en",
 }: UserInviteProps) => {
   const { heading, paragraphs, buttonText } = getUserInviteEmailTranslations(
@@ -26,6 +27,7 @@ export const UserInviteEmail = ({
     buttonText,
     buttonLink: createPasswordLink,
     primaryColor,
+    companyName,
   });
 };
 

--- a/packages/email-templates/src/templates/UserLongInactivityEmail.tsx
+++ b/packages/email-templates/src/templates/UserLongInactivityEmail.tsx
@@ -13,6 +13,7 @@ export const UserLongInactivityEmail = ({
   courseName,
   courseLink,
   primaryColor,
+  companyName,
   language = "en",
 }: UserLongInactivityProps) => {
   const { heading, paragraphs, buttonText } = getUserLongInactivityEmailTranslations(
@@ -26,6 +27,7 @@ export const UserLongInactivityEmail = ({
     buttonText,
     buttonLink: courseLink,
     primaryColor,
+    companyName,
   });
 };
 

--- a/packages/email-templates/src/templates/UserShortInactivityEmail.tsx
+++ b/packages/email-templates/src/templates/UserShortInactivityEmail.tsx
@@ -13,6 +13,7 @@ export const UserShortInactivityEmail = ({
   courseName,
   courseLink,
   primaryColor,
+  companyName,
   language = "en",
 }: UserShortInactivityProps) => {
   const { heading, paragraphs, buttonText } = getUserShortInactivityEmailTranslations(
@@ -26,6 +27,7 @@ export const UserShortInactivityEmail = ({
     buttonText,
     buttonLink: courseLink,
     primaryColor,
+    companyName,
   });
 };
 

--- a/packages/email-templates/src/templates/WelcomeEmail.tsx
+++ b/packages/email-templates/src/templates/WelcomeEmail.tsx
@@ -11,6 +11,7 @@ export type WelcomeEmailProps = {
 export const WelcomeEmail = ({
   coursesLink,
   primaryColor = "#4796FD",
+  companyName,
   language = "en",
 }: WelcomeEmailProps) => {
   const { heading, paragraphs, buttonText } = getWelcomeEmailTranslations(language);
@@ -21,6 +22,7 @@ export const WelcomeEmail = ({
     buttonText,
     buttonLink: coursesLink,
     primaryColor,
+    companyName,
   });
 };
 

--- a/packages/email-templates/src/types.ts
+++ b/packages/email-templates/src/types.ts
@@ -2,6 +2,7 @@ export type Language = "en" | "pl";
 
 export type DefaultEmailSettings = {
   primaryColor: string;
+  companyName: string;
   language: Language;
 };
 
@@ -11,4 +12,4 @@ export type EmailContent = {
   buttonText: string;
 };
 
-export type BaseEmailSettings = Pick<DefaultEmailSettings, "primaryColor">;
+export type BaseEmailSettings = Omit<DefaultEmailSettings, "language">;


### PR DESCRIPTION
## Issue(s)
- #1386 

## Overview
This PR updates email templates to use the tenant/company name from company information instead of a hardcoded `Mentingo.com` label.

Changes included:
- Read `companyName` from global settings in `EmailService` with fallback to `Mentingo.com`.
- Propagated `companyName` through all email template props and into `BaseEmailTemplate`.
- Updated footer text in base template from static branding to dynamic company name.

## Business Value
Email branding now reflects tenant-specific company information, which improves consistency and white-label experience for end users.

## Screenshots / Video
<img width="2365" height="1576" alt="image" src="https://github.com/user-attachments/assets/3fc77287-6791-405d-9575-e1bff79abb59" />

