### PR TITLE
chore: show a dedicated AI mentor loading state when moving between lessons

### DIFF
--- a/apps/web/app/modules/Courses/Lesson/Lesson.page.tsx
+++ b/apps/web/app/modules/Courses/Lesson/Lesson.page.tsx
@@ -7,10 +7,12 @@ import { useTranslation } from "react-i18next";
 import { useCourse, useCurrentUser, useLesson } from "~/api/queries";
 import { queryClient } from "~/api/queryClient";
 import ErrorPage from "~/components/ErrorPage/ErrorPage";
+import { LoaderWithTextSequence } from "~/components/LoaderWithTextSequence";
 import { PageWrapper } from "~/components/PageWrapper";
 import { getNextVideoUrl } from "~/components/VideoPlayer/autoplayFlow";
 import { useVideoPlayer } from "~/components/VideoPlayer/VideoPlayerContext";
 import { useLearningTimeTracker } from "~/hooks/useLearningTimeTracker";
+import { LessonType } from "~/modules/Admin/EditCourse/EditCourse.types";
 import Loader from "~/modules/common/Loader/Loader";
 import { useVideoPreferencesStore } from "~/modules/common/store/useVideoPreferencesStore";
 import { CourseAccessProvider } from "~/modules/Courses/context/CourseAccessProvider";
@@ -126,9 +128,17 @@ export default function LessonPage() {
   }
 
   if (!lesson || !course) {
+    const targetLessonType = course?.chapters
+      .flatMap((chapter) => chapter.lessons)
+      .find((courseLesson) => courseLesson.id === lessonId)?.type;
+
     return (
       <div className="fixed inset-0 grid place-items-center">
-        <Loader />
+        {targetLessonType === LessonType.AI_MENTOR ? (
+          <LoaderWithTextSequence preset="aiMentor" />
+        ) : (
+          <Loader />
+        )}
       </div>
     );
   }


### PR DESCRIPTION
## Issue(s)
- #1146 

## Overview
This PR fixes the loading state shown when navigating to the next lesson and the target lesson is `ai_mentor`.

Now, during fallback rendering, we detect the target lesson type from the already loaded course chapters. If the target lesson type is `ai_mentor`, we render `LoaderWithTextSequence` with the `aiMentor` preset. 

## Business Value
This improves consistency and perceived quality in the student learning flow.

When users move to an AI mentor lesson, they now see the same contextual loading experience they get elsewhere for AI mentor interactions. This reduces confusion during transitions and better communicates that the AI mentor session is being prepared.

## Screenshots / Video

https://github.com/user-attachments/assets/4c4e386d-b797-48b1-8e63-4add3d6a436d

