### PR TITLE
chore: improve platform security with automated vulnerability scanning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,10 +50,13 @@ TRIVY_SEVERITY ?= HIGH,CRITICAL
 TRIVY_EXIT_CODE ?= 1
 TRIVY_REPORTS_DIR ?= reports/trivy
 
-.PHONY: check-tools
-check-tools:
-	@command -v docker >/dev/null 2>&1 || (echo "Error: docker is not installed or not in PATH." && exit 1)
+.PHONY: check-trivy
+check-trivy:
 	@command -v trivy >/dev/null 2>&1 || (echo "Error: trivy is not installed or not in PATH." && exit 1)
+
+.PHONY: check-tools
+check-tools: check-trivy
+	@command -v docker >/dev/null 2>&1 || (echo "Error: docker is not installed or not in PATH." && exit 1)
 
 .PHONY: docker-build-api
 docker-build-api:
@@ -129,16 +132,18 @@ trivy-scan: check-tools
 .PHONY: trivy-scan-library
 trivy-scan-library: check-tools
 	@mkdir -p $(TRIVY_REPORTS_DIR)
+	@docker image inspect $(API_IMAGE) >/dev/null 2>&1 || (echo "Error: image not found: $(API_IMAGE). Build it first (e.g. make docker-build-api)." && exit 1)
+	@docker image inspect $(WEB_IMAGE) >/dev/null 2>&1 || (echo "Error: image not found: $(WEB_IMAGE). Build it first (e.g. make docker-build-web)." && exit 1)
 	@echo "==> Scanning library vulnerabilities in $(API_IMAGE)"
 	@api_exit=0; \
-	trivy image --vuln-type library --severity $(TRIVY_SEVERITY) --ignore-unfixed --exit-code $(TRIVY_EXIT_CODE) $(API_IMAGE) || api_exit=$$?; \
-	trivy image --vuln-type library --severity $(TRIVY_SEVERITY) --ignore-unfixed --exit-code 0 --format json -o $(TRIVY_REPORTS_DIR)/api-library.json $(API_IMAGE); \
-	trivy image --vuln-type library --severity $(TRIVY_SEVERITY) --ignore-unfixed --exit-code 0 --format sarif -o $(TRIVY_REPORTS_DIR)/api-library.sarif $(API_IMAGE); \
+	trivy image --pkg-types library --severity $(TRIVY_SEVERITY) --ignore-unfixed --exit-code 0 --format json -o $(TRIVY_REPORTS_DIR)/api-library.json $(API_IMAGE) || api_exit=1; \
+	if [ $$api_exit -eq 0 ] && grep -q '"VulnerabilityID"' $(TRIVY_REPORTS_DIR)/api-library.json && [ "$(TRIVY_EXIT_CODE)" != "0" ]; then api_exit=$(TRIVY_EXIT_CODE); fi; \
+	trivy convert --format sarif -o $(TRIVY_REPORTS_DIR)/api-library.sarif $(TRIVY_REPORTS_DIR)/api-library.json || api_exit=1; \
 	echo "==> Scanning library vulnerabilities in $(WEB_IMAGE)"; \
 	web_exit=0; \
-	trivy image --vuln-type library --severity $(TRIVY_SEVERITY) --ignore-unfixed --exit-code $(TRIVY_EXIT_CODE) $(WEB_IMAGE) || web_exit=$$?; \
-	trivy image --vuln-type library --severity $(TRIVY_SEVERITY) --ignore-unfixed --exit-code 0 --format json -o $(TRIVY_REPORTS_DIR)/web-library.json $(WEB_IMAGE); \
-	trivy image --vuln-type library --severity $(TRIVY_SEVERITY) --ignore-unfixed --exit-code 0 --format sarif -o $(TRIVY_REPORTS_DIR)/web-library.sarif $(WEB_IMAGE); \
+	trivy image --pkg-types library --severity $(TRIVY_SEVERITY) --ignore-unfixed --exit-code 0 --format json -o $(TRIVY_REPORTS_DIR)/web-library.json $(WEB_IMAGE) || web_exit=1; \
+	if [ $$web_exit -eq 0 ] && grep -q '"VulnerabilityID"' $(TRIVY_REPORTS_DIR)/web-library.json && [ "$(TRIVY_EXIT_CODE)" != "0" ]; then web_exit=$(TRIVY_EXIT_CODE); fi; \
+	trivy convert --format sarif -o $(TRIVY_REPORTS_DIR)/web-library.sarif $(TRIVY_REPORTS_DIR)/web-library.json || web_exit=1; \
 	echo "==> Filtered library vulnerability table (only reports with findings)"; \
 	found=0; \
 	for report in $(TRIVY_REPORTS_DIR)/api-library.json $(TRIVY_REPORTS_DIR)/web-library.json; do \
@@ -161,5 +166,45 @@ trivy-scan-library: check-tools
 		exit 1; \
 	fi
 
+.PHONY: trivy-scan-fs
+trivy-scan-fs: check-trivy
+	@mkdir -p $(TRIVY_REPORTS_DIR)
+	@echo "==> Scanning filesystem vulnerabilities in repository"
+	@scan_exit=0; \
+	trivy fs --scanners vuln --pkg-types library --severity $(TRIVY_SEVERITY) --ignore-unfixed --exit-code 0 --format json -o $(TRIVY_REPORTS_DIR)/fs-library.json . || scan_exit=1; \
+	if [ $$scan_exit -eq 0 ] && grep -q '"VulnerabilityID"' $(TRIVY_REPORTS_DIR)/fs-library.json && [ "$(TRIVY_EXIT_CODE)" != "0" ]; then scan_exit=$(TRIVY_EXIT_CODE); fi; \
+	trivy convert --format sarif -o $(TRIVY_REPORTS_DIR)/fs-library.sarif $(TRIVY_REPORTS_DIR)/fs-library.json || scan_exit=1; \
+	echo "==> Filtered filesystem vulnerability table (only when findings exist)"; \
+	if grep -q '"VulnerabilityID"' $(TRIVY_REPORTS_DIR)/fs-library.json; then \
+		trivy convert --format table $(TRIVY_REPORTS_DIR)/fs-library.json; \
+	else \
+		echo "No filesystem library vulnerabilities detected for severity $(TRIVY_SEVERITY)."; \
+	fi; \
+	echo "Trivy filesystem reports generated in $(TRIVY_REPORTS_DIR)"; \
+	exit $$scan_exit
+
+.PHONY: trivy-scan-config
+trivy-scan-config: check-trivy
+	@mkdir -p $(TRIVY_REPORTS_DIR)
+	@echo "==> Scanning configuration misconfigurations in repository"
+	@scan_exit=0; \
+	trivy config --severity $(TRIVY_SEVERITY) --exit-code 0 --format json -o $(TRIVY_REPORTS_DIR)/config.json . || scan_exit=1; \
+	if [ $$scan_exit -eq 0 ] && grep -q '"Misconfigurations"' $(TRIVY_REPORTS_DIR)/config.json && grep -q '"Status":"FAIL"' $(TRIVY_REPORTS_DIR)/config.json && [ "$(TRIVY_EXIT_CODE)" != "0" ]; then scan_exit=$(TRIVY_EXIT_CODE); fi; \
+	trivy convert --format sarif -o $(TRIVY_REPORTS_DIR)/config.sarif $(TRIVY_REPORTS_DIR)/config.json || scan_exit=1; \
+	echo "==> Filtered configuration table (only when findings exist)"; \
+	if grep -q '"Status":"FAIL"' $(TRIVY_REPORTS_DIR)/config.json; then \
+		trivy convert --format table $(TRIVY_REPORTS_DIR)/config.json; \
+	else \
+		echo "No failing configuration findings detected for severity $(TRIVY_SEVERITY)."; \
+	fi; \
+	echo "Trivy config reports generated in $(TRIVY_REPORTS_DIR)"; \
+	exit $$scan_exit
+
 .PHONY: security-scan
 security-scan: docker-build trivy-scan
+
+.PHONY: security-scan-library
+security-scan-library: docker-build trivy-scan-library
+
+.PHONY: security-scan-full
+security-scan-full: docker-build trivy-scan trivy-scan-library trivy-scan-fs trivy-scan-config


### PR DESCRIPTION
<!--
 1. Make sure you have correct branch name i.e. `ab_prefix_123_task_name`, where `123` is a issue ID, and `ab` is an author
 2. Make sure you have meaningful title related to task with correct prefix: feat/fix/chore/style/docs/refactor
 3. Reference multiple issues in one PR by listing them in the issues section
 4. Make sure all necessary sections are filled, remove obsolete sections
 5. Do a self review first
 6. Check if your PR includes only code related to your task
 7. `Notes` is used for additional info but also to notify if any action is required
-->
## Overview

This PR adds a structured Trivy security scanning workflow to the `Makefile`, including image scans, library-only scans, filesystem scans, and config scans, with unified reporting and CI-friendly exit behavior.

## What Changed

- `trivy-scan-api` / `trivy-scan-web`
  - Scan container images
  - Generate JSON + SARIF reports
- `trivy-summary`
  - Prints filtered table output only for reports with findings
- `trivy-scan`
  - Runs API + Web image scans and summary
- `trivy-scan-library`
  - Scans image libraries only (`--pkg-types library`)
  - Validates image existence before scanning
  - Generates JSON + SARIF + filtered table output
- `trivy-scan-fs`
  - Scans repository filesystem for library vulnerabilities
  - Generates JSON + SARIF + filtered table output
- `trivy-scan-config`
  - Scans repository configuration misconfigurations
  - Generates JSON + SARIF + filtered table output

## New Composite Security Targets

- `security-scan`
  - `docker-build` + `trivy-scan`
- `security-scan-library`
  - `docker-build` + `trivy-scan-library`
- `security-scan-full`
  - `docker-build` + all scan modes:
    - image (`trivy-scan`)
    - image libraries (`trivy-scan-library`)
    - filesystem (`trivy-scan-fs`)
    - config (`trivy-scan-config`)

## Behavioral Improvements

- Reports are generated even when vulnerabilities are found.
- Exit code handling supports CI failure while still printing final summaries.
- Output is easier to consume due to filtered end-of-run tables.
