### PR TITLE
feat: add video upload queueing to make uploads smoother and more reliable

### DIFF
--- a/apps/web/app/components/RichText/Editor.tsx
+++ b/apps/web/app/components/RichText/Editor.tsx
@@ -2,7 +2,6 @@ import { ALLOWED_LESSON_IMAGE_FILE_TYPES, detectVideoProviderFromUrl } from "@re
 import { EditorContent, useEditor, type Editor as TiptapEditor } from "@tiptap/react";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 
-import { Progress } from "~/components/ui/progress";
 import { cn } from "~/lib/utils";
 
 import { detectPresentationProvider } from "./extensions/utils/presentation";
@@ -22,7 +21,7 @@ type EditorProps = {
   parentClassName?: string;
   lessonId?: string;
   allowFiles?: boolean;
-  acceptedFileTypes?: string[];
+  acceptedFileTypes?: readonly string[];
   variant?: "base" | "content";
 };
 
@@ -34,7 +33,6 @@ const Editor = ({
   onChange,
   onUpload,
   onCtrlSave,
-  uploadProgress,
   id,
   parentClassName,
   allowFiles = false,
@@ -158,11 +156,6 @@ const Editor = ({
         acceptedFileTypes={acceptedFileTypes}
         onUpload={onUpload}
       />
-      {uploadProgress && (
-        <div className="border-t border-neutral-200 relative">
-          <Progress value={uploadProgress} className="h-3 rounded-none" />
-        </div>
-      )}
       <EditorContent id={id} editor={editor} placeholder={placeholder} className={editorClasses} />
     </div>
   );

--- a/apps/web/app/components/RichText/RichTextUploadQueue.tsx
+++ b/apps/web/app/components/RichText/RichTextUploadQueue.tsx
@@ -1,0 +1,207 @@
+import {
+  CheckCircle2,
+  ChevronDown,
+  ChevronUp,
+  Clock3,
+  Loader2,
+  Trash2,
+  X,
+  XCircle,
+} from "lucide-react";
+import { useMemo, useState } from "react";
+import { match } from "ts-pattern";
+
+import { Button } from "~/components/ui/button";
+import { CircularProgress } from "~/components/ui/circular-progress";
+import { Progress } from "~/components/ui/progress";
+import { ACTIVE_UPLOAD_STATUSES, UPLOAD_STATUS } from "~/hooks/useRichTextUploadQueue";
+import { cn } from "~/lib/utils";
+
+import type { RichTextUploadQueueItem, RichTextUploadStatus } from "~/hooks/useRichTextUploadQueue";
+
+type RichTextUploadQueueProps = {
+  items: RichTextUploadQueueItem[];
+  onClearFinished: () => void;
+  onRemoveItem: (id: string) => void;
+};
+
+const statusMeta = {
+  [UPLOAD_STATUS.QUEUED]: { label: "Queued", icon: Clock3, colorClass: "text-neutral-600" },
+  [UPLOAD_STATUS.UPLOADING]: {
+    label: "Uploading",
+    icon: Loader2,
+    colorClass: "text-primary-700",
+  },
+  [UPLOAD_STATUS.PROCESSING]: {
+    label: "Processing",
+    icon: Loader2,
+    colorClass: "text-secondary-700",
+  },
+  [UPLOAD_STATUS.SUCCESS]: { label: "Done", icon: CheckCircle2, colorClass: "text-success-700" },
+  [UPLOAD_STATUS.FAILED]: { label: "Failed", icon: XCircle, colorClass: "text-error-700" },
+} satisfies Record<
+  RichTextUploadStatus,
+  { label: string; icon: typeof CheckCircle2; colorClass: string }
+>;
+
+const getItemProgress = (status: RichTextUploadStatus, progress: number | null) =>
+  match(status)
+    .with(UPLOAD_STATUS.QUEUED, () => 0)
+    .with(UPLOAD_STATUS.SUCCESS, () => 100)
+    .with(UPLOAD_STATUS.FAILED, () => 0)
+    .with(UPLOAD_STATUS.PROCESSING, () => 100)
+    .otherwise(() => progress ?? 0);
+
+export const RichTextUploadQueue = ({
+  items,
+  onClearFinished,
+  onRemoveItem,
+}: RichTextUploadQueueProps) => {
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  const activeItems = useMemo(
+    () => items.filter((item) => ACTIVE_UPLOAD_STATUSES.includes(item.status)),
+    [items],
+  );
+
+  const hasFinished = useMemo(
+    () =>
+      items.some(
+        (item) => item.status === UPLOAD_STATUS.SUCCESS || item.status === UPLOAD_STATUS.FAILED,
+      ),
+    [items],
+  );
+
+  const overallProgress = useMemo(() => {
+    if (!activeItems.length) return 100;
+
+    const total = activeItems.reduce(
+      (sum, item) => sum + getItemProgress(item.status, item.progress),
+      0,
+    );
+
+    return Math.round(total / activeItems.length);
+  }, [activeItems]);
+
+  if (!items.length) return null;
+
+  return (
+    <section
+      className="pointer-events-auto w-full overflow-hidden rounded-xl border border-neutral-200 bg-white"
+      aria-label="Upload queue"
+    >
+      <button
+        type="button"
+        className="flex w-full items-center justify-between gap-3 border-b border-neutral-200 bg-gradient-to-b from-neutral-50 to-white px-4 py-3 text-left"
+        onClick={() => setIsExpanded((prev) => !prev)}
+      >
+        <div className="flex items-center gap-3">
+          <CircularProgress
+            value={overallProgress}
+            size={52}
+            circleStrokeWidth={4}
+            progressStrokeWidth={4}
+            showLabel
+            renderLabel={(value) => `${value}%`}
+            labelClassName="text-sm font-semibold text-neutral-800"
+          />
+          <div>
+            <p className="text-lg font-semibold text-neutral-950">Uploads</p>
+            <p className="text-sm text-neutral-600">
+              {activeItems.length ? `${activeItems.length} active` : `${items.length} completed`}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          {hasFinished && (
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              className="h-8 px-2 text-neutral-600 hover:bg-neutral-100 hover:text-neutral-800"
+              onClick={(event) => {
+                event.stopPropagation();
+                onClearFinished();
+              }}
+            >
+              <Trash2 className="mr-1.5 size-3.5" />
+              Clear
+            </Button>
+          )}
+          <span className="rounded-md p-1.5 text-neutral-600">
+            {isExpanded ? <ChevronDown className="size-5" /> : <ChevronUp className="size-5" />}
+          </span>
+        </div>
+      </button>
+
+      {isExpanded && (
+        <div className="max-h-[360px] space-y-2.5 overflow-y-auto bg-neutral-50/60 p-3">
+          {items.map(({ status, id, progress, errorMessage, fileName }) => {
+            const { icon: StatusIcon, label, colorClass } = statusMeta[status];
+            const isActive = ACTIVE_UPLOAD_STATUSES.includes(status);
+            const isAnimated =
+              status === UPLOAD_STATUS.UPLOADING || status === UPLOAD_STATUS.PROCESSING;
+            const showProgress =
+              status === UPLOAD_STATUS.UPLOADING || status === UPLOAD_STATUS.QUEUED;
+            const itemProgress = getItemProgress(status, progress);
+
+            return (
+              <article
+                key={id}
+                className="rounded-xl border border-neutral-200 bg-white px-3.5 py-3 shadow-[0_2px_10px_-8px_rgba(15,23,42,0.5)]"
+              >
+                <div className="flex items-start gap-3">
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-semibold text-neutral-900">{fileName}</p>
+                    <div className="mt-1 flex items-center gap-2">
+                      <StatusIcon
+                        className={cn("size-4", colorClass, isAnimated && "animate-spin")}
+                      />
+                      <p className={cn("text-xs font-medium", colorClass)}>
+                        {label}
+                        {status === UPLOAD_STATUS.UPLOADING && progress !== null
+                          ? ` (${progress}%)`
+                          : ""}
+                      </p>
+                    </div>
+                    {errorMessage && <p className="mt-1 text-xs text-error-700">{errorMessage}</p>}
+                  </div>
+
+                  {isActive ? (
+                    <CircularProgress
+                      value={itemProgress}
+                      size={34}
+                      circleStrokeWidth={3}
+                      progressStrokeWidth={3}
+                      className="self-center"
+                      showLabel={status === UPLOAD_STATUS.UPLOADING}
+                      renderLabel={(value) => `${value}`}
+                      labelClassName="text-[10px] font-semibold text-neutral-700"
+                    />
+                  ) : (
+                    <Button
+                      type="button"
+                      size="icon"
+                      variant="ghost"
+                      className="size-7 self-center rounded-full text-neutral-500 hover:bg-neutral-100 hover:text-neutral-700"
+                      onClick={() => onRemoveItem(id)}
+                    >
+                      <X className="size-4" />
+                    </Button>
+                  )}
+                </div>
+
+                {showProgress && (
+                  <div className="mt-2.5">
+                    <Progress value={itemProgress} className="h-1.5" />
+                  </div>
+                )}
+              </article>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+};

--- a/apps/web/app/components/RichText/toolbar/EditorToolbar.tsx
+++ b/apps/web/app/components/RichText/toolbar/EditorToolbar.tsx
@@ -1,4 +1,5 @@
 import { ALLOWED_LESSON_IMAGE_FILE_TYPES } from "@repo/shared";
+import { NodeSelection, TextSelection } from "@tiptap/pm/state";
 import {
   Bold,
   Code,
@@ -33,7 +34,7 @@ import type React from "react";
 type EditorToolbarProps = {
   editor: Editor;
   allowFiles?: boolean;
-  acceptedFileTypes?: string[];
+  acceptedFileTypes?: readonly string[];
   onUpload?: (file?: File, editor?: Editor | null) => Promise<void>;
 };
 
@@ -68,14 +69,28 @@ const EditorToolbar = ({
 
   const acceptedImages = acceptedFileTypes.join(",");
 
+  const moveCursorAfterCurrentSelection = () => {
+    const { state, view } = editor;
+    const { selection } = state;
+
+    const targetPos = selection instanceof NodeSelection ? selection.to + 1 : selection.to;
+
+    const clampedPos = Math.max(1, Math.min(targetPos, state.doc.content.size));
+    const nextSelection = TextSelection.create(state.doc, clampedPos);
+
+    view.dispatch(state.tr.setSelection(nextSelection).scrollIntoView());
+  };
+
   const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
+    const files = Array.from(e.target.files ?? []);
+    for (const [index, file] of files.entries()) {
+      if (index > 0) moveCursorAfterCurrentSelection();
 
-    onUpload?.(file, editor);
-
-    if (fileUploadRef.current) {
-      fileUploadRef.current.value = "";
+      await onUpload?.(file, editor);
+      moveCursorAfterCurrentSelection();
     }
+
+    if (fileUploadRef.current) fileUploadRef.current.value = "";
   };
 
   return (
@@ -110,6 +125,7 @@ const EditorToolbar = ({
                   ref={fileUploadRef}
                   onChange={handleUpload}
                   accept={acceptedImages}
+                  multiple
                 />
                 <Button
                   size="sm"

--- a/apps/web/app/components/ui/toast.tsx
+++ b/apps/web/app/components/ui/toast.tsx
@@ -9,16 +9,16 @@ const ToastProvider = ToastPrimitives.Provider;
 
 const ToastViewport = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Viewport>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
->(({ className, ...props }, ref) => (
-  <ToastPrimitives.Viewport
-    ref={ref}
-    className={cn(
-      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
-      className,
-    )}
-    {...props}
-  />
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport> & { queueSlot?: React.ReactNode }
+>(({ className, queueSlot, ...props }, ref) => (
+  <div className="pointer-events-none fixed top-0 z-[100] flex w-full flex-col-reverse gap-3 p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]">
+    {queueSlot}
+    <ToastPrimitives.Viewport
+      ref={ref}
+      className={cn("flex max-h-screen w-full flex-col-reverse gap-2 sm:flex-col", className)}
+      {...props}
+    />
+  </div>
 ));
 ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
 

--- a/apps/web/app/components/ui/toaster.tsx
+++ b/apps/web/app/components/ui/toaster.tsx
@@ -1,6 +1,7 @@
 import { Loader2 } from "lucide-react";
 import { match } from "ts-pattern";
 
+import { RichTextUploadQueue } from "~/components/RichText/RichTextUploadQueue";
 import {
   Toast,
   ToastClose,
@@ -10,12 +11,13 @@ import {
   ToastViewport,
 } from "~/components/ui/toast";
 import { useToast } from "~/components/ui/use-toast";
-
+import { useRichTextUploadQueue } from "~/hooks/useRichTextUploadQueue";
 
 import { Icon } from "../Icon";
 
 export function Toaster() {
   const { toasts } = useToast();
+  const { items, clearFinished, remove } = useRichTextUploadQueue();
 
   return (
     <ToastProvider>
@@ -44,7 +46,15 @@ export function Toaster() {
           </Toast>
         );
       })}
-      <ToastViewport />
+      <ToastViewport
+        queueSlot={
+          <RichTextUploadQueue
+            items={items}
+            onClearFinished={clearFinished}
+            onRemoveItem={remove}
+          />
+        }
+      />
     </ToastProvider>
   );
 }

--- a/apps/web/app/hooks/buildRichTextFileUploadHandler.ts
+++ b/apps/web/app/hooks/buildRichTextFileUploadHandler.ts
@@ -10,9 +10,11 @@ import {
 import { match } from "ts-pattern";
 
 import { buildEntityResourceUrl, insertResourceIntoEditor } from "~/hooks/useEntityResourceUpload";
+import { UPLOAD_STATUS } from "~/hooks/useRichTextUploadQueue";
 
 import type { Editor as TiptapEditor } from "@tiptap/react";
 import type { InitVideoUploadResponse } from "~/api/generated-api";
+import type { RichTextUploadKind, RichTextUploadStatus } from "~/hooks/useRichTextUploadQueue";
 
 const DISPLAY_MODE = {
   PREVIEW: "preview",
@@ -24,6 +26,10 @@ type DisplayMode = (typeof DISPLAY_MODE)[keyof typeof DISPLAY_MODE];
 type VideoUploadArgs = {
   file: File;
   session: InitVideoUploadResponse;
+  onUploadingStart?: () => void;
+  onProgress?: (progress: number) => void;
+  onUploaded?: () => void;
+  onError?: (error: Error) => void;
 };
 
 type BuildRichTextFileUploadHandlerArgs = {
@@ -33,6 +39,17 @@ type BuildRichTextFileUploadHandlerArgs = {
   uploadResourceFile: (file: File) => Promise<string>;
   askForDisplayMode: (filename: string) => Promise<DisplayMode | null>;
   onVideoUploadError: (error: unknown) => void;
+  fallbackUploadErrorMessage: string;
+  uploadQueue?: {
+    enqueue: (args: { fileName: string; kind: RichTextUploadKind }) => string;
+    setStatus: (
+      id: string,
+      status: RichTextUploadStatus,
+      options?: { errorMessage?: string },
+    ) => void;
+    setProgress: (id: string, progress: number) => void;
+    attachUploadId: (id: string, uploadId: string) => void;
+  };
 };
 
 export const RICH_TEXT_ACCEPTED_FILE_TYPES = [
@@ -75,6 +92,8 @@ export const buildRichTextFileUploadHandler = ({
   uploadResourceFile,
   askForDisplayMode,
   onVideoUploadError,
+  fallbackUploadErrorMessage,
+  uploadQueue,
 }: BuildRichTextFileUploadHandlerArgs) => {
   return async (file?: File, editor?: TiptapEditor | null) => {
     if (!file) return;
@@ -89,16 +108,23 @@ export const buildRichTextFileUploadHandler = ({
 
     if (isVideo) {
       let insertedResourceUrl: string | null = null;
+      const queueId = uploadQueue?.enqueue({ fileName: file.name, kind: "video" });
+      if (queueId) {
+        uploadQueue?.setStatus(queueId, UPLOAD_STATUS.QUEUED);
+      }
 
       try {
         const session = await getVideoSessionForFile(file);
+        if (queueId) {
+          uploadQueue?.attachUploadId(queueId, session.uploadId);
+        }
 
         if (session.resourceId && editor) {
           insertedResourceUrl = buildEntityResourceUrl(session.resourceId, entityType);
 
           editor
             .chain()
-            .insertContent("<br />")
+            .focus()
             .setVideoEmbed({
               src: insertedResourceUrl,
               sourceType: session.provider === "s3" ? "external" : "internal",
@@ -106,14 +132,44 @@ export const buildRichTextFileUploadHandler = ({
             .run();
         }
 
-        await uploadVideo({ file, session });
+        await uploadVideo({
+          file,
+          session,
+          onUploadingStart: () => {
+            if (queueId) uploadQueue?.setStatus(queueId, UPLOAD_STATUS.UPLOADING);
+          },
+          onProgress: (progress) => {
+            if (queueId) uploadQueue?.setProgress(queueId, progress);
+          },
+          onUploaded: () => {
+            if (queueId) uploadQueue?.setStatus(queueId, UPLOAD_STATUS.SUCCESS);
+          },
+          onError: (error) => {
+            if (queueId) {
+              uploadQueue?.setStatus(queueId, UPLOAD_STATUS.FAILED, {
+                errorMessage: error.message,
+              });
+            }
+          },
+        });
       } catch (error) {
         if (editor && insertedResourceUrl) {
           removeVideoEmbedBySource(editor, insertedResourceUrl);
         }
+        if (queueId) {
+          uploadQueue?.setStatus(queueId, UPLOAD_STATUS.FAILED, {
+            errorMessage: error instanceof Error ? error.message : fallbackUploadErrorMessage,
+          });
+        }
         onVideoUploadError(error);
       }
       return;
+    }
+
+    const queueId = uploadQueue?.enqueue({ fileName: file.name, kind: "resource" });
+
+    if (queueId) {
+      uploadQueue?.setStatus(queueId, UPLOAD_STATUS.UPLOADING);
     }
 
     let displayMode: DisplayMode = DISPLAY_MODE.PREVIEW;
@@ -124,7 +180,22 @@ export const buildRichTextFileUploadHandler = ({
       displayMode = selectedMode;
     }
 
-    const resourceId = await uploadResourceFile(file);
+    let resourceId: string;
+    try {
+      resourceId = await uploadResourceFile(file);
+
+      if (queueId) {
+        uploadQueue?.setProgress(queueId, 100);
+        uploadQueue?.setStatus(queueId, UPLOAD_STATUS.SUCCESS);
+      }
+    } catch (error) {
+      if (queueId) {
+        uploadQueue?.setStatus(queueId, UPLOAD_STATUS.FAILED, {
+          errorMessage: error instanceof Error ? error.message : fallbackUploadErrorMessage,
+        });
+      }
+      throw error;
+    }
 
     insertResourceIntoEditor({
       editor,

--- a/apps/web/app/hooks/buildRichTextFileUploadHandler.ts
+++ b/apps/web/app/hooks/buildRichTextFileUploadHandler.ts
@@ -1,0 +1,142 @@
+import {
+  ALLOWED_EXCEL_FILE_TYPES,
+  ALLOWED_LESSON_IMAGE_FILE_TYPES,
+  ALLOWED_PDF_FILE_TYPES,
+  ALLOWED_PRESENTATION_FILE_TYPES,
+  ALLOWED_VIDEO_FILE_TYPES,
+  ALLOWED_WORD_FILE_TYPES,
+  type EntityType,
+} from "@repo/shared";
+import { match } from "ts-pattern";
+
+import { buildEntityResourceUrl, insertResourceIntoEditor } from "~/hooks/useEntityResourceUpload";
+
+import type { Editor as TiptapEditor } from "@tiptap/react";
+import type { InitVideoUploadResponse } from "~/api/generated-api";
+
+const DISPLAY_MODE = {
+  PREVIEW: "preview",
+  DOWNLOAD: "download",
+} as const;
+
+type DisplayMode = (typeof DISPLAY_MODE)[keyof typeof DISPLAY_MODE];
+
+type VideoUploadArgs = {
+  file: File;
+  session: InitVideoUploadResponse;
+};
+
+type BuildRichTextFileUploadHandlerArgs = {
+  entityType: EntityType;
+  getVideoSessionForFile: (file: File) => Promise<InitVideoUploadResponse>;
+  uploadVideo: (args: VideoUploadArgs) => Promise<void>;
+  uploadResourceFile: (file: File) => Promise<string>;
+  askForDisplayMode: (filename: string) => Promise<DisplayMode | null>;
+  onVideoUploadError: (error: unknown) => void;
+};
+
+export const RICH_TEXT_ACCEPTED_FILE_TYPES = [
+  ...ALLOWED_LESSON_IMAGE_FILE_TYPES,
+  ...ALLOWED_VIDEO_FILE_TYPES,
+  ...ALLOWED_EXCEL_FILE_TYPES,
+  ...ALLOWED_PDF_FILE_TYPES,
+  ...ALLOWED_WORD_FILE_TYPES,
+  ...ALLOWED_PRESENTATION_FILE_TYPES,
+] as const;
+
+const removeVideoEmbedBySource = (editor: TiptapEditor, src: string) => {
+  editor
+    .chain()
+    .focus()
+    .command(({ state, tr, dispatch }) => {
+      let found = false;
+
+      state.doc.descendants((node, pos) => {
+        if (node.type.name !== "video") return true;
+        if (node.attrs.src !== src) return true;
+
+        tr.delete(pos, pos + node.nodeSize);
+        found = true;
+        return false;
+      });
+
+      if (!found) return false;
+
+      dispatch?.(tr);
+      return true;
+    })
+    .run();
+};
+
+export const buildRichTextFileUploadHandler = ({
+  entityType,
+  getVideoSessionForFile,
+  uploadVideo,
+  uploadResourceFile,
+  askForDisplayMode,
+  onVideoUploadError,
+}: BuildRichTextFileUploadHandlerArgs) => {
+  return async (file?: File, editor?: TiptapEditor | null) => {
+    if (!file) return;
+
+    const isVideo = ALLOWED_VIDEO_FILE_TYPES.includes(file.type);
+    const isPresentation = ALLOWED_PRESENTATION_FILE_TYPES.includes(file.type);
+    const isPdf = ALLOWED_PDF_FILE_TYPES.includes(file.type);
+    const isDocument =
+      isPdf ||
+      ALLOWED_EXCEL_FILE_TYPES.includes(file.type) ||
+      ALLOWED_WORD_FILE_TYPES.includes(file.type);
+
+    if (isVideo) {
+      let insertedResourceUrl: string | null = null;
+
+      try {
+        const session = await getVideoSessionForFile(file);
+
+        if (session.resourceId && editor) {
+          insertedResourceUrl = buildEntityResourceUrl(session.resourceId, entityType);
+
+          editor
+            .chain()
+            .insertContent("<br />")
+            .setVideoEmbed({
+              src: insertedResourceUrl,
+              sourceType: session.provider === "s3" ? "external" : "internal",
+            })
+            .run();
+        }
+
+        await uploadVideo({ file, session });
+      } catch (error) {
+        if (editor && insertedResourceUrl) {
+          removeVideoEmbedBySource(editor, insertedResourceUrl);
+        }
+        onVideoUploadError(error);
+      }
+      return;
+    }
+
+    let displayMode: DisplayMode = DISPLAY_MODE.PREVIEW;
+
+    if (isPresentation || isPdf) {
+      const selectedMode = await askForDisplayMode(file.name);
+      if (!selectedMode) return;
+      displayMode = selectedMode;
+    }
+
+    const resourceId = await uploadResourceFile(file);
+
+    insertResourceIntoEditor({
+      editor,
+      resourceId,
+      entityType,
+      file,
+      resourceType: match({ isPresentation, isPdf, isDocument })
+        .with({ isPresentation: true }, () => "presentation" as const)
+        .with({ isPdf: true }, () => "pdf" as const)
+        .with({ isDocument: true }, () => "document" as const)
+        .otherwise(() => "other" as const),
+      displayMode: isPresentation || isDocument ? displayMode : DISPLAY_MODE.PREVIEW,
+    });
+  };
+};

--- a/apps/web/app/hooks/useEntityResourceUpload.ts
+++ b/apps/web/app/hooks/useEntityResourceUpload.ts
@@ -52,7 +52,7 @@ export const insertResourceIntoEditor = ({
   displayMode = "preview",
 }: InsertResourceArgs) => {
   const resourceUrl = buildEntityResourceUrl(resourceId, entityType);
-  const chain = editor?.chain().insertContent("<br />");
+  const chain = editor?.chain().focus();
 
   if (resourceType === "presentation") {
     if (displayMode === "download") {

--- a/apps/web/app/hooks/useGlobalVideoUploadNotifications.ts
+++ b/apps/web/app/hooks/useGlobalVideoUploadNotifications.ts
@@ -5,6 +5,7 @@ import { match } from "ts-pattern";
 
 import { acquireSocket, releaseSocket } from "~/api/socket";
 import { useToast } from "~/components/ui/use-toast";
+import { emitVideoUploadStatusEvent } from "~/hooks/videoUploadStatusBus";
 
 import type { VideoUploadStatus } from "@repo/shared";
 
@@ -34,6 +35,8 @@ export function useGlobalVideoUploadNotifications() {
     }
 
     const handleUploadStatusChange = (notification: UploadNotification) => {
+      emitVideoUploadStatusEvent(notification);
+
       match(notification.status)
         .with(VIDEO_UPLOAD_STATUS.PROCESSED, () =>
           toast({

--- a/apps/web/app/hooks/useRichTextUploadQueue.ts
+++ b/apps/web/app/hooks/useRichTextUploadQueue.ts
@@ -1,0 +1,209 @@
+import { VIDEO_UPLOAD_STATUS } from "@repo/shared";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { match } from "ts-pattern";
+
+import { subscribeVideoUploadStatusEvent } from "~/hooks/videoUploadStatusBus";
+
+export const UPLOAD_STATUS = {
+  QUEUED: VIDEO_UPLOAD_STATUS.QUEUED,
+  UPLOADING: "uploading",
+  PROCESSING: VIDEO_UPLOAD_STATUS.UPLOADED,
+  SUCCESS: VIDEO_UPLOAD_STATUS.PROCESSED,
+  FAILED: VIDEO_UPLOAD_STATUS.FAILED,
+} as const;
+
+export const ACTIVE_UPLOAD_STATUSES: readonly RichTextUploadStatus[] = [
+  UPLOAD_STATUS.QUEUED,
+  UPLOAD_STATUS.UPLOADING,
+  UPLOAD_STATUS.PROCESSING,
+];
+
+export type RichTextUploadStatus = (typeof UPLOAD_STATUS)[keyof typeof UPLOAD_STATUS];
+
+export type RichTextUploadKind = "video" | "resource";
+
+export type RichTextUploadQueueItem = {
+  id: string;
+  fileName: string;
+  kind: RichTextUploadKind;
+  status: RichTextUploadStatus;
+  progress: number | null;
+  uploadId?: string;
+  errorMessage?: string;
+  createdAt: number;
+};
+
+type EnqueueArgs = {
+  fileName: string;
+  kind: RichTextUploadKind;
+};
+
+type QueueState = {
+  items: RichTextUploadQueueItem[];
+};
+
+type QueueListener = (state: QueueState) => void;
+
+let queueState: QueueState = { items: [] };
+const queueListeners: QueueListener[] = [];
+let statusBusUnsubscribe: (() => void) | null = null;
+
+const setQueueState = (updater: (prev: QueueState) => QueueState) => {
+  queueState = updater(queueState);
+  queueListeners.forEach((listener) => listener(queueState));
+};
+
+const ensureStatusBusSubscription = () => {
+  if (statusBusUnsubscribe) return;
+
+  statusBusUnsubscribe = subscribeVideoUploadStatusEvent((event) => {
+    setQueueState((prevState) => ({
+      ...prevState,
+      items: prevState.items.map((item) => {
+        if (item.uploadId !== event.uploadId) return item;
+
+        if (event.status === VIDEO_UPLOAD_STATUS.PROCESSED) {
+          return { ...item, status: UPLOAD_STATUS.SUCCESS, progress: 100 };
+        }
+
+        if (event.status === VIDEO_UPLOAD_STATUS.FAILED) {
+          return {
+            ...item,
+            status: UPLOAD_STATUS.FAILED,
+            progress: 0,
+            errorMessage: event.error ?? "Upload failed",
+          };
+        }
+
+        if (event.status === VIDEO_UPLOAD_STATUS.UPLOADED) {
+          return { ...item, status: UPLOAD_STATUS.SUCCESS, progress: 100 };
+        }
+
+        return item;
+      }),
+    }));
+  });
+};
+
+export const useRichTextUploadQueue = () => {
+  const [state, setState] = useState<QueueState>(queueState);
+
+  useEffect(() => {
+    ensureStatusBusSubscription();
+
+    queueListeners.push(setState);
+
+    return () => {
+      const index = queueListeners.indexOf(setState);
+
+      if (index > -1) queueListeners.splice(index, 1);
+    };
+  }, []);
+
+  const enqueue = useCallback(({ fileName, kind }: EnqueueArgs) => {
+    const id = crypto.randomUUID();
+
+    setQueueState((prevState) => ({
+      ...prevState,
+      items: [
+        {
+          id,
+          fileName,
+          kind,
+          status: UPLOAD_STATUS.QUEUED,
+          progress: 0,
+          createdAt: Date.now(),
+        },
+        ...prevState.items,
+      ],
+    }));
+
+    return id;
+  }, []);
+
+  const setStatus = useCallback(
+    (id: string, status: RichTextUploadStatus, options?: { errorMessage?: string }) => {
+      setQueueState((prevState) => ({
+        ...prevState,
+        items: prevState.items.map((item) =>
+          item.id === id
+            ? {
+                ...item,
+                status,
+                errorMessage: options?.errorMessage,
+                progress: match(status)
+                  .with(UPLOAD_STATUS.QUEUED, () => 0)
+                  .with(UPLOAD_STATUS.SUCCESS, () => 100)
+                  .with(UPLOAD_STATUS.FAILED, () => 0)
+                  .otherwise(() => item.progress),
+              }
+            : item,
+        ),
+      }));
+    },
+    [],
+  );
+
+  const setProgress = useCallback((id: string, progress: number) => {
+    setQueueState((prevState) => ({
+      ...prevState,
+      items: prevState.items.map((item) =>
+        item.id === id
+          ? {
+              ...item,
+              progress,
+              status: item.status === UPLOAD_STATUS.QUEUED ? UPLOAD_STATUS.UPLOADING : item.status,
+            }
+          : item,
+      ),
+    }));
+  }, []);
+
+  const attachUploadId = useCallback((id: string, uploadId: string) => {
+    setQueueState((prevState) => ({
+      ...prevState,
+      items: prevState.items.map((item) =>
+        item.id === id
+          ? {
+              ...item,
+              uploadId,
+            }
+          : item,
+      ),
+    }));
+  }, []);
+
+  const clearFinished = useCallback(() => {
+    setQueueState((prevState) => ({
+      ...prevState,
+      items: prevState.items.filter(
+        (item) => item.status !== UPLOAD_STATUS.SUCCESS && item.status !== UPLOAD_STATUS.FAILED,
+      ),
+    }));
+  }, []);
+
+  const remove = useCallback((id: string) => {
+    setQueueState((prevState) => ({
+      ...prevState,
+      items: prevState.items.filter((item) => item.id !== id),
+    }));
+  }, []);
+
+  const hasActiveUploads = useMemo(
+    () => state.items.some((item) => ACTIVE_UPLOAD_STATUSES.includes(item.status)),
+    [state.items],
+  );
+
+  return {
+    items: state.items,
+    enqueue,
+    setStatus,
+    setProgress,
+    attachUploadId,
+    clearFinished,
+    remove,
+    hasActiveUploads,
+  };
+};
+
+export type RichTextUploadQueueController = ReturnType<typeof useRichTextUploadQueue>;

--- a/apps/web/app/hooks/useTusVideoUpload.ts
+++ b/apps/web/app/hooks/useTusVideoUpload.ts
@@ -19,6 +19,10 @@ type GetSessionArgs = {
 type UploadArgs = {
   file: File;
   session: TusUploadSession;
+  onUploadingStart?: () => void;
+  onProgress?: (progress: number) => void;
+  onUploaded?: () => void;
+  onError?: (error: Error) => void;
 };
 
 const normalizeTusHeaders = (headers: object): Record<string, string> =>
@@ -50,7 +54,7 @@ export const useTusVideoUpload = () => {
   );
 
   const uploadVideo = useCallback(
-    async ({ file, session }: UploadArgs) => {
+    async ({ file, session, onUploadingStart, onProgress, onUploaded, onError }: UploadArgs) => {
       if (!session.tusEndpoint || !session.tusHeaders || !session.expiresAt) {
         throw new Error("Missing upload configuration");
       }
@@ -87,6 +91,7 @@ export const useTusVideoUpload = () => {
             duration: Number.POSITIVE_INFINITY,
             variant: "loading",
           });
+          onUploadingStart?.();
 
           const upload = new tus.Upload(file, {
             endpoint: session.tusEndpoint,
@@ -104,9 +109,11 @@ export const useTusVideoUpload = () => {
               if (bytesTotal === 0) return;
               const progress = Math.round((bytesUploaded / bytesTotal) * 100);
               setUploadProgress(progress);
+              onProgress?.(progress);
             },
             onError: (error) => {
               clearUpload(session.uploadId);
+              onError?.(error);
               reject(error);
             },
             onSuccess: () => {
@@ -116,6 +123,7 @@ export const useTusVideoUpload = () => {
                 duration: Number.POSITIVE_INFINITY,
                 variant: "success",
               });
+              onUploaded?.();
               resolve();
             },
           });

--- a/apps/web/app/hooks/videoUploadStatusBus.ts
+++ b/apps/web/app/hooks/videoUploadStatusBus.ts
@@ -1,0 +1,25 @@
+import type { VideoUploadStatus } from "@repo/shared";
+
+export type VideoUploadNotificationEvent = {
+  uploadId: string;
+  status: VideoUploadStatus;
+  fileKey?: string;
+  fileUrl?: string;
+  error?: string;
+};
+
+type Listener = (event: VideoUploadNotificationEvent) => void;
+
+const listeners = new Set<Listener>();
+
+export const emitVideoUploadStatusEvent = (event: VideoUploadNotificationEvent) => {
+  listeners.forEach((listener) => listener(event));
+};
+
+export const subscribeVideoUploadStatusEvent = (listener: Listener) => {
+  listeners.add(listener);
+
+  return () => {
+    listeners.delete(listener);
+  };
+};

--- a/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/ContentLessonForm/ContentLessonForm.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/ContentLessonForm/ContentLessonForm.tsx
@@ -1,15 +1,6 @@
-import {
-  ALLOWED_EXCEL_FILE_TYPES,
-  ALLOWED_LESSON_IMAGE_FILE_TYPES,
-  ALLOWED_PDF_FILE_TYPES,
-  ALLOWED_PRESENTATION_FILE_TYPES,
-  ALLOWED_VIDEO_FILE_TYPES,
-  ALLOWED_WORD_FILE_TYPES,
-  ENTITY_TYPES,
-} from "@repo/shared";
+import { ENTITY_TYPES } from "@repo/shared";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { match } from "ts-pattern";
 
 import { useInitializeLessonContext } from "~/api/mutations/admin/useInitializeLessonContext";
 import { useInitVideoUpload } from "~/api/mutations/admin/useInitVideoUpload";
@@ -22,10 +13,10 @@ import { Label } from "~/components/ui/label";
 import { useToast } from "~/components/ui/use-toast";
 import { useLeaveModal } from "~/context/LeaveModalContext";
 import {
-  buildEntityResourceUrl,
-  insertResourceIntoEditor,
-  useEntityResourceUpload,
-} from "~/hooks/useEntityResourceUpload";
+  buildRichTextFileUploadHandler,
+  RICH_TEXT_ACCEPTED_FILE_TYPES,
+} from "~/hooks/buildRichTextFileUploadHandler";
+import { useEntityResourceUpload } from "~/hooks/useEntityResourceUpload";
 import { useTusVideoUpload } from "~/hooks/useTusVideoUpload";
 import { useUploadDisplayModeDialog } from "~/hooks/useUploadDisplayModeDialog";
 import DeleteConfirmationModal from "~/modules/Admin/components/DeleteConfirmationModal";
@@ -39,7 +30,6 @@ import { useContentLessonForm } from "./hooks/useContentLessonForm";
 
 import type { Chapter, Lesson } from "../../../EditCourse.types";
 import type { SupportedLanguages } from "@repo/shared";
-import type { Editor as TiptapEditor } from "@tiptap/react";
 
 type ContentLessonProps = {
   setContentTypeToDisplay: (contentTypeToDisplay: string) => void;
@@ -88,115 +78,40 @@ const ContentLessonForm = ({
     setIsModalOpen(true);
   };
 
-  const removeVideoEmbedBySource = (editor: TiptapEditor, src: string) => {
-    editor
-      .chain()
-      .focus()
-      .command(({ state, tr, dispatch }) => {
-        let found = false;
-
-        state.doc.descendants((node, pos) => {
-          if (node.type.name !== "video") return true;
-          if (node.attrs.src !== src) return true;
-
-          tr.delete(pos, pos + node.nodeSize);
-          found = true;
-          return false;
-        });
-
-        if (!found) return false;
-
-        dispatch?.(tr);
-        return true;
-      })
-      .run();
-  };
-
-  const handleFileUpload = async (file?: File, editor?: TiptapEditor | null) => {
-    if (!file) return;
-
-    const isVideo = ALLOWED_VIDEO_FILE_TYPES.includes(file.type);
-    const isPresentation = ALLOWED_PRESENTATION_FILE_TYPES.includes(file.type);
-    const isPdf = ALLOWED_PDF_FILE_TYPES.includes(file.type);
-    const isDocument =
-      isPdf ||
-      ALLOWED_EXCEL_FILE_TYPES.includes(file.type) ||
-      ALLOWED_WORD_FILE_TYPES.includes(file.type);
-
-    if (isVideo) {
-      let insertedResourceUrl: string | null = null;
-
-      try {
-        const session = await getSessionForFile({
-          file,
-          init: () =>
-            initVideoUpload({
-              filename: file.name,
-              sizeBytes: file.size,
-              mimeType: file.type,
-              title: file.name,
-              resource: "lesson-content",
-              contextId,
-              entityId: lessonToEdit?.id,
-              entityType: ENTITY_TYPES.LESSON,
-            }),
-        });
-
-        if (session.resourceId && editor) {
-          insertedResourceUrl = buildEntityResourceUrl(session.resourceId, ENTITY_TYPES.LESSON);
-
-          editor
-            .chain()
-            .insertContent("<br />")
-            .setVideoEmbed({
-              src: insertedResourceUrl,
-              sourceType: session.provider === "s3" ? "external" : "internal",
-            })
-            .run();
-        }
-
-        await uploadVideo({ file, session });
-      } catch (error) {
-        if (editor && insertedResourceUrl) removeVideoEmbedBySource(editor, insertedResourceUrl);
-
-        console.error("Error uploading video:", error);
-        toast({
-          description: t("uploadFile.toast.videoFailed"),
-          variant: "destructive",
-        });
-      }
-      return;
-    }
-
-    let displayMode: "preview" | "download" = "preview";
-
-    if (isPresentation || isPdf) {
-      const selectedMode = await askForDisplayMode(file.name);
-      if (!selectedMode) return;
-      displayMode = selectedMode;
-    }
-
-    const resourceId = await uploadResource({
-      file,
-      entityType: ENTITY_TYPES.LESSON,
-      entityId: lessonToEdit?.id,
-      contextId,
-      language,
-    });
-
-    insertResourceIntoEditor({
-      editor,
-      resourceId,
-      entityType: ENTITY_TYPES.LESSON,
-      file,
-      resourceType: match({ isPresentation, isPdf, isDocument })
-        .with({ isPresentation: true }, () => "presentation" as const)
-        .with({ isPdf: true }, () => "pdf" as const)
-        .with({ isDocument: true }, () => "document" as const)
-        .otherwise(() => "other" as const),
-      displayMode: isPresentation || isDocument ? displayMode : "preview",
-    });
-  };
+  const handleFileUpload = buildRichTextFileUploadHandler({
+    entityType: ENTITY_TYPES.LESSON,
+    getVideoSessionForFile: (file) =>
+      getSessionForFile({
+        file,
+        init: () =>
+          initVideoUpload({
+            filename: file.name,
+            sizeBytes: file.size,
+            mimeType: file.type,
+            title: file.name,
+            resource: "lesson-content",
+            contextId,
+            entityId: lessonToEdit?.id,
+            entityType: ENTITY_TYPES.LESSON,
+          }),
+      }),
+    uploadVideo,
+    uploadResourceFile: (file) =>
+      uploadResource({
+        file,
+        entityType: ENTITY_TYPES.LESSON,
+        entityId: lessonToEdit?.id,
+        contextId,
+        language,
+      }),
+    askForDisplayMode,
+    onVideoUploadError: () => {
+      toast({
+        description: t("uploadFile.toast.videoFailed"),
+        variant: "destructive",
+      });
+    },
+  });
 
   const missingTranslations =
     lessonToEdit && !lessonToEdit.title.trim() && !lessonToEdit.description.trim();
@@ -293,14 +208,7 @@ const ContentLessonForm = ({
                     content={field.value}
                     lessonId={lessonToEdit?.id}
                     allowFiles={!!lessonToEdit?.id || !!contextId}
-                    acceptedFileTypes={[
-                      ...ALLOWED_LESSON_IMAGE_FILE_TYPES,
-                      ...ALLOWED_VIDEO_FILE_TYPES,
-                      ...ALLOWED_EXCEL_FILE_TYPES,
-                      ...ALLOWED_PDF_FILE_TYPES,
-                      ...ALLOWED_WORD_FILE_TYPES,
-                      ...ALLOWED_PRESENTATION_FILE_TYPES,
-                    ]}
+                    acceptedFileTypes={RICH_TEXT_ACCEPTED_FILE_TYPES}
                     onUpload={handleFileUpload}
                     uploadProgress={isUploading ? (uploadProgress ?? 0) : null}
                     onCtrlSave={() => form.handleSubmit(onSubmit)()}

--- a/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/ContentLessonForm/ContentLessonForm.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/ContentLessonForm/ContentLessonForm.tsx
@@ -17,6 +17,7 @@ import {
   RICH_TEXT_ACCEPTED_FILE_TYPES,
 } from "~/hooks/buildRichTextFileUploadHandler";
 import { useEntityResourceUpload } from "~/hooks/useEntityResourceUpload";
+import { useRichTextUploadQueue } from "~/hooks/useRichTextUploadQueue";
 import { useTusVideoUpload } from "~/hooks/useTusVideoUpload";
 import { useUploadDisplayModeDialog } from "~/hooks/useUploadDisplayModeDialog";
 import DeleteConfirmationModal from "~/modules/Admin/components/DeleteConfirmationModal";
@@ -68,7 +69,8 @@ const ContentLessonForm = ({
   const { mutateAsync: initVideoUpload } = useInitVideoUpload();
   const { uploadResource } = useEntityResourceUpload();
   const { askForDisplayMode, dialog: uploadDisplayModeDialog } = useUploadDisplayModeDialog();
-  const { getSessionForFile, uploadVideo, isUploading, uploadProgress } = useTusVideoUpload();
+  const { getSessionForFile, uploadVideo } = useTusVideoUpload();
+  const { enqueue, setStatus, setProgress, attachUploadId } = useRichTextUploadQueue();
 
   const onCloseModal = () => {
     setIsModalOpen(false);
@@ -110,6 +112,13 @@ const ContentLessonForm = ({
         description: t("uploadFile.toast.videoFailed"),
         variant: "destructive",
       });
+    },
+    fallbackUploadErrorMessage: t("uploadFile.toast.videoFailed"),
+    uploadQueue: {
+      enqueue,
+      setStatus,
+      setProgress,
+      attachUploadId,
     },
   });
 
@@ -210,7 +219,6 @@ const ContentLessonForm = ({
                     allowFiles={!!lessonToEdit?.id || !!contextId}
                     acceptedFileTypes={RICH_TEXT_ACCEPTED_FILE_TYPES}
                     onUpload={handleFileUpload}
-                    uploadProgress={isUploading ? (uploadProgress ?? 0) : null}
                     onCtrlSave={() => form.handleSubmit(onSubmit)()}
                     {...field}
                   />

--- a/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/ContentLessonForm/ContentLessonForm.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/ContentLessonForm/ContentLessonForm.tsx
@@ -20,6 +20,7 @@ import { Button } from "~/components/ui/button";
 import { Form, FormControl, FormField, FormItem } from "~/components/ui/form";
 import { Label } from "~/components/ui/label";
 import { useToast } from "~/components/ui/use-toast";
+import { useLeaveModal } from "~/context/LeaveModalContext";
 import {
   buildEntityResourceUrl,
   insertResourceIntoEditor,
@@ -28,6 +29,7 @@ import {
 import { useTusVideoUpload } from "~/hooks/useTusVideoUpload";
 import { useUploadDisplayModeDialog } from "~/hooks/useUploadDisplayModeDialog";
 import DeleteConfirmationModal from "~/modules/Admin/components/DeleteConfirmationModal";
+import LeaveConfirmationModal from "~/modules/Admin/components/LeaveConfirmationModal";
 import { MissingTranslationsAlert } from "~/modules/Admin/EditCourse/components/MissingTranslationsAlert";
 
 import { ContentTypes, DeleteContentType } from "../../../EditCourse.types";
@@ -55,6 +57,7 @@ const ContentLessonForm = ({
   language,
 }: ContentLessonProps) => {
   const [contextId, setContextId] = useState<string | undefined>(undefined);
+  const [isValidated, setIsValidated] = useState(false);
 
   const { form, onSubmit, onDelete } = useContentLessonForm({
     chapterToEdit,
@@ -65,6 +68,8 @@ const ContentLessonForm = ({
   });
   const { t } = useTranslation();
   const { toast } = useToast();
+  const { isLeaveModalOpen, closeLeaveModal, setIsCurrectFormDirty, setIsLeavingContent } =
+    useLeaveModal();
 
   const { mutate: initializeLessonContext } = useInitializeLessonContext();
 
@@ -83,6 +88,30 @@ const ContentLessonForm = ({
     setIsModalOpen(true);
   };
 
+  const removeVideoEmbedBySource = (editor: TiptapEditor, src: string) => {
+    editor
+      .chain()
+      .focus()
+      .command(({ state, tr, dispatch }) => {
+        let found = false;
+
+        state.doc.descendants((node, pos) => {
+          if (node.type.name !== "video") return true;
+          if (node.attrs.src !== src) return true;
+
+          tr.delete(pos, pos + node.nodeSize);
+          found = true;
+          return false;
+        });
+
+        if (!found) return false;
+
+        dispatch?.(tr);
+        return true;
+      })
+      .run();
+  };
+
   const handleFileUpload = async (file?: File, editor?: TiptapEditor | null) => {
     if (!file) return;
 
@@ -95,6 +124,8 @@ const ContentLessonForm = ({
       ALLOWED_WORD_FILE_TYPES.includes(file.type);
 
     if (isVideo) {
+      let insertedResourceUrl: string | null = null;
+
       try {
         const session = await getSessionForFile({
           file,
@@ -111,21 +142,23 @@ const ContentLessonForm = ({
             }),
         });
 
-        await uploadVideo({ file, session });
-
-        if (session.resourceId) {
-          const resourceUrl = buildEntityResourceUrl(session.resourceId, ENTITY_TYPES.LESSON);
+        if (session.resourceId && editor) {
+          insertedResourceUrl = buildEntityResourceUrl(session.resourceId, ENTITY_TYPES.LESSON);
 
           editor
-            ?.chain()
+            .chain()
             .insertContent("<br />")
             .setVideoEmbed({
-              src: resourceUrl,
+              src: insertedResourceUrl,
               sourceType: session.provider === "s3" ? "external" : "internal",
             })
             .run();
         }
+
+        await uploadVideo({ file, session });
       } catch (error) {
+        if (editor && insertedResourceUrl) removeVideoEmbedBySource(editor, insertedResourceUrl);
+
         console.error("Error uploading video:", error);
         toast({
           description: t("uploadFile.toast.videoFailed"),
@@ -176,6 +209,37 @@ const ContentLessonForm = ({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  const { isDirty } = form.formState;
+
+  useEffect(() => {
+    setIsCurrectFormDirty(isDirty);
+  }, [isDirty, setIsCurrectFormDirty]);
+
+  const handleValidationSuccess = () => {
+    setIsValidated(true);
+  };
+
+  const handleValidationError = () => {
+    setIsValidated(false);
+    closeLeaveModal();
+  };
+
+  const onValidateLeave = () => {
+    form.handleSubmit(handleValidationSuccess, handleValidationError)();
+  };
+
+  const onCloseLeaveModal = () => {
+    closeLeaveModal();
+    setIsCurrectFormDirty(false);
+    setIsLeavingContent(false);
+  };
+
+  const onSaveLeaveModal = () => {
+    form.handleSubmit(onSubmit)();
+    closeLeaveModal();
+    setIsLeavingContent(false);
+  };
 
   return (
     <div className="flex flex-col gap-y-6 rounded-lg bg-white p-8">
@@ -274,6 +338,13 @@ const ContentLessonForm = ({
         onClose={onCloseModal}
         onDelete={onDelete}
         contentType={DeleteContentType.CONTENT}
+      />
+      <LeaveConfirmationModal
+        open={isLeaveModalOpen || false}
+        onClose={onCloseLeaveModal}
+        onSave={onSaveLeaveModal}
+        onValidate={onValidateLeave}
+        isValidated={isValidated}
       />
       {uploadDisplayModeDialog}
     </div>

--- a/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/ContentLessonForm/hooks/useContentLessonForm.ts
+++ b/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/ContentLessonForm/hooks/useContentLessonForm.ts
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import { useCreateBetaContentLesson } from "~/api/mutations/admin/useBetaCreateContentLesson";
 import { useDeleteLesson } from "~/api/mutations/admin/useDeleteLesson";
 import { useUpdateContentLesson } from "~/api/mutations/admin/useUpdateContentLesson";
+import { useLeaveModal } from "~/context/LeaveModalContext";
 import {
   type Chapter,
   ContentTypes,
@@ -38,6 +39,7 @@ export const useContentLessonForm = ({
   const { mutateAsync: createContentLesson } = useCreateBetaContentLesson();
   const { mutateAsync: updateTextBlockItem } = useUpdateContentLesson();
   const { mutateAsync: deleteLesson } = useDeleteLesson();
+  const { isLeavingContent, setIsCurrectFormDirty } = useLeaveModal();
   const { t } = useTranslation();
 
   const form = useForm<ContentLessonFormValues>({
@@ -84,7 +86,9 @@ export const useContentLessonForm = ({
         setOpenChapter && setOpenChapter(chapterToEdit.id);
       }
 
-      setContentTypeToDisplay(ContentTypes.EMPTY);
+      if (!isLeavingContent) setContentTypeToDisplay(ContentTypes.EMPTY);
+
+      setIsCurrectFormDirty(false);
     } catch (error) {
       console.error("Error creating text block:", error);
     }

--- a/apps/web/app/modules/Articles/ArticleForm.page.tsx
+++ b/apps/web/app/modules/Articles/ArticleForm.page.tsx
@@ -1,19 +1,13 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useNavigate, useParams } from "@remix-run/react";
 import {
-  ALLOWED_EXCEL_FILE_TYPES,
   ALLOWED_LESSON_IMAGE_FILE_TYPES,
-  ALLOWED_PDF_FILE_TYPES,
-  ALLOWED_PRESENTATION_FILE_TYPES,
-  ALLOWED_VIDEO_FILE_TYPES,
-  ALLOWED_WORD_FILE_TYPES,
   ENTITY_TYPES,
   type SupportedLanguages,
 } from "@repo/shared";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { match } from "ts-pattern";
 import { z } from "zod";
 
 import { useAddArticleLanguage } from "~/api/mutations/admin/useAddArticleLanguage";
@@ -32,12 +26,12 @@ import { Form, FormControl, FormField, FormItem, FormMessage } from "~/component
 import { Label } from "~/components/ui/label";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
 import { useToast } from "~/components/ui/use-toast";
-import { useClearVideoOnTabChange } from "~/hooks/useClearVideoOnTabChange";
 import {
-  buildEntityResourceUrl,
-  insertResourceIntoEditor,
-  useEntityResourceUpload,
-} from "~/hooks/useEntityResourceUpload";
+  buildRichTextFileUploadHandler,
+  RICH_TEXT_ACCEPTED_FILE_TYPES,
+} from "~/hooks/buildRichTextFileUploadHandler";
+import { useClearVideoOnTabChange } from "~/hooks/useClearVideoOnTabChange";
+import { useEntityResourceUpload } from "~/hooks/useEntityResourceUpload";
 import { useHandleImageUpload } from "~/hooks/useHandleImageUpload";
 import { useTusVideoUpload } from "~/hooks/useTusVideoUpload";
 import { useUploadDisplayModeDialog } from "~/hooks/useUploadDisplayModeDialog";
@@ -48,7 +42,7 @@ import Loader from "../common/Loader/Loader";
 import { useLanguageStore } from "../Dashboard/Settings/Language/LanguageStore";
 
 import type { Editor as TiptapEditor } from "@tiptap/react";
-import type { InitVideoUploadResponse, UpdateArticleBody } from "~/api/generated-api";
+import type { UpdateArticleBody } from "~/api/generated-api";
 
 type ArticleFormValues = {
   title: string;
@@ -191,84 +185,42 @@ function ArticleFormPage({ defaultValues }: ArticleFormPageProps) {
     navigate(`/articles/${articleId}`);
   };
 
+  const sharedFileUploadHandler = buildRichTextFileUploadHandler({
+    entityType: ENTITY_TYPES.ARTICLES,
+    getVideoSessionForFile: (file) =>
+      getSessionForFile({
+        file,
+        init: () =>
+          initVideoUpload({
+            filename: file.name,
+            sizeBytes: file.size,
+            mimeType: file.type,
+            title: file.name,
+            resource: ENTITY_TYPES.ARTICLES,
+            entityId: articleId,
+            entityType: ENTITY_TYPES.ARTICLES,
+          }),
+      }),
+    uploadVideo,
+    uploadResourceFile: (file) =>
+      uploadResource({
+        file,
+        entityType: ENTITY_TYPES.ARTICLES,
+        entityId: articleId,
+        language: articleLanguage,
+      }),
+    askForDisplayMode,
+    onVideoUploadError: () => {
+      toast({
+        description: t("uploadFile.toast.videoFailed"),
+        variant: "destructive",
+      });
+    },
+  });
+
   const handleFileUpload = async (file?: File, editor?: TiptapEditor | null) => {
     if (!file || !articleId || !articleLanguage) return;
-
-    const isVideo = ALLOWED_VIDEO_FILE_TYPES.includes(file.type);
-    if (isVideo) {
-      try {
-        const session: InitVideoUploadResponse = await getSessionForFile({
-          file,
-          init: () =>
-            initVideoUpload({
-              filename: file.name,
-              sizeBytes: file.size,
-              mimeType: file.type,
-              title: file.name,
-              resource: ENTITY_TYPES.ARTICLES,
-              entityId: articleId,
-              entityType: ENTITY_TYPES.ARTICLES,
-            }),
-        });
-
-        await uploadVideo({ file, session });
-
-        if (session.resourceId) {
-          const resourceUrl = buildEntityResourceUrl(session.resourceId, ENTITY_TYPES.ARTICLES);
-
-          editor
-            ?.chain()
-            .insertContent("<br />")
-            .setVideoEmbed({
-              src: resourceUrl,
-              sourceType: session.provider === "s3" ? "external" : "internal",
-            })
-            .run();
-        }
-      } catch (error) {
-        console.error("Error uploading video:", error);
-        toast({
-          description: t("uploadFile.toast.videoFailed"),
-          variant: "destructive",
-        });
-      }
-      return;
-    }
-
-    const isPresentation = ALLOWED_PRESENTATION_FILE_TYPES.includes(file.type);
-    const isPdf = ALLOWED_PDF_FILE_TYPES.includes(file.type);
-    const isDocument =
-      isPdf ||
-      ALLOWED_EXCEL_FILE_TYPES.includes(file.type) ||
-      ALLOWED_WORD_FILE_TYPES.includes(file.type);
-
-    let displayMode: "preview" | "download" = "preview";
-
-    if (isPresentation || isPdf) {
-      const selectedMode = await askForDisplayMode(file.name);
-      if (!selectedMode) return;
-      displayMode = selectedMode;
-    }
-
-    const resourceId = await uploadResource({
-      file,
-      entityType: ENTITY_TYPES.ARTICLES,
-      entityId: articleId,
-      language: articleLanguage,
-    });
-
-    insertResourceIntoEditor({
-      editor,
-      resourceId,
-      entityType: ENTITY_TYPES.ARTICLES,
-      file,
-      resourceType: match({ isPresentation, isPdf, isDocument })
-        .with({ isPresentation: true }, () => "presentation" as const)
-        .with({ isPdf: true }, () => "pdf" as const)
-        .with({ isDocument: true }, () => "document" as const)
-        .otherwise(() => "other" as const),
-      displayMode: isPresentation || isDocument ? displayMode : "preview",
-    });
+    await sharedFileUploadHandler(file, editor);
   };
 
   const fetchPreview = useCallback(
@@ -419,14 +371,7 @@ function ArticleFormPage({ defaultValues }: ArticleFormPageProps) {
                               id="content"
                               content={field.value}
                               allowFiles
-                              acceptedFileTypes={[
-                                ...ALLOWED_LESSON_IMAGE_FILE_TYPES,
-                                ...ALLOWED_VIDEO_FILE_TYPES,
-                                ...ALLOWED_EXCEL_FILE_TYPES,
-                                ...ALLOWED_PDF_FILE_TYPES,
-                                ...ALLOWED_WORD_FILE_TYPES,
-                                ...ALLOWED_PRESENTATION_FILE_TYPES,
-                              ]}
+                              acceptedFileTypes={RICH_TEXT_ACCEPTED_FILE_TYPES}
                               onUpload={handleFileUpload}
                               uploadProgress={isUploading ? (uploadProgress ?? 0) : null}
                               onChange={field.onChange}

--- a/apps/web/app/modules/Articles/ArticleForm.page.tsx
+++ b/apps/web/app/modules/Articles/ArticleForm.page.tsx
@@ -20,6 +20,7 @@ import ImageUploadInput from "~/components/FileUploadInput/ImageUploadInput";
 import { FormTextField } from "~/components/Form/FormTextField";
 import { PageWrapper } from "~/components/PageWrapper";
 import { ContentEditor } from "~/components/RichText/Editor";
+import { RichTextUploadQueue } from "~/components/RichText/RichTextUploadQueue";
 import Viewer from "~/components/RichText/Viever";
 import { Button } from "~/components/ui/button";
 import { Form, FormControl, FormField, FormItem, FormMessage } from "~/components/ui/form";
@@ -33,6 +34,7 @@ import {
 import { useClearVideoOnTabChange } from "~/hooks/useClearVideoOnTabChange";
 import { useEntityResourceUpload } from "~/hooks/useEntityResourceUpload";
 import { useHandleImageUpload } from "~/hooks/useHandleImageUpload";
+import { useRichTextUploadQueue } from "~/hooks/useRichTextUploadQueue";
 import { useTusVideoUpload } from "~/hooks/useTusVideoUpload";
 import { useUploadDisplayModeDialog } from "~/hooks/useUploadDisplayModeDialog";
 import { LanguageSelector } from "~/modules/Articles/LanguageSelector";
@@ -89,7 +91,9 @@ function ArticleFormPage({ defaultValues }: ArticleFormPageProps) {
 
   const { mutateAsync: previewArticle, isPending: isPreviewLoading } = usePreviewArticle();
   const [previewContent, setPreviewContent] = useState("");
-  const { getSessionForFile, uploadVideo, isUploading, uploadProgress } = useTusVideoUpload();
+  const { getSessionForFile, uploadVideo } = useTusVideoUpload();
+  const { items, enqueue, setStatus, setProgress, attachUploadId, clearFinished, remove } =
+    useRichTextUploadQueue();
   const { askForDisplayMode, dialog: uploadDisplayModeDialog } = useUploadDisplayModeDialog();
 
   const pageTitle = t("adminArticleView.form.editTitle");
@@ -215,6 +219,13 @@ function ArticleFormPage({ defaultValues }: ArticleFormPageProps) {
         description: t("uploadFile.toast.videoFailed"),
         variant: "destructive",
       });
+    },
+    fallbackUploadErrorMessage: t("uploadFile.toast.videoFailed"),
+    uploadQueue: {
+      enqueue,
+      setStatus,
+      setProgress,
+      attachUploadId,
     },
   });
 
@@ -373,8 +384,12 @@ function ArticleFormPage({ defaultValues }: ArticleFormPageProps) {
                               allowFiles
                               acceptedFileTypes={RICH_TEXT_ACCEPTED_FILE_TYPES}
                               onUpload={handleFileUpload}
-                              uploadProgress={isUploading ? (uploadProgress ?? 0) : null}
                               onChange={field.onChange}
+                            />
+                            <RichTextUploadQueue
+                              items={items}
+                              onClearFinished={clearFinished}
+                              onRemoveItem={remove}
                             />
                             <FormMessage />
                           </div>

--- a/apps/web/app/modules/News/NewsForm.page.tsx
+++ b/apps/web/app/modules/News/NewsForm.page.tsx
@@ -16,6 +16,7 @@ import {
 import { useClearVideoOnTabChange } from "~/hooks/useClearVideoOnTabChange";
 import { useEntityResourceUpload } from "~/hooks/useEntityResourceUpload";
 import { useHandleImageUpload } from "~/hooks/useHandleImageUpload";
+import { useRichTextUploadQueue } from "~/hooks/useRichTextUploadQueue";
 import { useTusVideoUpload } from "~/hooks/useTusVideoUpload";
 import { useUploadDisplayModeDialog } from "~/hooks/useUploadDisplayModeDialog";
 
@@ -25,6 +26,7 @@ import ImageUploadInput from "../../components/FileUploadInput/ImageUploadInput"
 import { FormTextField } from "../../components/Form/FormTextField";
 import { PageWrapper } from "../../components/PageWrapper";
 import { ContentEditor } from "../../components/RichText/Editor";
+import { RichTextUploadQueue } from "../../components/RichText/RichTextUploadQueue";
 import Viewer from "../../components/RichText/Viever";
 import { Button } from "../../components/ui/button";
 import { Form, FormControl, FormField, FormItem, FormMessage } from "../../components/ui/form";
@@ -94,7 +96,9 @@ function NewsFormPage({ defaultValues }: NewsFormPageProps) {
   const { mutateAsync: updateNews } = useUpdateNews();
   const { uploadResource } = useEntityResourceUpload();
   const { mutateAsync: initVideoUpload } = useInitVideoUpload();
-  const { getSessionForFile, uploadVideo, isUploading, uploadProgress } = useTusVideoUpload();
+  const { getSessionForFile, uploadVideo } = useTusVideoUpload();
+  const { items, enqueue, setStatus, setProgress, attachUploadId, clearFinished, remove } =
+    useRichTextUploadQueue();
   const { toast } = useToast();
   const { mutateAsync: previewNews, isPending: isPreviewLoading } = usePreviewNews();
   const [previewContent, setPreviewContent] = useState("");
@@ -207,6 +211,13 @@ function NewsFormPage({ defaultValues }: NewsFormPageProps) {
         description: t("uploadFile.toast.videoFailed"),
         variant: "destructive",
       });
+    },
+    fallbackUploadErrorMessage: t("uploadFile.toast.videoFailed"),
+    uploadQueue: {
+      enqueue,
+      setStatus,
+      setProgress,
+      attachUploadId,
     },
   });
 
@@ -420,8 +431,12 @@ function NewsFormPage({ defaultValues }: NewsFormPageProps) {
                               allowFiles
                               acceptedFileTypes={RICH_TEXT_ACCEPTED_FILE_TYPES}
                               onUpload={handleFileUpload}
-                              uploadProgress={isUploading ? (uploadProgress ?? 0) : null}
                               {...field}
+                            />
+                            <RichTextUploadQueue
+                              items={items}
+                              onClearFinished={clearFinished}
+                              onRemoveItem={remove}
                             />
                             <FormMessage />
                           </div>

--- a/apps/web/app/modules/News/NewsForm.page.tsx
+++ b/apps/web/app/modules/News/NewsForm.page.tsx
@@ -1,29 +1,20 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useNavigate, useParams } from "@remix-run/react";
-import {
-  ALLOWED_EXCEL_FILE_TYPES,
-  ALLOWED_LESSON_IMAGE_FILE_TYPES,
-  ALLOWED_PDF_FILE_TYPES,
-  ALLOWED_PRESENTATION_FILE_TYPES,
-  ALLOWED_VIDEO_FILE_TYPES,
-  ALLOWED_WORD_FILE_TYPES,
-  ENTITY_TYPES,
-} from "@repo/shared";
+import { ALLOWED_LESSON_IMAGE_FILE_TYPES, ENTITY_TYPES } from "@repo/shared";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useLocation } from "react-use";
-import { match } from "ts-pattern";
 import { z } from "zod";
 
 import { useInitVideoUpload } from "~/api/mutations/admin/useInitVideoUpload";
 import { useToast } from "~/components/ui/use-toast";
-import { useClearVideoOnTabChange } from "~/hooks/useClearVideoOnTabChange";
 import {
-  buildEntityResourceUrl,
-  insertResourceIntoEditor,
-  useEntityResourceUpload,
-} from "~/hooks/useEntityResourceUpload";
+  buildRichTextFileUploadHandler,
+  RICH_TEXT_ACCEPTED_FILE_TYPES,
+} from "~/hooks/buildRichTextFileUploadHandler";
+import { useClearVideoOnTabChange } from "~/hooks/useClearVideoOnTabChange";
+import { useEntityResourceUpload } from "~/hooks/useEntityResourceUpload";
 import { useHandleImageUpload } from "~/hooks/useHandleImageUpload";
 import { useTusVideoUpload } from "~/hooks/useTusVideoUpload";
 import { useUploadDisplayModeDialog } from "~/hooks/useUploadDisplayModeDialog";
@@ -185,84 +176,43 @@ function NewsFormPage({ defaultValues }: NewsFormPageProps) {
     navigate(`/news/${id}`);
   };
 
+  const sharedFileUploadHandler = buildRichTextFileUploadHandler({
+    entityType: ENTITY_TYPES.NEWS,
+    getVideoSessionForFile: (file) =>
+      getSessionForFile({
+        file,
+        init: () =>
+          initVideoUpload({
+            filename: file.name,
+            sizeBytes: file.size,
+            mimeType: file.type,
+            title: file.name,
+            resource: ENTITY_TYPES.NEWS,
+            entityId: id,
+            entityType: ENTITY_TYPES.NEWS,
+          }),
+      }),
+    uploadVideo,
+    uploadResourceFile: (file) =>
+      uploadResource({
+        file,
+        entityType: ENTITY_TYPES.NEWS,
+        entityId: id,
+        language,
+      }),
+    askForDisplayMode,
+    onVideoUploadError: (error) => {
+      console.error("Error uploading video:", error);
+      toast({
+        description: t("uploadFile.toast.videoFailed"),
+        variant: "destructive",
+      });
+    },
+  });
+
   const handleFileUpload = async (file?: File, editor?: TipTapEditor | null) => {
     if (!file || !id) return;
-
-    const isVideo = ALLOWED_VIDEO_FILE_TYPES.includes(file.type);
-    const isPresentation = ALLOWED_PRESENTATION_FILE_TYPES.includes(file.type);
-    const isPdf = ALLOWED_PDF_FILE_TYPES.includes(file.type);
-    const isDocument =
-      isPdf ||
-      ALLOWED_EXCEL_FILE_TYPES.includes(file.type) ||
-      ALLOWED_WORD_FILE_TYPES.includes(file.type);
-
-    if (isVideo) {
-      try {
-        const session = await getSessionForFile({
-          file,
-          init: () =>
-            initVideoUpload({
-              filename: file.name,
-              sizeBytes: file.size,
-              mimeType: file.type,
-              title: file.name,
-              resource: ENTITY_TYPES.NEWS,
-              entityId: id,
-              entityType: ENTITY_TYPES.NEWS,
-            }),
-        });
-
-        await uploadVideo({ file, session });
-
-        if (session.resourceId) {
-          const resourceUrl = buildEntityResourceUrl(session.resourceId, ENTITY_TYPES.NEWS);
-
-          editor
-            ?.chain()
-            .insertContent("<br />")
-            .setVideoEmbed({
-              src: resourceUrl,
-              sourceType: session.provider === "s3" ? "external" : "internal",
-            })
-            .run();
-        }
-      } catch (error) {
-        console.error("Error uploading video:", error);
-        toast({
-          description: t("uploadFile.toast.videoFailed"),
-          variant: "destructive",
-        });
-      }
-      return;
-    }
-
-    let displayMode: "preview" | "download" = "preview";
-
-    if (isPresentation || isPdf) {
-      const selectedMode = await askForDisplayMode(file.name);
-      if (!selectedMode) return;
-      displayMode = selectedMode;
-    }
-
-    const resourceId = await uploadResource({
-      file,
-      entityType: ENTITY_TYPES.NEWS,
-      entityId: id,
-      language,
-    });
-
-    insertResourceIntoEditor({
-      editor,
-      resourceId,
-      entityType: ENTITY_TYPES.NEWS,
-      file,
-      resourceType: match({ isPresentation, isPdf, isDocument })
-        .with({ isPresentation: true }, () => "presentation" as const)
-        .with({ isPdf: true }, () => "pdf" as const)
-        .with({ isDocument: true }, () => "document" as const)
-        .otherwise(() => "other" as const),
-      displayMode: isPresentation || isDocument ? displayMode : "preview",
-    });
+    await sharedFileUploadHandler(file, editor);
   };
 
   useEffect(() => {
@@ -468,14 +418,7 @@ function NewsFormPage({ defaultValues }: NewsFormPageProps) {
                               id="content"
                               content={field.value}
                               allowFiles
-                              acceptedFileTypes={[
-                                ...ALLOWED_LESSON_IMAGE_FILE_TYPES,
-                                ...ALLOWED_VIDEO_FILE_TYPES,
-                                ...ALLOWED_EXCEL_FILE_TYPES,
-                                ...ALLOWED_PDF_FILE_TYPES,
-                                ...ALLOWED_WORD_FILE_TYPES,
-                                ...ALLOWED_PRESENTATION_FILE_TYPES,
-                              ]}
+                              acceptedFileTypes={RICH_TEXT_ACCEPTED_FILE_TYPES}
                               onUpload={handleFileUpload}
                               uploadProgress={isUploading ? (uploadProgress ?? 0) : null}
                               {...field}


### PR DESCRIPTION
## Issue(s)
[](https://github.com/Selleo/mentingo/issues/)

## Overview
This PR improves rich text media upload UX and reliability across editor-based forms (`ContentLessonForm`, `ArticleForm`, `NewsForm`) and related upload infrastructure.

It introduces a rich text upload queue to track per-file upload state (especially video/resource uploads), surfaces upload progress/feedback in the editor flow, and centralizes upload handling logic into a reusable hook.

Additionally, for lesson content editing, it adds leave-confirmation behavior and improves instant video upload handling with rollback on error to prevent inconsistent form state.

## Business Value
- Reduces risk of user confusion and content loss during media uploads in rich text editors.
- Improves confidence and transparency for long-running uploads by exposing upload state/notifications.
- Standardizes upload behavior across multiple content forms, reducing bugs and maintenance cost.
- Improves editing safety in lesson flow by warning on unsaved exits and rolling back failed instant uploads.

## Screenshots / Video

https://github.com/user-attachments/assets/58971ef9-cf96-4fcf-88ab-310e35cbc161

