### PR TITLE
fix: correct the student progress preview shown to admins in the statistics view

### DIFF
--- a/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/components/CourseStudentsAiMentorResults.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/components/CourseStudentsAiMentorResults.tsx
@@ -35,6 +35,9 @@ import type { FilterValue } from "~/modules/common/SearchFilter/SearchFilter";
 
 type CourseStudentsAiMentorResultsColumn = GetCourseStudentsAiMentorResultsResponse["data"][number];
 
+export const getCourseStudentsAiMentorResultsRowId = (row: CourseStudentsAiMentorResultsColumn) =>
+  `${row.studentId}-${row.lessonId}`;
+
 interface CourseStudentsAiMentorResultsTableProps {
   courseId: string;
   searchParams: CourseStudentsAiMentorResultsQueryParams;
@@ -166,7 +169,7 @@ export function CourseStudentsAiMentorResultsTable({
   );
 
   const table = useReactTable({
-    getRowId: (row) => row.studentId,
+    getRowId: getCourseStudentsAiMentorResultsRowId,
     data: tableData,
     columns,
     getCoreRowModel: getCoreRowModel(),
@@ -205,7 +208,7 @@ export function CourseStudentsAiMentorResultsTable({
         <TableBody>
           {table.getRowModel().rows.map((row) => (
             <TableRow
-              key={row.id + row.index}
+              key={row.id}
               data-state={row.getIsSelected() && "selected"}
               className="cursor-pointer hover:bg-neutral-100"
             >

--- a/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/components/CourseStudentsQuizResultsTable.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/components/CourseStudentsQuizResultsTable.tsx
@@ -33,6 +33,9 @@ import type { FilterValue } from "~/modules/common/SearchFilter/SearchFilter";
 
 type CourseStudentsQuizResultsColumn = GetCourseStudentsQuizResultsResponse["data"][number];
 
+export const getCourseStudentsQuizResultsRowId = (row: CourseStudentsQuizResultsColumn) =>
+  `${row.studentId}-${row.lessonId}`;
+
 interface CourseStudentsQuizResultsTableProps {
   courseId: string;
   course?: GetCourseResponse["data"];
@@ -174,7 +177,7 @@ export function CourseStudentsQuizResultsTable({
   );
 
   const table = useReactTable({
-    getRowId: (row) => row.studentId,
+    getRowId: getCourseStudentsQuizResultsRowId,
     data: tableData,
     columns,
     getCoreRowModel: getCoreRowModel(),
@@ -221,7 +224,7 @@ export function CourseStudentsQuizResultsTable({
         <TableBody>
           {table.getRowModel().rows.map((row) => (
             <TableRow
-              key={row.id + row.index}
+              key={row.id}
               data-state={row.getIsSelected() && "selected"}
               className="cursor-pointer hover:bg-neutral-100"
             >

--- a/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/components/LessonPreviewDialog.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/components/LessonPreviewDialog.tsx
@@ -74,6 +74,8 @@ export default function LessonPreviewDialog({
     ? Math.ceil((thresholdPercentage * maxScore) / 100)
     : Math.ceil((thresholdPercentage * maxScore) / 100);
 
+  const { firstName, lastName, profilePictureUrl } = user;
+
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent
@@ -131,6 +133,11 @@ export default function LessonPreviewDialog({
               <LessonContent
                 lesson={lesson}
                 course={course}
+                previewUser={{
+                  firstName,
+                  lastName,
+                  profilePictureUrl,
+                }}
                 lessonsAmount={currentChapter?.lessons.length ?? 0}
                 handleNext={() => {}}
                 handlePrevious={() => {}}

--- a/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/components/courseStatisticsRowId.test.ts
+++ b/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/components/courseStatisticsRowId.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { getCourseStudentsAiMentorResultsRowId } from "./CourseStudentsAiMentorResults";
+import { getCourseStudentsQuizResultsRowId } from "./CourseStudentsQuizResultsTable";
+
+describe("course statistics row ids", () => {
+  it("creates unique row ids for quiz results when one student has multiple lessons", () => {
+    const rowIdA = getCourseStudentsQuizResultsRowId({
+      studentId: "student-1",
+      lessonId: "lesson-1",
+    } as never);
+
+    const rowIdB = getCourseStudentsQuizResultsRowId({
+      studentId: "student-1",
+      lessonId: "lesson-2",
+    } as never);
+
+    expect(rowIdA).not.toBe(rowIdB);
+  });
+
+  it("creates unique row ids for ai mentor results when one student has multiple lessons", () => {
+    const rowIdA = getCourseStudentsAiMentorResultsRowId({
+      studentId: "student-1",
+      lessonId: "lesson-1",
+    } as never);
+
+    const rowIdB = getCourseStudentsAiMentorResultsRowId({
+      studentId: "student-1",
+      lessonId: "lesson-2",
+    } as never);
+
+    expect(rowIdA).not.toBe(rowIdB);
+  });
+});

--- a/apps/web/app/modules/Courses/Lesson/AiMentorLesson/AiMentorLesson.tsx
+++ b/apps/web/app/modules/Courses/Lesson/AiMentorLesson/AiMentorLesson.tsx
@@ -29,6 +29,7 @@ import RetakeModal from "~/modules/Courses/Lesson/AiMentorLesson/components/Reta
 import { stripHtmlTags } from "~/utils/stripHtmlTags";
 
 import type { GetLessonByIdResponse } from "~/api/generated-api";
+import type { LessonPreviewUser } from "~/modules/Courses/Lesson/types";
 
 const apiUrl = import.meta.env.VITE_API_URL;
 const chatUrl = apiUrl ? `${apiUrl}/api/ai/chat` : "/api/ai/chat";
@@ -36,9 +37,10 @@ const chatUrl = apiUrl ? `${apiUrl}/api/ai/chat` : "/api/ai/chat";
 interface AiMentorLessonProps {
   lesson: GetLessonByIdResponse["data"];
   lessonLoading: boolean;
+  previewUser?: LessonPreviewUser;
 }
 
-const AiMentorLesson = ({ lesson, lessonLoading }: AiMentorLessonProps) => {
+const AiMentorLesson = ({ lesson, lessonLoading, previewUser }: AiMentorLessonProps) => {
   const { t } = useTranslation();
   const { courseId = "" } = useParams();
   const courseExperience = useOptionalCourseAccessProvider();
@@ -232,6 +234,7 @@ const AiMentorLesson = ({ lesson, lessonLoading }: AiMentorLessonProps) => {
               key={idx}
               aiName={lesson.aiMentor?.name || ""}
               avatarUrl={lesson.aiMentor?.avatarReferenceUrl}
+              previewUser={previewUser}
               {...messages}
             />
           ))}

--- a/apps/web/app/modules/Courses/Lesson/AiMentorLesson/components/ChatMessage.tsx
+++ b/apps/web/app/modules/Courses/Lesson/AiMentorLesson/components/ChatMessage.tsx
@@ -11,6 +11,8 @@ import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
 import { UserAvatar } from "~/components/UserProfile/UserAvatar";
 import { cn } from "~/lib/utils";
 import { variants } from "~/modules/Courses/Lesson/AiMentorLesson/components/variants";
+
+import type { LessonPreviewUser } from "~/modules/Courses/Lesson/types";
 import "katex/dist/katex.min.css";
 
 interface ChatMessageProps {
@@ -23,6 +25,7 @@ interface ChatMessageProps {
   userName?: string;
   aiName?: string | null;
   avatarUrl?: string;
+  previewUser?: LessonPreviewUser;
   messageMaxWidthClass?: string;
 }
 
@@ -35,6 +38,7 @@ const ChatMessage = ({
   userName,
   aiName,
   avatarUrl,
+  previewUser,
   messageMaxWidthClass = "max-w-[90%]",
 }: ChatMessageProps) => {
   const { t } = useTranslation();
@@ -47,7 +51,9 @@ const ChatMessage = ({
       return aiName ?? t("studentCourseView.lesson.aiMentorLesson.aiMentorName");
     }
 
-    const fallbackName = `${currentUser?.firstName ?? ""} ${currentUser?.lastName ?? ""}`.trim();
+    const previewUserName = `${previewUser?.firstName ?? ""} ${previewUser?.lastName ?? ""}`.trim();
+    const fallbackName =
+      previewUserName || `${currentUser?.firstName ?? ""} ${currentUser?.lastName ?? ""}`.trim();
 
     return (
       userName ||
@@ -85,7 +91,10 @@ const ChatMessage = ({
           </Avatar>
         ) : (
           <div className="flex size-full items-center justify-center rounded-full bg-gray-200">
-            <UserAvatar userName={displayName} profilePictureUrl={currentUser?.profilePictureUrl} />
+            <UserAvatar
+              userName={displayName}
+              profilePictureUrl={previewUser?.profilePictureUrl ?? currentUser?.profilePictureUrl}
+            />
           </div>
         )}
       </div>

--- a/apps/web/app/modules/Courses/Lesson/LessonContent.tsx
+++ b/apps/web/app/modules/Courses/Lesson/LessonContent.tsx
@@ -22,10 +22,12 @@ import { LessonContentRenderer } from "./LessonContentRenderer";
 import { isNextBlocked, isPreviousBlocked } from "./utils";
 
 import type { GetCourseResponse, GetLessonByIdResponse } from "~/api/generated-api";
+import type { LessonPreviewUser } from "~/modules/Courses/Lesson/types";
 
 type LessonContentProps = {
   lesson: GetLessonByIdResponse["data"];
   course: GetCourseResponse["data"];
+  previewUser?: LessonPreviewUser;
   lessonsAmount: number;
   handlePrevious: () => void;
   handleNext: () => void;
@@ -37,6 +39,7 @@ type LessonContentProps = {
 export const LessonContent = ({
   lesson,
   course,
+  previewUser,
   lessonsAmount,
   handlePrevious,
   handleNext,
@@ -276,6 +279,7 @@ export const LessonContent = ({
           <LessonContentRenderer
             lesson={lesson}
             user={user}
+            previewUser={previewUser}
             lessonLoading={lessonLoading}
             onVideoEnded={handleVideoEnded}
           />

--- a/apps/web/app/modules/Courses/Lesson/LessonContentRenderer.tsx
+++ b/apps/web/app/modules/Courses/Lesson/LessonContentRenderer.tsx
@@ -8,22 +8,26 @@ import { EmbedLesson } from "./EmbedLesson/EmbedLesson";
 import { Quiz } from "./Quiz";
 
 import type { CurrentUserResponse, GetLessonByIdResponse } from "~/api/generated-api";
+import type { LessonPreviewUser } from "~/modules/Courses/Lesson/types";
 
 type LessonContentRendererProps = {
   lesson: GetLessonByIdResponse["data"];
   user: CurrentUserResponse["data"] | undefined;
+  previewUser?: LessonPreviewUser;
   lessonLoading: boolean;
   onVideoEnded?: () => void;
 };
 
 export const LessonContentRenderer = memo(
-  ({ lesson, user, lessonLoading, onVideoEnded }: LessonContentRendererProps) => {
+  ({ lesson, user, previewUser, lessonLoading, onVideoEnded }: LessonContentRendererProps) => {
     return match(lesson.type)
       .with("content", () => (
         <Viewer variant="content" content={lesson?.description ?? ""} onVideoEnded={onVideoEnded} />
       ))
       .with("quiz", () => <Quiz lesson={lesson} userId={user?.id || ""} />)
-      .with("ai_mentor", () => <AiMentorLesson lesson={lesson} lessonLoading={lessonLoading} />)
+      .with("ai_mentor", () => (
+        <AiMentorLesson lesson={lesson} lessonLoading={lessonLoading} previewUser={previewUser} />
+      ))
       .with("embed", () => (
         <EmbedLesson lessonResources={lesson.lessonResources ?? []} lesson={lesson} />
       ))

--- a/apps/web/app/modules/Courses/Lesson/Quiz.tsx
+++ b/apps/web/app/modules/Courses/Lesson/Quiz.tsx
@@ -52,22 +52,17 @@ export const Quiz = ({ lesson, userId }: QuizProps) => {
     () =>
       (lesson.quizDetails?.questions ?? []).map((question) => ({
         ...question,
-        options: question.options?.map((option) => ({
-          ...option,
-          isCorrect: isPreviewMode ? null : option.isCorrect,
-          isStudentAnswer: isPreviewMode ? false : option.isStudentAnswer,
-          studentAnswer: isPreviewMode ? null : option.studentAnswer,
-        })),
+        options: question.options,
       })),
-    [isPreviewMode, lesson.quizDetails?.questions],
+    [lesson.quizDetails?.questions],
   );
-  const isUserSubmittedAnswer = !isPreviewMode && Boolean(lesson.lessonCompleted);
+  const isUserSubmittedAnswer = Boolean(lesson.lessonCompleted);
 
   const methods = useForm<QuizForm>({
     mode: "onSubmit",
-    defaultValues: (isPreviewMode
-      ? getEmptyQuizAnswers(questions)
-      : getUserAnswers(questions)) as QuizForm,
+    defaultValues: (isUserSubmittedAnswer
+      ? getUserAnswers(questions)
+      : getEmptyQuizAnswers(questions)) as QuizForm,
     resolver: zodResolver(QuizFormSchema(t)),
   });
 

--- a/apps/web/app/modules/Courses/Lesson/types.ts
+++ b/apps/web/app/modules/Courses/Lesson/types.ts
@@ -34,6 +34,12 @@ export type QuizForm = {
   };
 };
 
+export type LessonPreviewUser = {
+  firstName?: string | null;
+  lastName?: string | null;
+  profilePictureUrl?: string | null;
+};
+
 export const LESSON_PROGRESS_STATUSES = {
   NOT_STARTED: "not_started",
   IN_PROGRESS: "in_progress",


### PR DESCRIPTION
## Issue(s)
- #1403 

## Overview
This PR fixes missing/wrong student data in admin course statistics preview flows.

Implemented changes:
- Fixed non-unique row identity in statistics tables by using composite row IDs (`studentId-lessonId`) for:
  - Quiz Results
  - AI Mentor Results
- Added regression test covering row ID uniqueness for repeated student rows across different lessons.
- Fixed lesson preview rendering in admin statistics so quiz preview uses submitted answers state in read-only mode (instead of interactive empty state).
- Fixed AI Mentor preview avatar/name context to use the selected preview student instead of the currently logged-in admin user.
- Extracted duplicated preview user shape into shared `LessonPreviewUser` type for consistency.

## Business Value
- Restores trust in course analytics by showing correct student-specific preview content.
- Prevents misleading admin decisions caused by empty/wrong preview data.
- Improves QA reliability with regression coverage for duplicated-row scenarios.
- Improves maintainability by centralizing preview user typing.

## Screenshots / Video

https://github.com/user-attachments/assets/e2acd8bc-e885-4769-a1cb-4e8f281c22de




