### PR TITLE
fix: prevent layout overflow on the course settings page

### DIFF
--- a/apps/web/app/modules/Admin/EditCourse/EditCourse.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/EditCourse.tsx
@@ -223,7 +223,7 @@ const EditCourse = () => {
   ];
 
   return (
-    <PageWrapper breadcrumbs={breadcrumbs}>
+    <PageWrapper breadcrumbs={breadcrumbs} className="relative">
       <Tabs value={activeTab} className="flex h-full flex-col gap-y-4">
         <div className="flex w-full flex-col gap-y-4 rounded-lg border border-gray-200 bg-white px-8 py-6 shadow-md">
           <div className="flex items-center justify-between">


### PR DESCRIPTION
<!--
 1. Make sure you have correct branch name i.e. `ab_prefix_123_task_name`, where `123` is a issue ID, and `ab` is an author
 2. Make sure you have meaningful title related to task with correct prefix: feat/fix/chore/style/docs/refactor
 3. Reference multiple issues in one PR by listing them in the issues section
 4. Make sure all necessary sections are filled, remove obsolete sections
 5. Do a self review first
 6. Check if your PR includes only code related to your task
 7. `Notes` is used for additional info but also to notify if any action is required
-->

## Issue(s)
[1346](https://github.com/Selleo/mentingo/issues/1346)

## Overview

This PR fixes overflow behavior on the Edit Course settings page.

Change made:

- Updated apps/web/app/modules/Admin/EditCourse/EditCourse.tsx to pass className="relative" to
  PageWrapper.

This ensures positioning/overflow context is properly scoped within the Edit Course view,
preventing the page from scrolling outside the intended content area.

## Business Value

This improves usability and visual stability in the course configuration flow by eliminating
unintended scrolling behavior on the settings page. End users (admins/content creators) get a more
predictable editing experience with fewer layout glitches.

## Screenshots / Video

https://github.com/user-attachments/assets/ad7dd89a-6b0a-4cbf-b0ff-2470866db96b
