### PR TITLE
fix: prevent crashes when non-authors open draft courses

### DIFF
--- a/apps/api/src/courses/__tests__/course.controller.e2e-spec.ts
+++ b/apps/api/src/courses/__tests__/course.controller.e2e-spec.ts
@@ -3292,5 +3292,65 @@ describe("CourseController (e2e)", () => {
         .where(eq(courses.id, course.id));
       expect(courseAfter.shortId).toHaveLength(5);
     });
+
+    it.each([
+      ["draft", "Draft course"],
+      ["private", "Private course"],
+    ] as const)("allows admin to lookup %s course even when not author", async (status, title) => {
+      const admin = await userFactory
+        .withCredentials({ password })
+        .withAdminSettings(db)
+        .create({ role: USER_ROLES.ADMIN });
+      const contentCreator = await userFactory
+        .withCredentials({ password })
+        .withContentCreatorSettings(db)
+        .create({ role: USER_ROLES.CONTENT_CREATOR });
+      const category = await categoryFactory.create();
+      const course = await courseFactory.create({
+        authorId: contentCreator.id,
+        categoryId: category.id,
+        status,
+        title,
+      });
+
+      const response = await request(app.getHttpServer())
+        .get("/api/course/lookup")
+        .query({ id: course.id, language: "en" })
+        .set("Cookie", await cookieFor(admin, app))
+        .expect(200);
+
+      expect(response.body.data.status).toBe("found");
+      expect(response.body.data.slug).toBeDefined();
+    });
+
+    it.each([
+      ["draft", "Draft course"],
+      ["private", "Private course"],
+    ] as const)(
+      "allows admin to get %s course details even when not author",
+      async (status, title) => {
+        const admin = await userFactory
+          .withCredentials({ password })
+          .withAdminSettings(db)
+          .create({ role: USER_ROLES.ADMIN });
+        const contentCreator = await userFactory
+          .withCredentials({ password })
+          .withContentCreatorSettings(db)
+          .create({ role: USER_ROLES.CONTENT_CREATOR });
+        const category = await categoryFactory.create();
+        const course = await courseFactory.create({
+          authorId: contentCreator.id,
+          categoryId: category.id,
+          status,
+          title,
+        });
+
+        await request(app.getHttpServer())
+          .get("/api/course")
+          .query({ id: course.id, language: "en" })
+          .set("Cookie", await cookieFor(admin, app))
+          .expect(200);
+      },
+    );
   });
 });

--- a/apps/api/src/courses/__tests__/course.controller.e2e-spec.ts
+++ b/apps/api/src/courses/__tests__/course.controller.e2e-spec.ts
@@ -3300,11 +3300,11 @@ describe("CourseController (e2e)", () => {
       const admin = await userFactory
         .withCredentials({ password })
         .withAdminSettings(db)
-        .create({ role: USER_ROLES.ADMIN });
+        .create({ role: SYSTEM_ROLE_SLUGS.ADMIN });
       const contentCreator = await userFactory
         .withCredentials({ password })
         .withContentCreatorSettings(db)
-        .create({ role: USER_ROLES.CONTENT_CREATOR });
+        .create({ role: SYSTEM_ROLE_SLUGS.CONTENT_CREATOR });
       const category = await categoryFactory.create();
       const course = await courseFactory.create({
         authorId: contentCreator.id,
@@ -3332,11 +3332,11 @@ describe("CourseController (e2e)", () => {
         const admin = await userFactory
           .withCredentials({ password })
           .withAdminSettings(db)
-          .create({ role: USER_ROLES.ADMIN });
+          .create({ role: SYSTEM_ROLE_SLUGS.ADMIN });
         const contentCreator = await userFactory
           .withCredentials({ password })
           .withContentCreatorSettings(db)
-          .create({ role: USER_ROLES.CONTENT_CREATOR });
+          .create({ role: SYSTEM_ROLE_SLUGS.CONTENT_CREATOR });
         const category = await categoryFactory.create();
         const course = await courseFactory.create({
           authorId: contentCreator.id,

--- a/apps/api/src/courses/course.controller.ts
+++ b/apps/api/src/courses/course.controller.ts
@@ -22,6 +22,7 @@ import {
   ALLOWED_LESSON_IMAGE_FILE_TYPES,
   PERMISSIONS,
   SupportedLanguages,
+  type PermissionKey,
 } from "@repo/shared";
 import { Type } from "@sinclair/typebox";
 import { Request } from "express";
@@ -374,12 +375,12 @@ export class CourseController {
     @Query("id") idOrSlug: string,
     @Query("language") language: SupportedLanguages,
     @CurrentUser("userId") currentUserId: UUIDType,
-    @CurrentUser("role") currentUserRole?: UserRole,
+    @CurrentUser("permissions") currentUserPermissions: PermissionKey[] = [],
   ): Promise<BaseResponse<CommonShowCourse>> {
     const course = await this.courseService.getCourse(
       idOrSlug,
       currentUserId,
-      currentUserRole,
+      currentUserPermissions,
       language,
     );
     return new BaseResponse(course);
@@ -398,13 +399,13 @@ export class CourseController {
     @Query("id") idOrSlug: string,
     @Query("language") language: SupportedLanguages,
     @CurrentUser("userId") currentUserId?: UUIDType,
-    @CurrentUser("role") currentUserRole?: UserRole,
+    @CurrentUser("permissions") currentUserPermissions: PermissionKey[] = [],
   ): Promise<BaseResponse<CourseLookupResponse>> {
     const result = await this.courseService.lookupCourse(
       idOrSlug,
       language,
       currentUserId,
-      currentUserRole,
+      currentUserPermissions,
     );
 
     return new BaseResponse(result);

--- a/apps/api/src/courses/course.controller.ts
+++ b/apps/api/src/courses/course.controller.ts
@@ -374,8 +374,14 @@ export class CourseController {
     @Query("id") idOrSlug: string,
     @Query("language") language: SupportedLanguages,
     @CurrentUser("userId") currentUserId: UUIDType,
+    @CurrentUser("role") currentUserRole?: UserRole,
   ): Promise<BaseResponse<CommonShowCourse>> {
-    const course = await this.courseService.getCourse(idOrSlug, currentUserId, language);
+    const course = await this.courseService.getCourse(
+      idOrSlug,
+      currentUserId,
+      currentUserRole,
+      language,
+    );
     return new BaseResponse(course);
   }
 
@@ -392,8 +398,14 @@ export class CourseController {
     @Query("id") idOrSlug: string,
     @Query("language") language: SupportedLanguages,
     @CurrentUser("userId") currentUserId?: UUIDType,
+    @CurrentUser("role") currentUserRole?: UserRole,
   ): Promise<BaseResponse<CourseLookupResponse>> {
-    const result = await this.courseService.lookupCourse(idOrSlug, language, currentUserId);
+    const result = await this.courseService.lookupCourse(
+      idOrSlug,
+      language,
+      currentUserId,
+      currentUserRole,
+    );
 
     return new BaseResponse(result);
   }

--- a/apps/api/src/courses/course.service.ts
+++ b/apps/api/src/courses/course.service.ts
@@ -1031,6 +1031,7 @@ export class CourseService {
   async getCourse(
     idOrSlug: UUIDType | string,
     userId: UUIDType,
+    userRole: UserRole | undefined,
     language: SupportedLanguages,
   ): Promise<CommonShowCourse> {
     const { courseId: id, slug: currentSlug } = match(
@@ -1091,9 +1092,15 @@ export class CourseService {
 
     const isEnrolled = !!course.enrolled;
     const NON_PUBLIC_STATUSES = ["draft", "private"];
+    const isAdmin = userRole === USER_ROLES.ADMIN;
 
     if (!course) throw new NotFoundException("Course not found");
-    if (userId !== course.authorId && NON_PUBLIC_STATUSES.includes(course.status) && !isEnrolled)
+    if (
+      !isAdmin &&
+      userId !== course.authorId &&
+      NON_PUBLIC_STATUSES.includes(course.status) &&
+      !isEnrolled
+    )
       throw new ForbiddenException("You have no access to this course");
 
     const courseChapterList = await this.db
@@ -1223,6 +1230,7 @@ export class CourseService {
     idOrSlug: string,
     language: SupportedLanguages,
     userId?: UUIDType,
+    userRole?: UserRole,
   ): Promise<CourseLookupResponse> {
     const lookupResult = await this.courseSlugService.getCourseIdBySlug(idOrSlug, language);
 
@@ -1258,9 +1266,11 @@ export class CourseService {
 
     const isEnrolled = !!course.enrolled;
     const NON_PUBLIC_STATUSES = ["draft", "private"];
+    const isAdmin = userRole === USER_ROLES.ADMIN;
 
     if (userId !== undefined) {
       if (
+        !isAdmin &&
         userId !== course.authorId &&
         NON_PUBLIC_STATUSES.includes(course.status) &&
         !isEnrolled

--- a/apps/api/src/courses/course.service.ts
+++ b/apps/api/src/courses/course.service.ts
@@ -9,7 +9,14 @@ import {
   NotFoundException,
 } from "@nestjs/common";
 import { BaseEmailTemplate } from "@repo/email-templates";
-import { COURSE_ENROLLMENT, SUPPORTED_LANGUAGES, ENTITY_TYPES, PERMISSIONS } from "@repo/shared";
+import {
+  COURSE_ENROLLMENT,
+  SUPPORTED_LANGUAGES,
+  ENTITY_TYPES,
+  PERMISSIONS,
+  type PermissionKey,
+  type SupportedLanguages,
+} from "@repo/shared";
 import { load as loadHtml } from "cheerio";
 import {
   and,
@@ -143,7 +150,6 @@ import type { CommonShowBetaCourse, CommonShowCourse } from "./schemas/showCours
 import type { UpdateCourseBody } from "./schemas/updateCourse.schema";
 import type { UpdateCourseSettings } from "./schemas/updateCourseSettings.schema";
 import type { CoursesSettings } from "./types/settings";
-import type { SupportedLanguages } from "@repo/shared";
 import type { SQL } from "drizzle-orm";
 import type { AnyPgColumn } from "drizzle-orm/pg-core";
 import type { CourseActivityLogSnapshot } from "src/activity-logs/types";
@@ -1031,7 +1037,7 @@ export class CourseService {
   async getCourse(
     idOrSlug: UUIDType | string,
     userId: UUIDType,
-    userRole: UserRole | undefined,
+    userPermissions: PermissionKey[] = [],
     language: SupportedLanguages,
   ): Promise<CommonShowCourse> {
     const { courseId: id, slug: currentSlug } = match(
@@ -1092,7 +1098,7 @@ export class CourseService {
 
     const isEnrolled = !!course.enrolled;
     const NON_PUBLIC_STATUSES = ["draft", "private"];
-    const isAdmin = userRole === USER_ROLES.ADMIN;
+    const isAdmin = hasPermission(userPermissions, PERMISSIONS.COURSE_UPDATE);
 
     if (!course) throw new NotFoundException("Course not found");
     if (
@@ -1230,7 +1236,7 @@ export class CourseService {
     idOrSlug: string,
     language: SupportedLanguages,
     userId?: UUIDType,
-    userRole?: UserRole,
+    userPermissions: PermissionKey[] = [],
   ): Promise<CourseLookupResponse> {
     const lookupResult = await this.courseSlugService.getCourseIdBySlug(idOrSlug, language);
 
@@ -1266,7 +1272,7 @@ export class CourseService {
 
     const isEnrolled = !!course.enrolled;
     const NON_PUBLIC_STATUSES = ["draft", "private"];
-    const isAdmin = userRole === USER_ROLES.ADMIN;
+    const isAdmin = hasPermission(userPermissions, PERMISSIONS.COURSE_UPDATE);
 
     if (userId !== undefined) {
       if (

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "prettier": "^3.3.3",
     "prettier-plugin-tailwindcss": "0.6.9",
     "tsc-files": "^1.1.4",
-    "turbo": "^2.2.3"
+    "turbo": "^2.2.3",
+    "typescript": "5.4.5"
   },
   "packageManager": "pnpm@10.22.0",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,10 +28,13 @@ importers:
         version: 0.6.9(prettier@3.4.1)
       tsc-files:
         specifier: ^1.1.4
-        version: 1.1.4(typescript@5.9.3)
+        version: 1.1.4(typescript@5.4.5)
       turbo:
         specifier: ^2.2.3
         version: 2.3.3
+      typescript:
+        specifier: 5.4.5
+        version: 5.4.5
 
   apps/api:
     dependencies:
@@ -35573,9 +35576,9 @@ snapshots:
 
   ts-pattern@5.2.0: {}
 
-  tsc-files@1.1.4(typescript@5.9.3):
+  tsc-files@1.1.4(typescript@5.4.5):
     dependencies:
-      typescript: 5.9.3
+      typescript: 5.4.5
 
   tsconfck@3.1.4(typescript@5.4.5):
     optionalDependencies:


### PR DESCRIPTION
## Issue(s)
- #1342 

## Overview
- Fixed backend access logic for course preview/details so `admin` users can access `draft` and `private` courses even when they are not the course author.
- Updated `GET /api/course` and `GET /api/course/lookup` flow to pass current user role into service-level authorization checks.
- Added e2e regression tests covering admin non-author access for both endpoints and both non-public statuses.

## Business Value
- Removes a blocker where admins could see courses in listings but then failed to open preview/details due to `404`.
- Aligns backend behavior with admin expectations and platform role permissions.
- Reduces support overhead and improves reliability of admin workflows around course management and preview.

## Screenshots / Video

https://github.com/user-attachments/assets/7ea3ce47-5215-4431-8c49-847e1a7ac06b



