### PR TITLE
chore: bump AWS credentials action to v4 across deployment workflows

### DIFF
--- a/.github/workflows/deploy-api-demo.yml
+++ b/.github/workflows/deploy-api-demo.yml
@@ -38,7 +38,7 @@ jobs:
           echo "✅ Wrote version $TAG_VERSION to apps/api/version.json"
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy-api-staging.yml
+++ b/.github/workflows/deploy-api-staging.yml
@@ -43,7 +43,7 @@ jobs:
           echo "✅ Wrote version $TAG_VERSION to apps/api/version.json"
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy-webapp-demo.yml
+++ b/.github/workflows/deploy-webapp-demo.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-tags: true
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy-webapp-staging.yml
+++ b/.github/workflows/deploy-webapp-staging.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-tags: true
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -303,7 +303,7 @@ This guide provides a complete walkthrough for deploying the Mentingo applicatio
               echo "{ \"version\": \"$TAG_VERSION\" }" > apps/api/version.json
               echo "✅ Wrote version $TAG_VERSION to apps/api/version.json"
           - name: Configure AWS credentials
-            uses: aws-actions/configure-aws-credentials@v1-node16
+            uses: aws-actions/configure-aws-credentials@v4
             with:
               aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
               aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -360,7 +360,7 @@ This guide provides a complete walkthrough for deploying the Mentingo applicatio
               echo "{ \"version\": \"$TAG_VERSION\" }" > apps/web/version.json
               echo "✅ Wrote version $TAG_VERSION to apps/web/version.json"
           - name: Configure AWS credentials
-            uses: aws-actions/configure-aws-credentials@v1-node16
+            uses: aws-actions/configure-aws-credentials@v4
             with:
               aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
               aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Overview
Updated all deployment workflows and the deployment guide to use `aws-actions/configure-aws-credentials@v4` instead of the deprecated `@v1-node16` version.

## Business Value
Keeps the deployment pipeline on a supported AWS credentials action version, reducing the risk of breakage from deprecated runtime support and keeping the demo/staging deployment setup consistent across code and documentation.
