### PR TITLE
fix: make the emoji picker work properly in AI mentor chat

### DIFF
--- a/apps/web/app/modules/Courses/Lesson/AiMentorLesson/components/LessonEmojiPicker.tsx
+++ b/apps/web/app/modules/Courses/Lesson/AiMentorLesson/components/LessonEmojiPicker.tsx
@@ -10,11 +10,9 @@ interface Props {
 
 export function LessonEmojiPicker({ setInput, input }: Props) {
   const { t } = useTranslation();
+
   return (
-    <EmojiPicker.Root
-      className="isolate flex h-[368px] w-fit flex-col bg-white dark:bg-neutral-900"
-      onEmojiSelect={({ emoji }) => setInput(input + emoji)}
-    >
+    <EmojiPicker.Root className="isolate flex h-[368px] w-fit flex-col bg-white dark:bg-neutral-900">
       <EmojiPicker.Search
         className="z-10 mx-2 mt-2 appearance-none rounded-md bg-neutral-100 px-2.5 py-2 text-sm dark:bg-neutral-800 focus:outline-primary"
         placeholder={t("adminCourseView.curriculum.lesson.other.emoji.search")}
@@ -50,6 +48,7 @@ export function LessonEmojiPicker({ setInput, input }: Props) {
                 variant="ghost"
                 type="button"
                 {...props}
+                onClick={() => setInput(input + emoji.emoji)}
               >
                 {emoji.emoji}
               </Button>


### PR DESCRIPTION
<!--
 1. Make sure you have correct branch name i.e. `ab_prefix_123_task_name`, where `123` is a issue ID, and `ab` is an author
 2. Make sure you have meaningful title related to task with correct prefix: feat/fix/chore/style/docs/refactor
 3. Reference multiple issues in one PR by listing them in the issues section
 4. Make sure all necessary sections are filled, remove obsolete sections
 5. Do a self review first
 6. Check if your PR includes only code related to your task
 7. `Notes` is used for additional info but also to notify if any action is required
-->

## Issue(s)
[1183](https://github.com/Selleo/mentingo/issues/1183)

## Overview

Updated the AI Mentor emoji picker so emoji insertion is triggered from the rendered emoji button instead of the picker root. This restores the expected insert behavior when selecting an emoji in apps/
web/app/modules/Courses/Lesson/AiMentorLesson/components/LessonEmojiPicker.tsx.

## Business Value

Users can reliably add emojis while composing AI Mentor lesson content. This removes a broken interaction in the lesson editor and keeps the authoring flow consistent and usable.

## Screenshots/Video
https://github.com/user-attachments/assets/71462b5e-f015-4a78-ad1d-a71eb53cb0d2


