### PR TITLE
chore: improve video uploads with fully parallel processing for faster performance

### DIFF
--- a/apps/api/src/ai/services/ai.service.ts
+++ b/apps/api/src/ai/services/ai.service.ts
@@ -7,7 +7,7 @@ import {
   UnauthorizedException,
 } from "@nestjs/common";
 import { trace } from "@opentelemetry/api";
-import { PERMISSIONS } from "@repo/shared";
+import { PERMISSIONS, hasPermission } from "@repo/shared";
 import { experimental_transcribe, generateObject, jsonSchema, type Message, streamText } from "ai";
 import { eq } from "drizzle-orm";
 import _ from "lodash";
@@ -315,10 +315,15 @@ export class AiService {
 
     const [lesson] = await this.aiRepository.checkLessonAssignment(lessonId, userId);
 
-    if (!lesson.isAssigned && !lesson.isFreemium)
+    if (
+      !lesson.isAssigned &&
+      !lesson.isFreemium &&
+      !hasPermission(permissions, PERMISSIONS.COURSE_UPDATE_OWN) &&
+      !hasPermission(permissions, PERMISSIONS.COURSE_UPDATE)
+    )
       throw new UnauthorizedException("You are not assigned to this lesson");
 
-    if (permissions.includes(PERMISSIONS.COURSE_UPDATE_OWN) && !lesson.isAssigned) {
+    if (hasPermission(permissions, PERMISSIONS.COURSE_UPDATE_OWN) && !lesson.isAssigned) {
       const courseAuthorId = await this.aiRepository.getCourseAuthorByLesson(lessonId);
 
       if (courseAuthorId !== userId) {

--- a/apps/web/app/components/RichText/Editor.tsx
+++ b/apps/web/app/components/RichText/Editor.tsx
@@ -40,6 +40,7 @@ const Editor = ({
   variant = "content",
 }: EditorProps) => {
   const editorRef = useRef<TiptapEditor | null>(null);
+  const lastEmittedContentRef = useRef(content ?? "");
 
   const extensions = useMemo(
     () => (variant === "base" ? baseEditorPlugins : contentEditorPlugins),
@@ -111,7 +112,9 @@ const Editor = ({
     extensions,
     content: content,
     onUpdate: ({ editor }) => {
-      onChange(editor.getHTML());
+      const nextContent = editor.getHTML();
+      lastEmittedContentRef.current = nextContent;
+      onChange(nextContent);
     },
     onDrop: handleDrop,
     editorProps: {
@@ -128,8 +131,14 @@ const Editor = ({
   }, [editor]);
 
   useEffect(() => {
-    if (editor && content !== editor.getHTML()) {
+    if (
+      editor &&
+      content !== undefined &&
+      content !== editor.getHTML() &&
+      content !== lastEmittedContentRef.current
+    ) {
       editor.commands.setContent(content || "");
+      lastEmittedContentRef.current = content || "";
     }
   }, [content, editor]);
 

--- a/apps/web/app/components/RichText/extensions/utils/video.ts
+++ b/apps/web/app/components/RichText/extensions/utils/video.ts
@@ -21,6 +21,10 @@ export type VideoEmbedAttrs = {
   hasError: boolean;
   autoplay: VideoAutoplay;
   index: number | null;
+  uploadId: string | null;
+  uploadLabel: string | null;
+  uploadStatus: "uploading" | "failed" | null;
+  uploadErrorMessage: string | null;
 };
 
 const isVideoSourceType = (value: string | null | undefined): value is VideoSourceType =>
@@ -70,6 +74,10 @@ type VideoEmbedAttrsInput = {
   hasError?: boolean | string | null;
   autoplay?: string | null;
   index?: number | string | null;
+  uploadId?: string | null;
+  uploadLabel?: string | null;
+  uploadStatus?: "uploading" | "failed" | null;
+  uploadErrorMessage?: string | null;
 };
 
 const normalizeVideoIndex = (value: number | string | null | undefined): number | null => {
@@ -109,6 +117,14 @@ export const normalizeVideoEmbedAttributes = (attrs: VideoEmbedAttrsInput): Vide
     hasError,
     autoplay,
     index,
+    uploadId: typeof attrs.uploadId === "string" ? attrs.uploadId : null,
+    uploadLabel: typeof attrs.uploadLabel === "string" ? attrs.uploadLabel : null,
+    uploadStatus:
+      attrs.uploadStatus === "uploading" || attrs.uploadStatus === "failed"
+        ? attrs.uploadStatus
+        : null,
+    uploadErrorMessage:
+      typeof attrs.uploadErrorMessage === "string" ? attrs.uploadErrorMessage : null,
   };
 };
 
@@ -126,6 +142,11 @@ export const getVideoEmbedAttrsFromElement = (element: HTMLElement): VideoEmbedA
   const errorAttr = element.getAttribute("data-error");
   const autoplayAttr = element.getAttribute("data-autoplay");
   const indexAttr = element.getAttribute("data-index");
+  const uploadId = element.getAttribute("data-upload-id") ?? null;
+  const uploadLabel = element.getAttribute("data-upload-label") ?? null;
+  const uploadStatus =
+    (element.getAttribute("data-upload-status") as "uploading" | "failed" | null) ?? null;
+  const uploadErrorMessage = element.getAttribute("data-upload-error-message") ?? null;
 
   const sourceType: VideoSourceType = match(sourceTypeAttr)
     .when(isVideoSourceType, (value) => value)
@@ -142,5 +163,9 @@ export const getVideoEmbedAttrsFromElement = (element: HTMLElement): VideoEmbedA
     autoplay: autoplayAttr,
     hasError: errorAttr,
     index: indexAttr,
+    uploadId,
+    uploadLabel,
+    uploadStatus,
+    uploadErrorMessage,
   });
 };

--- a/apps/web/app/components/RichText/extensions/utils/video.ts
+++ b/apps/web/app/components/RichText/extensions/utils/video.ts
@@ -10,6 +10,10 @@ import {
 } from "@repo/shared";
 import { match } from "ts-pattern";
 
+import { VIDEO_UPLOAD_NODE_STATUS } from "./videoUploadNode";
+
+import type { VideoUploadNodeStatus } from "./videoUploadNode";
+
 export const VIDEO_NODE_TYPE = "video" as const;
 
 export type VideoSourceType = "internal" | "external";
@@ -23,7 +27,7 @@ export type VideoEmbedAttrs = {
   index: number | null;
   uploadId: string | null;
   uploadLabel: string | null;
-  uploadStatus: "uploading" | "failed" | null;
+  uploadStatus: VideoUploadNodeStatus | null;
   uploadErrorMessage: string | null;
 };
 
@@ -76,7 +80,7 @@ type VideoEmbedAttrsInput = {
   index?: number | string | null;
   uploadId?: string | null;
   uploadLabel?: string | null;
-  uploadStatus?: "uploading" | "failed" | null;
+  uploadStatus?: VideoUploadNodeStatus | null;
   uploadErrorMessage?: string | null;
 };
 
@@ -120,7 +124,8 @@ export const normalizeVideoEmbedAttributes = (attrs: VideoEmbedAttrsInput): Vide
     uploadId: typeof attrs.uploadId === "string" ? attrs.uploadId : null,
     uploadLabel: typeof attrs.uploadLabel === "string" ? attrs.uploadLabel : null,
     uploadStatus:
-      attrs.uploadStatus === "uploading" || attrs.uploadStatus === "failed"
+      attrs.uploadStatus === VIDEO_UPLOAD_NODE_STATUS.UPLOADING ||
+      attrs.uploadStatus === VIDEO_UPLOAD_NODE_STATUS.FAILED
         ? attrs.uploadStatus
         : null,
     uploadErrorMessage:
@@ -145,7 +150,7 @@ export const getVideoEmbedAttrsFromElement = (element: HTMLElement): VideoEmbedA
   const uploadId = element.getAttribute("data-upload-id") ?? null;
   const uploadLabel = element.getAttribute("data-upload-label") ?? null;
   const uploadStatus =
-    (element.getAttribute("data-upload-status") as "uploading" | "failed" | null) ?? null;
+    (element.getAttribute("data-upload-status") as VideoUploadNodeStatus | null) ?? null;
   const uploadErrorMessage = element.getAttribute("data-upload-error-message") ?? null;
 
   const sourceType: VideoSourceType = match(sourceTypeAttr)

--- a/apps/web/app/components/RichText/extensions/utils/videoUploadNode.ts
+++ b/apps/web/app/components/RichText/extensions/utils/videoUploadNode.ts
@@ -1,0 +1,145 @@
+import { VIDEO_AUTOPLAY } from "@repo/shared";
+import { NodeSelection, TextSelection } from "@tiptap/pm/state";
+
+import type { Editor as TiptapEditor } from "@tiptap/react";
+
+export const VIDEO_UPLOAD_NODE_STATUS = {
+  UPLOADING: "uploading",
+  FAILED: "failed",
+} as const;
+
+export type VideoUploadNodeStatus =
+  (typeof VIDEO_UPLOAD_NODE_STATUS)[keyof typeof VIDEO_UPLOAD_NODE_STATUS];
+
+export type VideoUploadNodeAttrs = {
+  uploadId: string | null;
+  uploadLabel: string | null;
+  uploadStatus: VideoUploadNodeStatus | null;
+  uploadErrorMessage: string | null;
+};
+
+type VideoUploadNodeAttrsInput = Partial<VideoUploadNodeAttrs>;
+
+type VideoUploadNodeMatch = {
+  pos: number;
+  node: {
+    attrs: Record<string, unknown>;
+    nodeSize: number;
+  };
+};
+
+export const normalizeVideoUploadNodeAttrs = (
+  attrs: VideoUploadNodeAttrsInput,
+): VideoUploadNodeAttrs => ({
+  uploadId: typeof attrs.uploadId === "string" ? attrs.uploadId : null,
+  uploadLabel: typeof attrs.uploadLabel === "string" ? attrs.uploadLabel : null,
+  uploadStatus:
+    attrs.uploadStatus === VIDEO_UPLOAD_NODE_STATUS.UPLOADING ||
+    attrs.uploadStatus === VIDEO_UPLOAD_NODE_STATUS.FAILED
+      ? attrs.uploadStatus
+      : null,
+  uploadErrorMessage:
+    typeof attrs.uploadErrorMessage === "string" ? attrs.uploadErrorMessage : null,
+});
+
+export const getVideoUploadNodeDataAttributes = (attrs: VideoUploadNodeAttrs) => ({
+  "data-upload-id": attrs.uploadId ?? "",
+  "data-upload-label": attrs.uploadLabel ?? "",
+  "data-upload-status": attrs.uploadStatus ?? "",
+  "data-upload-error-message": attrs.uploadErrorMessage ?? "",
+});
+
+const findVideoUploadNode = (
+  editor: TiptapEditor,
+  uploadId: string,
+): VideoUploadNodeMatch | null => {
+  let match: VideoUploadNodeMatch | null = null;
+
+  editor.state.doc.descendants((node, pos) => {
+    if ((node.attrs as { uploadId?: unknown }).uploadId !== uploadId) return true;
+
+    match = {
+      pos,
+      node: {
+        attrs: node.attrs as Record<string, unknown>,
+        nodeSize: node.nodeSize,
+      },
+    };
+    return false;
+  });
+
+  return match;
+};
+
+export const updateVideoUploadNodeById = (
+  editor: TiptapEditor | null | undefined,
+  uploadId: string | null | undefined,
+  attrs: Partial<VideoUploadNodeAttrs> & Record<string, unknown>,
+) => {
+  if (!editor || !uploadId) return false;
+
+  const match = findVideoUploadNode(editor, uploadId);
+  if (!match) return false;
+
+  const nextAttrs = {
+    ...match.node.attrs,
+    ...attrs,
+    uploadId,
+  };
+
+  editor.view.dispatch(editor.state.tr.setNodeMarkup(match.pos, undefined, nextAttrs));
+  return true;
+};
+
+export const removeVideoUploadNodeById = (
+  editor: TiptapEditor | null | undefined,
+  uploadId: string | null | undefined,
+) => {
+  if (!editor || !uploadId) return false;
+
+  const match = findVideoUploadNode(editor, uploadId);
+  if (!match) return false;
+
+  editor.view.dispatch(editor.state.tr.delete(match.pos, match.pos + match.node.nodeSize));
+  return true;
+};
+
+export const insertVideoUploadPlaceholder = ({
+  editor,
+  uploadId,
+  uploadLabel,
+}: {
+  editor?: TiptapEditor | null;
+  uploadId: string;
+  uploadLabel: string;
+}) => {
+  if (!editor) return;
+
+  editor
+    .chain()
+    .focus()
+    .insertContent({
+      type: "video",
+      attrs: {
+        src: null,
+        uploadId,
+        uploadLabel,
+        uploadStatus: VIDEO_UPLOAD_NODE_STATUS.UPLOADING,
+        uploadErrorMessage: null,
+        sourceType: "external",
+        provider: "unknown",
+        hasError: false,
+        autoplay: VIDEO_AUTOPLAY.NO_AUTOPLAY,
+        index: null,
+      },
+    })
+    .run();
+
+  const { state, view } = editor;
+  const { selection } = state;
+  const targetPos = selection instanceof NodeSelection ? selection.to + 1 : selection.to;
+  const clampedPos = Math.max(1, Math.min(targetPos, state.doc.content.size));
+  const nextSelection = TextSelection.create(state.doc, clampedPos);
+
+  view.dispatch(state.tr.setSelection(nextSelection).scrollIntoView());
+};

--- a/apps/web/app/components/RichText/extensions/utils/videoUploadNode.ts
+++ b/apps/web/app/components/RichText/extensions/utils/videoUploadNode.ts
@@ -56,7 +56,7 @@ const findVideoUploadNode = (
   let match: VideoUploadNodeMatch | null = null;
 
   editor.state.doc.descendants((node, pos) => {
-    if ((node.attrs as { uploadId?: unknown }).uploadId !== uploadId) return true;
+    if (node.attrs.uploadId !== uploadId) return true;
 
     match = {
       pos,

--- a/apps/web/app/components/RichText/extensions/video.tsx
+++ b/apps/web/app/components/RichText/extensions/video.tsx
@@ -4,6 +4,11 @@ import { NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
 import { GripVertical, Video as VideoIcon, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
+import {
+  VIDEO_UPLOAD_NODE_STATUS,
+  getVideoUploadNodeDataAttributes,
+  normalizeVideoUploadNodeAttrs,
+} from "~/components/RichText/extensions/utils/videoUploadNode";
 import { Button } from "~/components/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "~/components/ui/tooltip";
 import { Video } from "~/components/VideoPlayer/Video";
@@ -27,6 +32,18 @@ type VideoViewerOptions = {
   resolveAutoplay?: (autoplay: VideoAutoplay) => VideoAutoplay;
 };
 
+const renderUploadCard = (label: string, errorMessage?: string | null) => (
+  <div className="flex w-full flex-col gap-1.5 rounded border border-dashed border-neutral-300 bg-neutral-50 px-3 py-2 text-sm text-neutral-700">
+    <div className="flex items-center gap-2">
+      <span className="inline-flex size-4 items-center justify-center">
+        <span className="size-3 animate-spin rounded-full border-2 border-neutral-400 border-t-transparent" />
+      </span>
+      <span className="truncate font-medium">{label}</span>
+    </div>
+    {errorMessage && <p className="text-xs text-error-700">{errorMessage}</p>}
+  </div>
+);
+
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {
     video: {
@@ -45,6 +62,7 @@ const getVideoDataAttributes = (attrs: VideoEmbedAttrs) => ({
   "data-autoplay": attrs.autoplay,
   ...(attrs.index !== null ? { "data-index": attrs.index } : {}),
   ...(attrs.hasError ? { "data-error": "true" } : {}),
+  ...getVideoUploadNodeDataAttributes(attrs),
 });
 
 const VideoEditorContent = ({
@@ -100,6 +118,34 @@ const VideoEditorView = ({ node, editor, getPos }: NodeViewProps) => {
   const { t } = useTranslation();
 
   const attrs = normalizeVideoEmbedAttributes(node.attrs);
+  const isPending = !attrs.src && attrs.uploadStatus !== VIDEO_UPLOAD_NODE_STATUS.FAILED;
+  const isFailed = !attrs.src && attrs.uploadStatus === VIDEO_UPLOAD_NODE_STATUS.FAILED;
+
+  if (isPending) {
+    return (
+      <NodeViewWrapper className="video-node block w-full">
+        {renderUploadCard(
+          attrs.uploadLabel ?? t("common.button.uploading"),
+          attrs.uploadErrorMessage,
+        )}
+      </NodeViewWrapper>
+    );
+  }
+
+  if (isFailed) {
+    return (
+      <NodeViewWrapper className="video-node block w-full">
+        <div className="flex w-full flex-col gap-1.5 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+          <span className="truncate font-medium">
+            {attrs.uploadLabel ?? t("common.button.uploading")}
+          </span>
+          <span className="text-xs">
+            {attrs.uploadErrorMessage ?? t("common.toast.somethingWentWrong")}
+          </span>
+        </div>
+      </NodeViewWrapper>
+    );
+  }
 
   if (!attrs.src) return null;
   const videoAttrs = attrs as VideoEmbedAttrs & { src: string };
@@ -199,6 +245,18 @@ const baseVideoNodeConfig: NodeConfig = {
       index: {
         default: null,
       },
+      uploadId: {
+        default: null,
+      },
+      uploadLabel: {
+        default: null,
+      },
+      uploadStatus: {
+        default: null,
+      },
+      uploadErrorMessage: {
+        default: null,
+      },
     };
   },
 
@@ -220,8 +278,19 @@ const baseVideoNodeConfig: NodeConfig = {
   },
 
   renderHTML({ HTMLAttributes }) {
-    const { src, sourceType, provider, hasError, autoplay, index, ...rest } =
-      HTMLAttributes as Record<string, unknown>;
+    const {
+      src,
+      sourceType,
+      provider,
+      hasError,
+      autoplay,
+      index,
+      uploadId,
+      uploadLabel,
+      uploadStatus,
+      uploadErrorMessage,
+      ...rest
+    } = HTMLAttributes as Record<string, unknown>;
 
     const normalized = normalizeVideoEmbedAttributes({
       src: typeof src === "string" ? src : null,
@@ -230,6 +299,16 @@ const baseVideoNodeConfig: NodeConfig = {
       hasError: hasError as boolean,
       autoplay: autoplay as VideoAutoplay,
       index: index as number | string | null,
+      ...normalizeVideoUploadNodeAttrs({
+        uploadId: typeof uploadId === "string" ? uploadId : null,
+        uploadLabel: typeof uploadLabel === "string" ? uploadLabel : null,
+        uploadStatus:
+          uploadStatus === VIDEO_UPLOAD_NODE_STATUS.UPLOADING ||
+          uploadStatus === VIDEO_UPLOAD_NODE_STATUS.FAILED
+            ? uploadStatus
+            : null,
+        uploadErrorMessage: typeof uploadErrorMessage === "string" ? uploadErrorMessage : null,
+      }),
     });
 
     return ["div", mergeAttributes(getVideoDataAttributes(normalized), rest)];

--- a/apps/web/app/components/RichText/toolbar/EditorToolbar.tsx
+++ b/apps/web/app/components/RichText/toolbar/EditorToolbar.tsx
@@ -1,5 +1,4 @@
 import { ALLOWED_LESSON_IMAGE_FILE_TYPES } from "@repo/shared";
-import { NodeSelection, TextSelection } from "@tiptap/pm/state";
 import {
   Bold,
   Code,
@@ -69,28 +68,13 @@ const EditorToolbar = ({
 
   const acceptedImages = acceptedFileTypes.join(",");
 
-  const moveCursorAfterCurrentSelection = () => {
-    const { state, view } = editor;
-    const { selection } = state;
-
-    const targetPos = selection instanceof NodeSelection ? selection.to + 1 : selection.to;
-
-    const clampedPos = Math.max(1, Math.min(targetPos, state.doc.content.size));
-    const nextSelection = TextSelection.create(state.doc, clampedPos);
-
-    view.dispatch(state.tr.setSelection(nextSelection).scrollIntoView());
-  };
-
   const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files ?? []);
-    for (const [index, file] of files.entries()) {
-      if (index > 0) moveCursorAfterCurrentSelection();
-
-      await onUpload?.(file, editor);
-      moveCursorAfterCurrentSelection();
-    }
+    if (!files.length || !onUpload) return;
 
     if (fileUploadRef.current) fileUploadRef.current.value = "";
+
+    await Promise.allSettled(files.map((file) => onUpload(file, editor)));
   };
 
   return (

--- a/apps/web/app/hooks/buildRichTextFileUploadHandler.ts
+++ b/apps/web/app/hooks/buildRichTextFileUploadHandler.ts
@@ -7,8 +7,11 @@ import {
   ALLOWED_WORD_FILE_TYPES,
   type EntityType,
 } from "@repo/shared";
-import { match } from "ts-pattern";
 
+import {
+  insertVideoUploadPlaceholder,
+  updateVideoUploadNodeById,
+} from "~/components/RichText/extensions/utils/videoUploadNode";
 import { buildEntityResourceUrl, insertResourceIntoEditor } from "~/hooks/useEntityResourceUpload";
 import { UPLOAD_STATUS } from "~/hooks/useRichTextUploadQueue";
 
@@ -22,6 +25,196 @@ const DISPLAY_MODE = {
 } as const;
 
 type DisplayMode = (typeof DISPLAY_MODE)[keyof typeof DISPLAY_MODE];
+
+const createSerialQueue = () => {
+  let tail = Promise.resolve();
+
+  return <T>(task: () => Promise<T> | T) => {
+    const next = tail.then(task, task);
+    tail = next.then(
+      () => undefined,
+      () => undefined,
+    );
+    return next;
+  };
+};
+
+const displayModePromptQueue = createSerialQueue();
+const videoInsertQueue = createSerialQueue();
+
+const askForDisplayModeSequentially = (
+  askForDisplayMode: (filename: string) => Promise<DisplayMode | null>,
+  filename: string,
+) => {
+  return displayModePromptQueue(() => askForDisplayMode(filename));
+};
+
+const insertPendingVideoNodeSequentially = async (args: {
+  editor?: TiptapEditor | null;
+  file: File;
+  uploadId: string;
+}) => {
+  await videoInsertQueue(() =>
+    insertVideoUploadPlaceholder({
+      editor: args.editor,
+      uploadId: args.uploadId,
+      uploadLabel: args.file.name,
+    }),
+  );
+};
+
+const handleVideoUpload = async ({
+  editor,
+  file,
+  entityType,
+  getVideoSessionForFile,
+  uploadVideo,
+  onVideoUploadError,
+  fallbackUploadErrorMessage,
+  uploadQueue,
+}: {
+  editor?: TiptapEditor | null;
+  file: File;
+  entityType: EntityType;
+  getVideoSessionForFile: (file: File) => Promise<InitVideoUploadResponse>;
+  uploadVideo: (args: VideoUploadArgs) => Promise<void>;
+  onVideoUploadError: (error: unknown) => void;
+  fallbackUploadErrorMessage: string;
+  uploadQueue?: BuildRichTextFileUploadHandlerArgs["uploadQueue"];
+}) => {
+  const queueId = uploadQueue?.enqueue({ fileName: file.name, kind: "video" });
+  const uploadId = queueId ?? crypto.randomUUID();
+
+  if (queueId) {
+    uploadQueue?.setStatus(queueId, UPLOAD_STATUS.QUEUED);
+  }
+
+  await insertPendingVideoNodeSequentially({
+    editor,
+    file,
+    uploadId,
+  });
+
+  try {
+    const session = await getVideoSessionForFile(file);
+    if (queueId) {
+      uploadQueue?.attachUploadId(queueId, session.uploadId);
+    }
+
+    if (session.resourceId) {
+      updateVideoUploadNodeById(editor, uploadId, {
+        src: buildEntityResourceUrl(session.resourceId, entityType),
+        sourceType: session.provider === "s3" ? "external" : "internal",
+        provider: session.provider,
+        hasError: false,
+        uploadStatus: null,
+        uploadErrorMessage: null,
+      });
+    }
+
+    await uploadVideo({
+      file,
+      session,
+      onUploadingStart: () => {
+        if (queueId) uploadQueue?.setStatus(queueId, UPLOAD_STATUS.UPLOADING);
+      },
+      onProgress: (progress) => {
+        if (queueId) uploadQueue?.setProgress(queueId, progress);
+      },
+      onUploaded: () => {
+        if (queueId) uploadQueue?.setStatus(queueId, UPLOAD_STATUS.SUCCESS);
+      },
+      onError: (error) => {
+        if (queueId) {
+          uploadQueue?.setStatus(queueId, UPLOAD_STATUS.FAILED, {
+            errorMessage: error.message,
+          });
+        }
+        updateVideoUploadNodeById(editor, uploadId, {
+          hasError: true,
+          uploadStatus: "failed",
+          uploadErrorMessage: error.message,
+        });
+      },
+    });
+  } catch (error) {
+    if (queueId) {
+      uploadQueue?.setStatus(queueId, UPLOAD_STATUS.FAILED, {
+        errorMessage: error instanceof Error ? error.message : fallbackUploadErrorMessage,
+      });
+    }
+    updateVideoUploadNodeById(editor, uploadId, {
+      uploadStatus: "failed",
+      uploadErrorMessage: error instanceof Error ? error.message : fallbackUploadErrorMessage,
+    });
+    onVideoUploadError(error);
+  }
+};
+
+const handleResourceUpload = async ({
+  editor,
+  file,
+  entityType,
+  resourceType,
+  displayModePrompt,
+  askForDisplayMode,
+  uploadResourceFile,
+  fallbackUploadErrorMessage,
+  uploadQueue,
+}: {
+  editor?: TiptapEditor | null;
+  file: File;
+  entityType: EntityType;
+  resourceType: RichTextResourceType;
+  displayModePrompt: boolean;
+  askForDisplayMode: (filename: string) => Promise<DisplayMode | null>;
+  uploadResourceFile: (file: File) => Promise<string>;
+  fallbackUploadErrorMessage: string;
+  uploadQueue?: BuildRichTextFileUploadHandlerArgs["uploadQueue"];
+}) => {
+  const queueId = uploadQueue?.enqueue({ fileName: file.name, kind: "resource" });
+
+  if (queueId) {
+    uploadQueue?.setStatus(queueId, UPLOAD_STATUS.UPLOADING);
+  }
+
+  let displayMode: DisplayMode = DISPLAY_MODE.PREVIEW;
+
+  if (displayModePrompt) {
+    const selectedMode = await askForDisplayModeSequentially(askForDisplayMode, file.name);
+    if (!selectedMode) {
+      if (queueId) uploadQueue?.remove?.(queueId);
+      return;
+    }
+    displayMode = selectedMode;
+  }
+
+  let resourceId: string;
+  try {
+    resourceId = await uploadResourceFile(file);
+
+    if (queueId) {
+      uploadQueue?.setProgress(queueId, 100);
+      uploadQueue?.setStatus(queueId, UPLOAD_STATUS.SUCCESS);
+    }
+  } catch (error) {
+    if (queueId) {
+      uploadQueue?.setStatus(queueId, UPLOAD_STATUS.FAILED, {
+        errorMessage: error instanceof Error ? error.message : fallbackUploadErrorMessage,
+      });
+    }
+    throw error;
+  }
+
+  insertResourceIntoEditor({
+    editor,
+    resourceId,
+    entityType,
+    file,
+    resourceType,
+    displayMode,
+  });
+};
 
 type VideoUploadArgs = {
   file: File;
@@ -49,6 +242,41 @@ type BuildRichTextFileUploadHandlerArgs = {
     ) => void;
     setProgress: (id: string, progress: number) => void;
     attachUploadId: (id: string, uploadId: string) => void;
+    remove?: (id: string) => void;
+  };
+};
+
+type RichTextResourceType = "presentation" | "pdf" | "document" | "other";
+
+type FileCharacteristics = {
+  isVideo: boolean;
+  isPresentation: boolean;
+  isPdf: boolean;
+  isDocument: boolean;
+  resourceType: RichTextResourceType;
+};
+
+const getFileCharacteristics = (file: File): FileCharacteristics => {
+  const isVideo = ALLOWED_VIDEO_FILE_TYPES.includes(file.type);
+  const isPresentation = ALLOWED_PRESENTATION_FILE_TYPES.includes(file.type);
+  const isPdf = ALLOWED_PDF_FILE_TYPES.includes(file.type);
+  const isDocument =
+    isPdf ||
+    ALLOWED_EXCEL_FILE_TYPES.includes(file.type) ||
+    ALLOWED_WORD_FILE_TYPES.includes(file.type);
+
+  return {
+    isVideo,
+    isPresentation,
+    isPdf,
+    isDocument,
+    resourceType: isPresentation
+      ? "presentation"
+      : isPdf
+        ? "pdf"
+        : isDocument
+          ? "document"
+          : "other",
   };
 };
 
@@ -60,30 +288,6 @@ export const RICH_TEXT_ACCEPTED_FILE_TYPES = [
   ...ALLOWED_WORD_FILE_TYPES,
   ...ALLOWED_PRESENTATION_FILE_TYPES,
 ] as const;
-
-const removeVideoEmbedBySource = (editor: TiptapEditor, src: string) => {
-  editor
-    .chain()
-    .focus()
-    .command(({ state, tr, dispatch }) => {
-      let found = false;
-
-      state.doc.descendants((node, pos) => {
-        if (node.type.name !== "video") return true;
-        if (node.attrs.src !== src) return true;
-
-        tr.delete(pos, pos + node.nodeSize);
-        found = true;
-        return false;
-      });
-
-      if (!found) return false;
-
-      dispatch?.(tr);
-      return true;
-    })
-    .run();
-};
 
 export const buildRichTextFileUploadHandler = ({
   entityType,
@@ -98,116 +302,32 @@ export const buildRichTextFileUploadHandler = ({
   return async (file?: File, editor?: TiptapEditor | null) => {
     if (!file) return;
 
-    const isVideo = ALLOWED_VIDEO_FILE_TYPES.includes(file.type);
-    const isPresentation = ALLOWED_PRESENTATION_FILE_TYPES.includes(file.type);
-    const isPdf = ALLOWED_PDF_FILE_TYPES.includes(file.type);
-    const isDocument =
-      isPdf ||
-      ALLOWED_EXCEL_FILE_TYPES.includes(file.type) ||
-      ALLOWED_WORD_FILE_TYPES.includes(file.type);
+    const { isVideo, isPresentation, isPdf, resourceType } = getFileCharacteristics(file);
 
     if (isVideo) {
-      let insertedResourceUrl: string | null = null;
-      const queueId = uploadQueue?.enqueue({ fileName: file.name, kind: "video" });
-      if (queueId) {
-        uploadQueue?.setStatus(queueId, UPLOAD_STATUS.QUEUED);
-      }
-
-      try {
-        const session = await getVideoSessionForFile(file);
-        if (queueId) {
-          uploadQueue?.attachUploadId(queueId, session.uploadId);
-        }
-
-        if (session.resourceId && editor) {
-          insertedResourceUrl = buildEntityResourceUrl(session.resourceId, entityType);
-
-          editor
-            .chain()
-            .focus()
-            .setVideoEmbed({
-              src: insertedResourceUrl,
-              sourceType: session.provider === "s3" ? "external" : "internal",
-            })
-            .run();
-        }
-
-        await uploadVideo({
-          file,
-          session,
-          onUploadingStart: () => {
-            if (queueId) uploadQueue?.setStatus(queueId, UPLOAD_STATUS.UPLOADING);
-          },
-          onProgress: (progress) => {
-            if (queueId) uploadQueue?.setProgress(queueId, progress);
-          },
-          onUploaded: () => {
-            if (queueId) uploadQueue?.setStatus(queueId, UPLOAD_STATUS.SUCCESS);
-          },
-          onError: (error) => {
-            if (queueId) {
-              uploadQueue?.setStatus(queueId, UPLOAD_STATUS.FAILED, {
-                errorMessage: error.message,
-              });
-            }
-          },
-        });
-      } catch (error) {
-        if (editor && insertedResourceUrl) {
-          removeVideoEmbedBySource(editor, insertedResourceUrl);
-        }
-        if (queueId) {
-          uploadQueue?.setStatus(queueId, UPLOAD_STATUS.FAILED, {
-            errorMessage: error instanceof Error ? error.message : fallbackUploadErrorMessage,
-          });
-        }
-        onVideoUploadError(error);
-      }
+      await handleVideoUpload({
+        editor,
+        file,
+        entityType,
+        getVideoSessionForFile,
+        uploadVideo,
+        onVideoUploadError,
+        fallbackUploadErrorMessage,
+        uploadQueue,
+      });
       return;
     }
 
-    const queueId = uploadQueue?.enqueue({ fileName: file.name, kind: "resource" });
-
-    if (queueId) {
-      uploadQueue?.setStatus(queueId, UPLOAD_STATUS.UPLOADING);
-    }
-
-    let displayMode: DisplayMode = DISPLAY_MODE.PREVIEW;
-
-    if (isPresentation || isPdf) {
-      const selectedMode = await askForDisplayMode(file.name);
-      if (!selectedMode) return;
-      displayMode = selectedMode;
-    }
-
-    let resourceId: string;
-    try {
-      resourceId = await uploadResourceFile(file);
-
-      if (queueId) {
-        uploadQueue?.setProgress(queueId, 100);
-        uploadQueue?.setStatus(queueId, UPLOAD_STATUS.SUCCESS);
-      }
-    } catch (error) {
-      if (queueId) {
-        uploadQueue?.setStatus(queueId, UPLOAD_STATUS.FAILED, {
-          errorMessage: error instanceof Error ? error.message : fallbackUploadErrorMessage,
-        });
-      }
-      throw error;
-    }
-
-    insertResourceIntoEditor({
+    await handleResourceUpload({
       editor,
-      resourceId,
-      entityType,
       file,
-      resourceType: match({ isPresentation, isPdf, isDocument })
-        .with({ isPresentation: true }, () => "presentation" as const)
-        .with({ isPdf: true }, () => "pdf" as const)
-        .with({ isDocument: true }, () => "document" as const)
-        .otherwise(() => "other" as const),
-      displayMode: isPresentation || isDocument ? displayMode : DISPLAY_MODE.PREVIEW,
+      entityType,
+      resourceType,
+      displayModePrompt: isPresentation || isPdf,
+      askForDisplayMode,
+      uploadResourceFile,
+      fallbackUploadErrorMessage,
+      uploadQueue,
     });
   };
 };

--- a/apps/web/app/hooks/buildRichTextFileUploadHandler.ts
+++ b/apps/web/app/hooks/buildRichTextFileUploadHandler.ts
@@ -10,6 +10,7 @@ import {
 import { match } from "ts-pattern";
 
 import {
+  VIDEO_UPLOAD_NODE_STATUS,
   insertVideoUploadPlaceholder,
   updateVideoUploadNodeById,
 } from "~/components/RichText/extensions/utils/videoUploadNode";
@@ -137,7 +138,7 @@ const handleVideoUpload = async ({
         }
         updateVideoUploadNodeById(editor, uploadId, {
           hasError: true,
-          uploadStatus: "failed",
+          uploadStatus: VIDEO_UPLOAD_NODE_STATUS.FAILED,
           uploadErrorMessage: error.message,
         });
       },
@@ -149,7 +150,7 @@ const handleVideoUpload = async ({
       });
     }
     updateVideoUploadNodeById(editor, uploadId, {
-      uploadStatus: "failed",
+      uploadStatus: VIDEO_UPLOAD_NODE_STATUS.FAILED,
       uploadErrorMessage: error instanceof Error ? error.message : fallbackUploadErrorMessage,
     });
     onVideoUploadError(error);

--- a/apps/web/app/hooks/buildRichTextFileUploadHandler.ts
+++ b/apps/web/app/hooks/buildRichTextFileUploadHandler.ts
@@ -7,12 +7,17 @@ import {
   ALLOWED_WORD_FILE_TYPES,
   type EntityType,
 } from "@repo/shared";
+import { match } from "ts-pattern";
 
 import {
   insertVideoUploadPlaceholder,
   updateVideoUploadNodeById,
 } from "~/components/RichText/extensions/utils/videoUploadNode";
-import { buildEntityResourceUrl, insertResourceIntoEditor } from "~/hooks/useEntityResourceUpload";
+import {
+  RICH_TEXT_RESOURCE_TYPE,
+  buildEntityResourceUrl,
+  insertResourceIntoEditor,
+} from "~/hooks/useEntityResourceUpload";
 import { UPLOAD_STATUS } from "~/hooks/useRichTextUploadQueue";
 
 import type { Editor as TiptapEditor } from "@tiptap/react";
@@ -246,10 +251,11 @@ type BuildRichTextFileUploadHandlerArgs = {
   };
 };
 
-type RichTextResourceType = "presentation" | "pdf" | "document" | "other";
+type RichTextResourceType = (typeof RICH_TEXT_RESOURCE_TYPE)[keyof typeof RICH_TEXT_RESOURCE_TYPE];
 
 type FileCharacteristics = {
   isVideo: boolean;
+  isImage: boolean;
   isPresentation: boolean;
   isPdf: boolean;
   isDocument: boolean;
@@ -257,6 +263,7 @@ type FileCharacteristics = {
 };
 
 const getFileCharacteristics = (file: File): FileCharacteristics => {
+  const isImage = ALLOWED_LESSON_IMAGE_FILE_TYPES.includes(file.type);
   const isVideo = ALLOWED_VIDEO_FILE_TYPES.includes(file.type);
   const isPresentation = ALLOWED_PRESENTATION_FILE_TYPES.includes(file.type);
   const isPdf = ALLOWED_PDF_FILE_TYPES.includes(file.type);
@@ -266,17 +273,22 @@ const getFileCharacteristics = (file: File): FileCharacteristics => {
     ALLOWED_WORD_FILE_TYPES.includes(file.type);
 
   return {
+    isImage,
     isVideo,
     isPresentation,
     isPdf,
     isDocument,
-    resourceType: isPresentation
-      ? "presentation"
-      : isPdf
-        ? "pdf"
-        : isDocument
-          ? "document"
-          : "other",
+    resourceType: match({
+      isImage,
+      isPresentation,
+      isPdf,
+      isDocument,
+    })
+      .with({ isImage: true }, () => RICH_TEXT_RESOURCE_TYPE.IMAGE)
+      .with({ isPresentation: true }, () => RICH_TEXT_RESOURCE_TYPE.PRESENTATION)
+      .with({ isPdf: true }, () => RICH_TEXT_RESOURCE_TYPE.PDF)
+      .with({ isDocument: true }, () => RICH_TEXT_RESOURCE_TYPE.DOCUMENT)
+      .otherwise(() => RICH_TEXT_RESOURCE_TYPE.OTHER),
   };
 };
 

--- a/apps/web/app/hooks/useEntityResourceUpload.ts
+++ b/apps/web/app/hooks/useEntityResourceUpload.ts
@@ -18,7 +18,16 @@ type UploadResourceArgs = {
   description?: string;
 };
 
-export type RichTextResourceType = "presentation" | "pdf" | "document" | "other";
+export const RICH_TEXT_RESOURCE_TYPE = {
+  PRESENTATION: "presentation",
+  PDF: "pdf",
+  DOCUMENT: "document",
+  IMAGE: "image",
+  OTHER: "other",
+} as const;
+
+export type RichTextResourceType =
+  (typeof RICH_TEXT_RESOURCE_TYPE)[keyof typeof RICH_TEXT_RESOURCE_TYPE];
 export type RichTextResourceDisplayMode = "preview" | "download";
 
 type InsertResourceArgs = {
@@ -100,7 +109,9 @@ export const insertResourceIntoEditor = ({
   }
 
   chain
-    ?.insertContent(`<a href="${resourceUrl}" data-resource-id="${resourceId}">${resourceUrl}</a>`)
+    ?.insertContent(
+      `<br /><a href="${resourceUrl}" data-resource-id="${resourceId}">${resourceUrl}</a>`,
+    )
     .run();
 };
 

--- a/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/ContentLessonForm/ContentLessonForm.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/ContentLessonForm/ContentLessonForm.tsx
@@ -70,7 +70,7 @@ const ContentLessonForm = ({
   const { uploadResource } = useEntityResourceUpload();
   const { askForDisplayMode, dialog: uploadDisplayModeDialog } = useUploadDisplayModeDialog();
   const { getSessionForFile, uploadVideo } = useTusVideoUpload();
-  const { enqueue, setStatus, setProgress, attachUploadId } = useRichTextUploadQueue();
+  const { enqueue, setStatus, setProgress, attachUploadId, remove } = useRichTextUploadQueue();
 
   const onCloseModal = () => {
     setIsModalOpen(false);
@@ -119,6 +119,7 @@ const ContentLessonForm = ({
       setStatus,
       setProgress,
       attachUploadId,
+      remove,
     },
   });
 

--- a/apps/web/app/modules/Articles/ArticleForm.page.tsx
+++ b/apps/web/app/modules/Articles/ArticleForm.page.tsx
@@ -226,6 +226,7 @@ function ArticleFormPage({ defaultValues }: ArticleFormPageProps) {
       setStatus,
       setProgress,
       attachUploadId,
+      remove,
     },
   });
 

--- a/apps/web/app/modules/News/NewsForm.page.tsx
+++ b/apps/web/app/modules/News/NewsForm.page.tsx
@@ -218,6 +218,7 @@ function NewsFormPage({ defaultValues }: NewsFormPageProps) {
       setStatus,
       setProgress,
       attachUploadId,
+      remove,
     },
   });
 


### PR DESCRIPTION
## Issue(s)
[1347](https://github.com/Selleo/mentingo/issues/1347)

## Overview

This PR improves rich text uploads in the editor:

- uploads multiple selected files in parallel instead of serially
- shows an inline video placeholder while the upload session is being initialized
- keeps failed video uploads visible in the editor with an error state
- preserves local upload-driven editor updates so content syncing does not overwrite pending changes

## Business Value

These changes improve the authoring experience for lessons, articles, and news:

- faster feedback when attaching multiple files
- clearer upload state for videos during longer upload flows
- fewer confusing editor states when a video upload fails
- more consistent handling of supported resource types

## Screenshots / Video

https://github.com/user-attachments/assets/e0b61404-040d-449d-9925-cb16db35cb6a

