### PR TITLE
test: add Q&A test coverage to improve platform reliability

### DIFF
--- a/apps/web/app/config/navigationConfig.ts
+++ b/apps/web/app/config/navigationConfig.ts
@@ -120,6 +120,7 @@ export const getNavigationConfig = (
                       label: t("navigationSideBar.qa"),
                       path: "qa",
                       iconName: "Quiz",
+                      testId: NAVIGATION_HANDLES.QA_LINK,
                     },
                   ] as NavigationItem[])
                 : []),

--- a/apps/web/app/modules/Dashboard/Settings/components/SettingItem.tsx
+++ b/apps/web/app/modules/Dashboard/Settings/components/SettingItem.tsx
@@ -21,6 +21,7 @@ interface SettingItemProps {
   icon?: ReactNode;
   disabled?: boolean;
   tooltipTranslationKey?: string;
+  testId?: string;
 }
 export function SettingItem({
   id,
@@ -29,6 +30,7 @@ export function SettingItem({
   checked,
   onCheckedChange,
   icon,
+  testId,
   tooltipTranslationKey = "",
   disabled = false,
 }: SettingItemProps) {
@@ -53,7 +55,7 @@ export function SettingItem({
         <TooltipProvider delayDuration={0}>
           <Tooltip>
             <TooltipTrigger>
-              <Switch disabled />
+              <Switch disabled data-testid={testId} />
             </TooltipTrigger>
             <TooltipContent
               side="top"
@@ -66,7 +68,7 @@ export function SettingItem({
           </Tooltip>
         </TooltipProvider>
       ) : (
-        <Switch id={id} checked={checked} onCheckedChange={onCheckedChange} />
+        <Switch id={id} checked={checked} onCheckedChange={onCheckedChange} data-testid={testId} />
       )}
     </div>
   );

--- a/apps/web/app/modules/Dashboard/Settings/components/admin/QAPreferences.tsx
+++ b/apps/web/app/modules/Dashboard/Settings/components/admin/QAPreferences.tsx
@@ -5,6 +5,8 @@ import { useChangeQASetting } from "~/api/mutations/admin/useChangeQASetting";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "~/components/ui/card";
 import { SettingItem } from "~/modules/Dashboard/Settings/components/SettingItem";
 
+import { QA_SETTINGS_HANDLES } from "../../../../../../e2e/data/qa/handles";
+
 import type { GlobalSettings } from "../../types";
 
 interface QAPreferencesProps {
@@ -16,7 +18,7 @@ export default function QAPreferences({ globalSettings }: QAPreferencesProps) {
   const { mutate: updateQAPreference } = useChangeQASetting();
 
   return (
-    <Card id="qa-preferences">
+    <Card id="qa-preferences" data-testid={QA_SETTINGS_HANDLES.PREFERENCES_CARD}>
       <CardHeader>
         <CardTitle className="h5">{t("qaPreferences.header")}</CardTitle>
         <CardDescription className="body-lg-md">{t("qaPreferences.subHeader")}</CardDescription>
@@ -28,6 +30,7 @@ export default function QAPreferences({ globalSettings }: QAPreferencesProps) {
           description={t(`qaPreferences.settings.qaEnabled.description`)}
           checked={globalSettings.QAEnabled}
           onCheckedChange={() => updateQAPreference(ALLOWED_QA_SETTINGS.QA_ENABLED)}
+          testId={QA_SETTINGS_HANDLES.ENABLED_SWITCH}
         />
         <SettingItem
           id="qa-public"
@@ -39,6 +42,7 @@ export default function QAPreferences({ globalSettings }: QAPreferencesProps) {
           }
           disabled={!globalSettings.QAEnabled}
           tooltipTranslationKey="qaPreferences.tooltip.disabled"
+          testId={QA_SETTINGS_HANDLES.PUBLIC_SWITCH}
         />
       </CardContent>
     </Card>

--- a/apps/web/app/modules/QA/CreateQA.page.tsx
+++ b/apps/web/app/modules/QA/CreateQA.page.tsx
@@ -31,6 +31,8 @@ import { useLanguageStore } from "~/modules/Dashboard/Settings/Language/Language
 import { qaFormSchema, type QAFormValues } from "~/modules/QA/qa.types";
 import { setPageTitle } from "~/utils/setPageTitle";
 
+import { QA_FORM_PAGE_HANDLES } from "../../../e2e/data/qa/handles";
+
 import type { MetaFunction } from "@remix-run/react";
 
 export const meta: MetaFunction = ({ matches }) => setPageTitle(matches, "pages.qa");
@@ -67,14 +69,21 @@ export default function CreateQAPage() {
         <form
           onSubmit={handleSubmit(onSubmit)}
           className="flex w-full max-w-[720px] flex-col gap-6"
+          data-testid={QA_FORM_PAGE_HANDLES.PAGE}
         >
           <div className="flex flex-wrap items-start justify-between gap-4 px-1">
             <h1 className="h5 md:h3">{t("qaView.create.header")}</h1>
             <div className="flex items-center gap-3">
               <Link to="/qa">
-                <Button variant="outline">{t("common.button.cancel")}</Button>
+                <Button variant="outline" data-testid={QA_FORM_PAGE_HANDLES.CANCEL_BUTTON}>
+                  {t("common.button.cancel")}
+                </Button>
               </Link>
-              <Button type="submit" disabled={!isValid || isPending}>
+              <Button
+                type="submit"
+                disabled={!isValid || isPending}
+                data-testid={QA_FORM_PAGE_HANDLES.SAVE_BUTTON}
+              >
                 {t("qaView.button.createNew")}
               </Button>
             </div>
@@ -120,12 +129,17 @@ export default function CreateQAPage() {
                           </TooltipProvider>
                         </Label>
                         <Select value={field.value} onValueChange={field.onChange}>
-                          <SelectTrigger>
+                          <SelectTrigger data-testid={QA_FORM_PAGE_HANDLES.LANGUAGE_SELECT}>
                             <SelectValue />
                           </SelectTrigger>
                           <SelectContent>
                             {courseLanguages.map((item) => (
-                              <SelectItem value={item.key} key={item.key} className="w-full">
+                              <SelectItem
+                                value={item.key}
+                                key={item.key}
+                                className="w-full"
+                                data-testid={QA_FORM_PAGE_HANDLES.languageOption(item.key)}
+                              >
                                 <div className="flex w-full items-center gap-2">
                                   <Icon name={item.iconName} className="size-4" />
                                   <span className="font-semibold">{t(item.translationKey)}</span>
@@ -147,7 +161,11 @@ export default function CreateQAPage() {
                   <span className="mr-1 text-error-600">*</span>
                   {t("qaView.fields.title")}
                 </Label>
-                <Input id="title" {...register("title")} />
+                <Input
+                  id="title"
+                  data-testid={QA_FORM_PAGE_HANDLES.TITLE_INPUT}
+                  {...register("title")}
+                />
                 {errors.title && <p className="text-sm text-destructive">{errors.title.message}</p>}
               </div>
               <div className="space-y-2">
@@ -155,7 +173,12 @@ export default function CreateQAPage() {
                   <span className="mr-1 text-error-600">*</span>
                   {t("qaView.fields.description")}
                 </Label>
-                <Textarea id="description" className="min-h-[180px]" {...register("description")} />
+                <Textarea
+                  id="description"
+                  className="min-h-[180px]"
+                  data-testid={QA_FORM_PAGE_HANDLES.DESCRIPTION_INPUT}
+                  {...register("description")}
+                />
                 {errors.description && (
                   <p className="text-sm text-destructive">{errors.description.message}</p>
                 )}

--- a/apps/web/app/modules/QA/EditQA.page.tsx
+++ b/apps/web/app/modules/QA/EditQA.page.tsx
@@ -18,6 +18,8 @@ import { QALanguageSelector } from "~/modules/QA/components/QALanguageSelector";
 import { qaFormSchema, type QAFormValues } from "~/modules/QA/qa.types";
 import { setPageTitle } from "~/utils/setPageTitle";
 
+import { QA_FORM_PAGE_HANDLES } from "../../../e2e/data/qa/handles";
+
 import type { MetaFunction } from "@remix-run/react";
 import type { SupportedLanguages } from "@repo/shared";
 
@@ -86,6 +88,7 @@ export default function EditQAPage() {
         <form
           onSubmit={handleSubmit(onSubmit)}
           className="flex w-full max-w-[720px] flex-col gap-6"
+          data-testid={QA_FORM_PAGE_HANDLES.PAGE}
         >
           <div className="flex flex-wrap items-start justify-between gap-4 px-1">
             <div className="space-y-2">
@@ -94,9 +97,15 @@ export default function EditQAPage() {
             <div className="flex w-full items-center gap-3 md:w-auto">
               <div className="ml-auto flex items-center gap-3">
                 <Link to="/qa">
-                  <Button variant="outline">{t("common.button.cancel")}</Button>
+                  <Button variant="outline" data-testid={QA_FORM_PAGE_HANDLES.CANCEL_BUTTON}>
+                    {t("common.button.cancel")}
+                  </Button>
                 </Link>
-                <Button type="submit" disabled={!isValid || isUpdating || isLoading}>
+                <Button
+                  type="submit"
+                  disabled={!isValid || isUpdating || isLoading}
+                  data-testid={QA_FORM_PAGE_HANDLES.SAVE_BUTTON}
+                >
                   {t("common.button.save")}
                 </Button>
               </div>
@@ -122,7 +131,11 @@ export default function EditQAPage() {
                   <span className="mr-1 text-error-600">*</span>
                   {t("qaView.fields.title")}
                 </Label>
-                <Input id="title" {...register("title")} />
+                <Input
+                  id="title"
+                  data-testid={QA_FORM_PAGE_HANDLES.TITLE_INPUT}
+                  {...register("title")}
+                />
                 {errors.title && <p className="text-sm text-destructive">{errors.title.message}</p>}
               </div>
               <div className="space-y-2">
@@ -130,7 +143,12 @@ export default function EditQAPage() {
                   <span className="mr-1 text-error-600">*</span>
                   {t("qaView.fields.description")}
                 </Label>
-                <Textarea id="description" className="min-h-[180px]" {...register("description")} />
+                <Textarea
+                  id="description"
+                  className="min-h-[180px]"
+                  data-testid={QA_FORM_PAGE_HANDLES.DESCRIPTION_INPUT}
+                  {...register("description")}
+                />
                 {errors.description && (
                   <p className="text-sm text-destructive">{errors.description.message}</p>
                 )}

--- a/apps/web/app/modules/QA/QA.page.tsx
+++ b/apps/web/app/modules/QA/QA.page.tsx
@@ -13,6 +13,8 @@ import { useLanguageStore } from "~/modules/Dashboard/Settings/Language/Language
 import QAItem from "~/modules/QA/components/QAItem";
 import { setPageTitle } from "~/utils/setPageTitle";
 
+import { QA_PAGE_HANDLES } from "../../../e2e/data/qa/handles";
+
 import type { MetaFunction } from "@remix-run/react";
 
 export const meta: MetaFunction = ({ matches }) => setPageTitle(matches, "pages.qa");
@@ -56,6 +58,7 @@ export default function QAPage() {
     <ContentAccessGuard type={ACCESS_GUARD.UNREGISTERED_QA_ACCESS}>
       <PageWrapper
         role="main"
+        data-testid={QA_PAGE_HANDLES.PAGE}
         className="!w-full !max-w-none"
         breadcrumbs={[{ title: t("navigationSideBar.qa"), href: "/qa" }]}
       >
@@ -63,17 +66,24 @@ export default function QAPage() {
           <div className="flex h-auto w-full flex-col gap-6">
             <div className="flex justify-between items-center">
               <div className="flex flex-col gap-2">
-                <h4 className="h4 font-semibold">{t("QA.header")}</h4>
+                <h4 className="h4 font-semibold" data-testid={QA_PAGE_HANDLES.HEADING}>
+                  {t("QA.header")}
+                </h4>
                 <h5 className="text-xl">{t("QA.subHeader")}</h5>
               </div>
               {canManageQA && (
                 <Link to="/qa/new" className="ml-2">
-                  <Button>{t("qaView.button.createNew")}</Button>
+                  <Button data-testid={QA_PAGE_HANDLES.CREATE_BUTTON}>
+                    {t("qaView.button.createNew")}
+                  </Button>
                 </Link>
               )}
             </div>
             {filteredQA && filteredQA.length > 0 && (
-              <div className="rounded-2xl bg-white border-border border overflow-hidden">
+              <div
+                className="rounded-2xl bg-white border-border border overflow-hidden"
+                data-testid={QA_PAGE_HANDLES.ITEM_LIST}
+              >
                 <Accordion
                   type="single"
                   collapsible

--- a/apps/web/app/modules/QA/components/CreateQALanguageDialog.tsx
+++ b/apps/web/app/modules/QA/components/CreateQALanguageDialog.tsx
@@ -10,6 +10,8 @@ import {
   DialogTitle,
 } from "~/components/ui/dialog";
 
+import { QA_LANGUAGE_SELECTOR_HANDLES } from "../../../../e2e/data/qa/handles";
+
 import type { SupportedLanguages } from "@repo/shared";
 
 type CreateQALanguageDialogProps = {
@@ -41,14 +43,19 @@ export const CreateQALanguageDialog = ({
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogContent>
+      <DialogContent data-testid={QA_LANGUAGE_SELECTOR_HANDLES.CREATE_DIALOG}>
         <DialogTitle>{t("adminCourseView.createLanguage.title")}</DialogTitle>
         <DialogDescription>{t("adminCourseView.createLanguage.description")}</DialogDescription>
         <DialogFooter>
           <Button variant="outline" onClick={() => setOpen(false)}>
             {t("contentCreatorView.button.cancel")}
           </Button>
-          <Button onClick={handleConfirm}>{t("contentCreatorView.button.confirm")}</Button>
+          <Button
+            onClick={handleConfirm}
+            data-testid={QA_LANGUAGE_SELECTOR_HANDLES.CREATE_CONFIRM_BUTTON}
+          >
+            {t("contentCreatorView.button.confirm")}
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/apps/web/app/modules/QA/components/DeleteQADialog.tsx
+++ b/apps/web/app/modules/QA/components/DeleteQADialog.tsx
@@ -12,12 +12,15 @@ import {
   DialogTrigger,
 } from "~/components/ui/dialog";
 
+import { QA_DELETE_DIALOG_HANDLES, QA_PAGE_HANDLES } from "../../../../e2e/data/qa/handles";
+
 interface DeleteQADialogProps {
+  qaId: string;
   onConfirm: () => Promise<void> | void;
   loading?: boolean;
 }
 
-export default function DeleteQADialog({ onConfirm, loading = false }: DeleteQADialogProps) {
+export default function DeleteQADialog({ qaId, onConfirm, loading = false }: DeleteQADialogProps) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
 
@@ -36,20 +39,35 @@ export default function DeleteQADialog({ onConfirm, loading = false }: DeleteQAD
           onClick={(event) => event.stopPropagation()}
           disabled={loading}
           className="gap-2 size-8 border-destructive text-destructive hover:bg-red-100 hover:border-destructive hover:text-destructive"
+          data-testid={QA_PAGE_HANDLES.itemDeleteButton(qaId)}
         >
           <Icon name="TrashIcon" className="size-4" />
         </Button>
       </DialogTrigger>
-      <DialogContent onClick={(event) => event.stopPropagation()}>
+      <DialogContent
+        onClick={(event) => event.stopPropagation()}
+        data-testid={QA_DELETE_DIALOG_HANDLES.DIALOG}
+      >
         <DialogHeader>
           <DialogTitle>{t("qaView.delete.title")}</DialogTitle>
         </DialogHeader>
         <p className="text-sm text-muted-foreground">{t("qaView.delete.confirm")}</p>
         <DialogFooter className="gap-2 sm:gap-0">
-          <Button variant="outline" onClick={() => setOpen(false)} type="button">
+          <Button
+            variant="outline"
+            onClick={() => setOpen(false)}
+            type="button"
+            data-testid={QA_DELETE_DIALOG_HANDLES.CANCEL_BUTTON}
+          >
             {t("common.button.cancel")}
           </Button>
-          <Button variant="destructive" onClick={handleConfirm} disabled={loading} type="button">
+          <Button
+            variant="destructive"
+            onClick={handleConfirm}
+            disabled={loading}
+            type="button"
+            data-testid={QA_DELETE_DIALOG_HANDLES.CONFIRM_BUTTON}
+          >
             {t("common.button.delete")}
           </Button>
         </DialogFooter>

--- a/apps/web/app/modules/QA/components/DeleteQALanguageDialog.tsx
+++ b/apps/web/app/modules/QA/components/DeleteQALanguageDialog.tsx
@@ -11,6 +11,8 @@ import {
   DialogTitle,
 } from "~/components/ui/dialog";
 
+import { QA_LANGUAGE_SELECTOR_HANDLES } from "../../../../e2e/data/qa/handles";
+
 import type { SupportedLanguages } from "@repo/shared";
 
 type DeleteQALanguageDialogProps = {
@@ -42,7 +44,7 @@ export const DeleteQALanguageDialog = ({
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogContent>
+      <DialogContent data-testid={QA_LANGUAGE_SELECTOR_HANDLES.DELETE_DIALOG}>
         <DialogHeader>
           <DialogTitle>{t("adminCourseView.deleteLanguage.title")}</DialogTitle>
           <DialogDescription>{t("adminCourseView.deleteLanguage.description")}</DialogDescription>
@@ -51,7 +53,11 @@ export const DeleteQALanguageDialog = ({
           <Button variant="outline" onClick={() => setOpen(false)}>
             {t("common.button.cancel")}
           </Button>
-          <Button variant="destructive" onClick={handleConfirm}>
+          <Button
+            variant="destructive"
+            onClick={handleConfirm}
+            data-testid={QA_LANGUAGE_SELECTOR_HANDLES.DELETE_CONFIRM_BUTTON}
+          >
             {t("common.button.proceed")}
           </Button>
         </DialogFooter>

--- a/apps/web/app/modules/QA/components/QAItem.tsx
+++ b/apps/web/app/modules/QA/components/QAItem.tsx
@@ -10,6 +10,8 @@ import { Button } from "~/components/ui/button";
 import { courseLanguages } from "~/modules/Admin/EditCourse/components/CourseLanguageSelector";
 import DeleteQADialog from "~/modules/QA/components/DeleteQADialog";
 
+import { QA_PAGE_HANDLES } from "../../../../e2e/data/qa/handles";
+
 import type { SupportedLanguages } from "@repo/shared";
 import type React from "react";
 
@@ -38,11 +40,21 @@ export default function QAItem({ title, description, canManageQA, id, availableL
   };
 
   return (
-    <AccordionItem value={id} id={`qa-${id}`} className="border-b border-border rounded-none">
-      <AccordionTrigger className="group w-full px-6 p-5 text-left text-base font-semibold hover:no-underline focus-visible:outline-none focus-visible:ring-0">
+    <AccordionItem
+      value={id}
+      id={`qa-${id}`}
+      className="border-b border-border rounded-none"
+      data-testid={QA_PAGE_HANDLES.item(id)}
+    >
+      <AccordionTrigger
+        className="group w-full px-6 p-5 text-left text-base font-semibold hover:no-underline focus-visible:outline-none focus-visible:ring-0"
+        data-testid={QA_PAGE_HANDLES.itemTrigger(id)}
+      >
         <div className="flex w-full items-center text-slate-900">
           <span className="text-primary font-semibold">Q:</span>
-          <span className="flex-1">&nbsp;{title}</span>
+          <span className="flex-1" data-testid={QA_PAGE_HANDLES.itemTitle(id)}>
+            &nbsp;{title}
+          </span>
           {canManageQA && (
             <Button
               onClick={handleEdit}
@@ -51,11 +63,12 @@ export default function QAItem({ title, description, canManageQA, id, availableL
               onKeyDown={(e) => e.key === "Enter" && handleEdit(e)}
               className="flex size-8 text-slate-500"
               aria-label={t("qaView.aria.editQuestion")}
+              data-testid={QA_PAGE_HANDLES.itemEditButton(id)}
             >
               <Pencil className="size-4" />
             </Button>
           )}
-          {canManageQA && <DeleteQADialog onConfirm={onDelete} loading={isDeleting} />}
+          {canManageQA && <DeleteQADialog qaId={id} onConfirm={onDelete} loading={isDeleting} />}
 
           <Badge variant="default" className="flex gap-2 ml-1 mr-3">
             {courseLanguages
@@ -67,10 +80,15 @@ export default function QAItem({ title, description, canManageQA, id, availableL
           <ChevronDown className="size-4 shrink-0 text-slate-500 transition-transform duration-200 group-data-[state=open]:rotate-180" />
         </div>
       </AccordionTrigger>
-      <AccordionContent className="px-6 text-base pb-4 leading-relaxed text-slate-700">
+      <AccordionContent
+        className="px-6 text-base pb-4 leading-relaxed text-slate-700"
+        data-testid={QA_PAGE_HANDLES.itemContent(id)}
+      >
         <div className="flex gap-2">
           <span className="text-primary font-semibold">A:</span>
-          <p className="flex-1">{description}</p>
+          <p className="flex-1" data-testid={QA_PAGE_HANDLES.itemDescription(id)}>
+            {description}
+          </p>
         </div>
       </AccordionContent>
     </AccordionItem>

--- a/apps/web/app/modules/QA/components/QALanguageSelector.tsx
+++ b/apps/web/app/modules/QA/components/QALanguageSelector.tsx
@@ -13,6 +13,8 @@ import {
 import { Separator } from "~/components/ui/separator";
 import { courseLanguages } from "~/modules/Admin/EditCourse/components/CourseLanguageSelector";
 
+import { QA_LANGUAGE_SELECTOR_HANDLES } from "../../../../e2e/data/qa/handles";
+
 import { CreateQALanguageDialog } from "./CreateQALanguageDialog";
 import { DeleteQALanguageDialog } from "./DeleteQALanguageDialog";
 
@@ -64,12 +66,17 @@ export const QALanguageSelector = ({ qaLanguage, qa, onChange }: QALanguageSelec
   return (
     <div className="flex gap-2 items-center">
       <Select value={qaLanguage} onValueChange={handleLanguageChange}>
-        <SelectTrigger className="min-w-[200px]">
+        <SelectTrigger className="min-w-[200px]" data-testid={QA_LANGUAGE_SELECTOR_HANDLES.SELECT}>
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
           {addedItems.map((item) => (
-            <SelectItem value={item.key} key={item.key} className="w-full">
+            <SelectItem
+              value={item.key}
+              key={item.key}
+              className="w-full"
+              data-testid={QA_LANGUAGE_SELECTOR_HANDLES.option(item.key)}
+            >
               <div className="flex w-full items-center gap-2">
                 <Icon name={item.iconName} className="size-4" />
                 <span className="font-semibold">{t(item.translationKey)}</span>
@@ -90,7 +97,11 @@ export const QALanguageSelector = ({ qaLanguage, qa, onChange }: QALanguageSelec
                 {t("adminCourseView.common.notAddedLanguages")}
               </div>
               {notAddedItems.map((item) => (
-                <SelectItem value={item.key} key={item.key}>
+                <SelectItem
+                  value={item.key}
+                  key={item.key}
+                  data-testid={QA_LANGUAGE_SELECTOR_HANDLES.option(item.key)}
+                >
                   <div className="flex w-full items-center gap-2">
                     <Icon name={item.iconName} className="size-4" />
                     <div className="flex flex-col leading-tight">
@@ -114,6 +125,7 @@ export const QALanguageSelector = ({ qaLanguage, qa, onChange }: QALanguageSelec
             setLanguageToDelete(qaLanguage);
             setIsDeleteDialogOpen(true);
           }}
+          data-testid={QA_LANGUAGE_SELECTOR_HANDLES.DELETE_BUTTON}
         >
           <Icon name="TrashIcon" className="size-5" />
         </Button>

--- a/apps/web/e2e/data/navigation/handles.ts
+++ b/apps/web/e2e/data/navigation/handles.ts
@@ -8,6 +8,7 @@ export const NAVIGATION_HANDLES = {
   CONTENT_GROUP: "navigation-content-toggle",
   NEWS_LINK: "navigation-news-link",
   ARTICLES_LINK: "navigation-articles-link",
+  QA_LINK: "navigation-qa-link",
   MANAGE_TOGGLE: "navigation-manage-toggle",
   USERS_LINK: "navigation-users-link",
   GROUPS_LINK: "navigation-groups-link",

--- a/apps/web/e2e/data/qa/handles.ts
+++ b/apps/web/e2e/data/qa/handles.ts
@@ -1,0 +1,47 @@
+import type { SupportedLanguages } from "@repo/shared";
+
+export const QA_PAGE_HANDLES = {
+  PAGE: "qa-page",
+  HEADING: "qa-page-heading",
+  CREATE_BUTTON: "qa-page-create-button",
+  ITEM_LIST: "qa-page-item-list",
+  item: (qaId: string) => `qa-page-item-${qaId}`,
+  itemTrigger: (qaId: string) => `qa-page-item-${qaId}-trigger`,
+  itemContent: (qaId: string) => `qa-page-item-${qaId}-content`,
+  itemTitle: (qaId: string) => `qa-page-item-${qaId}-title`,
+  itemDescription: (qaId: string) => `qa-page-item-${qaId}-description`,
+  itemEditButton: (qaId: string) => `qa-page-item-${qaId}-edit-button`,
+  itemDeleteButton: (qaId: string) => `qa-page-item-${qaId}-delete-button`,
+} as const;
+
+export const QA_FORM_PAGE_HANDLES = {
+  PAGE: "qa-form-page",
+  LANGUAGE_SELECT: "qa-form-language-select",
+  languageOption: (language: SupportedLanguages) => `qa-form-language-option-${language}`,
+  TITLE_INPUT: "qa-form-title-input",
+  DESCRIPTION_INPUT: "qa-form-description-input",
+  SAVE_BUTTON: "qa-form-save-button",
+  CANCEL_BUTTON: "qa-form-cancel-button",
+} as const;
+
+export const QA_LANGUAGE_SELECTOR_HANDLES = {
+  SELECT: "qa-language-select",
+  option: (language: SupportedLanguages) => `qa-language-option-${language}`,
+  DELETE_BUTTON: "qa-language-delete-button",
+  CREATE_DIALOG: "qa-language-create-dialog",
+  CREATE_CONFIRM_BUTTON: "qa-language-create-confirm-button",
+  DELETE_DIALOG: "qa-language-delete-dialog",
+  DELETE_CONFIRM_BUTTON: "qa-language-delete-confirm-button",
+} as const;
+
+export const QA_DELETE_DIALOG_HANDLES = {
+  DIALOG: "qa-delete-dialog",
+  CONFIRM_BUTTON: "qa-delete-confirm-button",
+  CANCEL_BUTTON: "qa-delete-cancel-button",
+} as const;
+
+export const QA_SETTINGS_HANDLES = {
+  PREFERENCES_CARD: "qa-settings-preferences-card",
+  ENABLED_SWITCH: "qa-settings-enabled-switch",
+  PUBLIC_SWITCH: "qa-settings-public-switch",
+} as const;

--- a/apps/web/e2e/factories/index.ts
+++ b/apps/web/e2e/factories/index.ts
@@ -4,6 +4,7 @@ import { CourseFactory } from "./course.factory";
 import { CurriculumFactory } from "./curriculum.factory";
 import { GroupFactory } from "./group.factory";
 import { NewsFactory } from "./news.factory";
+import { QAFactory } from "./qa.factory";
 import { TenantFactory } from "./tenant.factory";
 import { UserFactory } from "./user.factory";
 
@@ -16,6 +17,7 @@ export type FixtureFactories = {
   createCurriculumFactory: () => CurriculumFactory;
   createGroupFactory: () => GroupFactory;
   createNewsFactory: () => NewsFactory;
+  createQAFactory: () => QAFactory;
   createTenantFactory: () => TenantFactory;
   createUserFactory: () => UserFactory;
 };
@@ -27,6 +29,7 @@ export const createFixtureFactories = (apiClient: FixtureApiClient): FixtureFact
   let curriculumFactory: CurriculumFactory | undefined;
   let groupFactory: GroupFactory | undefined;
   let newsFactory: NewsFactory | undefined;
+  let qaFactory: QAFactory | undefined;
   let tenantFactory: TenantFactory | undefined;
   let userFactory: UserFactory | undefined;
 
@@ -55,6 +58,10 @@ export const createFixtureFactories = (apiClient: FixtureApiClient): FixtureFact
       newsFactory ??= new NewsFactory(apiClient);
       return newsFactory;
     },
+    createQAFactory: () => {
+      qaFactory ??= new QAFactory(apiClient);
+      return qaFactory;
+    },
     createTenantFactory: () => {
       tenantFactory ??= new TenantFactory(apiClient);
       return tenantFactory;
@@ -72,5 +79,6 @@ export { CourseFactory } from "./course.factory";
 export { CurriculumFactory } from "./curriculum.factory";
 export { GroupFactory } from "./group.factory";
 export { NewsFactory } from "./news.factory";
+export { QAFactory } from "./qa.factory";
 export { TenantFactory } from "./tenant.factory";
 export { UserFactory } from "./user.factory";

--- a/apps/web/e2e/factories/qa.factory.ts
+++ b/apps/web/e2e/factories/qa.factory.ts
@@ -1,0 +1,117 @@
+import { randomUUID } from "node:crypto";
+
+import type { FixtureApiClient } from "../utils/api-client";
+import type { SupportedLanguages } from "@repo/shared";
+import type {
+  CreateQABody,
+  GetAllQAResponse,
+  GetQAResponse,
+  UpdateQABody,
+} from "~/api/generated-api";
+
+export type QAFactoryRecord = GetQAResponse;
+export type QAFactoryListRecord = GetAllQAResponse[number];
+export type QAFactoryCreateInput = {
+  language?: SupportedLanguages;
+  title?: string;
+  description?: string;
+};
+export type QAFactoryUpdateInput = {
+  language?: SupportedLanguages;
+  title?: string;
+  description?: string;
+};
+
+const createQADefaults = () => {
+  const suffix = randomUUID().slice(0, 8);
+
+  return {
+    title: `Q&A question ${suffix}`,
+    description: `Q&A answer ${suffix}`,
+  };
+};
+
+export class QAFactory {
+  constructor(private readonly apiClient: FixtureApiClient) {}
+
+  async create(input: QAFactoryCreateInput = {}): Promise<QAFactoryRecord> {
+    const language = input.language ?? "en";
+    const defaults = createQADefaults();
+    const title = input.title ?? defaults.title;
+
+    await this.apiClient.api.qaControllerCreateQa({
+      language,
+      title,
+      description: input.description ?? defaults.description,
+    } satisfies CreateQABody);
+
+    const created = await this.findByTitle(title, language);
+
+    if (!created) {
+      throw new Error(`Failed to find created Q&A entry with title "${title}"`);
+    }
+
+    return this.getById(created.id, language);
+  }
+
+  async getById(id: string, language: SupportedLanguages = "en"): Promise<QAFactoryRecord> {
+    const response = await this.apiClient.api.qaControllerGetQa(id, { language });
+    return response.data;
+  }
+
+  async getAll(language: SupportedLanguages = "en"): Promise<GetAllQAResponse> {
+    const response = await this.apiClient.api.qaControllerGetAllQa({ language });
+    return response.data;
+  }
+
+  async findByTitle(
+    title: string,
+    language: SupportedLanguages = "en",
+  ): Promise<QAFactoryListRecord | null> {
+    const response = await this.apiClient.api.qaControllerGetAllQa({
+      language,
+      searchQuery: title,
+    });
+
+    return response.data.find((qa) => qa.title === title) ?? null;
+  }
+
+  async update(id: string, input: QAFactoryUpdateInput): Promise<QAFactoryRecord> {
+    const language = input.language ?? "en";
+
+    await this.apiClient.api.qaControllerUpdateQa(
+      id,
+      {
+        ...(input.title === undefined ? {} : { title: input.title }),
+        ...(input.description === undefined ? {} : { description: input.description }),
+      } satisfies UpdateQABody,
+      { language },
+    );
+
+    return this.getById(id, language);
+  }
+
+  async createLanguage(id: string, language: SupportedLanguages): Promise<QAFactoryRecord> {
+    await this.apiClient.api.qaControllerCreateLanguage(id, { language });
+    return this.getById(id, language);
+  }
+
+  async deleteLanguage(id: string, language: SupportedLanguages): Promise<void> {
+    await this.apiClient.api.qaControllerDeleteLanguage(id, { language });
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.apiClient.api.qaControllerDeleteQa(id);
+  }
+
+  async safeGetById(
+    id: string,
+    language: SupportedLanguages = "en",
+  ): Promise<QAFactoryRecord | null> {
+    try {
+      return await this.getById(id, language);
+    } catch {
+      return null;
+    }
+  }
+}

--- a/apps/web/e2e/flows/qa/create-qa-language.flow.ts
+++ b/apps/web/e2e/flows/qa/create-qa-language.flow.ts
@@ -1,0 +1,16 @@
+import { QA_FORM_PAGE_HANDLES, QA_LANGUAGE_SELECTOR_HANDLES } from "../../data/qa/handles";
+import { expect } from "../../fixtures/test.fixture";
+
+import { selectQALanguageFlow } from "./select-qa-language.flow";
+
+import type { Page } from "@playwright/test";
+import type { SupportedLanguages } from "@repo/shared";
+
+export const createQALanguageFlow = async (page: Page, language: SupportedLanguages) => {
+  await selectQALanguageFlow(page, language);
+  await page.getByTestId(QA_LANGUAGE_SELECTOR_HANDLES.CREATE_DIALOG).waitFor();
+  await page.getByTestId(QA_LANGUAGE_SELECTOR_HANDLES.CREATE_CONFIRM_BUTTON).click();
+  await expect(page.getByTestId(QA_LANGUAGE_SELECTOR_HANDLES.CREATE_DIALOG)).toHaveCount(0);
+  await expect(page.getByTestId(QA_FORM_PAGE_HANDLES.TITLE_INPUT)).toHaveValue("");
+  await expect(page.getByTestId(QA_FORM_PAGE_HANDLES.DESCRIPTION_INPUT)).toHaveValue("");
+};

--- a/apps/web/e2e/flows/qa/create-qa.flow.ts
+++ b/apps/web/e2e/flows/qa/create-qa.flow.ts
@@ -1,0 +1,18 @@
+import { fillQAFormFlow } from "./fill-qa-form.flow";
+import { openCreateQAPageFlow } from "./open-create-qa-page.flow";
+import { submitQAFormFlow } from "./submit-qa-form.flow";
+
+import type { Page } from "@playwright/test";
+import type { SupportedLanguages } from "@repo/shared";
+
+type CreateQAFlowInput = {
+  language?: SupportedLanguages;
+  title: string;
+  description: string;
+};
+
+export const createQAFlow = async (page: Page, input: CreateQAFlowInput) => {
+  await openCreateQAPageFlow(page);
+  await fillQAFormFlow(page, input);
+  await submitQAFormFlow(page);
+};

--- a/apps/web/e2e/flows/qa/delete-qa-language.flow.ts
+++ b/apps/web/e2e/flows/qa/delete-qa-language.flow.ts
@@ -1,0 +1,9 @@
+import { QA_LANGUAGE_SELECTOR_HANDLES } from "../../data/qa/handles";
+
+import type { Page } from "@playwright/test";
+
+export const deleteQALanguageFlow = async (page: Page) => {
+  await page.getByTestId(QA_LANGUAGE_SELECTOR_HANDLES.DELETE_BUTTON).click();
+  await page.getByTestId(QA_LANGUAGE_SELECTOR_HANDLES.DELETE_DIALOG).waitFor();
+  await page.getByTestId(QA_LANGUAGE_SELECTOR_HANDLES.DELETE_CONFIRM_BUTTON).click();
+};

--- a/apps/web/e2e/flows/qa/delete-qa.flow.ts
+++ b/apps/web/e2e/flows/qa/delete-qa.flow.ts
@@ -1,0 +1,8 @@
+import { QA_DELETE_DIALOG_HANDLES, QA_PAGE_HANDLES } from "../../data/qa/handles";
+
+import type { Page } from "@playwright/test";
+
+export const deleteQAFlow = async (page: Page, qaId: string) => {
+  await page.getByTestId(QA_PAGE_HANDLES.itemDeleteButton(qaId)).click();
+  await page.getByTestId(QA_DELETE_DIALOG_HANDLES.CONFIRM_BUTTON).click();
+};

--- a/apps/web/e2e/flows/qa/fill-qa-form.flow.ts
+++ b/apps/web/e2e/flows/qa/fill-qa-form.flow.ts
@@ -1,0 +1,28 @@
+import { QA_FORM_PAGE_HANDLES } from "../../data/qa/handles";
+
+import type { Page } from "@playwright/test";
+import type { SupportedLanguages } from "@repo/shared";
+
+type FillQAFormFlowInput = {
+  language?: SupportedLanguages;
+  title?: string;
+  description?: string;
+};
+
+export const fillQAFormFlow = async (
+  page: Page,
+  { language, title, description }: FillQAFormFlowInput,
+) => {
+  if (language !== undefined) {
+    await page.getByTestId(QA_FORM_PAGE_HANDLES.LANGUAGE_SELECT).click();
+    await page.getByTestId(QA_FORM_PAGE_HANDLES.languageOption(language)).click();
+  }
+
+  if (title !== undefined) {
+    await page.getByTestId(QA_FORM_PAGE_HANDLES.TITLE_INPUT).fill(title);
+  }
+
+  if (description !== undefined) {
+    await page.getByTestId(QA_FORM_PAGE_HANDLES.DESCRIPTION_INPUT).fill(description);
+  }
+};

--- a/apps/web/e2e/flows/qa/open-create-qa-page.flow.ts
+++ b/apps/web/e2e/flows/qa/open-create-qa-page.flow.ts
@@ -1,0 +1,11 @@
+import { QA_FORM_PAGE_HANDLES, QA_PAGE_HANDLES } from "../../data/qa/handles";
+
+import { openQAPageFlow } from "./open-qa-page.flow";
+
+import type { Page } from "@playwright/test";
+
+export const openCreateQAPageFlow = async (page: Page) => {
+  await openQAPageFlow(page);
+  await page.getByTestId(QA_PAGE_HANDLES.CREATE_BUTTON).click();
+  await page.getByTestId(QA_FORM_PAGE_HANDLES.PAGE).waitFor({ state: "visible" });
+};

--- a/apps/web/e2e/flows/qa/open-edit-qa-page.flow.ts
+++ b/apps/web/e2e/flows/qa/open-edit-qa-page.flow.ts
@@ -1,0 +1,12 @@
+import { QA_FORM_PAGE_HANDLES, QA_PAGE_HANDLES } from "../../data/qa/handles";
+
+import { openQAPageFlow } from "./open-qa-page.flow";
+
+import type { Page } from "@playwright/test";
+
+export const openEditQAPageFlow = async (page: Page, qaId: string) => {
+  await openQAPageFlow(page);
+  await page.getByTestId(QA_PAGE_HANDLES.itemEditButton(qaId)).click();
+  await page.waitForURL(new RegExp(`/qa/${qaId}(\\?.*)?$`));
+  await page.getByTestId(QA_FORM_PAGE_HANDLES.PAGE).waitFor({ state: "visible" });
+};

--- a/apps/web/e2e/flows/qa/open-qa-page.flow.ts
+++ b/apps/web/e2e/flows/qa/open-qa-page.flow.ts
@@ -1,0 +1,8 @@
+import { QA_PAGE_HANDLES } from "../../data/qa/handles";
+
+import type { Page } from "@playwright/test";
+
+export const openQAPageFlow = async (page: Page) => {
+  await page.goto("/qa");
+  await page.getByTestId(QA_PAGE_HANDLES.PAGE).waitFor({ state: "visible" });
+};

--- a/apps/web/e2e/flows/qa/select-qa-language.flow.ts
+++ b/apps/web/e2e/flows/qa/select-qa-language.flow.ts
@@ -1,0 +1,9 @@
+import { QA_LANGUAGE_SELECTOR_HANDLES } from "../../data/qa/handles";
+
+import type { Page } from "@playwright/test";
+import type { SupportedLanguages } from "@repo/shared";
+
+export const selectQALanguageFlow = async (page: Page, language: SupportedLanguages) => {
+  await page.getByTestId(QA_LANGUAGE_SELECTOR_HANDLES.SELECT).click();
+  await page.getByTestId(QA_LANGUAGE_SELECTOR_HANDLES.option(language)).click();
+};

--- a/apps/web/e2e/flows/qa/submit-qa-form.flow.ts
+++ b/apps/web/e2e/flows/qa/submit-qa-form.flow.ts
@@ -1,0 +1,11 @@
+import { QA_FORM_PAGE_HANDLES } from "../../data/qa/handles";
+import { expect } from "../../fixtures/test.fixture";
+
+import type { Page } from "@playwright/test";
+
+export const submitQAFormFlow = async (page: Page) => {
+  const saveButton = page.getByTestId(QA_FORM_PAGE_HANDLES.SAVE_BUTTON);
+
+  await expect(saveButton).toBeEnabled();
+  await saveButton.click();
+};

--- a/apps/web/e2e/flows/qa/update-qa.flow.ts
+++ b/apps/web/e2e/flows/qa/update-qa.flow.ts
@@ -1,0 +1,17 @@
+import { fillQAFormFlow } from "./fill-qa-form.flow";
+import { openEditQAPageFlow } from "./open-edit-qa-page.flow";
+import { submitQAFormFlow } from "./submit-qa-form.flow";
+
+import type { Page } from "@playwright/test";
+
+type UpdateQAFlowInput = {
+  qaId: string;
+  title?: string;
+  description?: string;
+};
+
+export const updateQAFlow = async (page: Page, input: UpdateQAFlowInput) => {
+  await openEditQAPageFlow(page, input.qaId);
+  await fillQAFormFlow(page, input);
+  await submitQAFormFlow(page);
+};

--- a/apps/web/e2e/specs/qa/create-qa.spec.ts
+++ b/apps/web/e2e/specs/qa/create-qa.spec.ts
@@ -1,0 +1,39 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { QA_PAGE_HANDLES } from "../../data/qa/handles";
+import { createQAFlow } from "../../flows/qa/create-qa.flow";
+
+import { expect, test } from "./qa-test.fixture";
+
+test("admin can create a Q&A entry", async ({ cleanup, factories, withWorkerPage }) => {
+  await withWorkerPage(USER_ROLE.admin, async ({ page }) => {
+    const qaFactory = factories.createQAFactory();
+    const title = `create-qa-question-${Date.now()}`;
+    const description = `create-qa-answer-${Date.now()}`;
+    let createdQAId = "";
+
+    cleanup.add(async () => {
+      if (!createdQAId) return;
+
+      const existingQA = await qaFactory.safeGetById(createdQAId);
+
+      if (existingQA) {
+        await qaFactory.delete(createdQAId);
+      }
+    });
+
+    await createQAFlow(page, { title, description });
+    await expect(page).toHaveURL(/\/qa$/);
+
+    await expect
+      .poll(async () => {
+        const createdQA = await qaFactory.findByTitle(title);
+        createdQAId = createdQA?.id ?? "";
+
+        return createdQA?.description;
+      })
+      .toBe(description);
+
+    await expect(page.getByTestId(QA_PAGE_HANDLES.item(createdQAId))).toBeVisible();
+  });
+});

--- a/apps/web/e2e/specs/qa/delete-qa.spec.ts
+++ b/apps/web/e2e/specs/qa/delete-qa.spec.ts
@@ -1,0 +1,35 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { QA_PAGE_HANDLES } from "../../data/qa/handles";
+import { deleteQAFlow } from "../../flows/qa/delete-qa.flow";
+import { openQAPageFlow } from "../../flows/qa/open-qa-page.flow";
+
+import { expect, test } from "./qa-test.fixture";
+
+test("admin can delete a Q&A entry", async ({ cleanup, factories, withWorkerPage }) => {
+  await withWorkerPage(USER_ROLE.admin, async ({ page }) => {
+    const qaFactory = factories.createQAFactory();
+    const qa = await qaFactory.create({
+      title: `delete-qa-question-${Date.now()}`,
+      description: `delete-qa-answer-${Date.now()}`,
+    });
+    let deleted = false;
+
+    cleanup.add(async () => {
+      if (deleted) return;
+
+      const existingQA = await qaFactory.safeGetById(qa.id);
+
+      if (existingQA) {
+        await qaFactory.delete(qa.id);
+      }
+    });
+
+    await openQAPageFlow(page);
+    await deleteQAFlow(page, qa.id);
+    deleted = true;
+
+    await expect(page.getByTestId(QA_PAGE_HANDLES.item(qa.id))).toHaveCount(0);
+    await expect.poll(async () => qaFactory.safeGetById(qa.id)).toBeNull();
+  });
+});

--- a/apps/web/e2e/specs/qa/language-management.spec.ts
+++ b/apps/web/e2e/specs/qa/language-management.spec.ts
@@ -1,0 +1,59 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { createQALanguageFlow } from "../../flows/qa/create-qa-language.flow";
+import { deleteQALanguageFlow } from "../../flows/qa/delete-qa-language.flow";
+import { fillQAFormFlow } from "../../flows/qa/fill-qa-form.flow";
+import { openEditQAPageFlow } from "../../flows/qa/open-edit-qa-page.flow";
+import { selectQALanguageFlow } from "../../flows/qa/select-qa-language.flow";
+import { submitQAFormFlow } from "../../flows/qa/submit-qa-form.flow";
+
+import { expect, test } from "./qa-test.fixture";
+
+test("admin can add update and delete a Q&A translation language", async ({
+  cleanup,
+  factories,
+  withWorkerPage,
+}) => {
+  await withWorkerPage(USER_ROLE.admin, async ({ page }) => {
+    const qaFactory = factories.createQAFactory();
+    const qa = await qaFactory.create({
+      language: "en",
+      title: `qa-translation-base-${Date.now()}`,
+      description: `qa-translation-base-answer-${Date.now()}`,
+    });
+    const germanTitle = `qa-translation-de-${Date.now()}`;
+    const germanDescription = `qa-translation-de-answer-${Date.now()}`;
+
+    cleanup.add(async () => {
+      const existingQA = await qaFactory.safeGetById(qa.id);
+
+      if (existingQA) {
+        await qaFactory.delete(qa.id);
+      }
+    });
+
+    await openEditQAPageFlow(page, qa.id);
+    await createQALanguageFlow(page, "de");
+    await fillQAFormFlow(page, {
+      title: germanTitle,
+      description: germanDescription,
+    });
+    await submitQAFormFlow(page);
+
+    await expect
+      .poll(async () => qaFactory.getById(qa.id, "de"))
+      .toMatchObject({
+        title: germanTitle,
+        description: germanDescription,
+        availableLocales: expect.arrayContaining(["en", "de"]),
+      });
+
+    await openEditQAPageFlow(page, qa.id);
+    await selectQALanguageFlow(page, "de");
+    await deleteQALanguageFlow(page);
+
+    await expect
+      .poll(async () => qaFactory.getById(qa.id, "en"))
+      .toMatchObject({ availableLocales: ["en"] });
+  });
+});

--- a/apps/web/e2e/specs/qa/language-visibility.spec.ts
+++ b/apps/web/e2e/specs/qa/language-visibility.spec.ts
@@ -1,0 +1,102 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { QA_PAGE_HANDLES } from "../../data/qa/handles";
+import { openQAPageFlow } from "../../flows/qa/open-qa-page.flow";
+
+import { expect, test } from "./qa-test.fixture";
+
+test("non-manager does not see Q&A entries missing the current UI language", async ({
+  apiClient,
+  cleanup,
+  factories,
+  withWorkerPage,
+}) => {
+  const qaFactory = factories.createQAFactory();
+  let qaId = "";
+
+  cleanup.add(async () => {
+    if (!qaId) return;
+
+    await withWorkerPage(USER_ROLE.admin, async () => {
+      const existingQA = await qaFactory.safeGetById(qaId);
+
+      if (existingQA) {
+        await qaFactory.delete(qaId);
+      }
+    });
+  });
+
+  await withWorkerPage(USER_ROLE.admin, async () => {
+    const qa = await qaFactory.create({
+      language: "en",
+      title: `qa-language-en-${Date.now()}`,
+      description: `qa-language-en-answer-${Date.now()}`,
+    });
+
+    qaId = qa.id;
+  });
+
+  await withWorkerPage(USER_ROLE.student, async ({ page }) => {
+    const originalSettingsResponse = await apiClient.api.settingsControllerGetUserSettings();
+    const originalLanguage = originalSettingsResponse.data.data?.language;
+
+    try {
+      await apiClient.api.settingsControllerUpdateUserSettings({ language: "de" });
+      await openQAPageFlow(page);
+
+      await expect(page.getByTestId(QA_PAGE_HANDLES.item(qaId))).toHaveCount(0);
+    } finally {
+      if (originalLanguage) {
+        await apiClient.api.settingsControllerUpdateUserSettings({ language: originalLanguage });
+      }
+    }
+  });
+});
+
+test("admin can see Q&A entries even when the current UI language is missing", async ({
+  apiClient,
+  cleanup,
+  factories,
+  withWorkerPage,
+}) => {
+  const qaFactory = factories.createQAFactory();
+  let qaId = "";
+
+  cleanup.add(async () => {
+    if (!qaId) return;
+
+    await withWorkerPage(USER_ROLE.admin, async () => {
+      const existingQA = await qaFactory.safeGetById(qaId);
+
+      if (existingQA) {
+        await qaFactory.delete(qaId);
+      }
+    });
+  });
+
+  await withWorkerPage(USER_ROLE.admin, async () => {
+    const qa = await qaFactory.create({
+      language: "en",
+      title: `qa-language-admin-${Date.now()}`,
+      description: `qa-language-admin-answer-${Date.now()}`,
+    });
+
+    qaId = qa.id;
+  });
+
+  await withWorkerPage(USER_ROLE.admin, async ({ page }) => {
+    const originalSettingsResponse = await apiClient.api.settingsControllerGetUserSettings();
+    const originalLanguage = originalSettingsResponse.data.data?.language;
+
+    try {
+      await apiClient.api.settingsControllerUpdateUserSettings({ language: "de" });
+      await openQAPageFlow(page);
+
+      await expect(page.getByTestId(QA_PAGE_HANDLES.item(qaId))).toBeVisible();
+    } finally {
+      if (originalLanguage) {
+        await apiClient.api.settingsControllerUpdateUserSettings({ language: originalLanguage });
+      }
+    }
+  });
+});

--- a/apps/web/e2e/specs/qa/public-access.spec.ts
+++ b/apps/web/e2e/specs/qa/public-access.spec.ts
@@ -1,0 +1,72 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { QA_PAGE_HANDLES } from "../../data/qa/handles";
+import { openQAPageFlow } from "../../flows/qa/open-qa-page.flow";
+import { ensureQAFeatures } from "../../utils/qa-features";
+
+import { expect, test } from "./qa-test.fixture";
+
+test("visitor can access Q&A when public access is enabled", async ({
+  apiClient,
+  cleanup,
+  createWorkspacePage,
+  factories,
+  withWorkerPage,
+}) => {
+  await withWorkerPage(USER_ROLE.admin, async () => {
+    const restoreQAFeatures = await ensureQAFeatures(apiClient, {
+      QAEnabled: true,
+      unregisteredUserQAAccessibility: true,
+    });
+
+    cleanup.add(restoreQAFeatures);
+
+    const qaFactory = factories.createQAFactory();
+    const qa = await qaFactory.create({
+      title: `public-qa-question-${Date.now()}`,
+      description: `public-qa-answer-${Date.now()}`,
+    });
+
+    cleanup.add(async () => {
+      const existingQA = await qaFactory.safeGetById(qa.id);
+
+      if (existingQA) {
+        await qaFactory.delete(qa.id);
+      }
+    });
+
+    const { context: publicContext, page: publicPage } = await createWorkspacePage();
+
+    try {
+      await openQAPageFlow(publicPage);
+      await expect(publicPage.getByTestId(QA_PAGE_HANDLES.item(qa.id))).toBeVisible();
+    } finally {
+      await publicContext.close();
+    }
+  });
+});
+
+test("visitor cannot access Q&A when public access is disabled", async ({
+  apiClient,
+  cleanup,
+  createWorkspacePage,
+  withWorkerPage,
+}) => {
+  await withWorkerPage(USER_ROLE.admin, async () => {
+    const restoreQAFeatures = await ensureQAFeatures(apiClient, {
+      QAEnabled: true,
+      unregisteredUserQAAccessibility: false,
+    });
+
+    cleanup.add(restoreQAFeatures);
+
+    const { context: publicContext, page: publicPage } = await createWorkspacePage();
+
+    try {
+      await publicPage.goto("/qa");
+      await expect(publicPage.getByTestId(QA_PAGE_HANDLES.PAGE)).toHaveCount(0);
+    } finally {
+      await publicContext.close();
+    }
+  });
+});

--- a/apps/web/e2e/specs/qa/qa-list.spec.ts
+++ b/apps/web/e2e/specs/qa/qa-list.spec.ts
@@ -1,0 +1,39 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { QA_PAGE_HANDLES } from "../../data/qa/handles";
+import { openQAPageFlow } from "../../flows/qa/open-qa-page.flow";
+
+import { expect, test } from "./qa-test.fixture";
+
+test("admin can browse Q&A list and open an answer", async ({
+  cleanup,
+  factories,
+  withReadonlyPage,
+}) => {
+  await withReadonlyPage(USER_ROLE.admin, async ({ page }) => {
+    const qaFactory = factories.createQAFactory();
+    const qa = await qaFactory.create({
+      title: `qa-list-question-${Date.now()}`,
+      description: `qa-list-answer-${Date.now()}`,
+    });
+
+    cleanup.add(async () => {
+      const existingQA = await qaFactory.safeGetById(qa.id);
+
+      if (existingQA) {
+        await qaFactory.delete(qa.id);
+      }
+    });
+
+    await openQAPageFlow(page);
+
+    await expect(page.getByTestId(QA_PAGE_HANDLES.item(qa.id))).toBeVisible();
+    await expect(page.getByTestId(QA_PAGE_HANDLES.itemTitle(qa.id))).toContainText(qa.title ?? "");
+
+    await page.getByTestId(QA_PAGE_HANDLES.itemTrigger(qa.id)).click();
+
+    await expect(page.getByTestId(QA_PAGE_HANDLES.itemDescription(qa.id))).toHaveText(
+      qa.description ?? "",
+    );
+  });
+});

--- a/apps/web/e2e/specs/qa/qa-test.fixture.ts
+++ b/apps/web/e2e/specs/qa/qa-test.fixture.ts
@@ -1,0 +1,65 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { test as base } from "../../fixtures/test.fixture";
+import { ensureQAEnabled } from "../../utils/qa-features";
+
+import type { PageHandle } from "../../fixtures/types";
+import type { UserRole } from "~/config/userRoles";
+
+type WithAuthPageOptions = {
+  root?: boolean;
+};
+
+type WithAuthPage = (
+  role: UserRole,
+  run: (handle: PageHandle) => Promise<void>,
+  options?: WithAuthPageOptions,
+) => Promise<void>;
+
+export const test = base.extend<{
+  withReadonlyPage: WithAuthPage;
+  withWorkerPage: WithAuthPage;
+}>({
+  withWorkerPage: async (
+    {
+      apiClient,
+      withWorkerPage,
+    }: {
+      apiClient: Parameters<typeof ensureQAEnabled>[0];
+      withWorkerPage: WithAuthPage;
+    },
+    use: (value: WithAuthPage) => Promise<void>,
+  ) => {
+    await use(async (role, run, options) => {
+      await withWorkerPage(
+        role,
+        async (handle) => {
+          await ensureQAEnabled(apiClient);
+          await run(handle);
+        },
+        options,
+      );
+    });
+  },
+  withReadonlyPage: async (
+    {
+      apiClient,
+      withReadonlyPage,
+      withWorkerPage,
+    }: {
+      apiClient: Parameters<typeof ensureQAEnabled>[0];
+      withReadonlyPage: WithAuthPage;
+      withWorkerPage: WithAuthPage;
+    },
+    use: (value: WithAuthPage) => Promise<void>,
+  ) => {
+    await use(async (role, run, options) => {
+      await withWorkerPage(USER_ROLE.admin, async () => {
+        await ensureQAEnabled(apiClient);
+      });
+      await withReadonlyPage(role, run, options);
+    });
+  },
+});
+
+export { expect } from "../../fixtures/test.fixture";

--- a/apps/web/e2e/specs/qa/role-access.spec.ts
+++ b/apps/web/e2e/specs/qa/role-access.spec.ts
@@ -1,0 +1,46 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { QA_PAGE_HANDLES } from "../../data/qa/handles";
+import { openQAPageFlow } from "../../flows/qa/open-qa-page.flow";
+
+import { expect, test } from "./qa-test.fixture";
+
+test("student can read Q&A without management actions", async ({
+  cleanup,
+  factories,
+  withReadonlyPage,
+  withWorkerPage,
+}) => {
+  const qaFactory = factories.createQAFactory();
+  let qaId = "";
+
+  cleanup.add(async () => {
+    if (!qaId) return;
+
+    await withWorkerPage(USER_ROLE.admin, async () => {
+      const existingQA = await qaFactory.safeGetById(qaId);
+
+      if (existingQA) {
+        await qaFactory.delete(qaId);
+      }
+    });
+  });
+
+  await withWorkerPage(USER_ROLE.admin, async () => {
+    const qa = await qaFactory.create({
+      title: `qa-role-question-${Date.now()}`,
+      description: `qa-role-answer-${Date.now()}`,
+    });
+
+    qaId = qa.id;
+  });
+
+  await withReadonlyPage(USER_ROLE.student, async ({ page }) => {
+    await openQAPageFlow(page);
+
+    await expect(page.getByTestId(QA_PAGE_HANDLES.item(qaId))).toBeVisible();
+    await expect(page.getByTestId(QA_PAGE_HANDLES.CREATE_BUTTON)).toHaveCount(0);
+    await expect(page.getByTestId(QA_PAGE_HANDLES.itemEditButton(qaId))).toHaveCount(0);
+    await expect(page.getByTestId(QA_PAGE_HANDLES.itemDeleteButton(qaId))).toHaveCount(0);
+  });
+});

--- a/apps/web/e2e/specs/qa/settings-gate.spec.ts
+++ b/apps/web/e2e/specs/qa/settings-gate.spec.ts
@@ -1,0 +1,65 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { NAVIGATION_HANDLES } from "../../data/navigation/handles";
+import { expect, test } from "../../fixtures/test.fixture";
+import { prepareNavigationPageFlow } from "../../flows/navigation/prepare-navigation-page.flow";
+import { ensureQAFeatures, setQAFeatureState } from "../../utils/qa-features";
+
+import type { Page } from "@playwright/test";
+
+const openContentMenuIfPresent = async (page: Page) => {
+  const qaLink = page.getByTestId(NAVIGATION_HANDLES.QA_LINK);
+
+  if (await qaLink.isVisible()) return;
+
+  const contentGroup = page.getByTestId(NAVIGATION_HANDLES.CONTENT_GROUP);
+
+  if (await contentGroup.isVisible({ timeout: 5_000 }).catch(() => false)) {
+    await contentGroup.click();
+  }
+};
+
+const openContentMenu = async (page: Page) => {
+  const qaLink = page.getByTestId(NAVIGATION_HANDLES.QA_LINK);
+
+  if (await qaLink.isVisible({ timeout: 5_000 }).catch(() => false)) return;
+
+  const contentGroup = page.getByTestId(NAVIGATION_HANDLES.CONTENT_GROUP);
+
+  await expect(contentGroup).toBeVisible({ timeout: 30_000 });
+  await contentGroup.click();
+};
+
+test("admin navigation reflects whether Q&A is enabled", async ({
+  apiClient,
+  cleanup,
+  withWorkerPage,
+}) => {
+  await withWorkerPage(USER_ROLE.admin, async ({ page }) => {
+    const restoreQAFeatures = await ensureQAFeatures(apiClient, {
+      QAEnabled: false,
+      unregisteredUserQAAccessibility: false,
+    });
+
+    cleanup.add(restoreQAFeatures);
+
+    await prepareNavigationPageFlow(page);
+    await openContentMenuIfPresent(page);
+    await expect(page.getByTestId(NAVIGATION_HANDLES.QA_LINK)).toHaveCount(0);
+  });
+
+  await setQAFeatureState(apiClient, { QAEnabled: true });
+  await expect
+    .poll(async () => {
+      const response = await apiClient.api.settingsControllerGetPublicGlobalSettings();
+      return response.data.data.QAEnabled;
+    })
+    .toBe(true);
+
+  await withWorkerPage(USER_ROLE.admin, async ({ page }) => {
+    await prepareNavigationPageFlow(page);
+    await openContentMenu(page);
+
+    await expect(page.getByTestId(NAVIGATION_HANDLES.QA_LINK)).toBeVisible({ timeout: 30_000 });
+  });
+});

--- a/apps/web/e2e/specs/qa/update-qa.spec.ts
+++ b/apps/web/e2e/specs/qa/update-qa.spec.ts
@@ -1,0 +1,39 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { updateQAFlow } from "../../flows/qa/update-qa.flow";
+
+import { expect, test } from "./qa-test.fixture";
+
+test("admin can update a Q&A entry", async ({ cleanup, factories, withWorkerPage }) => {
+  await withWorkerPage(USER_ROLE.admin, async ({ page }) => {
+    const qaFactory = factories.createQAFactory();
+    const qa = await qaFactory.create({
+      title: `update-qa-original-${Date.now()}`,
+      description: `update-qa-original-answer-${Date.now()}`,
+    });
+    const updatedTitle = `update-qa-updated-${Date.now()}`;
+    const updatedDescription = `update-qa-updated-answer-${Date.now()}`;
+
+    cleanup.add(async () => {
+      const existingQA = await qaFactory.safeGetById(qa.id);
+
+      if (existingQA) {
+        await qaFactory.delete(qa.id);
+      }
+    });
+
+    await updateQAFlow(page, {
+      qaId: qa.id,
+      title: updatedTitle,
+      description: updatedDescription,
+    });
+
+    await expect(page).toHaveURL(/\/qa$/);
+    await expect
+      .poll(async () => qaFactory.getById(qa.id))
+      .toMatchObject({
+        title: updatedTitle,
+        description: updatedDescription,
+      });
+  });
+});

--- a/apps/web/e2e/utils/qa-features.ts
+++ b/apps/web/e2e/utils/qa-features.ts
@@ -1,0 +1,72 @@
+import { ALLOWED_QA_SETTINGS } from "@repo/shared";
+
+import type { FixtureApiClient } from "./api-client";
+
+type QAFeatureState = {
+  QAEnabled: boolean;
+  unregisteredUserQAAccessibility: boolean;
+};
+
+const readQAFeatureState = async (apiClient: FixtureApiClient): Promise<QAFeatureState> => {
+  const response = await apiClient.api.settingsControllerGetPublicGlobalSettings();
+
+  return {
+    QAEnabled: response.data.data.QAEnabled,
+    unregisteredUserQAAccessibility: response.data.data.unregisteredUserQAAccessibility,
+  };
+};
+
+const setQAEnabled = async (apiClient: FixtureApiClient, enabled: boolean) => {
+  const state = await readQAFeatureState(apiClient);
+
+  if (state.QAEnabled === enabled) return;
+
+  await apiClient.api.settingsControllerUpdateQaSetting(ALLOWED_QA_SETTINGS.QA_ENABLED);
+};
+
+const setPublicQAAccess = async (apiClient: FixtureApiClient, enabled: boolean) => {
+  const state = await readQAFeatureState(apiClient);
+
+  if (state.unregisteredUserQAAccessibility === enabled) return;
+  if (!state.QAEnabled) {
+    await apiClient.api.settingsControllerUpdateQaSetting(ALLOWED_QA_SETTINGS.QA_ENABLED);
+  }
+
+  await apiClient.api.settingsControllerUpdateQaSetting(
+    ALLOWED_QA_SETTINGS.UNREGISTERED_USER_QA_ACCESSIBILITY,
+  );
+};
+
+export const setQAFeatureState = async (
+  apiClient: FixtureApiClient,
+  desiredState: Partial<QAFeatureState>,
+) => {
+  if (desiredState.QAEnabled === true) {
+    await setQAEnabled(apiClient, true);
+  }
+
+  if (desiredState.unregisteredUserQAAccessibility !== undefined) {
+    await setPublicQAAccess(apiClient, desiredState.unregisteredUserQAAccessibility);
+  }
+
+  if (desiredState.QAEnabled === false) {
+    await setQAEnabled(apiClient, false);
+  }
+};
+
+export const ensureQAEnabled = async (apiClient: FixtureApiClient) => {
+  await setQAFeatureState(apiClient, { QAEnabled: true });
+};
+
+export const ensureQAFeatures = async (
+  apiClient: FixtureApiClient,
+  desiredState: Partial<QAFeatureState>,
+) => {
+  const initialState = await readQAFeatureState(apiClient);
+
+  await setQAFeatureState(apiClient, desiredState);
+
+  return async () => {
+    await setQAFeatureState(apiClient, initialState);
+  };
+};


### PR DESCRIPTION
<!--
 1. Make sure you have correct branch name i.e. `ab_prefix_123_task_name`, where `123` is a issue ID, and `ab` is an author
 2. Make sure you have meaningful title related to task with correct prefix: feat/fix/chore/style/docs/refactor
 3. Reference multiple issues in one PR by listing them in the issues section
 4. Make sure all necessary sections are filled, remove obsolete sections
 5. Do a self review first
 6. Check if your PR includes only code related to your task
 7. `Notes` is used for additional info but also to notify if any action is required
-->

## Issue(s)
[1354](https://github.com/Selleo/mentingo/issues/1354)

## Overview
  <!--
  General description what it does
  -->

  Adds end-to-end coverage for the Q&A module.

  - Adds stable Q&A test handles across the Q&A list, form, language selector, delete dialogs,
    settings switches, and navigation item.
  - Adds a QAFactory for API-backed Q&A setup, lookup, update, translation, and cleanup.
  - Adds reusable Q&A E2E flows for opening pages, creating, updating, deleting, selecting/
    creating/deleting languages, and submitting forms.
  - Adds Q&A-specific test fixture support that enables Q&A for relevant specs without redundant
    per-test setup.
  - Covers Q&A list/read, create, update, delete, public access, role access, language visibility
    rules, translation management, and navigation/settings gate behavior.

  ## Business Value
  <!--
  Why are we doing this from a business perspective? What value does this bring to the project
  from end-users perspective?
  -->

  This improves confidence that learners and admins can reliably use the Q&A section across core
  scenarios, permissions, public access settings, and supported languages. It reduces regression
  risk around Q&A management, visibility, and localization behavior while keeping tests reusable
  and stable for future Q&A changes.
