### PR TITLE
fix: progress not being counted correctly after multiple quiz attempts

### DIFF
--- a/apps/api/src/studentLessonProgress/studentLessonProgress.service.ts
+++ b/apps/api/src/studentLessonProgress/studentLessonProgress.service.ts
@@ -107,7 +107,6 @@ export class StudentLessonProgressService {
     if (!accessCourseLessonWithDetails.isAssigned && !accessCourseLessonWithDetails.isFreemium)
       throw new UnauthorizedException("You don't have assignment to this lesson");
 
-    if (accessCourseLessonWithDetails.attempts > 1) return;
     const alreadyCompleted = accessCourseLessonWithDetails.lessonIsCompleted;
 
     const { language: actualLanguage } = await this.localizationService.getBaseLanguage(


### PR DESCRIPTION
## Issue(s)
- #1416 

## Overview
This PR fixes chapter/course progress updates for quiz retakes.

Previously, after multiple quiz attempts, the completion flow could return early in `StudentLessonProgressService.markLessonAsCompleted`, which prevented chapter progress recalculation from running for retaken quizzes.

The fix removes the early return based on `attempts > 1`, so successful completion on subsequent attempts still updates chapter and course progress correctly.

## Business Value
Learners who pass a quiz after retaking it now get correctly reflected progress in chapter/course tracking.

This improves progress data integrity, reduces user confusion, and prevents false negatives in completion metrics that can affect learner experience and reporting.
