### PR TITLE
fix: ensure the pricing tab is visible when available

### DIFF
--- a/apps/web/app/modules/Admin/EditCourse/EditCourse.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/EditCourse.tsx
@@ -202,7 +202,7 @@ const EditCourse = () => {
       : EDIT_COURSE_TABS.CURRICULUM;
 
   const { visibleCourseTabs, activeTab } = useMemo(() => {
-    const canShowPricingTab = Boolean(isStripeConfigured?.enabled && isMasterCourse);
+    const canShowPricingTab = Boolean(isStripeConfigured?.enabled);
 
     const visibleCourseTabs = (
       isExportedCourse
@@ -215,7 +215,7 @@ const EditCourse = () => {
       : (visibleCourseTabs[0]?.value ?? EDIT_COURSE_TABS.STATUS);
 
     return { visibleCourseTabs, activeTab };
-  }, [courseTabs, isExportedCourse, isMasterCourse, isStripeConfigured?.enabled, selectedTab]);
+  }, [courseTabs, isExportedCourse, isStripeConfigured?.enabled, selectedTab]);
 
   useEffect(() => {
     if (error) {
@@ -427,7 +427,7 @@ const EditCourse = () => {
             </LeaveModalProvider>
           )}
         </TabsContent>
-        {isMasterCourse && isStripeConfigured?.enabled && (
+        {isStripeConfigured?.enabled && (
           <TabsContent value={EDIT_COURSE_TABS.PRICING}>
             <CoursePricing
               courseId={course?.id || ""}


### PR DESCRIPTION
## Issue(s)
- #1341 

## Overview
Adjusted the Admin Edit Course tab visibility so the Pricing tab is shown whenever Stripe is enabled. The previous master-course restriction has been removed from both the tab list and the pricing panel render path, so pricing settings remain accessible for Stripe-enabled courses.

## Business Value
Admins can manage course pricing as soon as Stripe is configured, without being blocked by course origin. This makes monetization settings easier to reach and reduces confusion around when pricing can be edited.

## Screenshots / Video
<img width="2485" height="1117" alt="image" src="https://github.com/user-attachments/assets/ba98472a-24dd-40ec-bc83-557a730b0585" />
