### PR TITLE
fix: display the correct avatar in AI mentor lesson previews

### DIFF
--- a/apps/web/app/modules/Courses/Lesson/AiMentorLesson/components/ChatMessage.tsx
+++ b/apps/web/app/modules/Courses/Lesson/AiMentorLesson/components/ChatMessage.tsx
@@ -46,14 +46,21 @@ const ChatMessage = ({
 
   const isAssistant = role === "assistant";
 
+  const previewDisplayName =
+    `${previewUser?.firstName ?? ""} ${previewUser?.lastName ?? ""}`.trim();
+  const currentUserDisplayName =
+    `${currentUser?.firstName ?? ""} ${currentUser?.lastName ?? ""}`.trim();
+
+  const profilePictureUrl = useMemo(() => {
+    return previewUser ? previewUser.profilePictureUrl : currentUser?.profilePictureUrl;
+  }, [previewUser, currentUser?.profilePictureUrl]);
+
   const displayName = useMemo(() => {
     if (isAssistant) {
       return aiName ?? t("studentCourseView.lesson.aiMentorLesson.aiMentorName");
     }
 
-    const previewUserName = `${previewUser?.firstName ?? ""} ${previewUser?.lastName ?? ""}`.trim();
-    const fallbackName =
-      previewUserName || `${currentUser?.firstName ?? ""} ${currentUser?.lastName ?? ""}`.trim();
+    const fallbackName = previewUser ? previewDisplayName : currentUserDisplayName;
 
     return (
       userName ||
@@ -66,8 +73,11 @@ const ChatMessage = ({
     aiName,
     currentUser?.firstName,
     currentUser?.lastName,
+    currentUserDisplayName,
     isAssistant,
     name,
+    previewDisplayName,
+    previewUser,
     t,
     user?.name,
     userName,
@@ -91,10 +101,7 @@ const ChatMessage = ({
           </Avatar>
         ) : (
           <div className="flex size-full items-center justify-center rounded-full bg-gray-200">
-            <UserAvatar
-              userName={displayName}
-              profilePictureUrl={previewUser?.profilePictureUrl ?? currentUser?.profilePictureUrl}
-            />
+            <UserAvatar userName={displayName} profilePictureUrl={profilePictureUrl} />
           </div>
         )}
       </div>


### PR DESCRIPTION
## Issue(s)
- #1044 

## Overview
Fix student preview in lesson result dialog so AI mentor chat uses preview student identity instead of logged-in viewer identity when rendering avatar and display name.

## Business Value
Admin can review student lesson results without confusion from seeing their own avatar or name in preview mode. This keeps review flow accurate and reduces risk of misreading student chat context.

## Screenshots / Video

https://github.com/user-attachments/assets/76b4c90b-46e8-4770-acc5-6d1026e9b238
