### PR TITLE
chore: make MFA issuer use company name specified by provider

### DIFF
--- a/apps/api/src/auth/__tests__/auth.controller.e2e-spec.ts
+++ b/apps/api/src/auth/__tests__/auth.controller.e2e-spec.ts
@@ -305,6 +305,48 @@ describe("AuthController (e2e)", () => {
     });
   });
 
+  describe("POST /api/auth/mfa/setup", () => {
+    it("should use the company name from global settings as the MFA issuer", async () => {
+      const user = userFactory.build();
+      const password = "Password123@";
+
+      const registeredUser = await authService.register({
+        email: user.email,
+        firstName: user.firstName,
+        lastName: user.lastName,
+        password,
+        language: "en",
+      });
+
+      await settingsService.updateCompanyInformation({
+        companyName: "Acme Corp",
+      });
+
+      const { otpauth } = await authService.generateMFASecret(registeredUser.id);
+
+      expect(otpauth).toContain("issuer=Acme%20Corp");
+      expect(otpauth).toContain("Acme%20Corp%3A");
+    });
+
+    it("should fallback to mentingo when the company name is missing", async () => {
+      const user = userFactory.build();
+      const password = "Password123@";
+
+      const registeredUser = await authService.register({
+        email: user.email,
+        firstName: user.firstName,
+        lastName: user.lastName,
+        password,
+        language: "en",
+      });
+
+      const { otpauth } = await authService.generateMFASecret(registeredUser.id);
+
+      expect(otpauth).toContain("issuer=Mentingo");
+      expect(otpauth).toContain("Mentingo%3A");
+    });
+  });
+
   describe("POST /api/auth/logout", () => {
     it("should clear token cookies for a logged-in user", async () => {
       let accessToken = "";

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -832,7 +832,7 @@ export class AuthService {
 
     return {
       secret,
-      otpauth: `otpauth://totp/Mentingo:${user.email}?secret=${secret}&issuer=Mentingo`,
+      otpauth: await this.buildMfaOtpAuthUri(user.email, secret),
     };
   }
 
@@ -996,6 +996,21 @@ export class AuthService {
     if (!enforcedRoles.length || !roleSlugs.length) return false;
 
     return roleSlugs.some((roleSlug) => enforcedRoles.includes(roleSlug));
+  }
+
+  private async getMfaIssuerName(): Promise<string> {
+    const { companyInformation } = await this.settingsService.getGlobalSettings();
+    const companyName = companyInformation?.companyName;
+
+    return companyName || "Mentingo";
+  }
+
+  private async buildMfaOtpAuthUri(email: string, secret: string): Promise<string> {
+    const issuer = await this.getMfaIssuerName();
+
+    return `otpauth://totp/${encodeURIComponent(
+      `${issuer}:${email}`,
+    )}?secret=${secret}&issuer=${encodeURIComponent(issuer)}`;
   }
 
   private async getOnboardingStatus(userId: UUIDType, db?: DatabasePg) {


### PR DESCRIPTION
## Overview
Use the company name from global settings as the MFA issuer when generating the `otpauth://` URI. If no company name is configured, fall back to `Mentingo`.

## Business Value
This keeps MFA enrollment aligned with the tenant branding shown elsewhere in the product and avoids exposing the default platform name when a company name is available.
