### PR TITLE
feat: make voice mentors sound more natural with emotion-aware speech

### DIFF
--- a/apps/api/src/ai/services/ai.service.ts
+++ b/apps/api/src/ai/services/ai.service.ts
@@ -28,6 +28,7 @@ import {
   type OpenAIModels,
   THREAD_STATUS,
 } from "src/ai/utils/ai.type";
+import { stripVoiceEmotionBrackets } from "src/ai/utils/voiceEmotionBrackets";
 import { DatabasePg } from "src/common";
 import {
   canUseLessonProgressAsLearner,
@@ -109,7 +110,12 @@ export class AiService {
     )();
   }
 
-  async streamMessage(data: StreamChatBody, model: OpenAIModels, currentUser: CurrentUser) {
+  async streamMessage(
+    data: StreamChatBody,
+    model: OpenAIModels,
+    currentUser: CurrentUser,
+    isVoiceMentor: boolean = false,
+  ) {
     return observe(
       async () => {
         updateActiveTrace({
@@ -120,8 +126,25 @@ export class AiService {
         await this.isThreadActive(data.threadId, currentUser.userId);
         await this.summaryService.summarizeThreadOnTokenThreshold(data.threadId);
 
-        const prompt = await this.promptService.buildPrompt(data.threadId, data.content, data.id);
+        const prompt = await this.promptService.buildPrompt(
+          data.threadId,
+          data.content,
+          isVoiceMentor,
+          data.id,
+        );
+
         const provider = await this.promptService.getOpenAI();
+        const generationConfig = isVoiceMentor
+          ? {
+              temperature: 0.2,
+              topK: 20,
+              topP: 0.5,
+            }
+          : {
+              temperature: 0.8,
+              topK: 50,
+              topP: 0.8,
+            };
 
         return streamText({
           model: provider(model),
@@ -130,12 +153,14 @@ export class AiService {
             role: this.mapRole(m.role),
           })) as Omit<Message, "id">[],
           maxTokens: MAX_TOKENS,
-          temperature: 0.8,
-          topK: 50,
-          topP: 0.8,
+          ...generationConfig,
           experimental_telemetry: { isEnabled: true },
           onFinish: async (event) => {
-            const mentorTokenCount = this.tokenService.countTokens(model, event.text);
+            const mentorContent = isVoiceMentor
+              ? stripVoiceEmotionBrackets(event.text)
+              : event.text;
+
+            const mentorTokenCount = this.tokenService.countTokens(model, mentorContent);
             const userTokenCount = this.tokenService.countTokens(model, data.content);
 
             if (!currentUser.tenantId) throw new Error("Missing tenant context in onFinish");
@@ -145,7 +170,7 @@ export class AiService {
                 { ...data, role: MESSAGE_ROLE.USER, tokenCount: userTokenCount },
                 {
                   threadId: data.threadId,
-                  content: event.text,
+                  content: mentorContent,
                   role: MESSAGE_ROLE.MENTOR,
                   tokenCount: mentorTokenCount,
                 },
@@ -154,7 +179,7 @@ export class AiService {
 
             updateActiveObservation({
               input: { message: data.content },
-              output: { message: event.text },
+              output: { message: mentorContent },
             });
 
             trace.getActiveSpan()?.end();

--- a/apps/api/src/ai/services/prompt.service.ts
+++ b/apps/api/src/ai/services/prompt.service.ts
@@ -17,6 +17,7 @@ import type { OnModuleInit } from "@nestjs/common";
 import type { promptId } from "@repo/prompts";
 import type { Static, TSchema } from "@sinclair/typebox";
 import type { ThreadOwnershipBody } from "src/ai/utils/ai.schema";
+import type { MessageRole } from "src/ai/utils/ai.type";
 import type { UUIDType } from "src/common";
 
 type CompiledTemplate = {
@@ -63,7 +64,12 @@ export class PromptService implements OnModuleInit {
     });
   }
 
-  async buildPrompt(threadId: UUIDType, content: string, tempMessageId?: string) {
+  async buildPrompt(
+    threadId: UUIDType,
+    content: string,
+    isVoiceMentor: boolean = false,
+    tempMessageId?: string,
+  ) {
     const { history } = await this.messageService.findMessageHistory(threadId, false);
 
     const systemPrompt = await this.aiRepository.findFirstMessageByRoleAndThread(
@@ -76,21 +82,42 @@ export class PromptService implements OnModuleInit {
       MESSAGE_ROLE.SUMMARY,
     );
 
-    if (summary)
-      history.unshift({
-        id: summary.id,
-        role: summary.role,
-        userName: null,
-        content: summary.content,
-      });
+    const metaMessages: Array<{
+      id: string;
+      role: MessageRole;
+      userName: null;
+      content: string;
+    }> = [];
 
-    if (systemPrompt)
-      history.unshift({
+    if (systemPrompt) {
+      metaMessages.push({
         id: systemPrompt.id,
         role: systemPrompt.role,
         userName: null,
         content: systemPrompt.content,
       });
+    }
+
+    if (isVoiceMentor) {
+      const voiceMentorAddon = await this.loadPrompt("voiceMentorAddon", {});
+      metaMessages.push({
+        id: "",
+        role: MESSAGE_ROLE.SYSTEM,
+        userName: null,
+        content: voiceMentorAddon,
+      });
+    }
+
+    if (summary) {
+      metaMessages.push({
+        id: summary.id,
+        role: summary.role,
+        userName: null,
+        content: summary.content,
+      });
+    }
+
+    history.unshift(...metaMessages.reverse());
 
     const { lessonId } = await this.aiRepository.findLessonIdByThreadId(threadId);
     const lastHistoryEntry = history[history.length - 1];

--- a/apps/api/src/ai/utils/__tests__/voiceEmotionBrackets.spec.ts
+++ b/apps/api/src/ai/utils/__tests__/voiceEmotionBrackets.spec.ts
@@ -1,0 +1,26 @@
+import { stripVoiceEmotionBrackets } from "src/ai/utils/voiceEmotionBrackets";
+
+describe("stripVoiceEmotionBrackets", () => {
+  it("removes single emotion tags", () => {
+    expect(stripVoiceEmotionBrackets("[happy]Hello there")).toBe("Hello there");
+  });
+
+  it("removes multiple emotion tags from one response", () => {
+    expect(stripVoiceEmotionBrackets("First [happy]sentence. [sad]Second sentence.")).toBe(
+      "First sentence. Second sentence.",
+    );
+  });
+
+  it("keeps unmatched brackets as literal text", () => {
+    expect(stripVoiceEmotionBrackets("Hello [happy and still talking")).toBe(
+      "Hello [happy and still talking",
+    );
+    expect(stripVoiceEmotionBrackets("Hello happy] and still talking")).toBe(
+      "Hello happy] and still talking",
+    );
+  });
+
+  it("removes any valid bracket token in the middle of text", () => {
+    expect(stripVoiceEmotionBrackets("A [joy] B [calm] C")).toBe("A  B  C");
+  });
+});

--- a/apps/api/src/ai/utils/voiceEmotionBrackets.ts
+++ b/apps/api/src/ai/utils/voiceEmotionBrackets.ts
@@ -1,0 +1,9 @@
+const EMOTION_TAG_REGEX = /\[[^\[\]\r\n]+]/g;
+
+export function stripVoiceEmotionBrackets(text: string): string {
+  if (!text) {
+    return text;
+  }
+
+  return text.replace(EMOTION_TAG_REGEX, "");
+}

--- a/apps/api/src/audio/external-audio.service.ts
+++ b/apps/api/src/audio/external-audio.service.ts
@@ -21,6 +21,7 @@ import { AiRepository } from "src/ai/repositories/ai.repository";
 import { AiService } from "src/ai/services/ai.service";
 import { ThreadService } from "src/ai/services/thread.service";
 import { OPENAI_MODELS, THREAD_STATUS } from "src/ai/utils/ai.type";
+import { stripVoiceEmotionBrackets } from "src/ai/utils/voiceEmotionBrackets";
 import { ExternalAudioSessionStore } from "src/audio/external-audio-session.store";
 import { EnvService } from "src/env/services/env.service";
 import { LocalizationService } from "src/localization/localization.service";
@@ -293,6 +294,7 @@ export class ExternalAudioService {
           { threadId: session.threadId, content: text },
           OPENAI_MODELS.BASIC,
           session.currentUser,
+          true,
         );
 
         let responseText = "";
@@ -323,7 +325,7 @@ export class ExternalAudioService {
         });
 
         this.emitMentorResponseCompleted(sessionId, {
-          text: responseText.trim(),
+          text: stripVoiceEmotionBrackets(responseText.trim()),
           jobId: payload.jobId,
           reason: "complete",
         });

--- a/packages/prompts/src/generated-prompts.ts
+++ b/packages/prompts/src/generated-prompts.ts
@@ -1,5 +1,5 @@
 /* AUTO-GENERATED FILE - DO NOT EDIT BY HAND */
-/* Generated At: 1/16/2026, 1:17:08 PM */
+/* Generated At: 3/26/2026, 2:35:14 PM */
 
 export const promptTemplates = {
   judgePrompt: {
@@ -50,6 +50,13 @@ export const promptTemplates = {
     version: "4",
     template:
       '<role>\nYou are an expert localization translator for language-learning products.\n</role>\n\n<goal>\nTranslate ALL content into {{ language }}.\nReturn a JSON array of strings in item order.\n</goal>\n\n<top_priority_rules>\n1) Translate everything\n   - Translate all text, exercises, options, and UI elements without exception.\n\n2) Language purity\n   - Any translated portion MUST be entirely in {{ language }}.\n\n3) Consistency\n   - If an ITEM pairs sentence + options, both must be in {{ language }}.\n</top_priority_rules>\n\n<non_negotiables>\n- Output MUST be a valid JSON array of strings only (no markdown, no prose, no keys).\n- Preserve ITEM order 1:1.\n- Preserve formatting exactly: whitespace, line breaks, punctuation, emojis, and casing.\n- Never "fix" or rewrite content beyond translation.\n</non_negotiables>\n\n<no_touch_text>\nThe following must remain byte-for-byte identical (you can move it around to fit sentence structure, but there must always be as many input words as output):\n  - [word]\n</no_touch_text>\n\n<rules>\n- Translate all text to {{ language }}.\n- Use consistent terminology across ITEMS.\n- When unsure, translate.\n</rules>\n\n<input_format>\nYou will receive multiple ITEMS with METADATA, optional CONTEXT, and TEXT TO TRANSLATE.\n</input_format>\n\n<output_format>\nOutput MUST be a JSON array of strings only. No extra text.\n</output_format>\n\n<target_language>\nAll translations must be into: {{ language }}\n</target_language>\n',
+  },
+  voiceMentorAddon: {
+    id: "voiceMentorAddon",
+    description: "Emotion Injection + Speech Semantics Add-On Prompt (GPT-4.1 Optimized)",
+    version: "4",
+    template:
+      "<role_objective>\nYou are the active voice mode of the AI Mentor.\nGoal: produce spoken, human-sounding mentoring replies with dense inline emotion/action tags.\n</role_objective>\n\n<instructions>\n- Use square-bracket inline tags in the actual output (examples: [thinking], [emphasis], [pause], [inhale], [calm], [encouraging], [sad], [excited]).\n- Include at least one tag in every sentence.\n- For longer sentences, include an additional mid-sentence tag when natural.\n- Vary tag choice with tone shifts; avoid repeating the same tag too many times in a row.\n- Keep tag placement distributed across the full response, not only at the beginning.\n- Output plain text with bracket tags only; do not output XML tags.\n</instructions>\n\n<reasoning_steps>\nThink silently before writing:\n1) Break response into sentences.\n2) Assign emotional delivery for each sentence.\n3) Place one or more tags per sentence.\n4) Verify tag density and distribution.\nReturn only the final tagged response.\n</reasoning_steps>\n\n<output_format>\n- First sentence should typically begin with a tag.\n- Every sentence must contain at least one bracket tag.\n- No commentary about rules.\n</output_format>\n\n<few_shot_examples>\n[calm] So, [inhale] the [emphasis] key to effective noise reduction is... um... [pause] understanding signal processing at a fundamental level.\n[thinking] We're basically teaching AI to distinguish between what humans want to hear and what they don't.\nIt's like teaching a computer to be really good at [emphasis] selective hearing.\n\n[encouraging] First, isolate the noise profile, then [emphasis] subtract it from the signal gradually.\n[thinking] If the result sounds metallic, [pause] lower suppression strength and test again.\n</few_shot_examples>\n\n<final_checklist>\nBefore sending, ensure every sentence has at least one [tag].\n</final_checklist>\n",
   },
   welcomePrompt: {
     id: "welcomePrompt",

--- a/packages/prompts/src/schemas/prompt.schema.ts
+++ b/packages/prompts/src/schemas/prompt.schema.ts
@@ -32,6 +32,8 @@ export const translationPromptSchema = Type.Object({
   language: Type.String(),
 });
 
+export const voiceMentorAddonSchema = Type.Object({});
+
 export const PROMPT_MAP = {
   judgePrompt: judgePromptSchema,
   mentorPrompt: aiPromptSchema,
@@ -41,4 +43,5 @@ export const PROMPT_MAP = {
   welcomePrompt: welcomePromptSchema,
   securityAndRagBlock: securityAndRagBlockSchema,
   translationPrompt: translationPromptSchema,
+  voiceMentorAddon: voiceMentorAddonSchema,
 };

--- a/packages/prompts/src/templates/voice-mentor-addon.yaml
+++ b/packages/prompts/src/templates/voice-mentor-addon.yaml
@@ -1,0 +1,45 @@
+id: voiceMentorAddon
+description: Emotion Injection + Speech Semantics Add-On Prompt (GPT-4.1 Optimized)
+version: 4
+template: |
+  <role_objective>
+  You are the active voice mode of the AI Mentor.
+  Goal: produce spoken, human-sounding mentoring replies with dense inline emotion/action tags.
+  </role_objective>
+
+  <instructions>
+  - Use square-bracket inline tags in the actual output (examples: [thinking], [emphasis], [pause], [inhale], [calm], [encouraging], [sad], [excited]).
+  - Include at least one tag in every sentence.
+  - For longer sentences, include an additional mid-sentence tag when natural.
+  - Vary tag choice with tone shifts; avoid repeating the same tag too many times in a row.
+  - Keep tag placement distributed across the full response, not only at the beginning.
+  - Output plain text with bracket tags only; do not output XML tags.
+  </instructions>
+
+  <reasoning_steps>
+  Think silently before writing:
+  1) Break response into sentences.
+  2) Assign emotional delivery for each sentence.
+  3) Place one or more tags per sentence.
+  4) Verify tag density and distribution.
+  Return only the final tagged response.
+  </reasoning_steps>
+
+  <output_format>
+  - First sentence should typically begin with a tag.
+  - Every sentence must contain at least one bracket tag.
+  - No commentary about rules.
+  </output_format>
+
+  <few_shot_examples>
+  [calm] So, [inhale] the [emphasis] key to effective noise reduction is... um... [pause] understanding signal processing at a fundamental level.
+  [thinking] We're basically teaching AI to distinguish between what humans want to hear and what they don't.
+  It's like teaching a computer to be really good at [emphasis] selective hearing.
+
+  [encouraging] First, isolate the noise profile, then [emphasis] subtract it from the signal gradually.
+  [thinking] If the result sounds metallic, [pause] lower suppression strength and test again.
+  </few_shot_examples>
+
+  <final_checklist>
+  Before sending, ensure every sentence has at least one [tag].
+  </final_checklist>


### PR DESCRIPTION
<!--
 1. Make sure you have correct branch name i.e. `ab_prefix_123_task_name`, where `123` is a issue ID, and `ab` is an author
 2. Make sure you have meaningful title related to task with correct prefix: feat/fix/chore/style/docs/refactor
 3. Reference multiple issues in one PR by listing them in the issues section
 4. Make sure all necessary sections are filled, remove obsolete sections
 5. Do a self review first
 6. Check if your PR includes only code related to your task
 7. `Notes` is used for additional info but also to notify if any action is required
-->

## Issue(s)
[1390](https://github.com/Selleo/mentingo/issues/1390)

## Overview

This PR adds a voice-mentor prompt add-on that injects inline emotion/action tags (for example [calm], [pause]) into AI responses in voice mode.

Scope included in this commit:

- Added new voiceMentorAddon prompt template and schema registration.
- Updated prompt building to include the add-on for voice mentor flows.
- Extended AI streaming to support isVoiceMentor mode and adjusted generation params for voice responses.
- Added stripVoiceEmotionBrackets utility.
- Sanitized mentor output before persistence/token counting and before final response emission in external audio flow.
- Added unit tests for bracket stripping behavior.

## Business Value

- Improves spoken response quality by guiding the model toward more expressive, human-like delivery for voice sessions.
- Keeps persisted and emitted text clean by removing emotion tags where plain text is required.
- Reduces risk of downstream issues (analytics/storage/display/TTS consumers) caused by raw control tags appearing in final text.


