### PR TITLE
chore: update storage paths to make file management simpler and more organized

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -88,12 +88,15 @@ jobs:
           echo "::add-mask::$UNCLOUD_USER"
           echo "::add-mask::$UNCLOUD_PORT"
 
-          ssh -o BatchMode=yes uncloud-host true
+          echo "Testing raw SSH connectivity..."
+          if ! ssh -o BatchMode=yes uncloud-host true; then
+            echo "Raw SSH connectivity failed"
+            exit 1
+          fi
 
-          uc ps --connect "ssh+cli://uncloud-host" > /dev/null 2>&1
-
-          if [ $? -ne 0 ]; then
-            echo "Failed to connect to server"
+          echo "Testing Uncloud connectivity..."
+          if ! uc ls --connect "ssh+cli://uncloud-host"; then
+            echo "Uncloud connectivity failed"
             exit 1
           fi
 

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -88,15 +88,12 @@ jobs:
           echo "::add-mask::$UNCLOUD_USER"
           echo "::add-mask::$UNCLOUD_PORT"
 
-          echo "Testing raw SSH connectivity..."
-          if ! ssh -o BatchMode=yes uncloud-host true; then
-            echo "Raw SSH connectivity failed"
-            exit 1
-          fi
+          ssh -o BatchMode=yes uncloud-host true
 
-          echo "Testing Uncloud connectivity..."
-          if ! uc ls --connect "ssh+cli://uncloud-host"; then
-            echo "Uncloud connectivity failed"
+          uc ls --connect "ssh+cli://uncloud-host" > /dev/null 2>&1
+
+          if [ $? -ne 0 ]; then
+            echo "Failed to connect to server"
             exit 1
           fi
 

--- a/.github/workflows/reset-pr-preview-db.yml
+++ b/.github/workflows/reset-pr-preview-db.yml
@@ -82,7 +82,7 @@ jobs:
 
           ssh -o BatchMode=yes uncloud-host true
 
-          uc ps --connect "ssh+cli://uncloud-host" > /dev/null 2>&1
+          uc ls --connect "ssh+cli://uncloud-host" > /dev/null 2>&1
           if [ $? -ne 0 ]; then
             echo "Failed to connect to server"
             exit 1

--- a/apps/api/src/certificates/certificates.service.ts
+++ b/apps/api/src/certificates/certificates.service.ts
@@ -209,7 +209,8 @@ export class CertificatesService implements OnModuleDestroy {
     language?: SupportedLanguages,
   ): Promise<Buffer> {
     const shareLanguage = this.normalizeLanguage(language);
-    const imageKey = this.getShareImageKey(certificateId, shareLanguage);
+    const certificate = await this.getPublicShareCertificate(certificateId, shareLanguage);
+    const imageKey = this.getShareImageKey(certificate.tenantId, certificateId, shareLanguage);
 
     const exists = await this.s3Service.getFileExists(imageKey).catch((error) => {
       this.logger.warn(`Certificate share image existence check failed: ${error}`);
@@ -670,8 +671,12 @@ export class CertificatesService implements OnModuleDestroy {
     return url.toString();
   }
 
-  private getShareImageKey(certificateId: UUIDType, language: SupportedLanguages): string {
-    return `certificate-share/${certificateId}/${language}.png`;
+  private getShareImageKey(
+    tenantId: UUIDType,
+    certificateId: UUIDType,
+    language: SupportedLanguages,
+  ): string {
+    return `${tenantId}/certificate-share/${certificateId}/${language}.png`;
   }
 
   private normalizeLanguage(language?: string): SupportedLanguages {

--- a/apps/api/src/courses/course.service.ts
+++ b/apps/api/src/courses/course.service.ts
@@ -1655,7 +1655,11 @@ export class CourseService {
     let certificateSignatureReference = course.settings.certificateSignature ?? null;
 
     if (certificateSignature) {
-      const { fileKey } = await this.fileService.uploadFile(certificateSignature, "certificate");
+      const { fileKey } = await this.fileService.uploadFile(
+        certificateSignature,
+        "certificate",
+        currentUser.tenantId,
+      );
       certificateSignatureReference = fileKey;
     }
 
@@ -1877,7 +1881,7 @@ export class CourseService {
           try {
             const fileExtension = image.originalname.split(".").pop();
             const resource = `courses/${crypto.randomUUID()}.${fileExtension}`;
-            imageKey = await this.fileService.uploadFile(image, resource);
+            imageKey = await this.fileService.uploadFile(image, resource, currentUser.tenantId);
           } catch (error) {
             throw new ConflictException("Failed to upload course image");
           }

--- a/apps/api/src/file/file.controller.ts
+++ b/apps/api/src/file/file.controller.ts
@@ -28,6 +28,7 @@ import { Public } from "src/common/decorators/public.decorator";
 import { RequirePermission } from "src/common/decorators/require-permission.decorator";
 import { CurrentUser } from "src/common/decorators/user.decorator";
 import { PermissionsGuard } from "src/common/guards/permissions.guard";
+import { CurrentUserType } from "src/common/types/current-user.type";
 import {
   ALLOWED_MIME_TYPES,
   MAX_FILE_SIZE,
@@ -51,8 +52,6 @@ import {
   type VideoUploadStatusResponse,
 } from "./schemas/video-upload-status.schema";
 import { TusUploadService } from "./tus/tus-upload.service";
-
-import type { CurrentUserType } from "src/common/types/current-user.type";
 
 @UseGuards(PermissionsGuard)
 @Controller("file")
@@ -94,6 +93,7 @@ export class FileController {
     @UploadedFile()
     file: Express.Multer.File,
     @Body("resource") resource: string = "file",
+    @CurrentUser() currentUser: CurrentUserType,
   ): Promise<FileUploadResponse> {
     await FileGuard.validateFile(file, {
       allowedTypes: ALLOWED_MIME_TYPES,
@@ -101,7 +101,7 @@ export class FileController {
       maxVideoSize: MAX_VIDEO_SIZE,
     });
 
-    return await this.fileService.uploadFile(file, resource);
+    return await this.fileService.uploadFile(file, resource, currentUser.tenantId);
   }
 
   @RequirePermission(
@@ -119,9 +119,9 @@ export class FileController {
   })
   async initVideoUpload(
     @Body() payload: VideoInitBody,
-    @CurrentUser("userId") userId?: UUIDType,
+    @CurrentUser() currentUser?: CurrentUserType,
   ): Promise<VideoInitResponse> {
-    return this.fileService.initVideoUpload(payload, userId);
+    return this.fileService.initVideoUpload(payload, currentUser);
   }
 
   @Public()

--- a/apps/api/src/file/file.service.ts
+++ b/apps/api/src/file/file.service.ts
@@ -128,7 +128,7 @@ export class FileService {
       throw new BadRequestException("File upload failed - empty file");
     }
 
-    if (!tenantId) throw new BadRequestException("Missing tenant context for file upload");
+    if (!tenantId) throw new BadRequestException("files.toast.missingTenantContext");
 
     const isVideo = file.mimetype.startsWith("video/");
 

--- a/apps/api/src/file/file.service.ts
+++ b/apps/api/src/file/file.service.ts
@@ -44,6 +44,7 @@ import { BunnyVideoProvider } from "./providers/bunny-video.provider";
 import { S3VideoProvider } from "./providers/s3-video.provider";
 import { ThumbnailService } from "./thumbnail.service";
 import { CONTEXT_TTL, getContextKey } from "./utils/resourceCacheKeys";
+import { prefixTenantStorageKey } from "./utils/tenantStorageKey";
 import { VideoProcessingStateService } from "./video-processing-state.service";
 import { VideoUploadNotificationGateway } from "./video-upload-notification.gateway";
 
@@ -122,10 +123,12 @@ export class FileService {
     }
   }
 
-  async uploadFile(file: Express.Multer.File, resource: string) {
+  async uploadFile(file: Express.Multer.File, resource: string, tenantId?: UUIDType) {
     if (file.size === 0) {
       throw new BadRequestException("File upload failed - empty file");
     }
+
+    if (!tenantId) throw new BadRequestException("Missing tenant context for file upload");
 
     const isVideo = file.mimetype.startsWith("video/");
 
@@ -135,7 +138,11 @@ export class FileService {
       }
 
       const fileExtension = file.originalname.split(".").pop();
-      const fileKey = `${resource}/${randomUUID()}.${fileExtension}`;
+
+      const fileKey = prefixTenantStorageKey(
+        `${resource}/${randomUUID()}.${fileExtension}`,
+        tenantId,
+      );
 
       try {
         await this.s3Service.uploadFile(file.buffer, fileKey, file.mimetype);
@@ -196,7 +203,7 @@ export class FileService {
     placeholderKey: string,
   ) {
     try {
-      return provider.initVideoUpload(payload);
+      return await provider.initVideoUpload(payload);
     } catch (error) {
       await this.videoProcessingStateService.markFailed(uploadId, placeholderKey, error?.message);
       throw error;
@@ -266,7 +273,7 @@ export class FileService {
     return resourceResult.resourceId;
   }
 
-  async initVideoUpload(data: VideoInitBody, currentUserId?: UUIDType) {
+  async initVideoUpload(data: VideoInitBody, currentUser?: CurrentUserType) {
     const {
       filename,
       sizeBytes,
@@ -312,7 +319,7 @@ export class FileService {
       }
     }
 
-    await this.initializeVideoUploadState(uploadId, placeholderKey, fileType, currentUserId);
+    await this.initializeVideoUploadState(uploadId, placeholderKey, fileType, currentUser?.userId);
 
     const provider = await this.resolveVideoProvider();
     const providerResponse = await this.initProviderUpload(
@@ -322,6 +329,7 @@ export class FileService {
         title,
         mimeType,
         resource,
+        tenantId: currentUser?.tenantId,
       },
       uploadId,
       placeholderKey,
@@ -513,7 +521,7 @@ export class FileService {
 
     const checksum = getChecksum(file);
 
-    const { fileKey } = await this.uploadFile(file, resourceFolder);
+    const { fileKey } = await this.uploadFile(file, resourceFolder, currentUser?.tenantId);
 
     const { insertedResource } = await this.db.transaction(async (trx) => {
       const [insertedResource] = await trx

--- a/apps/api/src/file/providers/s3-video.provider.ts
+++ b/apps/api/src/file/providers/s3-video.provider.ts
@@ -26,7 +26,7 @@ export class S3VideoProvider implements VideoStorageProvider {
   async initVideoUpload(payload: VideoProviderInitPayload): Promise<VideoProviderInitResult> {
     const { filename, mimeType, resource, tenantId } = payload;
 
-    if (!tenantId) throw new BadRequestException("Missing tenant context for video upload");
+    if (!tenantId) throw new BadRequestException("files.toast.missingTenantContext");
 
     const extension = filename.split(".").pop() || "mp4";
     const fileKey = prefixTenantStorageKey(`${resource}/${randomUUID()}.${extension}`, tenantId);

--- a/apps/api/src/file/providers/s3-video.provider.ts
+++ b/apps/api/src/file/providers/s3-video.provider.ts
@@ -1,9 +1,11 @@
 import { randomUUID } from "crypto";
 
-import { Injectable } from "@nestjs/common";
+import { BadRequestException, Injectable } from "@nestjs/common";
 import { DEFAULT_TUS_CHUNK_SIZE, DEFAULT_TUS_TTL_MS, VIDEO_PROVIDERS } from "@repo/shared";
 
 import { S3Service } from "src/s3/s3.service";
+
+import { prefixTenantStorageKey } from "../utils/tenantStorageKey";
 
 import type {
   VideoProviderInitPayload,
@@ -22,9 +24,12 @@ export class S3VideoProvider implements VideoStorageProvider {
   }
 
   async initVideoUpload(payload: VideoProviderInitPayload): Promise<VideoProviderInitResult> {
-    const { filename, mimeType, resource } = payload;
+    const { filename, mimeType, resource, tenantId } = payload;
+
+    if (!tenantId) throw new BadRequestException("Missing tenant context for video upload");
+
     const extension = filename.split(".").pop() || "mp4";
-    const fileKey = `${resource}/${randomUUID()}.${extension}`;
+    const fileKey = prefixTenantStorageKey(`${resource}/${randomUUID()}.${extension}`, tenantId);
     const { uploadId } = await this.s3Service.createMultipartUpload(fileKey, mimeType);
     const expiresAt = new Date(Date.now() + DEFAULT_TUS_TTL_MS).toISOString();
 

--- a/apps/api/src/file/thumbnail.service.ts
+++ b/apps/api/src/file/thumbnail.service.ts
@@ -89,10 +89,12 @@ export class ThumbnailService {
       return this.bunnyStreamService.getThumbnailUrl(videoId);
     }
 
-    const exists = await this.s3Service.getFileExists(getVideoThumbnailKey(resourceId));
-    if (!exists) await this.extractThumbnail(resource.reference, resourceId);
+    const exists = await this.s3Service.getFileExists(
+      getVideoThumbnailKey(resourceId, resource.tenantId),
+    );
+    if (!exists) await this.extractThumbnail(resource.reference, resourceId, resource.tenantId);
 
-    return this.s3Service.getSignedUrl(getVideoThumbnailKey(resource.id));
+    return this.s3Service.getSignedUrl(getVideoThumbnailKey(resource.id, resource.tenantId));
   }
 
   private async getExternalThumbnail(sourceUrl: string, provider: VideoProvider) {
@@ -302,7 +304,7 @@ export class ThumbnailService {
     }
   }
 
-  private async extractThumbnail(reference: string, resourceId: UUIDType) {
+  private async extractThumbnail(reference: string, resourceId: UUIDType, tenantId?: UUIDType) {
     const signedUrl = await this.s3Service.getSignedUrl(reference);
     const args = [
       "-hide_banner",
@@ -412,7 +414,7 @@ export class ThumbnailService {
     await this.db.transaction(async (trx) => {
       await this.s3Service.uploadFile(
         output,
-        getVideoThumbnailKey(resourceId),
+        getVideoThumbnailKey(resourceId, tenantId),
         BASE_THUMBNAIL_CONTENT_TYPE,
       );
       await trx
@@ -421,7 +423,7 @@ export class ThumbnailService {
           metadata: setJsonbField(
             resources.metadata,
             "thumbnail",
-            getVideoThumbnailKey(resourceId),
+            getVideoThumbnailKey(resourceId, tenantId),
           ),
         })
         .where(eq(resources.id, resourceId));

--- a/apps/api/src/file/utils/tenantStorageKey.ts
+++ b/apps/api/src/file/utils/tenantStorageKey.ts
@@ -1,0 +1,7 @@
+import type { UUIDType } from "src/common";
+
+export function prefixTenantStorageKey(key: string, tenantId?: UUIDType) {
+  if (!tenantId) return key;
+
+  return `${tenantId}/${key.replace(/^\/+/, "")}`;
+}

--- a/apps/api/src/file/utils/videoThumbnail.ts
+++ b/apps/api/src/file/utils/videoThumbnail.ts
@@ -1,3 +1,5 @@
+import { prefixTenantStorageKey } from "./tenantStorageKey";
+
 import type { UUIDType } from "src/common";
 
 export const BASE_THUMBNAIL_EXTENSION = ".jpeg";
@@ -5,5 +7,5 @@ export const BASE_THUMBNAIL_CONTENT_TYPE = "image/jpeg";
 
 export const getVideoThumbnailFilename = (resourceId: UUIDType) =>
   `${resourceId}${BASE_THUMBNAIL_EXTENSION}`;
-export const getVideoThumbnailKey = (resourceId: UUIDType) =>
-  `thumbnail/${getVideoThumbnailFilename(resourceId)}`;
+export const getVideoThumbnailKey = (resourceId: UUIDType, tenantId?: UUIDType) =>
+  prefixTenantStorageKey(`thumbnail/${getVideoThumbnailFilename(resourceId)}`, tenantId);

--- a/apps/api/src/file/video-storage-provider.ts
+++ b/apps/api/src/file/video-storage-provider.ts
@@ -1,10 +1,12 @@
 import type { VideoProviderType } from "@repo/shared";
+import type { UUIDType } from "src/common";
 
 export type VideoProviderInitPayload = {
   filename: string;
   title?: string;
   mimeType: string;
   resource: string;
+  tenantId?: UUIDType;
 };
 
 export type VideoProviderInitResult = {

--- a/apps/api/src/lesson/__tests__/lesson.controller.e2e-spec.ts
+++ b/apps/api/src/lesson/__tests__/lesson.controller.e2e-spec.ts
@@ -1,5 +1,5 @@
 import { COURSE_ENROLLMENT, SYSTEM_ROLE_SLUGS } from "@repo/shared";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import request from "supertest";
 
 import { buildJsonbField } from "src/common/helpers/sqlHelpers";
@@ -7,7 +7,14 @@ import { FileService } from "src/file/file.service";
 import { LESSON_TYPES } from "src/lesson/lesson.type";
 import { QUESTION_TYPE } from "src/questions/schema/question.types";
 import { DB, DB_ADMIN } from "src/storage/db/db.providers";
-import { lessons, questions, questionAnswerOptions, studentCourses } from "src/storage/schema";
+import {
+  lessons,
+  questions,
+  questionAnswerOptions,
+  studentCourses,
+  studentLessonProgress,
+  studentQuestionAnswers,
+} from "src/storage/schema";
 
 import { createE2ETest } from "../../../test/create-e2e-test";
 import { createCategoryFactory } from "../../../test/factory/category.factory";
@@ -205,6 +212,32 @@ describe("LessonController (e2e) - quiz feedback redaction", () => {
     });
   };
 
+  const resetQuizAttemptState = async (studentId: UUIDType, lessonId: UUIDType) => {
+    const quizQuestions = await db
+      .select({ id: questions.id })
+      .from(questions)
+      .where(eq(questions.lessonId, lessonId));
+
+    await db.delete(studentQuestionAnswers).where(
+      and(
+        eq(studentQuestionAnswers.studentId, studentId),
+        inArray(
+          studentQuestionAnswers.questionId,
+          quizQuestions.map((question) => question.id),
+        ),
+      ),
+    );
+
+    await db
+      .delete(studentLessonProgress)
+      .where(
+        and(
+          eq(studentLessonProgress.studentId, studentId),
+          eq(studentLessonProgress.lessonId, lessonId),
+        ),
+      );
+  };
+
   describe("GET /api/lesson/:id - quiz feedback redaction", () => {
     it("should redact quiz feedback for student when quizFeedbackEnabled is false", async () => {
       const category = await categoryFactory.create();
@@ -350,6 +383,7 @@ describe("LessonController (e2e) - quiz feedback redaction", () => {
       const { lesson } = await createQuizLesson(course.id, chapter.id, contentCreator.id);
 
       const questionsAnswers = await buildQuizAnswers(lesson.id);
+      await resetQuizAttemptState(student.id, lesson.id);
 
       const response = await request(app.getHttpServer())
         .post("/api/lesson/evaluation-quiz")
@@ -455,11 +489,19 @@ describe("LessonController (e2e) - quiz feedback redaction", () => {
 
       expect(updatedResponse.body.data.isQuizFeedbackRedacted).toBe(true);
 
+      const evaluationStudent = await userFactory
+        .withCredentials({ password })
+        .withUserSettings(db)
+        .create({ role: SYSTEM_ROLE_SLUGS.STUDENT });
+      const evaluationStudentCookies = await cookieFor(evaluationStudent, app);
+      await enrollStudentToCourse(evaluationStudent.id, course.id);
+
       const questionsAnswers = await buildQuizAnswers(lesson.id);
+      await resetQuizAttemptState(evaluationStudent.id, lesson.id);
 
       const evaluationResponse = await request(app.getHttpServer())
         .post("/api/lesson/evaluation-quiz")
-        .set("Cookie", studentCookies)
+        .set("Cookie", evaluationStudentCookies)
         .send({
           lessonId: lesson.id,
           language: "en",

--- a/apps/api/src/lesson/services/adminLesson.service.ts
+++ b/apps/api/src/lesson/services/adminLesson.service.ts
@@ -1005,6 +1005,7 @@ export class AdminLessonService {
       relationshipType: RESOURCE_RELATIONSHIP_TYPES.ATTACHMENT,
       title: fileTitle,
       description: fileDescription,
+      currentUser,
       options: { contextId },
     });
 
@@ -1012,7 +1013,7 @@ export class AdminLessonService {
   }
 
   async uploadFileToLessonFromSignedUrl(
-    currentUserId: UUIDType,
+    currentUser: CurrentUserType,
     lessonId: UUIDType,
     signedUrl: string,
     options?: { originalFilename?: string },
@@ -1023,6 +1024,7 @@ export class AdminLessonService {
     const { fileKey, fileUrl } = await this.fileService.uploadFile(
       file,
       `${RESOURCE_CATEGORIES.LESSON}/lesson-content`,
+      currentUser.tenantId,
     );
 
     const [resource] = await this.adminLessonRepository.createLessonResources(lessonId, [
@@ -1034,7 +1036,7 @@ export class AdminLessonService {
           size: file.size,
           sourceUrl: signedUrl,
         },
-        uploadedById: currentUserId,
+        uploadedById: currentUser.userId,
       },
     ]);
 
@@ -1105,7 +1107,11 @@ export class AdminLessonService {
       return;
     }
 
-    const { fileKey } = await this.fileService.uploadFile(file, "lessons/ai-mentor-avatars");
+    const { fileKey } = await this.fileService.uploadFile(
+      file,
+      "lessons/ai-mentor-avatars",
+      currentUser.tenantId,
+    );
 
     await this.adminLessonRepository.updateAiMentorAvatar(lessonId, fileKey);
   }

--- a/apps/api/src/luma/luma.service.ts
+++ b/apps/api/src/luma/luma.service.ts
@@ -412,7 +412,7 @@ export class LumaService {
       }
 
       const uploaded = await this.adminLessonService.uploadFileToLessonFromSignedUrl(
-        currentUser.userId,
+        currentUser,
         lesson.id,
         signedUrl,
       );

--- a/apps/api/src/scorm/services/scorm.service.ts
+++ b/apps/api/src/scorm/services/scorm.service.ts
@@ -87,7 +87,7 @@ export class ScormService {
 
         const chapters = this.parseScormStructure(manifest);
 
-        const s3BaseKey = `scorm/${courseId}/${randomUUID()}`;
+        const s3BaseKey = `${currentUser.tenantId}/scorm/${courseId}/${randomUUID()}`;
         await Promise.all(
           entries
             .filter((entry) => !entry.isDirectory)

--- a/apps/api/src/settings/settings.service.ts
+++ b/apps/api/src/settings/settings.service.ts
@@ -728,7 +728,7 @@ export class SettingsService {
     let newValue: string | null = null;
     if (file) {
       const resource = "platform-logos";
-      const { fileKey } = await this.fileService.uploadFile(file, resource);
+      const { fileKey } = await this.fileService.uploadFile(file, resource, actor?.tenantId);
       newValue = fileKey;
     }
 
@@ -790,7 +790,7 @@ export class SettingsService {
     let newValue: string | null = null;
     if (file) {
       const resource = "platform-simple-logos";
-      const { fileKey } = await this.fileService.uploadFile(file, resource);
+      const { fileKey } = await this.fileService.uploadFile(file, resource, actor?.tenantId);
       newValue = fileKey;
     }
 
@@ -834,7 +834,7 @@ export class SettingsService {
     let newValue: string | null = null;
     if (file) {
       const resource = "login-backgrounds";
-      const { fileKey } = await this.fileService.uploadFile(file, resource);
+      const { fileKey } = await this.fileService.uploadFile(file, resource, actor?.tenantId);
       newValue = fileKey;
     }
 
@@ -1011,6 +1011,7 @@ export class SettingsService {
       const { fileKey } = await this.fileService.uploadFile(
         certificateBackground,
         "certificate-backgrounds",
+        actor?.tenantId,
       );
       certificateBackgroundValue = fileKey;
     }

--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -417,7 +417,11 @@ export class UserService {
     }
 
     if (userAvatar) {
-      const { fileKey } = await this.fileService.uploadFile(userAvatar, "user-avatars");
+      const { fileKey } = await this.fileService.uploadFile(
+        userAvatar,
+        "user-avatars",
+        existingUser.tenantId,
+      );
       data.userAvatar = fileKey;
     }
 

--- a/apps/web/app/locales/cs/translation.json
+++ b/apps/web/app/locales/cs/translation.json
@@ -2417,7 +2417,8 @@
     "toast": {
       "invalidData": "Nahrání souboru se nezdařilo – neplatná data souboru",
       "contentTypeMismatch": "Typ obsahu souboru neodpovídá poskytnutému typu obsahu",
-      "invalidFileType": "Neplatný typ souboru. Nahrajte soubor PNG nebo SVG."
+      "invalidFileType": "Neplatný typ souboru. Nahrajte soubor PNG nebo SVG.",
+      "missingTenantContext": "Chybí kontext organizace pro nahrání souboru"
     },
     "import": {
       "noFileUploaded": "Nebyl nahrán žádný soubor",

--- a/apps/web/app/locales/de/translation.json
+++ b/apps/web/app/locales/de/translation.json
@@ -2417,7 +2417,8 @@
     "toast": {
       "invalidData": "Datei-Upload fehlgeschlagen – ungültige Dateidaten",
       "contentTypeMismatch": "Der Dateiinhaltstyp stimmt nicht mit dem bereitgestellten Inhaltstyp überein",
-      "invalidFileType": "Ungültiger Dateityp. Bitte laden Sie eine PNG- oder SVG-Datei hoch."
+      "invalidFileType": "Ungültiger Dateityp. Bitte laden Sie eine PNG- oder SVG-Datei hoch.",
+      "missingTenantContext": "Fehlender Mandantenkontext für den Datei-Upload"
     },
     "import": {
       "noFileUploaded": "Keine Datei hochgeladen",

--- a/apps/web/app/locales/en/translation.json
+++ b/apps/web/app/locales/en/translation.json
@@ -2470,7 +2470,8 @@
     "toast": {
       "invalidData": "File upload failed - invalid file data",
       "contentTypeMismatch": "File content type does not match the provided content type",
-      "invalidFileType": "Invalid file type. Please upload a PNG or SVG file."
+      "invalidFileType": "Invalid file type. Please upload a PNG or SVG file.",
+      "missingTenantContext": "Missing tenant context for file upload"
     },
     "import": {
       "noFileUploaded": "No file uploaded",

--- a/apps/web/app/locales/lt/translation.json
+++ b/apps/web/app/locales/lt/translation.json
@@ -2417,7 +2417,8 @@
     "toast": {
       "invalidData": "Failo įkėlimas nepavyko – neteisingi failo duomenys",
       "contentTypeMismatch": "Failo turinio tipas neatitinka pateikto turinio tipo",
-      "invalidFileType": "Neteisingas failo tipas. Įkelkite PNG arba SVG failą."
+      "invalidFileType": "Neteisingas failo tipas. Įkelkite PNG arba SVG failą.",
+      "missingTenantContext": "Trūksta organizacijos konteksto failo įkėlimui"
     },
     "import": {
       "noFileUploaded": "Failas neįkeltas",

--- a/apps/web/app/locales/pl/translation.json
+++ b/apps/web/app/locales/pl/translation.json
@@ -2495,7 +2495,8 @@
     "toast": {
       "invalidData": "Nie udało się przesłać pliku - nieprawidłowe dane pliku",
       "contentTypeMismatch": "Typ zawartości pliku nie odpowiada podanemu typowi",
-      "invalidFileType": "Nieprawidłowy typ pliku. Prześlij plik PNG lub SVG."
+      "invalidFileType": "Nieprawidłowy typ pliku. Prześlij plik PNG lub SVG.",
+      "missingTenantContext": "Brak kontekstu organizacji dla przesyłania pliku"
     },
     "import": {
       "noFileUploaded": "Nie przesłano pliku",


### PR DESCRIPTION
## Issue(s)
- #1427 

## Overview
Updated file upload handling so uploaded objects are stored under tenant-prefixed S3 keys. This change threads `tenantId` through the main upload paths, tenant-aware video initialization, thumbnail generation, certificate share image storage, and the remaining direct upload call sites.

## Business Value
This keeps uploaded assets isolated by tenant at the storage layer, which improves data organization, reduces collision risk, and makes tenant-level cleanup and migration work safer.