### PR TITLE
fix: make course configuration toggles update correctly when changed

### DIFF
--- a/apps/api/src/courses/course.controller.ts
+++ b/apps/api/src/courses/course.controller.ts
@@ -95,10 +95,8 @@ import {
 } from "src/courses/schemas/showCourseCommon.schema";
 import { UpdateCourseBody, updateCourseSchema } from "src/courses/schemas/updateCourse.schema";
 import {
-  updateCourseSettingsMultipartSchema,
   updateCourseSettingsSchema,
   type UpdateCourseSettings,
-  type UpdateCourseSettingsMultipart,
 } from "src/courses/schemas/updateCourseSettings.schema";
 import {
   allCoursesValidation,
@@ -548,14 +546,17 @@ export class CourseController {
   @Validate({
     request: [
       { type: "param", name: "courseId", schema: UUIDSchema },
-      { type: "body", schema: updateCourseSettingsMultipartSchema },
+      {
+        type: "body",
+        schema: updateCourseSettingsSchema,
+        pipes: [new ValidateMultipartPipe(updateCourseSettingsSchema)],
+      },
     ],
     response: baseResponse(Type.Object({ message: Type.String() })),
   })
   async updateCourseSettings(
     @Param("courseId") courseId: UUIDType,
-    @Body(new ValidateMultipartPipe(updateCourseSettingsSchema))
-    body: UpdateCourseSettingsMultipart,
+    @Body() body: UpdateCourseSettings,
     @UploadedFile(
       getBaseFileTypePipe(
         buildFileTypeRegex([...ALLOWED_CERTIFICATE_SIGNATURE_FILE_TYPES]),
@@ -571,7 +572,7 @@ export class CourseController {
   ): Promise<BaseResponse<{ message: string }>> {
     await this.courseService.updateCourseSettings(
       courseId,
-      body as UpdateCourseSettings,
+      body,
       currentUser,
       certificateSignature,
     );

--- a/apps/api/src/courses/schemas/updateCourseSettings.schema.ts
+++ b/apps/api/src/courses/schemas/updateCourseSettings.schema.ts
@@ -1,21 +1,11 @@
 import { type Static, Type } from "@sinclair/typebox";
 
-import { coursesSettingsSchema } from "../types/settings";
-
-const multipartBooleanSchema = Type.Union([Type.Boolean(), Type.String()]);
-
 export const updateCourseSettingsSchema = Type.Object({
-  ...Type.Partial(coursesSettingsSchema).properties,
-  removeCertificateSignature: Type.Optional(Type.Boolean()),
-});
-
-export const updateCourseSettingsMultipartSchema = Type.Object({
-  lessonSequenceEnabled: Type.Optional(multipartBooleanSchema),
-  quizFeedbackEnabled: Type.Optional(multipartBooleanSchema),
+  lessonSequenceEnabled: Type.Optional(Type.Boolean()),
+  quizFeedbackEnabled: Type.Optional(Type.Boolean()),
   certificateFontColor: Type.Optional(Type.String()),
-  removeCertificateSignature: Type.Optional(multipartBooleanSchema),
+  removeCertificateSignature: Type.Optional(Type.Boolean()),
   certificateSignature: Type.Optional(Type.String({ format: "binary" })),
 });
 
 export type UpdateCourseSettings = Static<typeof updateCourseSettingsSchema>;
-export type UpdateCourseSettingsMultipart = Static<typeof updateCourseSettingsMultipartSchema>;

--- a/apps/api/src/swagger/api-schema.json
+++ b/apps/api/src/swagger/api-schema.json
@@ -18796,37 +18796,16 @@
         "type": "object",
         "properties": {
           "lessonSequenceEnabled": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "string"
-              }
-            ]
+            "type": "boolean"
           },
           "quizFeedbackEnabled": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "string"
-              }
-            ]
+            "type": "boolean"
           },
           "certificateFontColor": {
             "type": "string"
           },
           "removeCertificateSignature": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "string"
-              }
-            ]
+            "type": "boolean"
           },
           "certificateSignature": {
             "format": "binary",

--- a/apps/web/app/api/generated-api.ts
+++ b/apps/web/app/api/generated-api.ts
@@ -1832,10 +1832,10 @@ export interface UpdateHasCertificateResponse {
 }
 
 export interface UpdateCourseSettingsBody {
-  lessonSequenceEnabled?: boolean | string;
-  quizFeedbackEnabled?: boolean | string;
+  lessonSequenceEnabled?: boolean;
+  quizFeedbackEnabled?: boolean;
   certificateFontColor?: string;
-  removeCertificateSignature?: boolean | string;
+  removeCertificateSignature?: boolean;
   /** @format binary */
   certificateSignature?: File;
 }


### PR DESCRIPTION
<!--
 1. Make sure you have correct branch name i.e. `ab_prefix_123_task_name`, where `123` is a issue ID, and `ab` is an author
 2. Make sure you have meaningful title related to task with correct prefix: feat/fix/chore/style/docs/refactor
 3. Reference multiple issues in one PR by listing them in the issues section
 4. Make sure all necessary sections are filled, remove obsolete sections
 5. Do a self review first
 6. Check if your PR includes only code related to your task
 7. `Notes` is used for additional info but also to notify if any action is required
-->

## Issue(s)
[1410](https://github.com/Selleo/mentingo/issues/1410)

## Overview

This PR fixes course settings toggle updates for PATCH /api/course/settings/:courseId by making
multipart body parsing and validation consistent.

Key changes:

- Unified course settings update payload into a single schema (updateCourseSettingsSchema) with
  boolean fields for toggle values.
- Moved ValidateMultipartPipe(updateCourseSettingsSchema) into the @Validate request body pipes
  config, so multipart values are transformed before schema validation.
- Simplified controller typing/casting by using one UpdateCourseSettings type in the handler and
  service call.
- Regenerated API contract artifacts (api-schema.json, generated-api.ts) to reflect the updated
  request schema.

## Business Value

This prevents course configuration toggles from being ignored or mis-validated during updates, so
admins/content creators can reliably change course behavior (e.g. lesson sequence and quiz
feedback) without inconsistent API handling. It improves trust in settings management and reduces
support/debugging overhead caused by toggle state update failures.

## Screenshots / Video

https://github.com/user-attachments/assets/bf7bda4b-223f-47c9-81a1-4bb2c6e07769

