### PR TITLE
fix: resolve issue preventing users from completing lessons with videos

### DIFF
--- a/apps/web/app/components/RichText/Viever.tsx
+++ b/apps/web/app/components/RichText/Viever.tsx
@@ -16,13 +16,14 @@ import {
 } from "./videoAutoplayPolicy";
 
 import type { VideoAutoplay } from "@repo/shared";
+import type { VideoEndedHandler } from "~/components/VideoPlayer/VideoPlayer.types";
 
 type ViewerProps = {
   content: string;
   style?: "default" | "prose";
   className?: string;
   variant?: "default" | "article" | "news" | "content";
-  onVideoEnded?: () => void;
+  onVideoEnded?: VideoEndedHandler;
   videoAutoplayPolicy?: RichTextVideoAutoplayPolicy;
 };
 
@@ -75,14 +76,14 @@ const Viewer = ({
     selectedVariant.editor,
   );
 
-  const onVideoEndedRef = useRef<(() => void) | undefined>();
+  const onVideoEndedRef = useRef<VideoEndedHandler | undefined>();
 
   useEffect(() => {
     onVideoEndedRef.current = onVideoEnded;
   }, [onVideoEnded]);
 
-  const handleVideoEnded = useCallback(() => {
-    onVideoEndedRef.current?.();
+  const handleVideoEnded = useCallback<VideoEndedHandler>((event) => {
+    onVideoEndedRef.current?.(event);
   }, []);
 
   const extensions = useMemo(

--- a/apps/web/app/components/RichText/extensions/video.tsx
+++ b/apps/web/app/components/RichText/extensions/video.tsx
@@ -26,9 +26,10 @@ import {
 import type { VideoAutoplay } from "@repo/shared";
 import type { NodeConfig } from "@tiptap/core";
 import type { NodeViewProps } from "@tiptap/react";
+import type { VideoEndedHandler } from "~/components/VideoPlayer/VideoPlayer.types";
 
 type VideoViewerOptions = {
-  onVideoEnded?: () => void;
+  onVideoEnded?: VideoEndedHandler;
   resolveAutoplay?: (autoplay: VideoAutoplay) => VideoAutoplay;
 };
 

--- a/apps/web/app/components/VideoPlayer/Video.tsx
+++ b/apps/web/app/components/VideoPlayer/Video.tsx
@@ -10,6 +10,7 @@ import { useVideoPlayer } from "./VideoPlayerContext";
 import type { VideoAutoplay } from "@repo/shared";
 import type { KeyboardEvent } from "react";
 import type { VideoProvider } from "~/components/RichText/extensions/utils/video";
+import type { VideoEndedHandler } from "~/components/VideoPlayer/VideoPlayer.types";
 
 type Props = {
   src?: string | null;
@@ -19,7 +20,7 @@ type Props = {
   index?: number | null;
   isExternal?: boolean;
   isExternalUrl?: boolean;
-  onVideoEnded?: () => void;
+  onVideoEnded?: VideoEndedHandler;
 };
 
 export function Video({

--- a/apps/web/app/components/VideoPlayer/VideoPlayer.tsx
+++ b/apps/web/app/components/VideoPlayer/VideoPlayer.tsx
@@ -197,7 +197,7 @@ export const VideoPlayer = ({
     <div
       data-vjs-player
       className={cn(
-        "relative w-full overflow-hidden rounded-lg bg-black shadow-[0_8px_30px_rgba(18,21,33,0.28)]",
+        "relative w-full overflow-hidden bg-black shadow-[0_8px_30px_rgba(18,21,33,0.28)]",
         fill ? "h-full" : "aspect-video",
         className,
       )}

--- a/apps/web/app/components/VideoPlayer/VideoPlayer.types.ts
+++ b/apps/web/app/components/VideoPlayer/VideoPlayer.types.ts
@@ -1,6 +1,18 @@
+export const VIDEO_ENDED_SOURCE = {
+  MEDIA_ENDED: "media-ended",
+  AUTOPLAY_ACTION: "autoplay-action",
+  GO_NEXT_LESSON: "go-next-lesson",
+} as const;
+
+export type VideoEndedEvent = {
+  source: (typeof VIDEO_ENDED_SOURCE)[keyof typeof VIDEO_ENDED_SOURCE];
+};
+
+export type VideoEndedHandler = (event: VideoEndedEvent) => void;
+
 export type VideoPlayerProps = {
   url: string | null;
-  onVideoEnded?: () => void;
+  onVideoEnded?: VideoEndedHandler;
   isExternalUrl?: boolean;
 };
 

--- a/apps/web/app/components/VideoPlayer/VideoPlayerContext.tsx
+++ b/apps/web/app/components/VideoPlayer/VideoPlayerContext.tsx
@@ -1,6 +1,9 @@
 import { createContext, useContext, useState, useCallback, useRef } from "react";
 
 import type { VideoProvider } from "@repo/shared";
+import type { VideoEndedEvent } from "~/components/VideoPlayer/VideoPlayer.types";
+
+type VideoEndedHandler = (event: VideoEndedEvent) => void;
 
 type VideoState = {
   currentUrl: string | null;
@@ -15,13 +18,13 @@ type VideoContextValue = {
     url: string,
     provider: VideoProvider | null,
     isExternal: boolean,
-    onEnded?: () => void,
+    onEnded?: VideoEndedHandler,
     index?: number | null,
   ) => void;
   clearVideo: () => void;
-  setOnEnded: (onEnded: () => void) => void;
+  setOnEnded: (onEnded: VideoEndedHandler) => void;
   setPlaceholderElement: (el: HTMLElement | null) => void;
-  getOnEnded: () => (() => void) | undefined;
+  getOnEnded: () => VideoEndedHandler | undefined;
   registerVideoActivator: (url: string, activate: () => void) => () => void;
   activateVideoByUrl: (url: string) => boolean;
   state: VideoState;
@@ -46,17 +49,20 @@ export function VideoProvider({ children }: { children: React.ReactNode }) {
     index: null,
   });
 
-  const onEndedRef = useRef<(() => void) | undefined>();
+  const onEndedRef = useRef<VideoEndedHandler | undefined>();
   const videoActivatorsRef = useRef(new Map<string, () => void>());
 
-  const setOnEnded = useCallback((onEnded: () => void) => (onEndedRef.current = onEnded), []);
+  const setOnEnded = useCallback(
+    (onEnded: VideoEndedHandler) => (onEndedRef.current = onEnded),
+    [],
+  );
 
   const setVideo = useCallback(
     (
       url: string,
       provider: VideoProvider | null,
       isExternal: boolean,
-      onEnded?: () => void,
+      onEnded?: VideoEndedHandler,
       index?: number | null,
     ) => {
       onEndedRef.current = onEnded;

--- a/apps/web/app/components/VideoPlayer/VideoPlayerSingleton.tsx
+++ b/apps/web/app/components/VideoPlayer/VideoPlayerSingleton.tsx
@@ -12,6 +12,7 @@ import { usePlaceholderRect } from "./hooks/usePlaceholderRect";
 import { LoaderPlayNext } from "./LoaderPlayNext";
 import { VideoPlayer } from "./VideoPlayer";
 import { PLAY_NEXT_SECONDS } from "./VideoPlayer.constants";
+import { VIDEO_ENDED_SOURCE } from "./VideoPlayer.types";
 import { useVideoPlayer } from "./VideoPlayerContext";
 
 import type React from "react";
@@ -57,14 +58,14 @@ export function VideoPlayerSingleton() {
         const activated = activateVideoByUrl(url);
 
         if (!activated) {
-          getOnEnded()?.();
+          getOnEnded()?.({ source: VIDEO_ENDED_SOURCE.GO_NEXT_LESSON });
         }
       },
       goToNextLesson: () => {
-        getOnEnded()?.();
+        getOnEnded()?.({ source: VIDEO_ENDED_SOURCE.GO_NEXT_LESSON });
       },
       autoplayCurrentVideo: () => {
-        getOnEnded()?.();
+        getOnEnded()?.({ source: VIDEO_ENDED_SOURCE.AUTOPLAY_ACTION });
       },
     });
   }, [activateVideoByUrl, getOnEnded, onAutoplay]);
@@ -76,13 +77,15 @@ export function VideoPlayerSingleton() {
   });
 
   const handleEnded = useCallback(() => {
-    setShowPlayNext(
-      shouldShowPlayNextOverlay({
-        autoplayEnabled: autoplay,
-        action: autoplaySettings.currentAction,
-      }),
-    );
-  }, [autoplay, autoplaySettings]);
+    getOnEnded()?.({ source: VIDEO_ENDED_SOURCE.MEDIA_ENDED });
+
+    const shouldShowOverlay = shouldShowPlayNextOverlay({
+      autoplayEnabled: autoplay,
+      action: autoplaySettings.currentAction,
+    });
+
+    setShowPlayNext(shouldShowOverlay);
+  }, [autoplay, autoplaySettings.currentAction, getOnEnded]);
 
   const activeRect = rect ?? lastRect;
   const canRender = (Boolean(activeRect) || isAnyFullscreen) && (currentUrl || showPlayNext);

--- a/apps/web/app/components/VideoPlayer/videoPlayer.css
+++ b/apps/web/app/components/VideoPlayer/videoPlayer.css
@@ -7,7 +7,7 @@
   width: 100%;
   height: 100%;
   position: relative;
-  border-radius: 0.75rem;
+  border-radius: 0;
   overflow: hidden;
   background: #000;
 }

--- a/apps/web/app/modules/Courses/Lesson/Lesson.page.tsx
+++ b/apps/web/app/modules/Courses/Lesson/Lesson.page.tsx
@@ -68,6 +68,8 @@ export default function LessonPage() {
   const { state, clearVideo } = useVideoPlayer();
 
   const { autoplay, setAutoplaySettings, autoplaySettings } = useVideoPreferencesStore();
+  const lessonType = lesson?.type;
+  const lessonHasAutoplayTrigger = lesson?.hasAutoplayTrigger;
 
   useEffect(() => {
     setAutoplaySettings({ currentAction: VIDEO_AUTOPLAY.NO_AUTOPLAY, nextVideoUrl: undefined });
@@ -91,9 +93,9 @@ export default function LessonPage() {
   ]);
 
   useEffect(() => {
-    if (!lesson) return;
+    if (!lessonType) return;
 
-    if (lesson.type !== "content") {
+    if (lessonType !== "content") {
       clearVideo();
       return;
     }
@@ -103,12 +105,10 @@ export default function LessonPage() {
       return;
     }
 
-    const hasAutoplayTrigger = lesson.hasAutoplayTrigger;
-
-    if (!hasAutoplayTrigger) {
+    if (!lessonHasAutoplayTrigger) {
       clearVideo();
     }
-  }, [lesson, autoplay, clearVideo]);
+  }, [lessonId, lessonType, lessonHasAutoplayTrigger, autoplay, clearVideo]);
 
   useEffect(() => {
     if (lessonError) {

--- a/apps/web/app/modules/Courses/Lesson/LessonContent.tsx
+++ b/apps/web/app/modules/Courses/Lesson/LessonContent.tsx
@@ -9,7 +9,7 @@ import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
 import { Switch } from "~/components/ui/switch";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "~/components/ui/tooltip";
-import { shouldAutoAdvanceLessonWithoutNextVideo } from "~/components/VideoPlayer/autoplayFlow";
+import { VIDEO_ENDED_SOURCE } from "~/components/VideoPlayer/VideoPlayer.types";
 import { useVideoPlayer } from "~/components/VideoPlayer/VideoPlayerContext";
 import { useLessonsSequence } from "~/hooks/useLessonsSequence";
 import { LessonType } from "~/modules/Admin/EditCourse/EditCourse.types";
@@ -22,6 +22,7 @@ import { LessonContentRenderer } from "./LessonContentRenderer";
 import { isNextBlocked, isPreviousBlocked } from "./utils";
 
 import type { GetCourseResponse, GetLessonByIdResponse } from "~/api/generated-api";
+import type { VideoEndedEvent } from "~/components/VideoPlayer/VideoPlayer.types";
 import type { LessonPreviewUser } from "~/modules/Courses/Lesson/types";
 
 type LessonContentProps = {
@@ -183,31 +184,39 @@ export const LessonContent = ({
     }
   }, [lesson.id, lesson.hasVideo, clearVideo]);
 
-  const handleVideoEnded = useCallback(() => {
-    setIsNextDisabled(false);
+  const handleVideoEnded = useCallback(
+    (event: VideoEndedEvent) => {
+      const isMediaEnded = event.source === VIDEO_ENDED_SOURCE.MEDIA_ENDED;
 
-    if (
-      shouldAutoAdvanceLessonWithoutNextVideo({
-        autoplayEnabled: autoplay,
-        action: autoplaySettings.currentAction,
-        nextVideoUrl: autoplaySettings.nextVideoUrl,
-      })
-    ) {
-      if (isEffectiveStudentExperience) {
+      setIsNextDisabled(false);
+
+      const isLastVideoInLesson = !autoplaySettings.nextVideoUrl;
+
+      if (
+        isMediaEnded &&
+        isEffectiveStudentExperience &&
+        lesson.hasVideo &&
+        !lesson.lessonCompleted &&
+        isLastVideoInLesson
+      ) {
         markLessonAsCompleted({ lessonId: lesson.id, language });
       }
-      handleNext();
-    }
-  }, [
-    autoplay,
-    autoplaySettings.currentAction,
-    autoplaySettings.nextVideoUrl,
-    isEffectiveStudentExperience,
-    markLessonAsCompleted,
-    lesson.id,
-    language,
-    handleNext,
-  ]);
+
+      if (event.source === VIDEO_ENDED_SOURCE.GO_NEXT_LESSON) {
+        handleNext();
+      }
+    },
+    [
+      autoplaySettings.nextVideoUrl,
+      isEffectiveStudentExperience,
+      markLessonAsCompleted,
+      lesson.id,
+      lesson.hasVideo,
+      lesson.lessonCompleted,
+      language,
+      handleNext,
+    ],
+  );
 
   useEffect(() => {
     setOnEnded(handleVideoEnded);

--- a/apps/web/app/modules/Courses/Lesson/LessonContentRenderer.tsx
+++ b/apps/web/app/modules/Courses/Lesson/LessonContentRenderer.tsx
@@ -8,6 +8,7 @@ import { EmbedLesson } from "./EmbedLesson/EmbedLesson";
 import { Quiz } from "./Quiz";
 
 import type { CurrentUserResponse, GetLessonByIdResponse } from "~/api/generated-api";
+import type { VideoEndedHandler } from "~/components/VideoPlayer/VideoPlayer.types";
 import type { LessonPreviewUser } from "~/modules/Courses/Lesson/types";
 
 type LessonContentRendererProps = {
@@ -15,7 +16,7 @@ type LessonContentRendererProps = {
   user: CurrentUserResponse["data"] | undefined;
   previewUser?: LessonPreviewUser;
   lessonLoading: boolean;
-  onVideoEnded?: () => void;
+  onVideoEnded?: VideoEndedHandler;
 };
 
 export const LessonContentRenderer = memo(


### PR DESCRIPTION
## Overview
Refactor the video end-handling flow to use a typed event payload with a consistent `source` field across the VideoPlayer, RichText video embeds, and lesson playback logic.

This change makes it explicit whether the end event came from:
- the media finishing naturally
- an autoplay action
- advancing to the next lesson

The lesson flow now uses that source to decide when to mark a lesson as completed and when to advance to the next lesson, instead of relying on an untyped callback.

## Business Value
This reduces ambiguity in video completion behavior and makes autoplay/lesson progression easier to reason about.

It also lowers the risk of accidental completion or navigation when video ending comes from a non-media source, which improves the reliability of the student viewing experience.

## Screenshots / Video

https://github.com/user-attachments/assets/bdfcb7d8-f5bb-4bd1-bfb6-4e3010652eb0
