### PR TITLE
chore: remove line insert before resources in content lesson editor

### DIFF
--- a/apps/web/app/hooks/useEntityResourceUpload.ts
+++ b/apps/web/app/hooks/useEntityResourceUpload.ts
@@ -52,7 +52,7 @@ export const insertResourceIntoEditor = ({
   displayMode = "preview",
 }: InsertResourceArgs) => {
   const resourceUrl = buildEntityResourceUrl(resourceId, entityType);
-  const chain = editor?.chain().insertContent("<br />");
+  const chain = editor?.chain();
 
   if (resourceType === "presentation") {
     if (displayMode === "download") {

--- a/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/ContentLessonForm/ContentLessonForm.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/ContentLessonForm/ContentLessonForm.tsx
@@ -118,7 +118,6 @@ const ContentLessonForm = ({
 
           editor
             ?.chain()
-            .insertContent("<br />")
             .setVideoEmbed({
               src: resourceUrl,
               sourceType: session.provider === "s3" ? "external" : "internal",

--- a/apps/web/app/modules/Articles/ArticleForm.page.tsx
+++ b/apps/web/app/modules/Articles/ArticleForm.page.tsx
@@ -218,7 +218,6 @@ function ArticleFormPage({ defaultValues }: ArticleFormPageProps) {
 
           editor
             ?.chain()
-            .insertContent("<br />")
             .setVideoEmbed({
               src: resourceUrl,
               sourceType: session.provider === "s3" ? "external" : "internal",

--- a/apps/web/app/modules/News/NewsForm.page.tsx
+++ b/apps/web/app/modules/News/NewsForm.page.tsx
@@ -219,7 +219,6 @@ function NewsFormPage({ defaultValues }: NewsFormPageProps) {
 
           editor
             ?.chain()
-            .insertContent("<br />")
             .setVideoEmbed({
               src: resourceUrl,
               sourceType: session.provider === "s3" ? "external" : "internal",


### PR DESCRIPTION
## Issue(s)
[Issue #1359](https://github.com/Selleo/mentingo/issues/1359)

## Overview
Removed redundant line break insertion in rich-text upload flows so embedded content is inserted without extra blank lines above it.

Changes included in this commit:
- Removed `.insertContent("<br />")` before video embed insertion in content lessons.
- Removed `.insertContent("<br />")` before video embed insertion in articles.
- Removed `.insertContent("<br />")` before video embed insertion in news.
- Updated shared `insertResourceIntoEditor` helper to stop pre-inserting `<br />` before resource nodes.

## Business Value
Prevents accidental extra spacing in authored content, resulting in cleaner lesson/article/news presentation and less manual cleanup for content creators.

## Screenshots / Video

https://github.com/user-attachments/assets/760fedfc-9364-4424-833b-eb6f5f4a67a3

