### PR TITLE
test: add coverage for news and articles flows

### DIFF
--- a/apps/web/app/config/navigationConfig.ts
+++ b/apps/web/app/config/navigationConfig.ts
@@ -100,6 +100,7 @@ export const getNavigationConfig = (
                       label: t("navigationSideBar.news"),
                       path: `news`,
                       iconName: "News",
+                      testId: NAVIGATION_HANDLES.NEWS_LINK,
                     },
                   ] as NavigationItem[])
                 : []),
@@ -109,6 +110,7 @@ export const getNavigationConfig = (
                       label: t("navigationSideBar.articles"),
                       path: `articles`,
                       iconName: "Articles",
+                      testId: NAVIGATION_HANDLES.ARTICLES_LINK,
                     },
                   ] as NavigationItem[])
                 : []),

--- a/apps/web/app/modules/Articles/ArticleDetails.page.tsx
+++ b/apps/web/app/modules/Articles/ArticleDetails.page.tsx
@@ -17,6 +17,7 @@ import { ContentAccessGuard } from "~/Guards/AccessGuard";
 import { usePermissions } from "~/hooks/usePermissions";
 import { cn } from "~/lib/utils";
 
+import { ARTICLE_DETAILS_PAGE_HANDLES } from "../../../e2e/data/articles/handles";
 import Loader from "../common/Loader/Loader";
 import { useLanguageStore } from "../Dashboard/Settings/Language/LanguageStore";
 
@@ -84,6 +85,7 @@ export default function ArticleDetailsPage() {
   return (
     <ContentAccessGuard type={ACCESS_GUARD.UNREGISTERED_ARTICLES_ACCESS}>
       <PageWrapper
+        data-testid={ARTICLE_DETAILS_PAGE_HANDLES.PAGE}
         breadcrumbs={[
           { title: t("navigationSideBar.articles"), href: "/articles" },
           { title: article.title, href: `/articles/${article.id}` },
@@ -96,6 +98,7 @@ export default function ArticleDetailsPage() {
         {canEdit && (
           <div className="flex justify-end gap-2 max-w-6xl mx-auto w-full">
             <Button
+              data-testid={ARTICLE_DETAILS_PAGE_HANDLES.EDIT_BUTTON}
               variant="outline"
               className="gap-2"
               onClick={() => {
@@ -122,9 +125,11 @@ export default function ArticleDetailsPage() {
             })}
           >
             <h1 className="text-[40px] font-bold leading-[1.1] text-neutral-950">
-              {article.title}
+              <span data-testid={ARTICLE_DETAILS_PAGE_HANDLES.TITLE}>{article.title}</span>
             </h1>
-            <p className="text-lg font-normal leading-8 text-neutral-700">{article.summary}</p>
+            <p className="text-lg font-normal leading-8 text-neutral-700">
+              <span data-testid={ARTICLE_DETAILS_PAGE_HANDLES.SUMMARY}>{article.summary}</span>
+            </p>
             <div className="flex flex-wrap items-center gap-1 text-sm font-normal leading-5 text-neutral-700">
               <div className="flex items-center gap-2 px-3 py-1">
                 <Icon name="User" className="text-neutral-600 size-4" />
@@ -162,6 +167,7 @@ export default function ArticleDetailsPage() {
 
           <div className="mx-auto flex w-full items-center justify-between pb-6 px-6">
             <Button
+              data-testid={ARTICLE_DETAILS_PAGE_HANDLES.PREVIOUS_BUTTON}
               variant="ghost"
               className="flex items-center gap-2 select-none disabled:opacity-50"
               onClick={() => {
@@ -176,6 +182,7 @@ export default function ArticleDetailsPage() {
               </span>
             </Button>
             <Button
+              data-testid={ARTICLE_DETAILS_PAGE_HANDLES.NEXT_BUTTON}
               variant="ghost"
               className="flex items-center gap-2 select-none disabled:opacity-50"
               onClick={() => {

--- a/apps/web/app/modules/Articles/ArticleForm.page.tsx
+++ b/apps/web/app/modules/Articles/ArticleForm.page.tsx
@@ -40,6 +40,7 @@ import { useUploadDisplayModeDialog } from "~/hooks/useUploadDisplayModeDialog";
 import { LanguageSelector } from "~/modules/Articles/LanguageSelector";
 import { filterChangedData } from "~/utils/filterChangedData";
 
+import { ARTICLE_FORM_PAGE_HANDLES } from "../../../e2e/data/articles/handles";
 import Loader from "../common/Loader/Loader";
 import { useLanguageStore } from "../Dashboard/Settings/Language/LanguageStore";
 
@@ -263,7 +264,11 @@ function ArticleFormPage({ defaultValues }: ArticleFormPageProps) {
   }
 
   return (
-    <PageWrapper breadcrumbs={breadcrumbs} className="bg-neutral-50/80">
+    <PageWrapper
+      breadcrumbs={breadcrumbs}
+      className="bg-neutral-50/80"
+      data-testid={ARTICLE_FORM_PAGE_HANDLES.PAGE}
+    >
       <div className="mx-auto w-full max-w-6xl mt-10">
         <div className="flex flex-col gap-8 rounded-3xl bg-white p-8 shadow-sm ring-1 ring-neutral-100">
           <header className="flex flex-col gap-2 border-b border-neutral-200 pb-4">
@@ -306,6 +311,7 @@ function ArticleFormPage({ defaultValues }: ArticleFormPageProps) {
                     control={form.control}
                     name="title"
                     placeholder={t("adminArticleView.form.placeholders.title")}
+                    data-testid={ARTICLE_FORM_PAGE_HANDLES.TITLE_INPUT}
                   />
                 </div>
 
@@ -317,6 +323,7 @@ function ArticleFormPage({ defaultValues }: ArticleFormPageProps) {
                     control={form.control}
                     name="summary"
                     placeholder={t("adminArticleView.form.placeholders.summary")}
+                    data-testid={ARTICLE_FORM_PAGE_HANDLES.SUMMARY_INPUT}
                   />
                 </div>
               </div>
@@ -368,10 +375,16 @@ function ArticleFormPage({ defaultValues }: ArticleFormPageProps) {
                       className="flex flex-col gap-3"
                     >
                       <TabsList className="w-fit bg-primary-50">
-                        <TabsTrigger value="editor">
+                        <TabsTrigger
+                          value="editor"
+                          data-testid={ARTICLE_FORM_PAGE_HANDLES.CONTENT_EDITOR_TAB}
+                        >
                           {t("adminArticleView.form.editor")}
                         </TabsTrigger>
-                        <TabsTrigger value="preview">
+                        <TabsTrigger
+                          value="preview"
+                          data-testid={ARTICLE_FORM_PAGE_HANDLES.CONTENT_PREVIEW_TAB}
+                        >
                           {t("adminArticleView.form.preview")}
                         </TabsTrigger>
                       </TabsList>
@@ -419,6 +432,7 @@ function ArticleFormPage({ defaultValues }: ArticleFormPageProps) {
 
               <div className="flex items-center justify-end gap-3 border-t border-neutral-200 pt-4">
                 <Button
+                  data-testid={ARTICLE_FORM_PAGE_HANDLES.CANCEL_BUTTON}
                   type="button"
                   variant="ghost"
                   className="border border-transparent text-neutral-700 hover:border-neutral-200 hover:bg-neutral-100"
@@ -428,7 +442,9 @@ function ArticleFormPage({ defaultValues }: ArticleFormPageProps) {
                 >
                   {t("common.button.cancel")}
                 </Button>
-                <Button type="submit">{t("adminArticleView.form.saveButton")}</Button>
+                <Button data-testid={ARTICLE_FORM_PAGE_HANDLES.SAVE_BUTTON} type="submit">
+                  {t("adminArticleView.form.saveButton")}
+                </Button>
               </div>
             </form>
           </Form>

--- a/apps/web/app/modules/Articles/Articles.page.tsx
+++ b/apps/web/app/modules/Articles/Articles.page.tsx
@@ -8,6 +8,8 @@ import { PageWrapper } from "~/components/PageWrapper";
 import { ContentAccessGuard } from "~/Guards/AccessGuard";
 import { useLanguageStore } from "~/modules/Dashboard/Settings/Language/LanguageStore";
 
+import { ARTICLES_PAGE_HANDLES } from "../../../e2e/data/articles/handles";
+
 function ArticlesPage() {
   const { t } = useTranslation();
 
@@ -25,6 +27,7 @@ function ArticlesPage() {
   return (
     <ContentAccessGuard type={ACCESS_GUARD.UNREGISTERED_ARTICLES_ACCESS}>
       <PageWrapper
+        data-testid={ARTICLES_PAGE_HANDLES.PAGE}
         breadcrumbs={[
           {
             title: t("navigationSideBar.articles"),

--- a/apps/web/app/modules/Articles/components/ArticlesTOC/ArticlesTOCAddFab.tsx
+++ b/apps/web/app/modules/Articles/components/ArticlesTOC/ArticlesTOCAddFab.tsx
@@ -11,6 +11,8 @@ import {
   DropdownMenuTrigger,
 } from "~/components/ui/dropdown-menu";
 
+import { ARTICLES_TOC_HANDLES } from "../../../../../e2e/data/articles/handles";
+
 type ArticlesTOCAddFabProps = {
   onRequestClose: () => void;
   onCreateSection?: () => void;
@@ -31,6 +33,7 @@ export function ArticlesTOCAddFab({
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button
+          data-testid={ARTICLES_TOC_HANDLES.ADD_ACTION}
           type="button"
           variant="primary"
           size="icon"
@@ -47,6 +50,7 @@ export function ArticlesTOCAddFab({
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
         <DropdownMenuItem
+          data-testid={ARTICLES_TOC_HANDLES.CREATE_SECTION_ACTION}
           className={menuItemClassName}
           onSelect={() => {
             onRequestClose();
@@ -57,6 +61,7 @@ export function ArticlesTOCAddFab({
           {t("adminArticleView.toc.actions.newSection")}
         </DropdownMenuItem>
         <DropdownMenuItem
+          data-testid={ARTICLES_TOC_HANDLES.CREATE_ARTICLE_ACTION}
           className={menuItemClassName}
           onSelect={() => {
             onRequestClose();

--- a/apps/web/app/modules/Articles/components/ArticlesTOC/ArticlesTOCHeader.tsx
+++ b/apps/web/app/modules/Articles/components/ArticlesTOC/ArticlesTOCHeader.tsx
@@ -13,6 +13,8 @@ import {
 } from "~/components/ui/dropdown-menu";
 import { usePermissions } from "~/hooks/usePermissions";
 
+import { ARTICLES_TOC_HANDLES } from "../../../../../e2e/data/articles/handles";
+
 type ArticlesTOCHeaderProps = {
   onRequestClose?: () => void;
   onCreateSection?: () => void;
@@ -43,6 +45,7 @@ export function ArticlesTOCHeader({
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
+                data-testid={ARTICLES_TOC_HANDLES.ADD_ACTION}
                 variant="ghost"
                 size="icon"
                 aria-label={t("adminArticleView.toc.actions.add")}
@@ -57,6 +60,7 @@ export function ArticlesTOCHeader({
               </DropdownMenuLabel>
               <DropdownMenuSeparator />
               <DropdownMenuItem
+                data-testid={ARTICLES_TOC_HANDLES.CREATE_SECTION_ACTION}
                 className={menuItemClassName}
                 onSelect={() => {
                   onRequestClose?.();
@@ -67,6 +71,7 @@ export function ArticlesTOCHeader({
                 {t("adminArticleView.toc.actions.newSection")}
               </DropdownMenuItem>
               <DropdownMenuItem
+                data-testid={ARTICLES_TOC_HANDLES.CREATE_ARTICLE_ACTION}
                 className={menuItemClassName}
                 onSelect={() => {
                   onRequestClose?.();

--- a/apps/web/app/modules/Articles/components/ArticlesTOC/ArticlesTOCPanel.tsx
+++ b/apps/web/app/modules/Articles/components/ArticlesTOC/ArticlesTOCPanel.tsx
@@ -4,6 +4,8 @@ import { useEffect, useMemo, useState } from "react";
 import { Separator } from "~/components/ui/separator";
 import { usePermissions } from "~/hooks/usePermissions";
 
+import { ARTICLES_TOC_HANDLES } from "../../../../../e2e/data/articles/handles";
+
 import { ArticlesTOCAddFab } from "./ArticlesTOCAddFab";
 import { ArticlesTOCHeader } from "./ArticlesTOCHeader";
 import { ArticlesTOCSection } from "./ArticlesTOCSection";
@@ -50,7 +52,10 @@ export function ArticlesTOCPanel({
   }, [sectionIds]);
 
   return (
-    <div className="relative border-l flex size-full min-h-0 flex-col bg-white pt-4">
+    <div
+      className="relative border-l flex size-full min-h-0 flex-col bg-white pt-4"
+      data-testid={ARTICLES_TOC_HANDLES.PANEL}
+    >
       <ArticlesTOCHeader
         onRequestClose={onRequestClose}
         onCreateSection={onCreateSection}

--- a/apps/web/app/modules/Articles/components/ArticlesTOC/ArticlesTOCSection.tsx
+++ b/apps/web/app/modules/Articles/components/ArticlesTOC/ArticlesTOCSection.tsx
@@ -5,6 +5,8 @@ import { Button } from "~/components/ui/button";
 import { usePermissions } from "~/hooks/usePermissions";
 import { cn } from "~/lib/utils";
 
+import { ARTICLES_TOC_HANDLES } from "../../../../../e2e/data/articles/handles";
+
 type Article = { id: string; title: string };
 type Section = { id: string; title: string; articles: Article[] };
 
@@ -30,7 +32,7 @@ export function ArticlesTOCSection({
   });
 
   return (
-    <div className="py-0.5">
+    <div className="py-0.5" data-testid={ARTICLES_TOC_HANDLES.section(section.id)}>
       <div className="group flex w-full items-center gap-1 overflow-hidden rounded-md px-1 py-0.5 text-neutral-700 transition-colors hover:bg-primary-50 hover:text-primary-700">
         <Button
           type="button"
@@ -86,6 +88,7 @@ export function ArticlesTOCSection({
             return (
               <div key={article.id}>
                 <Button
+                  data-testid={ARTICLES_TOC_HANDLES.article(article.id)}
                   type="button"
                   variant="ghost"
                   className={cn(

--- a/apps/web/app/modules/Articles/components/ArticlesTOC/CreateArticleDialog.tsx
+++ b/apps/web/app/modules/Articles/components/ArticlesTOC/CreateArticleDialog.tsx
@@ -18,6 +18,8 @@ import {
   SelectValue,
 } from "~/components/ui/select";
 
+import { CREATE_ARTICLE_DIALOG_HANDLES } from "../../../../../e2e/data/articles/handles";
+
 type SectionOption = { id: string; title: string };
 
 type CreateArticleDialogProps = {
@@ -51,7 +53,7 @@ export function CreateArticleDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md">
+      <DialogContent className="max-w-md" data-testid={CREATE_ARTICLE_DIALOG_HANDLES.DIALOG}>
         <DialogHeader>
           <DialogTitle>{t("adminArticleView.dialog.createArticle.title")}</DialogTitle>
         </DialogHeader>
@@ -61,7 +63,10 @@ export function CreateArticleDialog({
             {t("adminArticleView.dialog.createArticle.sectionLabel")}
           </Label>
           <Select value={sectionId} onValueChange={setSectionId} disabled={!options.length}>
-            <SelectTrigger id="article-section-select">
+            <SelectTrigger
+              id="article-section-select"
+              data-testid={CREATE_ARTICLE_DIALOG_HANDLES.SECTION_SELECT}
+            >
               <SelectValue
                 placeholder={t("adminArticleView.dialog.createArticle.sectionPlaceholder")}
               />
@@ -81,6 +86,7 @@ export function CreateArticleDialog({
             {t("common.button.cancel")}
           </Button>
           <Button
+            data-testid={CREATE_ARTICLE_DIALOG_HANDLES.CREATE_BUTTON}
             type="button"
             onClick={() => onCreate(sectionId)}
             disabled={!canCreate}

--- a/apps/web/app/modules/Articles/components/DeleteArticleDialog.tsx
+++ b/apps/web/app/modules/Articles/components/DeleteArticleDialog.tsx
@@ -11,6 +11,8 @@ import {
   DialogTrigger,
 } from "~/components/ui/dialog";
 
+import { ARTICLE_DETAILS_PAGE_HANDLES } from "../../../../e2e/data/articles/handles";
+
 type DeleteArticleDialogProps = {
   articleId?: string;
   isDeleting?: boolean;
@@ -27,7 +29,12 @@ export function DeleteArticleDialog({
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <Button variant="outline" className="gap-2" disabled={isDeleting}>
+        <Button
+          data-testid={ARTICLE_DETAILS_PAGE_HANDLES.DELETE_BUTTON}
+          variant="outline"
+          className="gap-2"
+          disabled={isDeleting}
+        >
           <Icon name="TrashIcon" className="size-4" />
           <span className="text-sm font-semibold leading-5 text-neutral-800">
             {t("common.button.delete")}
@@ -35,7 +42,11 @@ export function DeleteArticleDialog({
         </Button>
       </DialogTrigger>
 
-      <DialogContent className="max-w-md" noCloseButton={isDeleting}>
+      <DialogContent
+        className="max-w-md"
+        noCloseButton={isDeleting}
+        data-testid={ARTICLE_DETAILS_PAGE_HANDLES.DELETE_DIALOG}
+      >
         <DialogTitle>{t("articlesView.deleteModal.title")}</DialogTitle>
         <DialogDescription>{t("articlesView.deleteModal.description")}</DialogDescription>
 
@@ -46,6 +57,7 @@ export function DeleteArticleDialog({
             </Button>
           </DialogClose>
           <Button
+            data-testid={ARTICLE_DETAILS_PAGE_HANDLES.DELETE_CONFIRM_BUTTON}
             onClick={() => {
               if (!articleId) return;
               onDelete(articleId);

--- a/apps/web/app/modules/News/News.page.tsx
+++ b/apps/web/app/modules/News/News.page.tsx
@@ -19,6 +19,7 @@ import {
 import { ContentAccessGuard } from "~/Guards/AccessGuard";
 import { usePermissions } from "~/hooks/usePermissions";
 
+import { NEWS_PAGE_HANDLES } from "../../../e2e/data/news/handles";
 import Loader from "../common/Loader/Loader";
 import { useLanguageStore } from "../Dashboard/Settings/Language/LanguageStore";
 
@@ -107,7 +108,9 @@ function NewsPage() {
       return (
         <>
           <div className="flex items-center justify-between pb-10">
-            <h1 className="h4">{t("newsView.header")}</h1>
+            <h1 className="h4" data-testid={NEWS_PAGE_HANDLES.HEADING}>
+              {t("newsView.header")}
+            </h1>
             <div className="flex items-center gap-3">
               {canManageNews && (
                 <Select
@@ -121,17 +124,28 @@ function NewsPage() {
                     setCurrentPage(1);
                   }}
                 >
-                  <SelectTrigger className="w-48">
+                  <SelectTrigger className="w-48" data-testid={NEWS_PAGE_HANDLES.STATUS_FILTER}>
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="published">{t("newsView.status.publishedMany")}</SelectItem>
-                    <SelectItem value="draft">{t("newsView.status.draftMany")}</SelectItem>
+                    <SelectItem
+                      value="published"
+                      data-testid={NEWS_PAGE_HANDLES.statusFilterOption("published")}
+                    >
+                      {t("newsView.status.publishedMany")}
+                    </SelectItem>
+                    <SelectItem
+                      value="draft"
+                      data-testid={NEWS_PAGE_HANDLES.statusFilterOption("draft")}
+                    >
+                      {t("newsView.status.draftMany")}
+                    </SelectItem>
                   </SelectContent>
                 </Select>
               )}
               {canManageNews && (
                 <Button
+                  data-testid={NEWS_PAGE_HANDLES.CREATE_BUTTON}
                   className="flex items-center justify-center rounded-full w-12 h-12"
                   variant="outline"
                   onClick={createEmptyNews}
@@ -143,7 +157,7 @@ function NewsPage() {
           </div>
 
           {firstNews || moreNews.length ? (
-            <>
+            <div data-testid={NEWS_PAGE_HANDLES.ITEM_LIST}>
               <NewsItem {...firstNews} isBig className="mb-6" />
 
               {moreNews.length ? (
@@ -153,7 +167,7 @@ function NewsPage() {
                   ))}
                 </div>
               ) : null}
-            </>
+            </div>
           ) : (
             <div className="flex items-center justify-center h-full">
               <h3 className="body-base-md">{t("newsView.notFound")}</h3>
@@ -191,6 +205,7 @@ function NewsPage() {
         </div>
       ) : (
         <PageWrapper
+          data-testid={NEWS_PAGE_HANDLES.PAGE}
           breadcrumbs={[
             {
               title: t("adminUsersView.breadcrumbs.news"),

--- a/apps/web/app/modules/News/NewsDetails.page.tsx
+++ b/apps/web/app/modules/News/NewsDetails.page.tsx
@@ -16,6 +16,7 @@ import { ContentAccessGuard } from "~/Guards/AccessGuard";
 import { usePermissions } from "~/hooks/usePermissions";
 import { cn } from "~/lib/utils";
 
+import { NEWS_DETAILS_PAGE_HANDLES } from "../../../e2e/data/news/handles";
 import Loader from "../common/Loader/Loader";
 import { useLanguageStore } from "../Dashboard/Settings/Language/LanguageStore";
 
@@ -78,6 +79,7 @@ export default function NewsDetailsPage() {
   return (
     <ContentAccessGuard type={ACCESS_GUARD.UNREGISTERED_NEWS_ACCESS}>
       <PageWrapper
+        data-testid={NEWS_DETAILS_PAGE_HANDLES.PAGE}
         breadcrumbs={[
           { title: t("navigationSideBar.news"), href: "/news" },
           { title: news.title, href: `/news/${news.id}` },
@@ -90,6 +92,7 @@ export default function NewsDetailsPage() {
         {canManageNews && (
           <div className="flex justify-end gap-2 max-w-6xl mx-auto w-full">
             <Button
+              data-testid={NEWS_DETAILS_PAGE_HANDLES.EDIT_BUTTON}
               variant="outline"
               className="gap-2"
               onClick={() => {
@@ -102,6 +105,7 @@ export default function NewsDetailsPage() {
               </span>
             </Button>
             <Button
+              data-testid={NEWS_DETAILS_PAGE_HANDLES.DELETE_BUTTON}
               variant="outline"
               className="w-28 gap-2"
               onClick={async () => {
@@ -141,8 +145,18 @@ export default function NewsDetailsPage() {
               "pt-10": !headerImageUrl,
             })}
           >
-            <h1 className="text-[40px] font-bold leading-[1.1] text-neutral-950">{news.title}</h1>
-            <p className="text-lg font-normal leading-8 text-neutral-700">{news.summary}</p>
+            <h1
+              className="text-[40px] font-bold leading-[1.1] text-neutral-950"
+              data-testid={NEWS_DETAILS_PAGE_HANDLES.TITLE}
+            >
+              {news.title}
+            </h1>
+            <p
+              className="text-lg font-normal leading-8 text-neutral-700"
+              data-testid={NEWS_DETAILS_PAGE_HANDLES.SUMMARY}
+            >
+              {news.summary}
+            </p>
             <div className="flex flex-wrap items-center gap-3 text-sm font-normal leading-5 text-neutral-700">
               <div className="flex items-center gap-2 rounded-full bg-white px-3 py-1 shadow-sm ring-1 ring-neutral-100">
                 <Icon name="Calendar" className="text-neutral-600 size-4" />
@@ -170,6 +184,7 @@ export default function NewsDetailsPage() {
 
           <div className="mx-auto flex w-full items-center justify-between pb-6 px-6">
             <Button
+              data-testid={NEWS_DETAILS_PAGE_HANDLES.PREVIOUS_BUTTON}
               variant="ghost"
               className="flex items-center gap-2 select-none disabled:opacity-50"
               onClick={() => {
@@ -183,6 +198,7 @@ export default function NewsDetailsPage() {
               </span>
             </Button>
             <Button
+              data-testid={NEWS_DETAILS_PAGE_HANDLES.NEXT_BUTTON}
               variant="ghost"
               className="flex items-center gap-2 select-none disabled:opacity-50"
               onClick={() => {

--- a/apps/web/app/modules/News/NewsForm.page.tsx
+++ b/apps/web/app/modules/News/NewsForm.page.tsx
@@ -20,6 +20,7 @@ import { useRichTextUploadQueue } from "~/hooks/useRichTextUploadQueue";
 import { useTusVideoUpload } from "~/hooks/useTusVideoUpload";
 import { useUploadDisplayModeDialog } from "~/hooks/useUploadDisplayModeDialog";
 
+import { NEWS_FORM_PAGE_HANDLES } from "../../../e2e/data/news/handles";
 import { usePreviewNews, useUpdateNews } from "../../api/mutations";
 import { useNews } from "../../api/queries";
 import ImageUploadInput from "../../components/FileUploadInput/ImageUploadInput";
@@ -272,7 +273,11 @@ function NewsFormPage({ defaultValues }: NewsFormPageProps) {
   }
 
   return (
-    <PageWrapper breadcrumbs={breadcrumbs} className="bg-neutral-50/80">
+    <PageWrapper
+      breadcrumbs={breadcrumbs}
+      className="bg-neutral-50/80"
+      data-testid={NEWS_FORM_PAGE_HANDLES.PAGE}
+    >
       <div className="mx-auto w-full max-w-6xl mt-10">
         <div className="flex flex-col gap-8 rounded-3xl bg-white p-8 shadow-sm ring-1 ring-neutral-100">
           <header className="flex flex-col gap-2 border-b border-neutral-200 pb-4">
@@ -308,6 +313,7 @@ function NewsFormPage({ defaultValues }: NewsFormPageProps) {
                     control={form.control}
                     name="title"
                     placeholder={t("newsView.placeholder.title")}
+                    data-testid={NEWS_FORM_PAGE_HANDLES.TITLE_INPUT}
                   />
                 </div>
 
@@ -323,12 +329,23 @@ function NewsFormPage({ defaultValues }: NewsFormPageProps) {
                         value={field.value}
                         onValueChange={(val) => field.onChange(val as "draft" | "published")}
                       >
-                        <SelectTrigger className="w-full">
+                        <SelectTrigger
+                          className="w-full"
+                          data-testid={NEWS_FORM_PAGE_HANDLES.STATUS_SELECT}
+                        >
                           <SelectValue placeholder="Select status" />
                         </SelectTrigger>
                         <SelectContent>
-                          <SelectItem value="draft">{t("newsView.status.draft")}</SelectItem>
-                          <SelectItem value="published">
+                          <SelectItem
+                            value="draft"
+                            data-testid={NEWS_FORM_PAGE_HANDLES.statusOption("draft")}
+                          >
+                            {t("newsView.status.draft")}
+                          </SelectItem>
+                          <SelectItem
+                            value="published"
+                            data-testid={NEWS_FORM_PAGE_HANDLES.statusOption("published")}
+                          >
                             {t("newsView.status.published")}
                           </SelectItem>
                         </SelectContent>
@@ -348,6 +365,7 @@ function NewsFormPage({ defaultValues }: NewsFormPageProps) {
                       <div className="flex items-center gap-3 rounded-xl h-[42px] py-2 px-3 border border-neutral-300">
                         <Switch
                           id="isPublic"
+                          data-testid={NEWS_FORM_PAGE_HANDLES.IS_PUBLIC_SWITCH}
                           checked={field.value}
                           onCheckedChange={field.onChange}
                           aria-label={t("newsView.field.isPublic")}
@@ -368,6 +386,7 @@ function NewsFormPage({ defaultValues }: NewsFormPageProps) {
                     control={form.control}
                     name="summary"
                     placeholder={t("newsView.placeholder.summary")}
+                    data-testid={NEWS_FORM_PAGE_HANDLES.SUMMARY_INPUT}
                   />
                 </div>
               </div>
@@ -419,8 +438,18 @@ function NewsFormPage({ defaultValues }: NewsFormPageProps) {
                       className="flex flex-col gap-3"
                     >
                       <TabsList className="w-fit bg-primary-50">
-                        <TabsTrigger value="editor">{t("newsView.editor")}</TabsTrigger>
-                        <TabsTrigger value="preview">{t("newsView.preview")}</TabsTrigger>
+                        <TabsTrigger
+                          value="editor"
+                          data-testid={NEWS_FORM_PAGE_HANDLES.CONTENT_EDITOR_TAB}
+                        >
+                          {t("newsView.editor")}
+                        </TabsTrigger>
+                        <TabsTrigger
+                          value="preview"
+                          data-testid={NEWS_FORM_PAGE_HANDLES.CONTENT_PREVIEW_TAB}
+                        >
+                          {t("newsView.preview")}
+                        </TabsTrigger>
                       </TabsList>
 
                       <TabsContent value="editor">
@@ -466,6 +495,7 @@ function NewsFormPage({ defaultValues }: NewsFormPageProps) {
 
               <div className="flex items-center justify-end gap-3 border-t border-neutral-200 pt-4">
                 <Button
+                  data-testid={NEWS_FORM_PAGE_HANDLES.CANCEL_BUTTON}
                   type="button"
                   variant="ghost"
                   className="border border-transparent text-neutral-700 hover:border-neutral-200 hover:bg-neutral-100"
@@ -475,7 +505,9 @@ function NewsFormPage({ defaultValues }: NewsFormPageProps) {
                 >
                   {t("common.button.cancel")}
                 </Button>
-                <Button type="submit">{t("common.button.save")}</Button>
+                <Button data-testid={NEWS_FORM_PAGE_HANDLES.SAVE_BUTTON} type="submit">
+                  {t("common.button.save")}
+                </Button>
               </div>
             </form>
           </Form>

--- a/apps/web/app/modules/News/NewsItem.tsx
+++ b/apps/web/app/modules/News/NewsItem.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from "@remix-run/react";
 import { formatDate } from "date-fns";
 
+import { NEWS_PAGE_HANDLES } from "../../../e2e/data/news/handles";
 import { Icon } from "../../components/Icon";
 import { cn } from "../../lib/utils";
 
@@ -30,6 +31,7 @@ function NewsItem({
 
   return (
     <button
+      data-testid={NEWS_PAGE_HANDLES.item(id)}
       className={cn(
         "relative overflow-hidden rounded-lg py-7 px-6 flex flex-col justify-end min-h-[380px] group",
         className,

--- a/apps/web/app/modules/News/components/NewsLanguageSelector.tsx
+++ b/apps/web/app/modules/News/components/NewsLanguageSelector.tsx
@@ -23,6 +23,8 @@ import {
 } from "~/components/ui/select";
 import { Separator } from "~/components/ui/separator";
 
+import { NEWS_LANGUAGE_SELECTOR_HANDLES } from "../../../../e2e/data/news/handles";
+
 import type { IconName } from "~/types/shared";
 
 const languageOptions: {
@@ -100,7 +102,10 @@ export const NewsLanguageSelector = ({
   return (
     <div className="flex items-center gap-2">
       <Select value={value} onValueChange={(val) => handleChange(val as SupportedLanguages)}>
-        <SelectTrigger className="min-w-[200px]">
+        <SelectTrigger
+          className="min-w-[200px]"
+          data-testid={NEWS_LANGUAGE_SELECTOR_HANDLES.SELECT}
+        >
           <SelectValue placeholder={t("newsView.language.label")} />
         </SelectTrigger>
         <SelectContent>
@@ -142,6 +147,7 @@ export const NewsLanguageSelector = ({
 
       {baseLanguage && baseLanguage !== value && (
         <Button
+          data-testid={NEWS_LANGUAGE_SELECTOR_HANDLES.DELETE_BUTTON}
           size="icon"
           type="button"
           variant="outline"
@@ -156,7 +162,7 @@ export const NewsLanguageSelector = ({
       )}
 
       <Dialog open={isCreateOpen} onOpenChange={setIsCreateOpen}>
-        <DialogContent>
+        <DialogContent data-testid={NEWS_LANGUAGE_SELECTOR_HANDLES.CREATE_DIALOG}>
           <DialogHeader>
             <DialogTitle>{t("newsView.language.createTitle")}</DialogTitle>
             <DialogDescription>
@@ -172,13 +178,18 @@ export const NewsLanguageSelector = ({
             <Button variant="outline" onClick={() => setIsCreateOpen(false)}>
               {t("common.button.cancel")}
             </Button>
-            <Button onClick={handleCreateLanguage}>{t("contentCreatorView.button.confirm")}</Button>
+            <Button
+              data-testid={NEWS_LANGUAGE_SELECTOR_HANDLES.CREATE_CONFIRM_BUTTON}
+              onClick={handleCreateLanguage}
+            >
+              {t("contentCreatorView.button.confirm")}
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
 
       <Dialog open={isDeleteOpen} onOpenChange={setIsDeleteOpen}>
-        <DialogContent>
+        <DialogContent data-testid={NEWS_LANGUAGE_SELECTOR_HANDLES.DELETE_DIALOG}>
           <DialogHeader>
             <DialogTitle>{t("newsView.language.deleteTitle")}</DialogTitle>
             <DialogDescription>
@@ -194,7 +205,11 @@ export const NewsLanguageSelector = ({
             <Button variant="outline" onClick={() => setIsDeleteOpen(false)}>
               {t("common.button.cancel")}
             </Button>
-            <Button variant="destructive" onClick={handleDeleteLanguage}>
+            <Button
+              data-testid={NEWS_LANGUAGE_SELECTOR_HANDLES.DELETE_CONFIRM_BUTTON}
+              variant="destructive"
+              onClick={handleDeleteLanguage}
+            >
               {t("common.button.proceed")}
             </Button>
           </DialogFooter>

--- a/apps/web/e2e/auth.setup.ts
+++ b/apps/web/e2e/auth.setup.ts
@@ -4,6 +4,7 @@ import { SYSTEM_ROLE_SLUGS } from "@repo/shared";
 import { login } from "./fixtures/auth.actions";
 import { createFixtureApiClient } from "./utils/api-client";
 import { AUTH_ACCOUNT_TEMPLATE, getAuthEmail, getReadonlyAuthStatePath } from "./utils/auth-email";
+import { ensureContentModulesEnabled } from "./utils/content-features";
 
 import type { Browser } from "@playwright/test";
 
@@ -105,6 +106,7 @@ setup("authenticate", async ({ browser }) => {
     await login(adminPage, ADMIN_EMAIL, ADMIN_PASSWORD);
     apiClient.syncTenantOrigin(new URL(adminPage.url()).origin);
     apiClient.syncCookies(await adminContext.cookies());
+    await ensureContentModulesEnabled(apiClient);
 
     for (const role of AUTH_ROLES) {
       await ensureUserAccount(

--- a/apps/web/e2e/data/articles/handles.ts
+++ b/apps/web/e2e/data/articles/handles.ts
@@ -1,0 +1,42 @@
+export const ARTICLES_PAGE_HANDLES = {
+  PAGE: "articles-page",
+} as const;
+
+export const ARTICLE_DETAILS_PAGE_HANDLES = {
+  PAGE: "article-details-page",
+  TITLE: "article-details-title",
+  SUMMARY: "article-details-summary",
+  EDIT_BUTTON: "article-details-edit-button",
+  DELETE_BUTTON: "article-details-delete-button",
+  DELETE_DIALOG: "article-details-delete-dialog",
+  DELETE_CONFIRM_BUTTON: "article-details-delete-confirm-button",
+  PREVIOUS_BUTTON: "article-details-previous-button",
+  NEXT_BUTTON: "article-details-next-button",
+} as const;
+
+export const ARTICLE_FORM_PAGE_HANDLES = {
+  PAGE: "article-form-page",
+  TITLE_INPUT: "article-form-title-input",
+  SUMMARY_INPUT: "article-form-summary-input",
+  CONTENT_EDITOR_TAB: "article-form-content-editor-tab",
+  CONTENT_PREVIEW_TAB: "article-form-content-preview-tab",
+  SAVE_BUTTON: "article-form-save-button",
+  CANCEL_BUTTON: "article-form-cancel-button",
+} as const;
+
+export const ARTICLES_TOC_HANDLES = {
+  PANEL: "articles-toc-panel",
+  ADD_ACTION: "articles-toc-add-action",
+  CREATE_SECTION_ACTION: "articles-toc-create-section-action",
+  CREATE_ARTICLE_ACTION: "articles-toc-create-article-action",
+  SECTION_PREFIX: "articles-toc-section-",
+  section: (sectionId: string) => `articles-toc-section-${sectionId}`,
+  ARTICLE_PREFIX: "articles-toc-article-",
+  article: (articleId: string) => `articles-toc-article-${articleId}`,
+} as const;
+
+export const CREATE_ARTICLE_DIALOG_HANDLES = {
+  DIALOG: "create-article-dialog",
+  SECTION_SELECT: "create-article-dialog-section-select",
+  CREATE_BUTTON: "create-article-dialog-create-button",
+} as const;

--- a/apps/web/e2e/data/navigation/handles.ts
+++ b/apps/web/e2e/data/navigation/handles.ts
@@ -6,6 +6,8 @@ export const NAVIGATION_HANDLES = {
   ANALYTICS_LINK: "navigation-analytics-link",
   PROGRESS_LINK: "navigation-progress-link",
   CONTENT_GROUP: "navigation-content-toggle",
+  NEWS_LINK: "navigation-news-link",
+  ARTICLES_LINK: "navigation-articles-link",
   MANAGE_TOGGLE: "navigation-manage-toggle",
   USERS_LINK: "navigation-users-link",
   GROUPS_LINK: "navigation-groups-link",

--- a/apps/web/e2e/data/news/handles.ts
+++ b/apps/web/e2e/data/news/handles.ts
@@ -1,0 +1,42 @@
+export const NEWS_PAGE_HANDLES = {
+  PAGE: "news-page",
+  HEADING: "news-page-heading",
+  STATUS_FILTER: "news-page-status-filter",
+  statusFilterOption: (status: "published" | "draft") => `news-page-status-filter-option-${status}`,
+  CREATE_BUTTON: "news-page-create-button",
+  ITEM_LIST: "news-page-item-list",
+  ITEM_PREFIX: "news-page-item-",
+  item: (newsId: string) => `news-page-item-${newsId}`,
+} as const;
+
+export const NEWS_DETAILS_PAGE_HANDLES = {
+  PAGE: "news-details-page",
+  TITLE: "news-details-title",
+  SUMMARY: "news-details-summary",
+  EDIT_BUTTON: "news-details-edit-button",
+  DELETE_BUTTON: "news-details-delete-button",
+  PREVIOUS_BUTTON: "news-details-previous-button",
+  NEXT_BUTTON: "news-details-next-button",
+} as const;
+
+export const NEWS_FORM_PAGE_HANDLES = {
+  PAGE: "news-form-page",
+  TITLE_INPUT: "news-form-title-input",
+  SUMMARY_INPUT: "news-form-summary-input",
+  STATUS_SELECT: "news-form-status-select",
+  statusOption: (status: "draft" | "published") => `news-form-status-option-${status}`,
+  IS_PUBLIC_SWITCH: "news-form-is-public-switch",
+  CONTENT_EDITOR_TAB: "news-form-content-editor-tab",
+  CONTENT_PREVIEW_TAB: "news-form-content-preview-tab",
+  SAVE_BUTTON: "news-form-save-button",
+  CANCEL_BUTTON: "news-form-cancel-button",
+} as const;
+
+export const NEWS_LANGUAGE_SELECTOR_HANDLES = {
+  SELECT: "news-language-select",
+  DELETE_BUTTON: "news-language-delete-button",
+  CREATE_DIALOG: "news-language-create-dialog",
+  CREATE_CONFIRM_BUTTON: "news-language-create-confirm-button",
+  DELETE_DIALOG: "news-language-delete-dialog",
+  DELETE_CONFIRM_BUTTON: "news-language-delete-confirm-button",
+} as const;

--- a/apps/web/e2e/data/test-data/entity-name.data.ts
+++ b/apps/web/e2e/data/test-data/entity-name.data.ts
@@ -19,4 +19,13 @@ export const TEST_DATA = {
     hostPrefix: "e2e-tenant",
     adminEmailPrefix: "e2e-tenant-admin",
   },
+  news: {
+    titlePrefix: "E2E News",
+    summaryPrefix: "E2E News Summary",
+  },
+  article: {
+    titlePrefix: "E2E Article",
+    summaryPrefix: "E2E Article Summary",
+    sectionTitlePrefix: "E2E Article Section",
+  },
 } as const;

--- a/apps/web/e2e/factories/article.factory.ts
+++ b/apps/web/e2e/factories/article.factory.ts
@@ -1,0 +1,220 @@
+import { randomUUID } from "node:crypto";
+
+import { TEST_DATA } from "../data/test-data/entity-name.data";
+
+import type { FixtureApiClient } from "../utils/api-client";
+import type { SupportedLanguages } from "@repo/shared";
+import type {
+  CreateArticleBody,
+  GetArticleResponse,
+  GetArticleSectionResponse,
+  GetArticleTocResponse,
+  UpdateArticleBody,
+  UpdateArticleSectionBody,
+} from "~/api/generated-api";
+
+export type ArticleFactoryRecord = GetArticleResponse["data"];
+export type ArticleSectionFactoryRecord = GetArticleSectionResponse["data"];
+export type ArticleTocSectionRecord = GetArticleTocResponse["data"]["sections"][number];
+
+export type ArticleFactoryCreateInput = {
+  language?: SupportedLanguages;
+  sectionId?: string;
+  sectionTitle?: string;
+  title?: string;
+  summary?: string;
+  content?: string;
+  status?: "draft" | "published";
+  isPublic?: boolean;
+};
+
+export type ArticleFactoryUpdateInput = Omit<
+  ArticleFactoryCreateInput,
+  "sectionId" | "sectionTitle"
+>;
+export type ArticleSectionFactoryCreateInput = {
+  language?: SupportedLanguages;
+  title?: string;
+};
+
+const createArticleDefaults = () => {
+  const suffix = randomUUID().slice(0, 8);
+
+  return {
+    title: `${TEST_DATA.article.titlePrefix} ${suffix}`,
+    summary: `${TEST_DATA.article.summaryPrefix} ${suffix}`,
+    content: `<p>${TEST_DATA.article.summaryPrefix} ${suffix}</p>`,
+    status: "published" as const,
+    isPublic: true,
+  };
+};
+
+const createSectionTitle = () =>
+  `${TEST_DATA.article.sectionTitlePrefix} ${randomUUID().slice(0, 8)}`;
+
+const toUpdateArticleFormData = (
+  language: SupportedLanguages,
+  data: ArticleFactoryUpdateInput,
+): FormData => {
+  const formData = new FormData();
+
+  formData.append("language", language);
+  if (data.title !== undefined) formData.append("title", data.title);
+  if (data.summary !== undefined) formData.append("summary", data.summary);
+  if (data.content !== undefined) formData.append("content", data.content);
+  if (data.status !== undefined) formData.append("status", data.status);
+  if (data.isPublic !== undefined) formData.append("isPublic", String(data.isPublic));
+
+  return formData;
+};
+
+export class ArticleFactory {
+  constructor(private readonly apiClient: FixtureApiClient) {}
+
+  async createSection(
+    input: ArticleSectionFactoryCreateInput = {},
+  ): Promise<ArticleSectionFactoryRecord> {
+    const language = input.language ?? "en";
+    const response = await this.apiClient.api.articlesControllerCreateArticleSection({ language });
+    const sectionId = response.data.data.id;
+
+    if (input.title) {
+      await this.updateSection(sectionId, { language, title: input.title });
+      return this.getSectionById(sectionId, language);
+    }
+
+    return this.getSectionById(sectionId, language);
+  }
+
+  async create(input: ArticleFactoryCreateInput = {}): Promise<ArticleFactoryRecord> {
+    const language = input.language ?? "en";
+    let sectionId = input.sectionId;
+
+    if (!sectionId) {
+      const section = await this.createSection({
+        language,
+        title: input.sectionTitle ?? createSectionTitle(),
+      });
+      sectionId = section.id;
+    }
+
+    const response = await this.apiClient.api.articlesControllerCreateArticle({
+      language,
+      sectionId,
+    } satisfies CreateArticleBody);
+
+    const articleId = response.data.data.id;
+    const defaults = createArticleDefaults();
+
+    await this.update(articleId, {
+      language,
+      title: input.title ?? defaults.title,
+      summary: input.summary ?? defaults.summary,
+      content: input.content ?? defaults.content,
+      status: input.status ?? defaults.status,
+      isPublic: input.isPublic ?? defaults.isPublic,
+    });
+
+    return this.getById(articleId, language);
+  }
+
+  async createWithSection(input: ArticleFactoryCreateInput = {}): Promise<{
+    article: ArticleFactoryRecord;
+    section: ArticleSectionFactoryRecord;
+  }> {
+    const language = input.language ?? "en";
+    const section = input.sectionId
+      ? await this.getSectionById(input.sectionId, language)
+      : await this.createSection({
+          language,
+          title: input.sectionTitle ?? createSectionTitle(),
+        });
+
+    const article = await this.create({
+      ...input,
+      language,
+      sectionId: section.id,
+    });
+
+    return { article, section };
+  }
+
+  async getById(id: string, language: SupportedLanguages = "en"): Promise<ArticleFactoryRecord> {
+    const response = await this.apiClient.api.articlesControllerGetArticle(id, { language });
+    return response.data.data;
+  }
+
+  async safeGetById(
+    id: string,
+    language: SupportedLanguages = "en",
+  ): Promise<ArticleFactoryRecord | null> {
+    try {
+      return await this.getById(id, language);
+    } catch {
+      return null;
+    }
+  }
+
+  async update(id: string, data: ArticleFactoryUpdateInput): Promise<ArticleFactoryRecord> {
+    const language = data.language ?? "en";
+
+    await this.apiClient.api.articlesControllerUpdateArticle(
+      id,
+      toUpdateArticleFormData(language, data) as unknown as UpdateArticleBody,
+    );
+
+    return this.getById(id, language);
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.apiClient.api.articlesControllerDeleteArticle(id);
+  }
+
+  async getSectionById(
+    id: string,
+    language: SupportedLanguages = "en",
+  ): Promise<ArticleSectionFactoryRecord> {
+    const response = await this.apiClient.api.articlesControllerGetArticleSection(id, { language });
+    return response.data.data;
+  }
+
+  async safeGetSectionById(
+    id: string,
+    language: SupportedLanguages = "en",
+  ): Promise<ArticleSectionFactoryRecord | null> {
+    try {
+      return await this.getSectionById(id, language);
+    } catch {
+      return null;
+    }
+  }
+
+  async updateSection(
+    id: string,
+    data: ArticleSectionFactoryCreateInput,
+  ): Promise<ArticleSectionFactoryRecord> {
+    const language = data.language ?? "en";
+
+    await this.apiClient.api.articlesControllerUpdateArticleSection(id, {
+      language,
+      title: data.title,
+    } as UpdateArticleSectionBody);
+
+    return this.getSectionById(id, language);
+  }
+
+  async deleteSection(id: string): Promise<void> {
+    await this.apiClient.api.articlesControllerDeleteArticleSection(id);
+  }
+
+  async getToc(
+    language: SupportedLanguages = "en",
+    isDraftMode?: boolean,
+  ): Promise<ArticleTocSectionRecord[]> {
+    const response = await this.apiClient.api.articlesControllerGetArticleToc({
+      language,
+      ...(isDraftMode === undefined ? {} : { isDraftMode }),
+    });
+    return response.data.data.sections;
+  }
+}

--- a/apps/web/e2e/factories/index.ts
+++ b/apps/web/e2e/factories/index.ts
@@ -1,27 +1,37 @@
+import { ArticleFactory } from "./article.factory";
 import { CategoryFactory } from "./category.factory";
 import { CourseFactory } from "./course.factory";
 import { GroupFactory } from "./group.factory";
+import { NewsFactory } from "./news.factory";
 import { TenantFactory } from "./tenant.factory";
 import { UserFactory } from "./user.factory";
 
 import type { FixtureApiClient } from "../utils/api-client";
 
 export type FixtureFactories = {
+  createArticleFactory: () => ArticleFactory;
   createCategoryFactory: () => CategoryFactory;
   createCourseFactory: () => CourseFactory;
   createGroupFactory: () => GroupFactory;
+  createNewsFactory: () => NewsFactory;
   createTenantFactory: () => TenantFactory;
   createUserFactory: () => UserFactory;
 };
 
 export const createFixtureFactories = (apiClient: FixtureApiClient): FixtureFactories => {
+  let articleFactory: ArticleFactory | undefined;
   let categoryFactory: CategoryFactory | undefined;
   let courseFactory: CourseFactory | undefined;
   let groupFactory: GroupFactory | undefined;
+  let newsFactory: NewsFactory | undefined;
   let tenantFactory: TenantFactory | undefined;
   let userFactory: UserFactory | undefined;
 
   return {
+    createArticleFactory: () => {
+      articleFactory ??= new ArticleFactory(apiClient);
+      return articleFactory;
+    },
     createCategoryFactory: () => {
       categoryFactory ??= new CategoryFactory(apiClient);
       return categoryFactory;
@@ -34,6 +44,10 @@ export const createFixtureFactories = (apiClient: FixtureApiClient): FixtureFact
       groupFactory ??= new GroupFactory(apiClient);
       return groupFactory;
     },
+    createNewsFactory: () => {
+      newsFactory ??= new NewsFactory(apiClient);
+      return newsFactory;
+    },
     createTenantFactory: () => {
       tenantFactory ??= new TenantFactory(apiClient);
       return tenantFactory;
@@ -45,8 +59,10 @@ export const createFixtureFactories = (apiClient: FixtureApiClient): FixtureFact
   };
 };
 
+export { ArticleFactory } from "./article.factory";
 export { CategoryFactory } from "./category.factory";
 export { CourseFactory } from "./course.factory";
 export { GroupFactory } from "./group.factory";
+export { NewsFactory } from "./news.factory";
 export { TenantFactory } from "./tenant.factory";
 export { UserFactory } from "./user.factory";

--- a/apps/web/e2e/factories/news.factory.ts
+++ b/apps/web/e2e/factories/news.factory.ts
@@ -1,0 +1,126 @@
+import { randomUUID } from "node:crypto";
+
+import { SUPPORTED_LANGUAGES } from "@repo/shared";
+
+import { TEST_DATA } from "../data/test-data/entity-name.data";
+
+import type { FixtureApiClient } from "../utils/api-client";
+import type { SupportedLanguages } from "@repo/shared";
+import type { GetNewsResponse, GetNewsListResponse, UpdateNewsBody } from "~/api/generated-api";
+
+export type NewsFactoryRecord = GetNewsResponse["data"];
+export type NewsFactoryListRecord = GetNewsListResponse["data"][number];
+export type NewsFactoryCreateInput = {
+  language?: SupportedLanguages;
+  title?: string;
+  summary?: string;
+  content?: string;
+  status?: "draft" | "published";
+  isPublic?: boolean;
+};
+
+export type NewsFactoryUpdateInput = NewsFactoryCreateInput;
+
+const createNewsDefaults = () => {
+  const suffix = randomUUID().slice(0, 8);
+
+  return {
+    title: `${TEST_DATA.news.titlePrefix} ${suffix}`,
+    summary: `${TEST_DATA.news.summaryPrefix} ${suffix}`,
+    content: `<p>${TEST_DATA.news.summaryPrefix} ${suffix}</p>`,
+    status: "published" as const,
+    isPublic: true,
+  };
+};
+
+const toUpdateNewsFormData = (
+  language: SupportedLanguages,
+  data: NewsFactoryUpdateInput,
+): FormData => {
+  const formData = new FormData();
+
+  formData.append("language", language);
+  if (data.title !== undefined) formData.append("title", data.title);
+  if (data.summary !== undefined) formData.append("summary", data.summary);
+  if (data.content !== undefined) formData.append("content", data.content);
+  if (data.status !== undefined) formData.append("status", data.status);
+  if (data.isPublic !== undefined) formData.append("isPublic", String(data.isPublic));
+
+  return formData;
+};
+
+export class NewsFactory {
+  constructor(private readonly apiClient: FixtureApiClient) {}
+
+  async create(input: NewsFactoryCreateInput = {}): Promise<NewsFactoryRecord> {
+    const language = input.language ?? "en";
+    const createResponse = await this.apiClient.api.newsControllerCreateNews({ language });
+    const createdId = createResponse.data.data.id;
+    const defaults = createNewsDefaults();
+
+    await this.update(createdId, {
+      language,
+      title: input.title ?? defaults.title,
+      summary: input.summary ?? defaults.summary,
+      content: input.content ?? defaults.content,
+      status: input.status ?? defaults.status,
+      isPublic: input.isPublic ?? defaults.isPublic,
+    });
+
+    return this.getById(createdId, language);
+  }
+
+  async getById(id: string, language: SupportedLanguages = "en"): Promise<NewsFactoryRecord> {
+    const response = await this.apiClient.api.newsControllerGetNews(id, { language });
+    return response.data.data;
+  }
+
+  async findByTitle(
+    title: string,
+    language: SupportedLanguages = "en",
+  ): Promise<NewsFactoryListRecord | null> {
+    const response = await this.apiClient.api.newsControllerGetNewsList({
+      language,
+      page: 1,
+      searchQuery: title,
+    });
+
+    return response.data.data.find((news) => news.title === title) ?? null;
+  }
+
+  async update(id: string, data: NewsFactoryUpdateInput): Promise<NewsFactoryRecord> {
+    const language = data.language ?? "en";
+
+    await this.apiClient.api.newsControllerUpdateNews(
+      id,
+      toUpdateNewsFormData(language, data) as unknown as UpdateNewsBody,
+    );
+
+    return this.getById(id, language);
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.apiClient.api.newsControllerDeleteNews(id);
+  }
+
+  async safeGetById(
+    id: string,
+    language: SupportedLanguages = "en",
+  ): Promise<NewsFactoryRecord | null> {
+    try {
+      return await this.getById(id, language);
+    } catch {
+      return null;
+    }
+  }
+
+  async safeGetByIdAnyLanguage(id: string): Promise<NewsFactoryRecord | null> {
+    for (const language of Object.values(SUPPORTED_LANGUAGES)) {
+      const news = await this.safeGetById(id, language);
+
+      if (news) return news;
+    }
+
+    return null;
+  }
+}

--- a/apps/web/e2e/flows/articles/delete-article.flow.ts
+++ b/apps/web/e2e/flows/articles/delete-article.flow.ts
@@ -1,0 +1,8 @@
+import { ARTICLE_DETAILS_PAGE_HANDLES } from "../../data/articles/handles";
+
+import type { Page } from "@playwright/test";
+
+export const deleteArticleFlow = async (page: Page) => {
+  await page.getByTestId(ARTICLE_DETAILS_PAGE_HANDLES.DELETE_BUTTON).click();
+  await page.getByTestId(ARTICLE_DETAILS_PAGE_HANDLES.DELETE_CONFIRM_BUTTON).click();
+};

--- a/apps/web/e2e/flows/articles/fill-article-form.flow.ts
+++ b/apps/web/e2e/flows/articles/fill-article-form.flow.ts
@@ -1,0 +1,21 @@
+import { ARTICLE_FORM_PAGE_HANDLES } from "../../data/articles/handles";
+
+import type { Page } from "@playwright/test";
+
+type FillArticleFormFlowInput = {
+  title?: string;
+  summary?: string;
+};
+
+export const fillArticleFormFlow = async (
+  page: Page,
+  { title, summary }: FillArticleFormFlowInput,
+) => {
+  if (title !== undefined) {
+    await page.getByTestId(ARTICLE_FORM_PAGE_HANDLES.TITLE_INPUT).fill(title);
+  }
+
+  if (summary !== undefined) {
+    await page.getByTestId(ARTICLE_FORM_PAGE_HANDLES.SUMMARY_INPUT).fill(summary);
+  }
+};

--- a/apps/web/e2e/flows/articles/open-article-details-page.flow.ts
+++ b/apps/web/e2e/flows/articles/open-article-details-page.flow.ts
@@ -1,0 +1,11 @@
+import { ARTICLE_DETAILS_PAGE_HANDLES } from "../../data/articles/handles";
+
+import type { Page } from "@playwright/test";
+
+export const openArticleDetailsPageFlow = async (page: Page, articleId: string) => {
+  await page.goto(`/articles/${articleId}`);
+  await page.waitForURL(new RegExp(`/articles/${articleId}(\\?.*)?$`));
+  await page
+    .getByTestId(ARTICLE_DETAILS_PAGE_HANDLES.PAGE)
+    .waitFor({ state: "visible", timeout: 30_000 });
+};

--- a/apps/web/e2e/flows/articles/open-create-article-dialog.flow.ts
+++ b/apps/web/e2e/flows/articles/open-create-article-dialog.flow.ts
@@ -1,0 +1,10 @@
+import { ARTICLES_TOC_HANDLES, CREATE_ARTICLE_DIALOG_HANDLES } from "../../data/articles/handles";
+import { expect } from "../../fixtures/test.fixture";
+
+import type { Page } from "@playwright/test";
+
+export const openCreateArticleDialogFlow = async (page: Page) => {
+  await page.getByTestId(ARTICLES_TOC_HANDLES.ADD_ACTION).click();
+  await page.getByTestId(ARTICLES_TOC_HANDLES.CREATE_ARTICLE_ACTION).click();
+  await expect(page.getByTestId(CREATE_ARTICLE_DIALOG_HANDLES.DIALOG)).toBeVisible();
+};

--- a/apps/web/e2e/flows/articles/submit-article-form.flow.ts
+++ b/apps/web/e2e/flows/articles/submit-article-form.flow.ts
@@ -1,0 +1,7 @@
+import { ARTICLE_FORM_PAGE_HANDLES } from "../../data/articles/handles";
+
+import type { Page } from "@playwright/test";
+
+export const submitArticleFormFlow = async (page: Page) => {
+  await page.getByTestId(ARTICLE_FORM_PAGE_HANDLES.SAVE_BUTTON).click();
+};

--- a/apps/web/e2e/flows/articles/update-article.flow.ts
+++ b/apps/web/e2e/flows/articles/update-article.flow.ts
@@ -1,0 +1,22 @@
+import { ARTICLE_FORM_PAGE_HANDLES } from "../../data/articles/handles";
+
+import { fillArticleFormFlow } from "./fill-article-form.flow";
+import { submitArticleFormFlow } from "./submit-article-form.flow";
+
+import type { Page } from "@playwright/test";
+
+type UpdateArticleFlowInput = {
+  articleId: string;
+  title?: string;
+  summary?: string;
+};
+
+export const updateArticleFlow = async (
+  page: Page,
+  { articleId, title, summary }: UpdateArticleFlowInput,
+) => {
+  await page.goto(`/articles/${articleId}/edit`);
+  await page.getByTestId(ARTICLE_FORM_PAGE_HANDLES.PAGE).waitFor({ state: "visible" });
+  await fillArticleFormFlow(page, { title, summary });
+  await submitArticleFormFlow(page);
+};

--- a/apps/web/e2e/flows/news/fill-news-form.flow.ts
+++ b/apps/web/e2e/flows/news/fill-news-form.flow.ts
@@ -1,0 +1,27 @@
+import { NEWS_FORM_PAGE_HANDLES } from "../../data/news/handles";
+
+import type { Page } from "@playwright/test";
+
+type FillNewsFormFlowInput = {
+  title?: string;
+  summary?: string;
+  status?: "draft" | "published";
+};
+
+export const fillNewsFormFlow = async (
+  page: Page,
+  { title, summary, status }: FillNewsFormFlowInput,
+) => {
+  if (title !== undefined) {
+    await page.getByTestId(NEWS_FORM_PAGE_HANDLES.TITLE_INPUT).fill(title);
+  }
+
+  if (summary !== undefined) {
+    await page.getByTestId(NEWS_FORM_PAGE_HANDLES.SUMMARY_INPUT).fill(summary);
+  }
+
+  if (status !== undefined) {
+    await page.getByTestId(NEWS_FORM_PAGE_HANDLES.STATUS_SELECT).click();
+    await page.getByTestId(NEWS_FORM_PAGE_HANDLES.statusOption(status)).click();
+  }
+};

--- a/apps/web/e2e/flows/news/open-create-news-page.flow.ts
+++ b/apps/web/e2e/flows/news/open-create-news-page.flow.ts
@@ -1,0 +1,9 @@
+import { NEWS_FORM_PAGE_HANDLES, NEWS_PAGE_HANDLES } from "../../data/news/handles";
+
+import type { Page } from "@playwright/test";
+
+export const openCreateNewsPageFlow = async (page: Page) => {
+  await page.goto("/news");
+  await page.getByTestId(NEWS_PAGE_HANDLES.CREATE_BUTTON).click();
+  await page.getByTestId(NEWS_FORM_PAGE_HANDLES.PAGE).waitFor({ state: "visible" });
+};

--- a/apps/web/e2e/flows/news/open-news-details-from-list.flow.ts
+++ b/apps/web/e2e/flows/news/open-news-details-from-list.flow.ts
@@ -1,0 +1,7 @@
+import { NEWS_PAGE_HANDLES } from "../../data/news/handles";
+
+import type { Page } from "@playwright/test";
+
+export const openNewsDetailsFromListFlow = async (page: Page, newsId: string) => {
+  await page.getByTestId(NEWS_PAGE_HANDLES.item(newsId)).click();
+};

--- a/apps/web/e2e/flows/news/open-news-details-page.flow.ts
+++ b/apps/web/e2e/flows/news/open-news-details-page.flow.ts
@@ -1,0 +1,8 @@
+import { NEWS_DETAILS_PAGE_HANDLES } from "../../data/news/handles";
+
+import type { Page } from "@playwright/test";
+
+export const openNewsDetailsPageFlow = async (page: Page, newsId: string) => {
+  await page.goto(`/news/${newsId}`);
+  await page.getByTestId(NEWS_DETAILS_PAGE_HANDLES.PAGE).waitFor({ state: "visible" });
+};

--- a/apps/web/e2e/flows/news/open-news-page.flow.ts
+++ b/apps/web/e2e/flows/news/open-news-page.flow.ts
@@ -1,0 +1,8 @@
+import { NEWS_PAGE_HANDLES } from "../../data/news/handles";
+
+import type { Page } from "@playwright/test";
+
+export const openNewsPageFlow = async (page: Page) => {
+  await page.goto("/news");
+  await page.getByTestId(NEWS_PAGE_HANDLES.PAGE).waitFor({ state: "visible" });
+};

--- a/apps/web/e2e/flows/news/submit-news-form.flow.ts
+++ b/apps/web/e2e/flows/news/submit-news-form.flow.ts
@@ -1,0 +1,7 @@
+import { NEWS_FORM_PAGE_HANDLES } from "../../data/news/handles";
+
+import type { Page } from "@playwright/test";
+
+export const submitNewsFormFlow = async (page: Page) => {
+  await page.getByTestId(NEWS_FORM_PAGE_HANDLES.SAVE_BUTTON).click();
+};

--- a/apps/web/e2e/flows/news/update-news.flow.ts
+++ b/apps/web/e2e/flows/news/update-news.flow.ts
@@ -1,0 +1,23 @@
+import { NEWS_FORM_PAGE_HANDLES } from "../../data/news/handles";
+
+import { fillNewsFormFlow } from "./fill-news-form.flow";
+import { submitNewsFormFlow } from "./submit-news-form.flow";
+
+import type { Page } from "@playwright/test";
+
+type UpdateNewsFlowInput = {
+  newsId: string;
+  title?: string;
+  summary?: string;
+  status?: "draft" | "published";
+};
+
+export const updateNewsFlow = async (
+  page: Page,
+  { newsId, title, summary, status }: UpdateNewsFlowInput,
+) => {
+  await page.goto(`/news/${newsId}/edit`);
+  await page.getByTestId(NEWS_FORM_PAGE_HANDLES.PAGE).waitFor({ state: "visible" });
+  await fillNewsFormFlow(page, { title, summary, status });
+  await submitNewsFormFlow(page);
+};

--- a/apps/web/e2e/specs/articles/articles-list.spec.ts
+++ b/apps/web/e2e/specs/articles/articles-list.spec.ts
@@ -1,0 +1,45 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { ARTICLES_TOC_HANDLES } from "../../data/articles/handles";
+import { expect, test } from "../../fixtures/test.fixture";
+import { openArticleDetailsPageFlow } from "../../flows/articles/open-article-details-page.flow";
+
+test("admin can browse articles list", async ({ cleanup, factories, withReadonlyPage }) => {
+  await withReadonlyPage(USER_ROLE.admin, async ({ page }) => {
+    const articleFactory = factories.createArticleFactory();
+    const prefix = `articles-list-${Date.now()}`;
+    const { article: firstArticle, section } = await articleFactory.createWithSection({
+      title: `${prefix}-first`,
+      status: "published",
+      isPublic: true,
+    });
+
+    const secondArticle = await articleFactory.create({
+      sectionId: section.id,
+      title: `${prefix}-second`,
+      status: "published",
+      isPublic: true,
+    });
+
+    cleanup.add(async () => {
+      const existingFirstArticle = await articleFactory.safeGetById(firstArticle.id);
+      const existingSecondArticle = await articleFactory.safeGetById(secondArticle.id);
+
+      await Promise.allSettled([
+        existingFirstArticle ? articleFactory.delete(firstArticle.id) : Promise.resolve(),
+        existingSecondArticle ? articleFactory.delete(secondArticle.id) : Promise.resolve(),
+      ]);
+
+      const existingSection = await articleFactory.safeGetSectionById(section.id);
+      if (existingSection && existingSection.assignedArticlesCount === 0) {
+        await articleFactory.deleteSection(section.id);
+      }
+    });
+
+    await openArticleDetailsPageFlow(page, firstArticle.id);
+
+    await expect(page.getByTestId(ARTICLES_TOC_HANDLES.PANEL)).toBeVisible();
+    await expect(page.getByTestId(ARTICLES_TOC_HANDLES.article(firstArticle.id))).toBeVisible();
+    await expect(page.getByTestId(ARTICLES_TOC_HANDLES.article(secondArticle.id))).toBeVisible();
+  });
+});

--- a/apps/web/e2e/specs/articles/create-article-with-section.spec.ts
+++ b/apps/web/e2e/specs/articles/create-article-with-section.spec.ts
@@ -1,0 +1,87 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { ARTICLES_TOC_HANDLES, CREATE_ARTICLE_DIALOG_HANDLES } from "../../data/articles/handles";
+import { expect, test } from "../../fixtures/test.fixture";
+import { openArticleDetailsPageFlow } from "../../flows/articles/open-article-details-page.flow";
+import { openCreateArticleDialogFlow } from "../../flows/articles/open-create-article-dialog.flow";
+
+test("admin can create section and article from articles TOC", async ({
+  cleanup,
+  factories,
+  withWorkerPage,
+}) => {
+  await withWorkerPage(USER_ROLE.admin, async ({ page }) => {
+    const articleFactory = factories.createArticleFactory();
+    const { article: seedArticle, section: seedSection } = await articleFactory.createWithSection({
+      status: "published",
+      isPublic: true,
+    });
+
+    let createdSectionId = "";
+    let createdArticleId = "";
+
+    cleanup.add(async () => {
+      const existingSeedArticle = await articleFactory.safeGetById(seedArticle.id);
+      const existingCreatedArticle = createdArticleId
+        ? await articleFactory.safeGetById(createdArticleId)
+        : null;
+      const existingCreatedSection = createdSectionId
+        ? await articleFactory.safeGetSectionById(createdSectionId)
+        : null;
+      const existingSeedSection = await articleFactory.safeGetSectionById(seedSection.id);
+
+      await Promise.allSettled([
+        existingCreatedArticle ? articleFactory.delete(createdArticleId) : Promise.resolve(),
+        existingSeedArticle ? articleFactory.delete(seedArticle.id) : Promise.resolve(),
+      ]);
+
+      if (existingCreatedSection && existingCreatedSection.assignedArticlesCount === 0) {
+        await articleFactory.deleteSection(createdSectionId);
+      }
+
+      if (existingSeedSection && existingSeedSection.assignedArticlesCount === 0) {
+        await articleFactory.deleteSection(seedSection.id);
+      }
+    });
+
+    await openArticleDetailsPageFlow(page, seedArticle.id);
+
+    const beforeSections = await articleFactory.getToc("en");
+    const beforeSectionIds = new Set(beforeSections.map((section) => section.id));
+
+    await page.getByTestId(ARTICLES_TOC_HANDLES.ADD_ACTION).click();
+    await page.getByTestId(ARTICLES_TOC_HANDLES.CREATE_SECTION_ACTION).click();
+
+    await expect
+      .poll(async () => {
+        const sections = await articleFactory.getToc("en");
+        const createdSection = sections.find((section) => !beforeSectionIds.has(section.id));
+        return createdSection?.id ?? "";
+      })
+      .not.toBe("");
+
+    const sectionsAfterCreate = await articleFactory.getToc("en");
+    const createdSection = sectionsAfterCreate.find((section) => !beforeSectionIds.has(section.id));
+
+    if (!createdSection) {
+      throw new Error("Expected created section in articles TOC");
+    }
+
+    createdSectionId = createdSection.id;
+
+    await openCreateArticleDialogFlow(page);
+
+    await page.getByTestId(CREATE_ARTICLE_DIALOG_HANDLES.SECTION_SELECT).click();
+    await page.getByRole("option", { name: createdSection.title }).click();
+    await page.getByTestId(CREATE_ARTICLE_DIALOG_HANDLES.CREATE_BUTTON).click();
+
+    await expect(page).toHaveURL(/\/articles\/[a-f0-9-]+$/);
+    createdArticleId = /\/articles\/([a-f0-9-]+)$/.exec(page.url())?.[1] ?? "";
+
+    if (!createdArticleId) {
+      throw new Error("Expected created article id in URL");
+    }
+
+    await expect(page.getByTestId(ARTICLES_TOC_HANDLES.article(createdArticleId))).toBeVisible();
+  });
+});

--- a/apps/web/e2e/specs/articles/delete-article.spec.ts
+++ b/apps/web/e2e/specs/articles/delete-article.spec.ts
@@ -1,0 +1,38 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { expect, test } from "../../fixtures/test.fixture";
+import { deleteArticleFlow } from "../../flows/articles/delete-article.flow";
+import { openArticleDetailsPageFlow } from "../../flows/articles/open-article-details-page.flow";
+
+test("admin can delete article from details page", async ({
+  cleanup,
+  factories,
+  withWorkerPage,
+}) => {
+  await withWorkerPage(USER_ROLE.admin, async ({ page }) => {
+    const articleFactory = factories.createArticleFactory();
+    const { article, section } = await articleFactory.createWithSection({
+      status: "published",
+      isPublic: true,
+    });
+
+    cleanup.add(async () => {
+      const existing = await articleFactory.safeGetById(article.id);
+      await Promise.allSettled([
+        existing ? articleFactory.delete(article.id) : Promise.resolve(),
+        articleFactory.deleteSection(section.id),
+      ]);
+    });
+
+    await openArticleDetailsPageFlow(page, article.id);
+    await deleteArticleFlow(page);
+
+    await expect(page).toHaveURL(/\/articles(\/[^/]+)?(\?.*)?$/);
+    await expect
+      .poll(async () => {
+        const deletedArticle = await articleFactory.safeGetById(article.id);
+        return deletedArticle;
+      })
+      .toBeNull();
+  });
+});

--- a/apps/web/e2e/specs/articles/open-article.spec.ts
+++ b/apps/web/e2e/specs/articles/open-article.spec.ts
@@ -1,0 +1,38 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { ARTICLE_DETAILS_PAGE_HANDLES, ARTICLES_TOC_HANDLES } from "../../data/articles/handles";
+import { expect, test } from "../../fixtures/test.fixture";
+import { openArticleDetailsPageFlow } from "../../flows/articles/open-article-details-page.flow";
+
+test("admin can open article details and see it in TOC", async ({
+  cleanup,
+  factories,
+  withReadonlyPage,
+}) => {
+  await withReadonlyPage(USER_ROLE.admin, async ({ page }) => {
+    const articleFactory = factories.createArticleFactory();
+    const title = `open-article-${Date.now()}`;
+    const summary = `open-article-summary-${Date.now()}`;
+    const { article, section } = await articleFactory.createWithSection({
+      title,
+      summary,
+      status: "published",
+      isPublic: true,
+    });
+
+    cleanup.add(async () => {
+      await Promise.allSettled([
+        articleFactory.delete(article.id),
+        articleFactory.deleteSection(section.id),
+      ]);
+    });
+
+    await openArticleDetailsPageFlow(page, article.id);
+
+    await expect(page).toHaveURL(new RegExp(`/articles/${article.id}$`));
+    await expect(page.getByTestId(ARTICLE_DETAILS_PAGE_HANDLES.TITLE)).toHaveText(title);
+    await expect(page.getByTestId(ARTICLE_DETAILS_PAGE_HANDLES.SUMMARY)).toHaveText(summary);
+    await expect(page.getByTestId(ARTICLES_TOC_HANDLES.PANEL)).toBeVisible();
+    await expect(page.getByTestId(ARTICLES_TOC_HANDLES.article(article.id))).toBeVisible();
+  });
+});

--- a/apps/web/e2e/specs/articles/public-access.spec.ts
+++ b/apps/web/e2e/specs/articles/public-access.spec.ts
@@ -1,0 +1,64 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { ARTICLE_DETAILS_PAGE_HANDLES, ARTICLES_TOC_HANDLES } from "../../data/articles/handles";
+import { expect, test } from "../../fixtures/test.fixture";
+import { ensureContentFeaturesEnabled } from "../../utils/content-features";
+
+test("visitor cannot see private article when public articles access is enabled", async ({
+  cleanup,
+  factories,
+  apiClient,
+  withReadonlyPage,
+}) => {
+  await withReadonlyPage(USER_ROLE.admin, async ({ page }) => {
+    const restoreContentFeatures = await ensureContentFeaturesEnabled(apiClient, {
+      publicArticles: true,
+    });
+
+    cleanup.add(restoreContentFeatures);
+
+    const articleFactory = factories.createArticleFactory();
+    const { article, section } = await articleFactory.createWithSection({
+      title: `article-private-${Date.now()}`,
+      summary: `article-private-summary-${Date.now()}`,
+      status: "published",
+      isPublic: false,
+    });
+
+    cleanup.add(async () => {
+      const existingArticle = await articleFactory.safeGetById(article.id);
+      if (existingArticle) {
+        await articleFactory.delete(article.id);
+      }
+
+      const existingSection = await articleFactory.safeGetSectionById(section.id);
+      if (existingSection && existingSection.assignedArticlesCount === 0) {
+        await articleFactory.deleteSection(section.id);
+      }
+    });
+
+    const browser = page.context().browser();
+
+    if (!browser) {
+      throw new Error("Expected browser instance for public context");
+    }
+
+    const publicContext = await browser.newContext();
+    await publicContext.addInitScript(() => {
+      localStorage.setItem(
+        "language-storage",
+        JSON.stringify({ state: { language: "en" }, version: 0 }),
+      );
+    });
+    const publicPage = await publicContext.newPage();
+
+    try {
+      await publicPage.goto(`/articles/${article.id}`);
+      await expect(publicPage).not.toHaveURL(/\/auth\/login$/);
+      await expect(publicPage.getByTestId(ARTICLE_DETAILS_PAGE_HANDLES.TITLE)).toHaveCount(0);
+      await expect(publicPage.getByTestId(ARTICLES_TOC_HANDLES.article(article.id))).toHaveCount(0);
+    } finally {
+      await publicContext.close();
+    }
+  });
+});

--- a/apps/web/e2e/specs/articles/role-access.spec.ts
+++ b/apps/web/e2e/specs/articles/role-access.spec.ts
@@ -1,0 +1,94 @@
+import { SUPPORTED_LANGUAGES } from "@repo/shared";
+
+import { USER_ROLE } from "~/config/userRoles";
+
+import { ARTICLE_DETAILS_PAGE_HANDLES, ARTICLES_TOC_HANDLES } from "../../data/articles/handles";
+import { expect, test } from "../../fixtures/test.fixture";
+import { openArticleDetailsPageFlow } from "../../flows/articles/open-article-details-page.flow";
+
+import type { ArticleFactory } from "../../factories/article.factory";
+import type { FixtureApiClient } from "../../utils/api-client";
+
+const ROLES: Array<{ role: USER_ROLE; title: string }> = [
+  { role: USER_ROLE.contentCreator, title: "content creator" },
+  { role: USER_ROLE.student, title: "student" },
+];
+
+const ensureArticleVisibilityForAllLocales = async ({
+  articleId,
+  apiClient,
+  articleFactory,
+  titlePrefix,
+  summaryPrefix,
+}: {
+  articleId: string;
+  apiClient: FixtureApiClient;
+  articleFactory: ArticleFactory;
+  titlePrefix: string;
+  summaryPrefix: string;
+}) => {
+  const baseArticle = await articleFactory.getById(articleId, SUPPORTED_LANGUAGES.EN);
+
+  for (const language of Object.values(SUPPORTED_LANGUAGES)) {
+    if (!baseArticle.availableLocales.includes(language)) {
+      await apiClient.api.articlesControllerAddNewLanguage(articleId, { language });
+    }
+
+    await articleFactory.update(articleId, {
+      language,
+      title: `${titlePrefix}-${language}`,
+      summary: `${summaryPrefix}-${language}`,
+      status: "published",
+      isPublic: true,
+    });
+  }
+};
+
+for (const { role, title } of ROLES) {
+  test(`${title} can open article details`, async ({ factories, apiClient, withReadonlyPage }) => {
+    const articleFactory = factories.createArticleFactory();
+    let articleId = "";
+    let articleTitlePrefix = "";
+    let sectionId = "";
+
+    await withReadonlyPage(USER_ROLE.admin, async () => {
+      const { article, section } = await articleFactory.createWithSection({
+        title: `article-role-${title.replace(/\s+/g, "-")}-${Date.now()}`,
+        summary: `article-role-summary-${Date.now()}`,
+        status: "published",
+        isPublic: true,
+      });
+
+      await ensureArticleVisibilityForAllLocales({
+        articleId: article.id,
+        apiClient,
+        articleFactory,
+        titlePrefix: `article-role-${title.replace(/\s+/g, "-")}`,
+        summaryPrefix: "article-role-summary",
+      });
+
+      articleId = article.id;
+      articleTitlePrefix = `article-role-${title.replace(/\s+/g, "-")}`;
+      sectionId = section.id;
+    });
+
+    try {
+      await withReadonlyPage(role, async ({ page }) => {
+        await openArticleDetailsPageFlow(page, articleId);
+
+        await expect(page).toHaveURL(new RegExp(`/articles/${articleId}$`));
+        await expect(page.getByTestId(ARTICLE_DETAILS_PAGE_HANDLES.TITLE)).toContainText(
+          articleTitlePrefix,
+        );
+        await expect(page.getByTestId(ARTICLES_TOC_HANDLES.article(articleId))).toBeVisible();
+      });
+    } finally {
+      await withReadonlyPage(USER_ROLE.admin, async () => {
+        await Promise.allSettled([
+          articleId ? articleFactory.delete(articleId) : Promise.resolve(),
+          sectionId ? articleFactory.deleteSection(sectionId) : Promise.resolve(),
+        ]);
+      });
+    }
+  });
+}

--- a/apps/web/e2e/specs/articles/update-article.spec.ts
+++ b/apps/web/e2e/specs/articles/update-article.spec.ts
@@ -1,0 +1,45 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { ARTICLE_DETAILS_PAGE_HANDLES } from "../../data/articles/handles";
+import { expect, test } from "../../fixtures/test.fixture";
+import { updateArticleFlow } from "../../flows/articles/update-article.flow";
+
+test("admin can update article title and summary", async ({
+  cleanup,
+  factories,
+  withWorkerPage,
+}) => {
+  await withWorkerPage(USER_ROLE.admin, async ({ page }) => {
+    const articleFactory = factories.createArticleFactory();
+    const { article, section } = await articleFactory.createWithSection({
+      status: "published",
+      isPublic: true,
+    });
+    const updatedTitle = `updated-article-${Date.now()}`;
+    const updatedSummary = `updated-article-summary-${Date.now()}`;
+
+    cleanup.add(async () => {
+      await Promise.allSettled([
+        articleFactory.delete(article.id),
+        articleFactory.deleteSection(section.id),
+      ]);
+    });
+
+    await updateArticleFlow(page, {
+      articleId: article.id,
+      title: updatedTitle,
+      summary: updatedSummary,
+    });
+
+    await expect(page).toHaveURL(new RegExp(`/articles/${article.id}$`));
+    await expect(page.getByTestId(ARTICLE_DETAILS_PAGE_HANDLES.TITLE)).toHaveText(updatedTitle);
+    await expect(page.getByTestId(ARTICLE_DETAILS_PAGE_HANDLES.SUMMARY)).toHaveText(updatedSummary);
+
+    await expect
+      .poll(async () => {
+        const updatedArticle = await articleFactory.getById(article.id);
+        return updatedArticle.title;
+      })
+      .toBe(updatedTitle);
+  });
+});

--- a/apps/web/e2e/specs/news/create-news.spec.ts
+++ b/apps/web/e2e/specs/news/create-news.spec.ts
@@ -1,0 +1,34 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { NEWS_DETAILS_PAGE_HANDLES } from "../../data/news/handles";
+import { expect, test } from "../../fixtures/test.fixture";
+import { fillNewsFormFlow } from "../../flows/news/fill-news-form.flow";
+import { openCreateNewsPageFlow } from "../../flows/news/open-create-news-page.flow";
+import { submitNewsFormFlow } from "../../flows/news/submit-news-form.flow";
+
+test("admin can create news from the news page", async ({ cleanup, factories, withWorkerPage }) => {
+  await withWorkerPage(USER_ROLE.admin, async ({ page }) => {
+    const newsFactory = factories.createNewsFactory();
+    const title = `create-news-${Date.now()}`;
+    const summary = `create-news-summary-${Date.now()}`;
+
+    await openCreateNewsPageFlow(page);
+    await fillNewsFormFlow(page, { title, summary, status: "published" });
+    await submitNewsFormFlow(page);
+
+    await expect(page).toHaveURL(/\/news\/[a-f0-9-]+$/);
+
+    const createdNewsId = /\/news\/([a-f0-9-]+)$/.exec(page.url())?.[1];
+
+    if (!createdNewsId) throw new Error("Expected created news id in URL");
+
+    cleanup.add(async () => {
+      const existingNews = await newsFactory.safeGetByIdAnyLanguage(createdNewsId);
+
+      if (existingNews) await newsFactory.delete(createdNewsId);
+    });
+
+    await expect(page.getByTestId(NEWS_DETAILS_PAGE_HANDLES.TITLE)).toHaveText(title);
+    await expect(page.getByTestId(NEWS_DETAILS_PAGE_HANDLES.SUMMARY)).toHaveText(summary);
+  });
+});

--- a/apps/web/e2e/specs/news/delete-news.spec.ts
+++ b/apps/web/e2e/specs/news/delete-news.spec.ts
@@ -1,0 +1,30 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { NEWS_DETAILS_PAGE_HANDLES } from "../../data/news/handles";
+import { expect, test } from "../../fixtures/test.fixture";
+import { openNewsDetailsPageFlow } from "../../flows/news/open-news-details-page.flow";
+
+test("admin can delete news from details page", async ({ cleanup, factories, withWorkerPage }) => {
+  await withWorkerPage(USER_ROLE.admin, async ({ page }) => {
+    const newsFactory = factories.createNewsFactory();
+    const news = await newsFactory.create({ status: "published", isPublic: true });
+
+    cleanup.add(async () => {
+      const existing = await newsFactory.safeGetById(news.id);
+      if (existing) {
+        await newsFactory.delete(news.id);
+      }
+    });
+
+    await openNewsDetailsPageFlow(page, news.id);
+    await page.getByTestId(NEWS_DETAILS_PAGE_HANDLES.DELETE_BUTTON).click();
+
+    await expect(page).toHaveURL(/\/news(\?.*)?$/);
+    await expect
+      .poll(async () => {
+        const deletedNews = await newsFactory.safeGetById(news.id);
+        return deletedNews;
+      })
+      .toBeNull();
+  });
+});

--- a/apps/web/e2e/specs/news/news-list.spec.ts
+++ b/apps/web/e2e/specs/news/news-list.spec.ts
@@ -1,0 +1,38 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { NEWS_PAGE_HANDLES } from "../../data/news/handles";
+import { expect, test } from "../../fixtures/test.fixture";
+import { openNewsPageFlow } from "../../flows/news/open-news-page.flow";
+
+test("admin can browse news list", async ({ cleanup, factories, withReadonlyPage }) => {
+  await withReadonlyPage(USER_ROLE.admin, async ({ page }) => {
+    const newsFactory = factories.createNewsFactory();
+    const prefix = `news-list-${Date.now()}`;
+    const firstNews = await newsFactory.create({
+      title: `${prefix}-first`,
+      status: "published",
+      isPublic: true,
+    });
+    const secondNews = await newsFactory.create({
+      title: `${prefix}-second`,
+      status: "published",
+      isPublic: true,
+    });
+
+    cleanup.add(async () => {
+      const existingFirstNews = await newsFactory.safeGetById(firstNews.id);
+      const existingSecondNews = await newsFactory.safeGetById(secondNews.id);
+
+      await Promise.allSettled([
+        existingFirstNews ? newsFactory.delete(firstNews.id) : Promise.resolve(),
+        existingSecondNews ? newsFactory.delete(secondNews.id) : Promise.resolve(),
+      ]);
+    });
+
+    await openNewsPageFlow(page);
+
+    await expect(page.getByTestId(NEWS_PAGE_HANDLES.HEADING)).toBeVisible();
+    await expect(page.getByTestId(NEWS_PAGE_HANDLES.item(firstNews.id))).toBeVisible();
+    await expect(page.getByTestId(NEWS_PAGE_HANDLES.item(secondNews.id))).toBeVisible();
+  });
+});

--- a/apps/web/e2e/specs/news/open-news.spec.ts
+++ b/apps/web/e2e/specs/news/open-news.spec.ts
@@ -1,0 +1,34 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { NEWS_DETAILS_PAGE_HANDLES } from "../../data/news/handles";
+import { expect, test } from "../../fixtures/test.fixture";
+import { openNewsDetailsFromListFlow } from "../../flows/news/open-news-details-from-list.flow";
+import { openNewsPageFlow } from "../../flows/news/open-news-page.flow";
+
+test("admin can open news details from news list", async ({
+  cleanup,
+  factories,
+  withReadonlyPage,
+}) => {
+  await withReadonlyPage(USER_ROLE.admin, async ({ page }) => {
+    const newsFactory = factories.createNewsFactory();
+    const title = `open-news-${Date.now()}`;
+    const summary = `open-news-summary-${Date.now()}`;
+    const news = await newsFactory.create({ title, summary, status: "published", isPublic: true });
+
+    cleanup.add(async () => {
+      const existingNews = await newsFactory.safeGetById(news.id);
+
+      if (existingNews) {
+        await newsFactory.delete(news.id);
+      }
+    });
+
+    await openNewsPageFlow(page);
+    await openNewsDetailsFromListFlow(page, news.id);
+
+    await expect(page).toHaveURL(new RegExp(`/news/${news.id}$`));
+    await expect(page.getByTestId(NEWS_DETAILS_PAGE_HANDLES.TITLE)).toHaveText(title);
+    await expect(page.getByTestId(NEWS_DETAILS_PAGE_HANDLES.SUMMARY)).toHaveText(summary);
+  });
+});

--- a/apps/web/e2e/specs/news/public-access.spec.ts
+++ b/apps/web/e2e/specs/news/public-access.spec.ts
@@ -1,0 +1,108 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { NEWS_DETAILS_PAGE_HANDLES, NEWS_PAGE_HANDLES } from "../../data/news/handles";
+import { expect, test } from "../../fixtures/test.fixture";
+import { openNewsPageFlow } from "../../flows/news/open-news-page.flow";
+import { ensureContentFeaturesEnabled } from "../../utils/content-features";
+
+test("visitor can access published news list and details when public news access is enabled", async ({
+  cleanup,
+  factories,
+  apiClient,
+  withReadonlyPage,
+}) => {
+  await withReadonlyPage(USER_ROLE.admin, async ({ page }) => {
+    const restoreContentFeatures = await ensureContentFeaturesEnabled(apiClient, {
+      publicNews: true,
+    });
+
+    cleanup.add(restoreContentFeatures);
+
+    const newsFactory = factories.createNewsFactory();
+    const news = await newsFactory.create({
+      title: `news-public-${Date.now()}`,
+      summary: `news-public-summary-${Date.now()}`,
+      status: "published",
+      isPublic: true,
+    });
+
+    cleanup.add(async () => {
+      const existingNews = await newsFactory.safeGetById(news.id);
+
+      if (existingNews) {
+        await newsFactory.delete(news.id);
+      }
+    });
+
+    const browser = page.context().browser();
+
+    if (!browser) {
+      throw new Error("Expected browser instance for public context");
+    }
+
+    const publicContext = await browser.newContext();
+    const publicPage = await publicContext.newPage();
+
+    try {
+      await openNewsPageFlow(publicPage);
+      await expect(publicPage.getByTestId(NEWS_PAGE_HANDLES.item(news.id))).toBeVisible();
+
+      await publicPage.getByTestId(NEWS_PAGE_HANDLES.item(news.id)).click();
+      await expect(publicPage).toHaveURL(new RegExp(`/news/${news.id}$`));
+      await expect(publicPage.getByTestId(NEWS_DETAILS_PAGE_HANDLES.TITLE)).toHaveText(news.title);
+    } finally {
+      await publicContext.close();
+    }
+  });
+});
+
+test("visitor cannot see private news when public news access is enabled", async ({
+  cleanup,
+  factories,
+  apiClient,
+  withReadonlyPage,
+}) => {
+  await withReadonlyPage(USER_ROLE.admin, async ({ page }) => {
+    const restoreContentFeatures = await ensureContentFeaturesEnabled(apiClient, {
+      publicNews: true,
+    });
+
+    cleanup.add(restoreContentFeatures);
+
+    const newsFactory = factories.createNewsFactory();
+    const news = await newsFactory.create({
+      title: `news-private-${Date.now()}`,
+      summary: `news-private-summary-${Date.now()}`,
+      status: "published",
+      isPublic: false,
+    });
+
+    cleanup.add(async () => {
+      const existingNews = await newsFactory.safeGetById(news.id);
+
+      if (existingNews) {
+        await newsFactory.delete(news.id);
+      }
+    });
+
+    const browser = page.context().browser();
+
+    if (!browser) {
+      throw new Error("Expected browser instance for public context");
+    }
+
+    const publicContext = await browser.newContext();
+    const publicPage = await publicContext.newPage();
+
+    try {
+      await openNewsPageFlow(publicPage);
+      await expect(publicPage.getByTestId(NEWS_PAGE_HANDLES.item(news.id))).toHaveCount(0);
+
+      await publicPage.goto(`/news/${news.id}`);
+      await expect(publicPage).not.toHaveURL(/\/auth\/login$/);
+      await expect(publicPage.getByTestId(NEWS_DETAILS_PAGE_HANDLES.TITLE)).toHaveCount(0);
+    } finally {
+      await publicContext.close();
+    }
+  });
+});

--- a/apps/web/e2e/specs/news/role-access.spec.ts
+++ b/apps/web/e2e/specs/news/role-access.spec.ts
@@ -1,0 +1,49 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { NEWS_DETAILS_PAGE_HANDLES, NEWS_PAGE_HANDLES } from "../../data/news/handles";
+import { expect, test } from "../../fixtures/test.fixture";
+import { openNewsDetailsFromListFlow } from "../../flows/news/open-news-details-from-list.flow";
+import { openNewsPageFlow } from "../../flows/news/open-news-page.flow";
+
+const ROLES: Array<{ role: USER_ROLE; title: string }> = [
+  { role: USER_ROLE.contentCreator, title: "content creator" },
+  { role: USER_ROLE.student, title: "student" },
+];
+
+for (const { role, title } of ROLES) {
+  test(`${title} can browse and open news details`, async ({ factories, withReadonlyPage }) => {
+    const newsFactory = factories.createNewsFactory();
+    let newsId = "";
+    let newsTitle = "";
+
+    await withReadonlyPage(USER_ROLE.admin, async () => {
+      const news = await newsFactory.create({
+        title: `news-role-${title.replace(/\s+/g, "-")}-${Date.now()}`,
+        summary: `news-role-summary-${Date.now()}`,
+        status: "published",
+        isPublic: true,
+      });
+
+      newsId = news.id;
+      newsTitle = news.title;
+    });
+
+    try {
+      await withReadonlyPage(role, async ({ page }) => {
+        await openNewsPageFlow(page);
+        await expect(page.getByTestId(NEWS_PAGE_HANDLES.item(newsId))).toBeVisible();
+
+        await openNewsDetailsFromListFlow(page, newsId);
+
+        await expect(page).toHaveURL(new RegExp(`/news/${newsId}$`));
+        await expect(page.getByTestId(NEWS_DETAILS_PAGE_HANDLES.TITLE)).toHaveText(newsTitle);
+      });
+    } finally {
+      await withReadonlyPage(USER_ROLE.admin, async () => {
+        const existingNews = newsId ? await newsFactory.safeGetById(newsId) : null;
+
+        await Promise.allSettled([existingNews ? newsFactory.delete(newsId) : Promise.resolve()]);
+      });
+    }
+  });
+}

--- a/apps/web/e2e/specs/news/update-news.spec.ts
+++ b/apps/web/e2e/specs/news/update-news.spec.ts
@@ -1,0 +1,40 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { NEWS_DETAILS_PAGE_HANDLES } from "../../data/news/handles";
+import { expect, test } from "../../fixtures/test.fixture";
+import { updateNewsFlow } from "../../flows/news/update-news.flow";
+
+test("admin can update news title and summary", async ({ cleanup, factories, withWorkerPage }) => {
+  await withWorkerPage(USER_ROLE.admin, async ({ page }) => {
+    const newsFactory = factories.createNewsFactory();
+    const news = await newsFactory.create({ status: "published", isPublic: true });
+    const updatedTitle = `updated-news-${Date.now()}`;
+    const updatedSummary = `updated-news-summary-${Date.now()}`;
+
+    cleanup.add(async () => {
+      const existingNews = await newsFactory.safeGetById(news.id);
+
+      if (existingNews) {
+        await newsFactory.delete(news.id);
+      }
+    });
+
+    await updateNewsFlow(page, {
+      newsId: news.id,
+      title: updatedTitle,
+      summary: updatedSummary,
+      status: "published",
+    });
+
+    await expect(page).toHaveURL(new RegExp(`/news/${news.id}$`));
+    await expect(page.getByTestId(NEWS_DETAILS_PAGE_HANDLES.TITLE)).toHaveText(updatedTitle);
+    await expect(page.getByTestId(NEWS_DETAILS_PAGE_HANDLES.SUMMARY)).toHaveText(updatedSummary);
+
+    await expect
+      .poll(async () => {
+        const updatedNews = await newsFactory.getById(news.id);
+        return updatedNews.title;
+      })
+      .toBe(updatedTitle);
+  });
+});

--- a/apps/web/e2e/strategy.md
+++ b/apps/web/e2e/strategy.md
@@ -332,12 +332,12 @@ Based on `playwright-strategy/03-capability-coverage.md`:
   - unread count
   - mark read
   - feed visibility
-- News
+- News -- DONE
   - list/open/create/update/delete
   - draft/preview
   - language variant add/delete
   - resource upload
-- Articles
+- Articles -- DONE
   - list/open/create/update/delete
   - sections + section languages
   - preview

--- a/apps/web/e2e/utils/content-features.ts
+++ b/apps/web/e2e/utils/content-features.ts
@@ -1,0 +1,110 @@
+import { ALLOWED_ARTICLES_SETTINGS, ALLOWED_NEWS_SETTINGS } from "@repo/shared";
+
+import type { FixtureApiClient } from "./api-client";
+
+type ContentFeatureKey =
+  | "unregisteredUserNewsAccessibility"
+  | "unregisteredUserArticlesAccessibility";
+
+type ContentFeatureState = {
+  unregisteredUserNewsAccessibility: boolean;
+  unregisteredUserArticlesAccessibility: boolean;
+};
+
+const readContentFeatureState = async (
+  apiClient: FixtureApiClient,
+): Promise<ContentFeatureState> => {
+  const response = await apiClient.api.settingsControllerGetPublicGlobalSettings();
+
+  return {
+    unregisteredUserNewsAccessibility: response.data.data.unregisteredUserNewsAccessibility,
+    unregisteredUserArticlesAccessibility: response.data.data.unregisteredUserArticlesAccessibility,
+  };
+};
+
+const readContentModuleState = async (apiClient: FixtureApiClient) => {
+  const response = await apiClient.api.settingsControllerGetPublicGlobalSettings();
+
+  return {
+    newsEnabled: response.data.data.newsEnabled,
+    articlesEnabled: response.data.data.articlesEnabled,
+  };
+};
+
+const setContentFeature = async (
+  apiClient: FixtureApiClient,
+  setting: ContentFeatureKey,
+  enabled: boolean,
+) => {
+  const state = await readContentFeatureState(apiClient);
+  const current = state[setting];
+
+  if (current === enabled) return;
+
+  if (setting === "unregisteredUserNewsAccessibility") {
+    await apiClient.api.settingsControllerUpdateNewsSetting("unregisteredUserNewsAccessibility");
+    return;
+  }
+
+  await apiClient.api.settingsControllerUpdateArticlesSetting(
+    "unregisteredUserArticlesAccessibility",
+  );
+};
+
+const setContentModule = async (
+  apiClient: FixtureApiClient,
+  setting: "newsEnabled" | "articlesEnabled",
+  enabled: boolean,
+) => {
+  const state = await readContentModuleState(apiClient);
+  const current = state[setting];
+
+  if (current === enabled) return;
+
+  if (setting === "newsEnabled") {
+    await apiClient.api.settingsControllerUpdateNewsSetting(ALLOWED_NEWS_SETTINGS.NEWS_ENABLED);
+    return;
+  }
+
+  await apiClient.api.settingsControllerUpdateArticlesSetting(
+    ALLOWED_ARTICLES_SETTINGS.ARTICLES_ENABLED,
+  );
+};
+
+export const ensureContentModulesEnabled = async (apiClient: FixtureApiClient) => {
+  await setContentModule(apiClient, "newsEnabled", true);
+  await setContentModule(apiClient, "articlesEnabled", true);
+};
+
+export const ensureContentFeaturesEnabled = async (
+  apiClient: FixtureApiClient,
+  options: {
+    publicNews?: boolean;
+    publicArticles?: boolean;
+  } = {},
+) => {
+  const desiredPublicNews = options.publicNews ?? false;
+  const desiredPublicArticles = options.publicArticles ?? false;
+
+  const initialState = await readContentFeatureState(apiClient);
+
+  await setContentFeature(apiClient, "unregisteredUserNewsAccessibility", desiredPublicNews);
+  await setContentFeature(
+    apiClient,
+    "unregisteredUserArticlesAccessibility",
+    desiredPublicArticles,
+  );
+
+  return async () => {
+    await setContentFeature(
+      apiClient,
+      "unregisteredUserNewsAccessibility",
+      initialState.unregisteredUserNewsAccessibility,
+    );
+    await setContentFeature(
+      apiClient,
+      "unregisteredUserArticlesAccessibility",
+      initialState.unregisteredUserArticlesAccessibility,
+    );
+  };
+};


### PR DESCRIPTION
## Issue(s)
- #1354 

## Overview
This change adds end-to-end coverage for the news and articles content flows.

It introduces reusable E2E fixtures, data handles, factories, and flow helpers for:

- news list, create, update, delete, and public access flows
- articles list, create, update, delete, open details, and access control flows
- shared content testing utilities for navigation, entity naming, and feature flags

It also includes the supporting UI adjustments in the web app so the content screens behave consistently under the new test coverage.

## Business Value
This reduces the risk of regressions in two high-traffic content areas: news and articles.

The new coverage improves confidence in:

- public access behavior
- role-based access behavior
- CRUD workflows for editors and admins
- nested article section handling

The reusable test helpers also make future content-related test work faster and less brittle.

### Notes

- [x] Fired up e2e tests and got a positive result
