### PR TITLE
chore: automatically play welcome message on voice ai mentor conversation start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ yarn-error.log*
 # Code
 .vscode
 .cursor
+.gitnexus

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -39,7 +39,7 @@
     "@aws-sdk/s3-request-presigner": "3.658.1",
     "@faker-js/faker": "8.4.1",
     "@golevelup/nestjs-stripe": "0.8.2",
-    "@japro/luma-sdk": "0.2.6",
+    "@japro/luma-sdk": "0.2.7",
     "@keyv/redis": "4.0.2",
     "@knaadh/nestjs-drizzle-postgres": "1.0.0",
     "@langchain/community": "0.3.56",

--- a/apps/api/src/audio/audio.gateway.ts
+++ b/apps/api/src/audio/audio.gateway.ts
@@ -12,7 +12,7 @@ import { PcmChunkMeta, VOICE_SOCKET_EVENT } from "@repo/shared";
 import { Server } from "socket.io";
 
 import { AudioService } from "src/audio/audio.service";
-import { StartAudioBody } from "src/audio/types/audio.types";
+import { SendTTSTriggerBody, StartAudioBody } from "src/audio/types/audio.types";
 import { TenantDbRunnerService } from "src/storage/db/tenant-db-runner.service";
 import { AuthenticatedSocket, WsJwtGuard } from "src/websocket";
 
@@ -87,5 +87,14 @@ export class AudioGateway implements OnGatewayInit, OnGatewayDisconnect, Realtim
   @SubscribeMessage(VOICE_SOCKET_EVENT.CANCEL_AUDIO)
   async cancelAudio(@ConnectedSocket() client: AuthenticatedSocket) {
     return await this.audioService.cancelAudio(client.id);
+  }
+
+  @UseGuards(WsJwtGuard)
+  @SubscribeMessage(VOICE_SOCKET_EVENT.TRIGGER_TTS)
+  async triggerTTS(
+    @ConnectedSocket() client: AuthenticatedSocket,
+    @MessageBody("payload") payload: SendTTSTriggerBody,
+  ) {
+    return await this.audioService.triggerTTS(client.id, payload);
   }
 }

--- a/apps/api/src/audio/audio.service.ts
+++ b/apps/api/src/audio/audio.service.ts
@@ -21,7 +21,11 @@ import { ExternalAudioService } from "./external-audio.service";
 
 import type { OnModuleInit } from "@nestjs/common";
 import type { PcmChunkMeta, VoiceAction } from "@repo/shared";
-import type { StartAudioBody, StopAudioMessage } from "src/audio/types/audio.types";
+import type {
+  SendTTSTriggerBody,
+  StartAudioBody,
+  StopAudioMessage,
+} from "src/audio/types/audio.types";
 import type { WsUser } from "src/websocket/websocket.types";
 
 @Injectable()
@@ -138,6 +142,10 @@ export class AudioService implements OnModuleInit {
   async handleDisconnect(sessionId: string) {
     this.externalAudioService.clearSession(sessionId);
     await this.clearAudioState(sessionId);
+  }
+
+  async triggerTTS(sessionId: string, payload: SendTTSTriggerBody) {
+    await this.externalAudioService.triggerTTS(sessionId, payload);
   }
 
   private async setupRedisSubscriber() {

--- a/apps/api/src/audio/external-audio.service.ts
+++ b/apps/api/src/audio/external-audio.service.ts
@@ -38,7 +38,7 @@ import type {
   PcmChunkMeta,
   SupportedLanguages,
 } from "@repo/shared";
-import type { StartAudioBody } from "src/audio/types/audio.types";
+import type { SendTTSTriggerBody, StartAudioBody } from "src/audio/types/audio.types";
 import type { ExternalAudioSession } from "src/audio/types/external-audio-session.types";
 import type { ExternalAudioStartResult } from "src/audio/types/external-audio.types";
 import type { UUIDType } from "src/common";
@@ -46,6 +46,7 @@ import type { WsUser } from "src/websocket/websocket.types";
 
 type VoiceMentorSocketHandlers = {
   disconnect: () => void;
+  audioStarted: () => void;
   mentorTranscription: (payload: MentorTranscriptionPayload) => Promise<void>;
   audioOutputChunk: (payload: { data: AudioSpeechEventPayload }) => void;
   audioOutputInterrupted: () => void;
@@ -127,6 +128,17 @@ export class ExternalAudioService {
     session.socket.removeAllListeners();
     session.socket.disconnect();
     this.sessionStore.delete(sessionId);
+  }
+
+  async triggerTTS(sessionId: string, payload: SendTTSTriggerBody) {
+    const session = this.sessionStore.get(sessionId);
+    if (session) {
+      session.activeTurnId = `tts-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+      session.socket.sendTTSTrigger(payload);
+      return true;
+    }
+
+    return false;
   }
 
   private async startAudioForVoiceMentor(
@@ -214,6 +226,7 @@ export class ExternalAudioService {
     socket.onAudioOutputChunk(handlers.audioOutputChunk);
     socket.onAudioOutputInterrupted(handlers.audioOutputInterrupted);
     socket.onAudioOutputComplete(handlers.audioOutputComplete);
+    socket.onAudioStarted(handlers.audioStarted);
   }
 
   private createVoiceMentorSocketHandlers(
@@ -224,6 +237,9 @@ export class ExternalAudioService {
     return {
       disconnect: () => {
         this.sessionStore.delete(sessionId);
+      },
+      audioStarted: () => {
+        this.realtimePublisher.emitToRoom(VOICE_SOCKET_EVENT.AUDIO_STARTED, sessionId, {});
       },
       mentorTranscription: async (payload) => {
         await this.handleMentorTranscription(sessionId, payload);

--- a/apps/api/src/audio/types/audio.types.ts
+++ b/apps/api/src/audio/types/audio.types.ts
@@ -15,3 +15,7 @@ export type StartAudioBody = {
   lessonId?: UUIDType;
   meta: StreamInitPayload;
 };
+
+export type SendTTSTriggerBody = {
+  content: string;
+};

--- a/apps/web/app/modules/Courses/Lesson/AiMentorLesson/AiMentorLesson.tsx
+++ b/apps/web/app/modules/Courses/Lesson/AiMentorLesson/AiMentorLesson.tsx
@@ -257,6 +257,7 @@ const AiMentorLesson = ({ lesson, lessonLoading }: AiMentorLessonProps) => {
           onAudioInterrupted={invalidateCurrentThreadMessages}
           onAudioOutputCompleted={invalidateCurrentThreadMessages}
           handleInputChange={handleInputChange}
+          messages={messages}
           input={input}
           setInput={setInput}
         />

--- a/apps/web/app/modules/Courses/Lesson/AiMentorLesson/components/LessonForm.tsx
+++ b/apps/web/app/modules/Courses/Lesson/AiMentorLesson/components/LessonForm.tsx
@@ -11,6 +11,7 @@ import { useTranscription } from "~/modules/Voice/hooks/useTranscription";
 import { useVoiceMentor } from "~/modules/Voice/hooks/useVoiceMentor";
 import { useVoiceModeUIState } from "~/modules/Voice/hooks/useVoiceModeUIState";
 
+import type { Message } from "@ai-sdk/react";
 import type { ChangeEvent, Dispatch, SetStateAction } from "react";
 
 interface LessonFormProps {
@@ -25,6 +26,7 @@ interface LessonFormProps {
   input: string;
   handleInputChange: (e: ChangeEvent<HTMLInputElement> | ChangeEvent<HTMLTextAreaElement>) => void;
   setInput: Dispatch<SetStateAction<string>>;
+  messages: Message[];
 }
 
 export const LessonForm = ({
@@ -39,10 +41,12 @@ export const LessonForm = ({
   input,
   handleInputChange,
   setInput,
+  messages,
 }: LessonFormProps) => {
   const { t } = useTranslation();
   const [showEmojiPicker, setShowEmojiPicker] = useState(false);
   const [isVoiceMode, setIsVoiceMode] = useState(false);
+  const [isVoiceMentorAudioStarted, setIsVoiceMentorAudioStarted] = useState(false);
   const [voiceLevel, setVoiceLevel] = useState(0);
   const [latestTranscript, setLatestTranscript] = useState("");
   const [latestResponse, setLatestResponse] = useState("");
@@ -51,6 +55,8 @@ export const LessonForm = ({
   const voiceModeUI = useVoiceModeUIState();
 
   const emojiRef = useRef<HTMLDivElement | null>(null);
+  const hasTriggeredWelcomeRef = useRef(false);
+  const triggerWelcomeMessageRef = useRef<(message: string) => Promise<boolean>>(async () => false);
   const toggleEmojiPicker = () => setShowEmojiPicker((prev) => !prev);
 
   const { startRecording, stopRecording, cancelTranscription } = useTranscription({
@@ -61,6 +67,7 @@ export const LessonForm = ({
     isRecording: isVoiceMentorMode,
     startVoiceMentor,
     cancelVoiceMentor,
+    triggerWelcomeMessage,
   } = useVoiceMentor({
     lessonId,
     setInput,
@@ -73,6 +80,9 @@ export const LessonForm = ({
     onMentorResponseCompleted: (text) => {
       setLatestResponse(text);
       onMentorResponseCompleted?.(text);
+    },
+    onAudioStarted: () => {
+      setIsVoiceMentorAudioStarted(true);
     },
     onAudioOutputCompleted: () => {
       voiceModeUI.onAudioOutputCompleted(isVoiceMentorMode);
@@ -104,6 +114,27 @@ export const LessonForm = ({
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [showEmojiPicker]);
 
+  useEffect(() => {
+    triggerWelcomeMessageRef.current = triggerWelcomeMessage;
+  }, [triggerWelcomeMessage]);
+
+  useEffect(() => {
+    if (!isVoiceMentorMode || !isVoiceMentorAudioStarted) {
+      return;
+    }
+
+    if (hasTriggeredWelcomeRef.current) {
+      return;
+    }
+
+    if (messages.length !== 1 || messages[0]?.role !== "assistant") {
+      return;
+    }
+
+    hasTriggeredWelcomeRef.current = true;
+    void triggerWelcomeMessageRef.current(messages[0].content);
+  }, [isVoiceMentorAudioStarted, isVoiceMentorMode, messages]);
+
   const startVoiceMode = async () => {
     if (isVoiceMentorMode) {
       const canceledMentor = await cancelVoiceMentor();
@@ -114,6 +145,7 @@ export const LessonForm = ({
     setShowEmojiPicker(false);
     const hasStarted = await startRecording();
     if (!hasStarted) return;
+
     setIsVoiceMode(true);
     setLatestTranscript("");
     setLatestResponse("");
@@ -142,6 +174,8 @@ export const LessonForm = ({
     if (isVoiceMode) {
       await cancelVoiceMode();
     }
+    hasTriggeredWelcomeRef.current = false;
+    setIsVoiceMentorAudioStarted(false);
     setShowEmojiPicker(false);
     const started = await startVoiceMentor();
     if (!started) {

--- a/apps/web/app/modules/Voice/hooks/useVoiceMentor.ts
+++ b/apps/web/app/modules/Voice/hooks/useVoiceMentor.ts
@@ -1,4 +1,4 @@
-import { VOICE_ACTION } from "@repo/shared";
+import { VOICE_ACTION, VOICE_SOCKET_EVENT } from "@repo/shared";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -29,6 +29,7 @@ type VoiceMentorProps = {
   onLevelChange: (level: number) => void;
   onMentorTranscription?: (text: string) => void;
   onMentorResponseCompleted?: (text: string) => void;
+  onAudioStarted?: () => void;
   onAudioOutputCompleted?: () => void;
   onAudioInterrupted?: () => void;
   onSpeechChunkSent?: () => void;
@@ -41,6 +42,7 @@ export function useVoiceMentor({
   onLevelChange,
   onMentorTranscription,
   onMentorResponseCompleted,
+  onAudioStarted,
   onAudioOutputCompleted,
   onAudioInterrupted,
   onSpeechChunkSent,
@@ -55,6 +57,7 @@ export function useVoiceMentor({
   const setInputRef = useRef(setInput);
   const onMentorTranscriptionRef = useRef(onMentorTranscription);
   const onMentorResponseCompletedRef = useRef(onMentorResponseCompleted);
+  const onAudioStartedRef = useRef(onAudioStarted);
   const onAudioOutputCompletedRef = useRef(onAudioOutputCompleted);
   const onAudioInterruptedRef = useRef(onAudioInterrupted);
   const onSpeechChunkSentRef = useRef(onSpeechChunkSent);
@@ -80,6 +83,10 @@ export function useVoiceMentor({
   useEffect(() => {
     onMentorResponseCompletedRef.current = onMentorResponseCompleted;
   }, [onMentorResponseCompleted]);
+
+  useEffect(() => {
+    onAudioStartedRef.current = onAudioStarted;
+  }, [onAudioStarted]);
 
   useEffect(() => {
     onAudioOutputCompletedRef.current = onAudioOutputCompleted;
@@ -195,6 +202,7 @@ export function useVoiceMentor({
       onAudioChunkReceived: () => onAudioChunkReceivedRef.current?.(),
       onMentorTranscription: (text) => onMentorTranscriptionRef.current?.(text),
       onMentorResponseCompleted: (text) => onMentorResponseCompletedRef.current?.(text),
+      onAudioStarted: () => onAudioStartedRef.current?.(),
       onAudioInterrupted: () => onAudioInterruptedRef.current?.(),
     });
 
@@ -253,6 +261,24 @@ export function useVoiceMentor({
     }
   };
 
+  const triggerWelcomeMessage = async (message: string) => {
+    try {
+      const socket = acquireSocket();
+      socket.connect();
+
+      socket.emit(VOICE_SOCKET_EVENT.TRIGGER_TTS, {
+        payload: {
+          content: message,
+        },
+      });
+
+      return true;
+    } catch (error) {
+      console.error("Failed to send trigger for welcome message", error);
+      return false;
+    }
+  };
+
   const cancelVoiceMentor = async () => {
     try {
       await teardownVoiceMentorCapture();
@@ -268,5 +294,6 @@ export function useVoiceMentor({
     startVoiceMentor,
     stopVoiceMentor,
     cancelVoiceMentor,
+    triggerWelcomeMessage,
   };
 }

--- a/apps/web/app/modules/Voice/hooks/voiceMentorSocketHandlers.ts
+++ b/apps/web/app/modules/Voice/hooks/voiceMentorSocketHandlers.ts
@@ -30,10 +30,12 @@ type VoiceMentorSocketHandlerDependencies = {
   onAudioChunkReceived?: () => void;
   onMentorTranscription?: (text: string) => void;
   onMentorResponseCompleted?: (text: string) => void;
+  onAudioStarted?: () => void;
   onAudioInterrupted?: () => void;
 };
 
 type SocketEventHandlerMap = {
+  [VOICE_SOCKET_EVENT.AUDIO_STARTED]: () => void;
   [VOICE_SOCKET_EVENT.STOP_AUDIO]: (payload: StopAudioEventPayload) => void;
   [VOICE_SOCKET_EVENT.AUDIO_SPEECH]: (payload: AudioSpeechEventPayload) => Promise<void>;
   [VOICE_SOCKET_EVENT.MENTOR_TRANSCRIPTION]: (payload: MentorTranscriptionEventPayload) => void;
@@ -45,6 +47,7 @@ type SocketEventHandlerMap = {
 };
 
 export const SUPPORTED_VOICE_MENTOR_SOCKET_EVENTS = [
+  VOICE_SOCKET_EVENT.AUDIO_STARTED,
   VOICE_SOCKET_EVENT.STOP_AUDIO,
   VOICE_SOCKET_EVENT.AUDIO_SPEECH,
   VOICE_SOCKET_EVENT.MENTOR_TRANSCRIPTION,
@@ -66,9 +69,13 @@ export function createVoiceMentorSocketHandlers({
   onAudioChunkReceived,
   onMentorTranscription,
   onMentorResponseCompleted,
+  onAudioStarted,
   onAudioInterrupted,
 }: VoiceMentorSocketHandlerDependencies): SocketEventHandlerMap {
   return {
+    [VOICE_SOCKET_EVENT.AUDIO_STARTED]: () => {
+      onAudioStarted?.();
+    },
     [VOICE_SOCKET_EVENT.STOP_AUDIO]: (data) => {
       if (data?.voiceAction !== VOICE_ACTION.VOICE_MENTOR) {
         return;

--- a/packages/prompts/src/generated-prompts.ts
+++ b/packages/prompts/src/generated-prompts.ts
@@ -1,5 +1,5 @@
 /* AUTO-GENERATED FILE - DO NOT EDIT BY HAND */
-/* Generated At: 4/1/2026, 5:14:52 PM */
+/* Generated At: 4/2/2026, 12:08:47 PM */
 
 export const promptTemplates = {
   judgePrompt: {

--- a/packages/shared/src/constants/voiceAction.ts
+++ b/packages/shared/src/constants/voiceAction.ts
@@ -7,6 +7,7 @@ export type VoiceAction = (typeof VOICE_ACTION)[keyof typeof VOICE_ACTION];
 
 export const VOICE_SOCKET_EVENT = {
   START_AUDIO: "startAudio",
+  AUDIO_STARTED: "audioStarted",
   AUDIO_CHUNK: "audioChunk",
   AUDIO_SPEECH: "audioSpeech",
   AUDIO_INTERRUPTED: "audioInterrupted",
@@ -15,6 +16,7 @@ export const VOICE_SOCKET_EVENT = {
   MENTOR_RESPONSE_COMPLETED: "mentorResponseCompleted",
   STOP_AUDIO: "stopAudio",
   CANCEL_AUDIO: "cancelAudio",
+  TRIGGER_TTS: "triggerTTS",
 } as const;
 
 export type VoiceSocketEvent = (typeof VOICE_SOCKET_EVENT)[keyof typeof VOICE_SOCKET_EVENT];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: 0.8.2
         version: 0.8.2(@nestjs/common@10.4.17(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.4.17)(rxjs@7.8.1)(stripe@18.5.0(@types/node@20.17.6))
       '@japro/luma-sdk':
-        specifier: 0.2.6
-        version: 0.2.6
+        specifier: 0.2.7
+        version: 0.2.7
       '@keyv/redis':
         specifier: 4.0.2
         version: 4.0.2
@@ -3063,8 +3063,8 @@ packages:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
 
-  '@japro/luma-sdk@0.2.6':
-    resolution: {integrity: sha512-IGhjpVPtTaiMctHQj/1EglFSrqRxj5dbQZbNMwXxMUokF0qXQCBjMZ4RKLyBM6wXDWozHawyJS6ntvQYGtJU2A==}
+  '@japro/luma-sdk@0.2.7':
+    resolution: {integrity: sha512-iaw/myYHpF0guPbZKk2w+1ZIOVYGCnPns+es4Ic+KL5hfcXlTDVyEKewvmhHzNTcW8AvSw3dCItPWv4X8BimFw==}
 
   '@jest/console@29.7.0':
     resolution: {integrity: sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==}
@@ -10000,15 +10000,6 @@ packages:
 
   debug@4.3.7:
     resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
-  debug@4.4.1:
-    resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -18824,7 +18815,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.1
+      debug: 4.4.3
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -18938,7 +18929,7 @@ snapshots:
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.1
+      debug: 4.4.3
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -19130,7 +19121,7 @@ snapshots:
 
   '@istanbuljs/schema@0.1.3': {}
 
-  '@japro/luma-sdk@0.2.6':
+  '@japro/luma-sdk@0.2.7':
     dependencies:
       axios: 1.13.5(debug@4.4.3)
       socket.io-client: 4.8.3
@@ -27674,10 +27665,6 @@ snapshots:
     optional: true
 
   debug@4.3.7:
-    dependencies:
-      ms: 2.1.3
-
-  debug@4.4.1:
     dependencies:
       ms: 2.1.3
 


### PR DESCRIPTION
<!--
 1. Make sure you have correct branch name i.e. `ab_prefix_123_task_name`, where `123` is a issue ID, and `ab` is an author
 2. Make sure you have meaningful title related to task with correct prefix: feat/fix/chore/style/docs/refactor
 3. Reference multiple issues in one PR by listing them in the issues section
 4. Make sure all necessary sections are filled, remove obsolete sections
 5. Do a self review first
 6. Check if your PR includes only code related to your task
 7. `Notes` is used for additional info but also to notify if any action is required
-->

## Issue(s)
[1406](https://github.com/Selleo/mentingo/issues/1406)

## Overview

This PR adds a dedicated TTS trigger flow for the AI Mentor welcome message in voice mode.

Key changes:

- Added new voice socket events: triggerTTS and audioStarted.
- Added backend socket handler (AudioGateway/AudioService/ExternalAudioService) to accept
  TRIGGER_TTS and forward { content } to external audio.
- Wired audioStarted event from external audio back to the client.
- Updated voice mentor frontend flow to:
    - listen for audioStarted,
    - trigger TTS once for the initial assistant welcome message when entering voice mentor mode,
    - reset trigger state when restarting/canceling voice mentor.
- Updated shared constants/types and bumped @japro/luma-sdk to 0.2.7.

## Business Value

This improves first-time voice mentor UX by making the initial assistant welcome message spoken
automatically, so users get immediate audible guidance without extra interaction.
It reduces friction at session start, makes voice mode feel more responsive and intentional, and
increases clarity for users who rely on audio-first interaction.

## Screenshots / Video

https://github.com/user-attachments/assets/1e6cd3ac-3fa5-49e1-9c02-9e07b8fb2333


