### PR TITLE
chore: hide the pricing tab when payments aren’t set up

### DIFF
--- a/apps/web/app/modules/Admin/EditCourse/EditCourse.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/EditCourse.tsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate, useParams, useSearchParams } from "@remix-run/react";
+import { Link, type MetaFunction, useNavigate, useParams, useSearchParams } from "@remix-run/react";
 import { COURSE_ORIGIN_TYPES, type SupportedLanguages } from "@repo/shared";
 import { Building } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -45,13 +45,18 @@ import CourseLessons from "./CourseLessons/CourseLessons";
 import CoursePricing from "./CoursePricing/CoursePricing";
 import CourseSettings from "./CourseSettings/CourseSettings";
 import CourseStatus from "./CourseStatus/CourseStatus";
-
-import type { Chapter } from "./EditCourse.types";
-import type { MetaFunction } from "@remix-run/react";
+import { EDIT_COURSE_TABS, type Chapter, type NavigationTab } from "./EditCourse.types";
 
 export const meta: MetaFunction = ({ matches }) => setPageTitle(matches, "pages.editCourse");
 
-const EXPORTED_COURSE_VISIBLE_TAB_VALUES = ["Status", "Enrolled"];
+const EXPORTED_COURSE_VISIBLE_TAB_VALUES: NavigationTab[] = [
+  EDIT_COURSE_TABS.STATUS,
+  EDIT_COURSE_TABS.ENROLLED,
+];
+const EDIT_COURSE_TAB_VALUES = Object.values(EDIT_COURSE_TABS) as NavigationTab[];
+
+const isEditCourseTab = (value: string | null): value is NavigationTab =>
+  value !== null && EDIT_COURSE_TAB_VALUES.includes(value as NavigationTab);
 
 const EditCourse = () => {
   const { t } = useTranslation();
@@ -145,7 +150,7 @@ const EditCourse = () => {
   }, [language, courseLanguage, course, isFetching]);
 
   const handleTabChange = useCallback(
-    (tabValue: string) => {
+    (tabValue: NavigationTab) => {
       setSearchParams((prevParams) => {
         const nextParams = new URLSearchParams(prevParams);
         nextParams.set("tab", tabValue);
@@ -180,7 +185,7 @@ const EditCourse = () => {
 
   const canRefetchChapterList =
     previousDataUpdatedAt && currentDataUpdatedAt && previousDataUpdatedAt < currentDataUpdatedAt;
-  const selectedTab = searchParams.get("tab") ?? EXPORTED_COURSE_VISIBLE_TAB_VALUES[0];
+  const rawSelectedTab = searchParams.get("tab");
 
   const { isExportedCourse, isMasterCourse } = useMemo(() => {
     const isExportedCourse = course?.originType === COURSE_ORIGIN_TYPES.EXPORTED;
@@ -189,17 +194,27 @@ const EditCourse = () => {
     return { isExportedCourse, isMasterCourse };
   }, [course]);
 
+  const selectedTab = isEditCourseTab(rawSelectedTab)
+    ? rawSelectedTab
+    : isExportedCourse
+      ? EDIT_COURSE_TABS.STATUS
+      : EDIT_COURSE_TABS.CURRICULUM;
+
   const { visibleCourseTabs, activeTab } = useMemo(() => {
-    const visibleCourseTabs = isExportedCourse
-      ? courseTabs.filter((tab) => EXPORTED_COURSE_VISIBLE_TAB_VALUES.includes(tab.value))
-      : courseTabs;
+    const canShowPricingTab = Boolean(isStripeConfigured?.enabled && isMasterCourse);
+
+    const visibleCourseTabs = (
+      isExportedCourse
+        ? courseTabs.filter((tab) => EXPORTED_COURSE_VISIBLE_TAB_VALUES.includes(tab.value))
+        : courseTabs
+    ).filter((tab) => tab.value !== EDIT_COURSE_TABS.PRICING || canShowPricingTab);
 
     const activeTab = visibleCourseTabs.some((tab) => tab.value === selectedTab)
       ? selectedTab
-      : EXPORTED_COURSE_VISIBLE_TAB_VALUES[0];
+      : (visibleCourseTabs[0]?.value ?? EDIT_COURSE_TABS.STATUS);
 
     return { visibleCourseTabs, activeTab };
-  }, [courseTabs, isExportedCourse, selectedTab]);
+  }, [courseTabs, isExportedCourse, isMasterCourse, isStripeConfigured?.enabled, selectedTab]);
 
   useEffect(() => {
     if (error) {
@@ -367,7 +382,7 @@ const EditCourse = () => {
             ))}
           </TabsList>
         </div>
-        <TabsContent value="Settings">
+        <TabsContent value={EDIT_COURSE_TABS.SETTINGS}>
           {isExportedCourse ? (
             <SharedCourseReadonlyNotice
               title={sharedCourseNotice.title}
@@ -389,7 +404,7 @@ const EditCourse = () => {
             />
           )}
         </TabsContent>
-        <TabsContent value="Curriculum" className="h-full">
+        <TabsContent value={EDIT_COURSE_TABS.CURRICULUM} className="h-full">
           {isExportedCourse ? (
             <SharedCourseReadonlyNotice
               title={sharedCourseNotice.title}
@@ -412,7 +427,7 @@ const EditCourse = () => {
           )}
         </TabsContent>
         {isMasterCourse && isStripeConfigured?.enabled && (
-          <TabsContent value="Pricing">
+          <TabsContent value={EDIT_COURSE_TABS.PRICING}>
             <CoursePricing
               courseId={course?.id || ""}
               currency={course?.currency}
@@ -421,18 +436,18 @@ const EditCourse = () => {
             />
           </TabsContent>
         )}
-        <TabsContent value="Status">
+        <TabsContent value={EDIT_COURSE_TABS.STATUS}>
           <CourseStatus
             courseId={course?.id || ""}
             status={course?.status || "draft"}
             language={language}
           />
         </TabsContent>
-        <TabsContent value="Enrolled">
+        <TabsContent value={EDIT_COURSE_TABS.ENROLLED}>
           <CourseEnrolled />
         </TabsContent>
         {isManagingTenantAdmin && (
-          <TabsContent value="Exports">
+          <TabsContent value={EDIT_COURSE_TABS.EXPORTS}>
             <SharedCourseExportsTabContent
               tenants={shareableTenants}
               selectedTenantIds={validSelectedTenantIds}

--- a/apps/web/app/modules/Admin/EditCourse/EditCourse.types.ts
+++ b/apps/web/app/modules/Admin/EditCourse/EditCourse.types.ts
@@ -1,7 +1,17 @@
 import type { Question } from "./CourseLessons/NewLesson/QuizLessonForm/QuizLessonForm.types";
 import type { AiMentorTTSPreset, AiMentorType, AiMentorVoiceMode } from "@repo/shared";
 
-export type NavigationTab = "Settings" | "Curriculum" | "Pricing" | "Status";
+export const EDIT_COURSE_TABS = {
+  SETTINGS: "Settings",
+  CURRICULUM: "Curriculum",
+  PRICING: "Pricing",
+  STATUS: "Status",
+  ENROLLED: "Enrolled",
+  EXPORTS: "Exports",
+} as const;
+
+export type EditCourseTab = (typeof EDIT_COURSE_TABS)[keyof typeof EDIT_COURSE_TABS];
+export type NavigationTab = EditCourseTab;
 
 type AiMentor = {
   id: string;

--- a/apps/web/app/modules/Admin/EditCourse/components/NavigationTabs.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/components/NavigationTabs.tsx
@@ -1,7 +1,7 @@
 import * as Tabs from "@radix-ui/react-tabs";
 import { useTranslation } from "react-i18next";
 
-import type { NavigationTab } from "../EditCourse.types";
+import { EDIT_COURSE_TABS, type NavigationTab } from "../EditCourse.types";
 
 type NavigationTabsProps = {
   setNavigationTabState: (navigationTabState: NavigationTab) => void;
@@ -25,14 +25,22 @@ const NavigationTabs = ({ setNavigationTabState }: NavigationTabsProps) => {
   return (
     <Tabs.Root
       className="flex flex-col"
-      defaultValue="Curriculum"
+      defaultValue={EDIT_COURSE_TABS.CURRICULUM}
       onValueChange={handleValueChange}
     >
       <Tabs.List className="flex items-center gap-5 border-b border-gray-200">
-        <TabTrigger value="Settings">{t("adminCourseView.common.settings")}</TabTrigger>
-        <TabTrigger value="Curriculum">{t("adminCourseView.common.curriculum")}</TabTrigger>
-        <TabTrigger value="Pricing">{t("adminCourseView.common.pricing")}</TabTrigger>
-        <TabTrigger value="Status">{t("adminCourseView.common.status")}</TabTrigger>
+        <TabTrigger value={EDIT_COURSE_TABS.SETTINGS}>
+          {t("adminCourseView.common.settings")}
+        </TabTrigger>
+        <TabTrigger value={EDIT_COURSE_TABS.CURRICULUM}>
+          {t("adminCourseView.common.curriculum")}
+        </TabTrigger>
+        <TabTrigger value={EDIT_COURSE_TABS.PRICING}>
+          {t("adminCourseView.common.pricing")}
+        </TabTrigger>
+        <TabTrigger value={EDIT_COURSE_TABS.STATUS}>
+          {t("adminCourseView.common.status")}
+        </TabTrigger>
       </Tabs.List>
     </Tabs.Root>
   );

--- a/apps/web/app/modules/Admin/EditCourse/hooks/useEditCourseTabs.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/hooks/useEditCourseTabs.tsx
@@ -4,6 +4,8 @@ import { useTranslation } from "react-i18next";
 import { useStripeConfigured } from "~/api/queries/useStripeConfigured";
 import { useUserRole } from "~/hooks/useUserRole";
 
+import { EDIT_COURSE_TABS } from "../EditCourse.types";
+
 export const useEditCourseTabs = () => {
   const { t } = useTranslation();
   const { data: isStripeConfigured } = useStripeConfigured();
@@ -12,26 +14,31 @@ export const useEditCourseTabs = () => {
 
   const baseTabs = useMemo(
     () => [
-      { label: t("adminCourseView.common.settings"), value: "Settings" },
-      { label: t("adminCourseView.common.curriculum"), value: "Curriculum" },
+      { label: t("adminCourseView.common.settings"), value: EDIT_COURSE_TABS.SETTINGS },
+      { label: t("adminCourseView.common.curriculum"), value: EDIT_COURSE_TABS.CURRICULUM },
       ...(isStripeConfigured?.enabled
         ? [
             {
               label: t("adminCourseView.common.pricing"),
-              value: "Pricing",
+              value: EDIT_COURSE_TABS.PRICING,
             },
           ]
         : []),
-      { label: t("adminCourseView.common.status"), value: "Status" },
+      { label: t("adminCourseView.common.status"), value: EDIT_COURSE_TABS.STATUS },
     ],
     [isStripeConfigured, t],
   );
 
   const adminTabs = useMemo(
     () => [
-      { label: t("adminCourseView.common.enrolledStudents"), value: "Enrolled" },
+      { label: t("adminCourseView.common.enrolledStudents"), value: EDIT_COURSE_TABS.ENROLLED },
       ...(isManagingTenantAdmin
-        ? [{ label: t("adminCourseView.sharedCourse.exportsTitle"), value: "Exports" }]
+        ? [
+            {
+              label: t("adminCourseView.sharedCourse.exportsTitle"),
+              value: EDIT_COURSE_TABS.EXPORTS,
+            },
+          ]
         : []),
     ],
     [isManagingTenantAdmin, t],


### PR DESCRIPTION
## Issue(s)
- #1341 

## Overview
- Refactored Edit Course tab handling to use a single shared constant map (`EDIT_COURSE_TABS`) instead of scattered string literals.
- Updated tab usage across:
  - `EditCourse.tsx`
  - `useEditCourseTabs.tsx`
  - `NavigationTabs.tsx`
  - `EditCourse.types.ts`
- Simplified and clarified tab selection logic:
  - Default tab is `Status` for exported courses.
  - Default tab is `Curriculum` for non-exported courses.
  - Invalid `tab` query param values are ignored and safely fall back to defaults.
- Ensured `Pricing` tab visibility is consistent with content rendering rules (Stripe enabled + master course).

## Business Value
- Reduces risk of tab-related regressions by centralizing tab IDs in one source of truth.
- Prevents confusing UX states (for example, visible tab without corresponding content).
- Keeps exported and non-exported course flows predictable with explicit default tabs.

## Screenshots / Video

https://github.com/user-attachments/assets/3b31d8d0-80b2-4be3-b0fb-92e76eefbaf5


https://github.com/user-attachments/assets/b649efca-9f33-4e0e-8fd0-564589f0f9f2

