### PR TITLE
chore: improve testing workflows with flexible browser selection and add nightly Firefox test runs

### DIFF
--- a/.github/workflows/e2e-nightly-firefox.yml
+++ b/.github/workflows/e2e-nightly-firefox.yml
@@ -1,14 +1,18 @@
+name: Nightly Firefox E2E
+
+env:
+  HUSKY: 0
+
 on:
-  pull_request:
-    types: [labeled]
-  workflow_call:
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch:
 
 jobs:
   e2e:
-    if: ${{ (github.event_name == 'pull_request' && github.event.label != null && github.event.label.name == 'run E2E tests ⚙️') || github.event_name == 'workflow_call' }}
     uses: ./.github/workflows/e2e.yml
     with:
-      browser: chromium
+      browser: firefox
     secrets:
       STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
       STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,7 +51,7 @@ jobs:
     environment:
       name: e2e
     env:
-      E2E_BROWSER: ${{ github.event_name == 'push' && 'all' || (inputs.browser || 'all') }}
+      E2E_BROWSER: ${{ github.event_name == 'push' && github.ref_name == 'staging' && 'chromium' || (github.event_name == 'push' && 'all' || (inputs.browser || 'all')) }}
 
     services:
       postgres:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,6 +22,12 @@ env:
 
 on:
   workflow_call:
+    inputs:
+      browser:
+        description: Playwright project to run
+        required: false
+        type: string
+        default: all
     secrets:
         STRIPE_SECRET_KEY:
           required: true
@@ -37,7 +43,6 @@ on:
     branches:
       - main
       - staging
-  workflow_dispatch:
 
 jobs:
   playwright:
@@ -45,6 +50,8 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: e2e
+    env:
+      E2E_BROWSER: ${{ github.event_name == 'push' && 'all' || (inputs.browser || 'all') }}
 
     services:
       postgres:
@@ -126,7 +133,23 @@ jobs:
             ${{ runner.os }}-playwright
 
       - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps chromium firefox
+        shell: bash
+        run: |
+          case "$E2E_BROWSER" in
+            chromium)
+              pnpm exec playwright install --with-deps chromium
+              ;;
+            firefox)
+              pnpm exec playwright install --with-deps firefox
+              ;;
+            all)
+              pnpm exec playwright install --with-deps chromium firefox
+              ;;
+            *)
+              echo "Unsupported E2E_BROWSER value: $E2E_BROWSER" >&2
+              exit 1
+              ;;
+          esac
         working-directory: ./apps/web
         env:
           PLAYWRIGHT_BROWSERS_PATH: /home/runner/.cache/ms-playwright
@@ -182,7 +205,23 @@ jobs:
             '
 
       - name: Run tests
-        run: VITE_TEST=true pnpm playwright test
+        shell: bash
+        run: |
+          case "$E2E_BROWSER" in
+            chromium)
+              VITE_TEST=true pnpm playwright test --project chromium
+              ;;
+            firefox)
+              VITE_TEST=true pnpm playwright test --project firefox
+              ;;
+            all)
+              VITE_TEST=true pnpm playwright test
+              ;;
+            *)
+              echo "Unsupported E2E_BROWSER value: $E2E_BROWSER" >&2
+              exit 1
+              ;;
+          esac
         working-directory: ./apps/web
         env:
           PLAYWRIGHT_BROWSERS_PATH: /home/runner/.cache/ms-playwright


### PR DESCRIPTION
## Issue(-s)
- #1354 

## Overview
This change updates the Playwright CI flow so pull requests and `staging` pushes run Chromium-only E2E tests, while Firefox E2E coverage moves to a separate nightly workflow that can also be triggered manually.

## Business Value
This reduces PR and staging CI runtime and feedback time by running only the browser required for those validations, while still preserving Firefox coverage on a scheduled cadence and on demand for regression checks.

### Notes

- [x] Fired up e2e tests and got a positive result
