### PR TITLE
test: add coverage for internationalization and improve test cases

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,12 +47,17 @@ on:
 
 jobs:
   playwright:
-    name: Playwright Tests
+    name: Playwright Tests (shard ${{ matrix.shard }}/2)
     runs-on: ubuntu-latest
     environment:
       name: e2e
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     env:
       E2E_BROWSER: ${{ github.event_name == 'push' && github.ref_name == 'staging' && 'chromium' || (github.event_name == 'push' && 'all' || (inputs.browser || 'all')) }}
+      PLAYWRIGHT_SHARD: ${{ matrix.shard }}
 
     services:
       postgres:
@@ -210,13 +215,13 @@ jobs:
         run: |
           case "$E2E_BROWSER" in
             chromium)
-              VITE_TEST=true pnpm playwright test --project chromium
+              VITE_TEST=true pnpm playwright test --project chromium --shard="${PLAYWRIGHT_SHARD}/2"
               ;;
             firefox)
-              VITE_TEST=true pnpm playwright test --project firefox
+              VITE_TEST=true pnpm playwright test --project firefox --shard="${PLAYWRIGHT_SHARD}/2"
               ;;
             all)
-              VITE_TEST=true pnpm playwright test
+              VITE_TEST=true pnpm playwright test --shard="${PLAYWRIGHT_SHARD}/2"
               ;;
             *)
               echo "Unsupported E2E_BROWSER value: $E2E_BROWSER" >&2
@@ -240,7 +245,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-artifacts
+          name: playwright-artifacts-shard-${{ matrix.shard }}
           path: |
             playwright-report
             test-results

--- a/apps/web/e2e/data/settings/handles.ts
+++ b/apps/web/e2e/data/settings/handles.ts
@@ -1,0 +1,4 @@
+export const SETTINGS_PAGE_SELECTORS = {
+  PAGE: "#settings-tabs",
+  LANGUAGE_CARD: "#change-language",
+} as const;

--- a/apps/web/e2e/flows/auth/open-login-page.flow.ts
+++ b/apps/web/e2e/flows/auth/open-login-page.flow.ts
@@ -2,13 +2,19 @@ import { expect, type Page } from "@playwright/test";
 
 import { LOGIN_PAGE_HANDLES } from "../../data/auth/handles";
 
-export const openLoginPageFlow = async (page: Page) => {
-  await page.context().clearCookies();
+type OpenLoginPageOptions = {
+  preserveSession?: boolean;
+};
 
-  await page.addInitScript(() => {
-    localStorage.clear();
-    sessionStorage.clear();
-  });
+export const openLoginPageFlow = async (page: Page, options: OpenLoginPageOptions = {}) => {
+  if (!options.preserveSession) {
+    await page.context().clearCookies();
+
+    await page.addInitScript(() => {
+      localStorage.clear();
+      sessionStorage.clear();
+    });
+  }
 
   await page.goto("/auth/login");
   await expect(page).toHaveURL("/auth/login");

--- a/apps/web/e2e/flows/groups/shift-select-group-range.flow.ts
+++ b/apps/web/e2e/flows/groups/shift-select-group-range.flow.ts
@@ -7,8 +7,14 @@ export const shiftSelectGroupRangeFlow = async (
   firstGroupId: string,
   lastGroupId: string,
 ) => {
-  await page.getByTestId(GROUPS_PAGE_HANDLES.rowCheckbox(firstGroupId)).click();
-  await page.getByTestId(GROUPS_PAGE_HANDLES.rowCheckbox(lastGroupId)).click({
-    modifiers: ["Shift"],
-  });
+  const firstRowCheckbox = page.getByTestId(GROUPS_PAGE_HANDLES.rowCheckbox(firstGroupId));
+  const lastRowCheckbox = page.getByTestId(GROUPS_PAGE_HANDLES.rowCheckbox(lastGroupId));
+
+  await firstRowCheckbox.click();
+  await page.keyboard.down("Shift");
+  try {
+    await lastRowCheckbox.click();
+  } finally {
+    await page.keyboard.up("Shift");
+  }
 };

--- a/apps/web/e2e/flows/settings/open-settings-page.flow.ts
+++ b/apps/web/e2e/flows/settings/open-settings-page.flow.ts
@@ -1,0 +1,14 @@
+import { expect, type Page } from "@playwright/test";
+
+import { NAVIGATION_HANDLES } from "../../data/navigation/handles";
+import { SETTINGS_PAGE_SELECTORS } from "../../data/settings/handles";
+import { clickHandleAndExpectUrlFlow } from "../click-handle-and-expect-url.flow";
+import { prepareNavigationPageFlow } from "../navigation/prepare-navigation-page.flow";
+
+export const openSettingsPageFlow = async (page: Page) => {
+  await prepareNavigationPageFlow(page);
+  await page.getByTestId(NAVIGATION_HANDLES.PROFILE_FOOTER).click();
+  await clickHandleAndExpectUrlFlow(page, NAVIGATION_HANDLES.SETTINGS_LINK, "/settings");
+  await expect(page.locator(SETTINGS_PAGE_SELECTORS.PAGE)).toBeVisible();
+  await expect(page.locator(SETTINGS_PAGE_SELECTORS.LANGUAGE_CARD)).toBeVisible();
+};

--- a/apps/web/e2e/specs/auth/mfa.spec.ts
+++ b/apps/web/e2e/specs/auth/mfa.spec.ts
@@ -11,46 +11,57 @@ import { generateTotpToken } from "../../utils/totp";
 
 const INITIAL_PASSWORD = "Password123@";
 
-test("admin can enable MFA and verify it on login", async ({ createIsolatedWorkspace }) => {
+test("admin can enable MFA and verify it on login", async ({
+  cleanup,
+  createIsolatedWorkspace,
+}) => {
   const workspace = await createIsolatedWorkspace({ role: USER_ROLE.admin });
+  const userFactory = workspace.factories.createUserFactory();
   const email = `mfa-${Date.now()}@example.com`;
 
-  const adminSession = await workspace.createTenantUserWithPasswordAndRole({
+  const user = await userFactory.register({
     email,
     firstName: "MFA",
     lastName: "User",
     password: INITIAL_PASSWORD,
-    role: USER_ROLE.admin,
   });
-  const { page } = adminSession;
 
-  await logout(page, { origin: workspace.origin });
+  cleanup.add(async () => {
+    await userFactory.delete(user.id);
+  });
+  cleanup.add(async () => {
+    await workspace.apiClient.api.settingsControllerUpdateMfaEnforcedRoles({
+      [SYSTEM_ROLE_SLUGS.ADMIN]: false,
+    });
+  });
 
+  await userFactory.update(user.id, { roleSlugs: [USER_ROLE.admin] });
   await workspace.apiClient.api.settingsControllerUpdateMfaEnforcedRoles({
     [SYSTEM_ROLE_SLUGS.ADMIN]: true,
   });
 
-  await login(page, email, INITIAL_PASSWORD, { origin: workspace.origin });
-  await expect(page).toHaveURL(`${workspace.origin}/auth/mfa`);
-  await expect(page.getByTestId(MFA_PAGE_HANDLES.PAGE)).toBeVisible();
+  await logout(workspace.page, { origin: workspace.origin });
 
-  const secret = (await page.getByTestId(MFA_PAGE_HANDLES.SECRET).textContent())?.trim();
+  await login(workspace.page, email, INITIAL_PASSWORD, { origin: workspace.origin });
+  await expect(workspace.page).toHaveURL(`${workspace.origin}/auth/mfa`);
+  await expect(workspace.page.getByTestId(MFA_PAGE_HANDLES.PAGE)).toBeVisible();
+
+  const secret = (await workspace.page.getByTestId(MFA_PAGE_HANDLES.SECRET).textContent())?.trim();
 
   if (!secret) throw new Error("Expected MFA setup secret to be visible");
 
-  await fillMfaTokenFlow(page, generateTotpToken(secret));
-  await submitMfaTokenFlow(page);
+  await fillMfaTokenFlow(workspace.page, generateTotpToken(secret));
+  await submitMfaTokenFlow(workspace.page);
 
-  await expect(page).toHaveURL(`${workspace.origin}/courses`);
+  await expect(workspace.page).toHaveURL(`${workspace.origin}/courses`);
 
-  await logout(page, { origin: workspace.origin });
-  await login(page, email, INITIAL_PASSWORD, { origin: workspace.origin });
-  await expect(page).toHaveURL(`${workspace.origin}/auth/mfa`);
+  await logout(workspace.page, { origin: workspace.origin });
+  await login(workspace.page, email, INITIAL_PASSWORD, { origin: workspace.origin });
+  await expect(workspace.page).toHaveURL(`${workspace.origin}/auth/mfa`);
+  await expect(workspace.page.getByTestId(MFA_PAGE_HANDLES.PAGE)).toBeVisible();
 
-  await expect(page.getByTestId(MFA_PAGE_HANDLES.PAGE)).toBeVisible();
+  await fillMfaTokenFlow(workspace.page, generateTotpToken(secret));
+  await submitMfaTokenFlow(workspace.page);
 
-  await fillMfaTokenFlow(page, generateTotpToken(secret));
-  await submitMfaTokenFlow(page);
-
-  await expect(page).toHaveURL(`${workspace.origin}/courses`);
+  await expect(workspace.page).toHaveURL(`${workspace.origin}/courses`);
 });

--- a/apps/web/e2e/specs/i18n/language-switch.spec.ts
+++ b/apps/web/e2e/specs/i18n/language-switch.spec.ts
@@ -7,9 +7,21 @@ import { prepareNavigationPageFlow } from "../../flows/navigation/prepare-naviga
 import { openSettingsPageFlow } from "../../flows/settings/open-settings-page.flow";
 
 test("admin can switch the UI language and see localized navigation", async ({
+  apiClient,
+  cleanup,
   withWorkerPage,
 }) => {
   await withWorkerPage(USER_ROLE.admin, async ({ page }) => {
+    const originalSettingsResponse = await apiClient.api.settingsControllerGetUserSettings();
+    const originalLanguage = originalSettingsResponse.data.data?.language;
+
+    cleanup.add(async () => {
+      if (originalLanguage)
+        await apiClient.api.settingsControllerUpdateUserSettings({
+          language: originalLanguage,
+        });
+    });
+
     await openSettingsPageFlow(page);
 
     const languageSelect = page.locator(SETTINGS_PAGE_SELECTORS.LANGUAGE_CARD);
@@ -29,8 +41,22 @@ test("admin can switch the UI language and see localized navigation", async ({
   });
 });
 
-test("admin language selection persists after reload", async ({ withWorkerPage }) => {
+test("admin language selection persists after reload", async ({
+  apiClient,
+  cleanup,
+  withWorkerPage,
+}) => {
   await withWorkerPage(USER_ROLE.admin, async ({ page }) => {
+    const originalSettingsResponse = await apiClient.api.settingsControllerGetUserSettings();
+    const originalLanguage = originalSettingsResponse.data.data?.language;
+
+    cleanup.add(async () => {
+      if (originalLanguage)
+        await apiClient.api.settingsControllerUpdateUserSettings({
+          language: originalLanguage,
+        });
+    });
+
     await openSettingsPageFlow(page);
 
     const languageSelect = page.locator(SETTINGS_PAGE_SELECTORS.LANGUAGE_CARD);

--- a/apps/web/e2e/specs/i18n/language-switch.spec.ts
+++ b/apps/web/e2e/specs/i18n/language-switch.spec.ts
@@ -1,0 +1,51 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { NAVIGATION_HANDLES } from "../../data/navigation/handles";
+import { SETTINGS_PAGE_SELECTORS } from "../../data/settings/handles";
+import { expect, test } from "../../fixtures/test.fixture";
+import { prepareNavigationPageFlow } from "../../flows/navigation/prepare-navigation-page.flow";
+import { openSettingsPageFlow } from "../../flows/settings/open-settings-page.flow";
+
+test("admin can switch the UI language and see localized navigation", async ({
+  withWorkerPage,
+}) => {
+  await withWorkerPage(USER_ROLE.admin, async ({ page }) => {
+    await openSettingsPageFlow(page);
+
+    const languageSelect = page.locator(SETTINGS_PAGE_SELECTORS.LANGUAGE_CARD);
+
+    await languageSelect.getByRole("combobox").click();
+    await page.getByRole("option", { name: "German" }).click();
+
+    await expect(page.locator("html")).toHaveAttribute("lang", "de");
+
+    await prepareNavigationPageFlow(page);
+
+    await expect(page.getByTestId(NAVIGATION_HANDLES.COURSES_LINK)).toHaveText("Kurse");
+    await expect(page.getByTestId(NAVIGATION_HANDLES.MANAGE_TOGGLE)).toHaveText("Verwalten");
+
+    await page.getByTestId(NAVIGATION_HANDLES.PROFILE_FOOTER).click();
+    await expect(page.getByTestId(NAVIGATION_HANDLES.SETTINGS_LINK)).toHaveText("Einstellungen");
+  });
+});
+
+test("admin language selection persists after reload", async ({ withWorkerPage }) => {
+  await withWorkerPage(USER_ROLE.admin, async ({ page }) => {
+    await openSettingsPageFlow(page);
+
+    const languageSelect = page.locator(SETTINGS_PAGE_SELECTORS.LANGUAGE_CARD);
+
+    await languageSelect.getByRole("combobox").click();
+    await page.getByRole("option", { name: "Polish" }).click();
+
+    await expect(page.locator("html")).toHaveAttribute("lang", "pl");
+
+    await page.reload();
+    await expect(page.locator("html")).toHaveAttribute("lang", "pl");
+
+    await prepareNavigationPageFlow(page);
+
+    await expect(page.getByTestId(NAVIGATION_HANDLES.COURSES_LINK)).toHaveText("Kursy");
+    await expect(page.getByTestId(NAVIGATION_HANDLES.MANAGE_TOGGLE)).toHaveText("Zarządzaj");
+  });
+});

--- a/apps/web/e2e/specs/i18n/localized-copy.spec.ts
+++ b/apps/web/e2e/specs/i18n/localized-copy.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "../../fixtures/test.fixture";
+import { fillLoginFormFlow } from "../../flows/auth/fill-login-form.flow";
+import { openLoginPageFlow } from "../../flows/auth/open-login-page.flow";
+import { submitLoginFormFlow } from "../../flows/auth/submit-login-form.flow";
+import { assertToastVisible } from "../../utils/assert-toast-visible";
+import { seedLanguageStorage } from "../../utils/language-storage";
+
+test("visitor sees localized auth copy when the language is stored in localStorage", async ({
+  createWorkspacePage,
+}) => {
+  const { context, page } = await createWorkspacePage({ root: true });
+
+  await seedLanguageStorage(context, "de");
+
+  try {
+    await openLoginPageFlow(page, { preserveSession: true });
+    await expect(page.locator("html")).toHaveAttribute("lang", "de");
+
+    await fillLoginFormFlow(page, `visitor-${Date.now()}@example.com`, "wrong-password");
+    await submitLoginFormFlow(page);
+
+    await expect(page).toHaveURL("/auth/login");
+    await assertToastVisible(page, "Ungültige E-Mail-Adresse oder ungültiges Passwort");
+  } finally {
+    await context.close();
+  }
+});

--- a/apps/web/e2e/strategy.md
+++ b/apps/web/e2e/strategy.md
@@ -349,7 +349,7 @@ Based on `playwright-strategy/03-capability-coverage.md`:
   - quiz submit/retake
   - AI mentor interaction entry
   - blocked/unblocked access
-- Announcements
+- Announcements -- DONE
   - create/list
   - unread count
   - mark read
@@ -381,7 +381,7 @@ Based on `playwright-strategy/03-capability-coverage.md`:
 - Support Mode
   - entry/exit
   - visibility/badge behavior
-- i18n
+- i18n -- DONE
   - language switch
   - localized navigation
   - localized validation/copy

--- a/apps/web/e2e/utils/language-storage.ts
+++ b/apps/web/e2e/utils/language-storage.ts
@@ -1,0 +1,16 @@
+import type { BrowserContext, Page } from "@playwright/test";
+import type { SupportedLanguages } from "@repo/shared";
+
+type LanguageStorageTarget = Pick<BrowserContext, "addInitScript"> | Pick<Page, "addInitScript">;
+
+export const seedLanguageStorage = async (
+  target: LanguageStorageTarget,
+  language: SupportedLanguages,
+) => {
+  await target.addInitScript(
+    ({ language }: { language: SupportedLanguages }) => {
+      localStorage.setItem("language-storage", JSON.stringify({ state: { language }, version: 0 }));
+    },
+    { language },
+  );
+};


### PR DESCRIPTION
## Issue(s)
- #1354 

## Overview
This change expands the web E2E suite with coverage for internationalization and stabilizes a few flaky flows.

Included in this commit:

- new i18n specs for language switching and localized auth copy
- a reusable helper for seeding language state in `localStorage`
- a dedicated flow for opening the settings page
- selector handles for the settings language card
- MFA test cleanup updates so state is reset after the run
- small flow adjustments to reduce E2E flakiness

## Business Value
This increases confidence that localized UI behavior works as expected and catches regressions in language handling before they reach production.

It also reduces flaky E2E failures, which makes the suite more reliable for validation in CI and shortens debugging time when tests fail.

### Notes

- [x] Fired up e2e tests and got a positive result
