### PR TITLE
fix: make Q&A visible to users who aren’t logged in

### DIFF
--- a/apps/web/app/modules/QA/QA.page.tsx
+++ b/apps/web/app/modules/QA/QA.page.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import useAllQA from "~/api/queries/useAllQA";
-import { useUserSettings } from "~/api/queries/useUserSettings";
 import { PageWrapper } from "~/components/PageWrapper";
 import { Accordion } from "~/components/ui/accordion";
 import { Button } from "~/components/ui/button";
@@ -22,8 +21,6 @@ export default function QAPage() {
   const { t } = useTranslation();
 
   const { hasAccess: canManageQA } = usePermissions({ required: PERMISSIONS.QA_MANAGE });
-  const { data: settings } = useUserSettings();
-
   const { language } = useLanguageStore();
 
   const { data: QA } = useAllQA(language);
@@ -51,11 +48,9 @@ export default function QAPage() {
     if (canManageQA) return QA;
 
     return QA?.filter((item) => {
-      if (!settings?.language) return false;
-
-      return item.availableLocales.includes(settings.language);
+      return item.availableLocales.includes(language);
     });
-  }, [QA, canManageQA, settings?.language]);
+  }, [QA, canManageQA, language]);
 
   return (
     <ContentAccessGuard type={ACCESS_GUARD.UNREGISTERED_QA_ACCESS}>


### PR DESCRIPTION
<!--
 1. Make sure you have correct branch name i.e. `ab_prefix_123_task_name`, where `123` is a issue ID, and `ab` is an author
 2. Make sure you have meaningful title related to task with correct prefix: feat/fix/chore/style/docs/refactor
 3. Reference multiple issues in one PR by listing them in the issues section
 4. Make sure all necessary sections are filled, remove obsolete sections
 5. Do a self review first
 6. Check if your PR includes only code related to your task
 7. `Notes` is used for additional info but also to notify if any action is required
-->

## Issue(s)
[1411](https://github.com/Selleo/mentingo/issues/1411)

## Overview

This PR fixes QA visibility for non-admin users on the QA page.

Previously, filtering for regular users relied on useUserSettings().language, and content could be
incorrectly hidden when settings were missing or not one of the expected values.
The fix removes the useUserSettings dependency and uses the active app language
(useLanguageStore().language) to filter QA.availableLocales consistently.

Scope of change:

- Updated apps/web/app/modules/QA/QA.page.tsx
- Removed useUserSettings import/usage
- Switched filtering logic to language from language store
- Updated memo dependencies accordingly

## Business Value

This ensures non-admin users reliably see QA content in their selected app language, reducing
false “empty QA” states and improving trust in the product’s help/support experience. It directly
  improves usability and lowers friction for end users trying to find answers.

## Screenshots / Video

https://github.com/user-attachments/assets/25bdf475-bb6a-4257-9c28-7d353d3c2106

