### PR TITLE
test: extend coverage with support mode functionality

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -295,7 +295,7 @@ jobs:
             IdentityFile ~/.ssh/id_ecdsa
             StrictHostKeyChecking no
             ControlMaster auto
-            ControlPersist 10m
+            ControlPersist 15m
             ControlPath ~/.ssh/control-%r@%h:%p
           EOF
           chmod 600 ~/.ssh/config
@@ -306,7 +306,8 @@ jobs:
 
           ssh -o BatchMode=yes uncloud-host true
 
-          uc ps --connect "ssh+cli://uncloud-host" > /dev/null 2>&1
+          uc ls --connect "ssh+cli://uncloud-host" > /dev/null 2>&1
+
           if [ $? -ne 0 ]; then
             echo "Failed to connect to server"
             exit 1
@@ -343,4 +344,4 @@ jobs:
         run: |
           set -euo pipefail
 
-          ssh -i ~/.ssh/id_ecdsa uncloud-host "docker image prune -f -a"
+          ssh uncloud-host "docker image prune -f -a"

--- a/apps/web/app/modules/SupportMode/SupportModeBanner.tsx
+++ b/apps/web/app/modules/SupportMode/SupportModeBanner.tsx
@@ -5,6 +5,8 @@ import { useExitSupportMode } from "~/api/mutations/useExitSupportMode";
 import { useCurrentUser } from "~/api/queries";
 import { Button } from "~/components/ui/button";
 
+import { SUPPORT_MODE_HANDLES } from "../../../e2e/data/support-mode/handles";
+
 const MINUTE = 60_000;
 
 const getMinutesLeft = (expiresAt?: string) => {
@@ -45,15 +47,19 @@ export function SupportModeBanner() {
   }
 
   return (
-    <div className="bg-warning-500 text-warning-950 px-4 py-2 text-sm flex items-center justify-between gap-3 border-b border-warning-600">
-      <p>{t("supportMode.banner.message")}</p>
+    <div
+      data-testid={SUPPORT_MODE_HANDLES.BANNER}
+      className="bg-warning-500 text-warning-950 px-4 py-2 text-sm flex items-center justify-between gap-3 border-b border-warning-600"
+    >
+      <p data-testid={SUPPORT_MODE_HANDLES.MESSAGE}>{t("supportMode.banner.message")}</p>
       <div className="flex items-center gap-3">
-        <span>
+        <span data-testid={SUPPORT_MODE_HANDLES.TIME_LEFT}>
           {t("supportMode.banner.timeLeft", "{{minutes}} min left", {
             minutes: minutesLeft,
           })}
         </span>
         <Button
+          data-testid={SUPPORT_MODE_HANDLES.EXIT_BUTTON}
           size="sm"
           className="bg-warning-600 hover:bg-warning-700 text-warning-50 border border-warning-700"
           onClick={() => exitSupportMode()}

--- a/apps/web/e2e/data/support-mode/handles.ts
+++ b/apps/web/e2e/data/support-mode/handles.ts
@@ -1,0 +1,6 @@
+export const SUPPORT_MODE_HANDLES = {
+  BANNER: "support-mode-banner",
+  MESSAGE: "support-mode-banner-message",
+  TIME_LEFT: "support-mode-banner-time-left",
+  EXIT_BUTTON: "support-mode-banner-exit-button",
+} as const;

--- a/apps/web/e2e/fixtures/test.fixture.ts
+++ b/apps/web/e2e/fixtures/test.fixture.ts
@@ -22,6 +22,7 @@ import {
 } from "../utils/auth-email";
 import { extractLinkFromMailhogMessage, waitForMailhogMessage } from "../utils/mailhog";
 import { markAllOnboardingComplete } from "../utils/onboarding";
+import { buildLmsLocalhostTenantHost } from "../utils/tenant-host";
 
 import { login } from "./auth.actions";
 import { cleanupFixture } from "./cleanup.fixture";
@@ -129,13 +130,11 @@ const createIsolatedTenantInput = (
   }
 
   const slug = randomUUID().slice(0, 8);
-  const baseUrl = new URL(baseURL);
-  const port = baseUrl.port ? `:${baseUrl.port}` : "";
 
   return {
     ...input,
     name: input?.name ?? `Isolated Workspace ${slug}`,
-    host: `${baseUrl.protocol}//${"e2e-tenant"}-${slug}.lms.localhost${port}`,
+    host: buildLmsLocalhostTenantHost(baseURL, `e2e-tenant-${slug}`),
     adminEmail: input?.adminEmail ?? `e2e-admin-${slug}@example.com`,
     adminFirstName: input?.adminFirstName ?? "Tenant",
     adminLastName: input?.adminLastName ?? "Admin",

--- a/apps/web/e2e/fixtures/test.fixture.ts
+++ b/apps/web/e2e/fixtures/test.fixture.ts
@@ -173,10 +173,12 @@ const addWorkspaceInitScript = async (context: BrowserContext, origin: string) =
   await context.addInitScript(
     ({ apiUrl, appUrl }: { apiUrl: string; appUrl: string }) => {
       const targetWindow = window as Window & { ENV?: Record<string, string> };
+      const currentOrigin = window.location.origin;
+
       targetWindow.ENV = {
         ...(targetWindow.ENV ?? {}),
-        VITE_API_URL: apiUrl,
-        VITE_APP_URL: appUrl,
+        VITE_API_URL: currentOrigin || apiUrl,
+        VITE_APP_URL: currentOrigin || appUrl,
       };
     },
     { apiUrl: origin, appUrl: origin },

--- a/apps/web/e2e/flows/tenants/enter-support-mode-from-list.flow.ts
+++ b/apps/web/e2e/flows/tenants/enter-support-mode-from-list.flow.ts
@@ -1,0 +1,7 @@
+import { TENANTS_PAGE_HANDLES } from "../../data/tenants/handles";
+
+import type { Page } from "@playwright/test";
+
+export const enterSupportModeFromListFlow = async (page: Page, tenantId: string) => {
+  await page.getByTestId(TENANTS_PAGE_HANDLES.supportModeButton(tenantId)).click();
+};

--- a/apps/web/e2e/specs/tenants/support-mode.spec.ts
+++ b/apps/web/e2e/specs/tenants/support-mode.spec.ts
@@ -1,0 +1,109 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { NAVIGATION_HANDLES } from "../../data/navigation/handles";
+import { SUPPORT_MODE_HANDLES } from "../../data/support-mode/handles";
+import { TENANTS_PAGE_HANDLES } from "../../data/tenants/handles";
+import { expect, test } from "../../fixtures/test.fixture";
+import { enterSupportModeFromListFlow } from "../../flows/tenants/enter-support-mode-from-list.flow";
+import { filterTenantsFlow } from "../../flows/tenants/filter-tenants.flow";
+import { openTenantsPageFlow } from "../../flows/tenants/open-tenants-page.flow";
+
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const requireOrigin = (origin?: string) => {
+  if (!origin) {
+    throw new Error("Expected authenticated page fixture to provide an origin");
+  }
+
+  return origin;
+};
+
+test("managing admin can enter support mode and see the support banner", async ({
+  cleanup,
+  factories,
+  withWorkerPage,
+}) => {
+  await withWorkerPage(
+    USER_ROLE.admin,
+    async ({ origin, page }) => {
+      const tenantFactory = factories.createTenantFactory();
+      const tenantSlug = Date.now();
+      const tenantName = `support-mode-${tenantSlug}`;
+      const appProtocol = new URL(requireOrigin(origin)).protocol;
+      const tenant = await tenantFactory.create({
+        name: tenantName,
+        host: `${appProtocol}//support-mode-${tenantSlug}.lms.localhost`,
+      });
+
+      cleanup.add(async () => {
+        await tenantFactory.deactivate(tenant.id);
+      });
+
+      await openTenantsPageFlow(page);
+      await filterTenantsFlow(page, tenantName);
+
+      const supportOrigin = new URL(tenant.host).origin;
+
+      await enterSupportModeFromListFlow(page, tenant.id);
+
+      await expect(page.getByTestId(SUPPORT_MODE_HANDLES.BANNER)).toBeVisible();
+      await expect(page).toHaveURL(new RegExp(`^${escapeRegExp(supportOrigin)}/courses$`));
+      await expect(page.getByTestId(SUPPORT_MODE_HANDLES.MESSAGE)).toBeVisible();
+      await expect(page.getByTestId(SUPPORT_MODE_HANDLES.TIME_LEFT)).toBeVisible();
+      await expect(page.getByTestId(SUPPORT_MODE_HANDLES.EXIT_BUTTON)).toBeVisible();
+
+      await page.getByTestId(NAVIGATION_HANDLES.PROFILE_FOOTER).click();
+      await expect(page.getByTestId(NAVIGATION_HANDLES.PROFILE_LINK)).toHaveCount(0);
+    },
+    { root: true },
+  );
+});
+
+test("support mode blocks super-admin access and can be exited", async ({
+  cleanup,
+  factories,
+  withWorkerPage,
+}) => {
+  await withWorkerPage(
+    USER_ROLE.admin,
+    async ({ origin, page }) => {
+      const tenantFactory = factories.createTenantFactory();
+      const tenantSlug = Date.now();
+      const tenantName = `support-mode-exit-${tenantSlug}`;
+      const appProtocol = new URL(requireOrigin(origin)).protocol;
+      const tenant = await tenantFactory.create({
+        name: tenantName,
+        host: `${appProtocol}//support-mode-exit-${tenantSlug}.lms.localhost`,
+      });
+
+      cleanup.add(async () => {
+        await tenantFactory.deactivate(tenant.id);
+      });
+
+      await openTenantsPageFlow(page);
+      await filterTenantsFlow(page, tenantName);
+
+      const supportOrigin = new URL(tenant.host).origin;
+      await enterSupportModeFromListFlow(page, tenant.id);
+
+      await expect(page.getByTestId(SUPPORT_MODE_HANDLES.BANNER)).toBeVisible();
+      await expect(page).toHaveURL(new RegExp(`^${escapeRegExp(supportOrigin)}/courses$`));
+      await expect(page.getByTestId(NAVIGATION_HANDLES.SUPER_ADMIN_GROUP)).toHaveCount(0);
+
+      const originalOrigin = requireOrigin(origin);
+      const supportExitNavigation = page.waitForURL(
+        new RegExp(`^${escapeRegExp(originalOrigin)}/`),
+      );
+      await page.getByTestId(SUPPORT_MODE_HANDLES.EXIT_BUTTON).click();
+      await supportExitNavigation;
+
+      await expect(page.getByTestId(SUPPORT_MODE_HANDLES.BANNER)).toHaveCount(0);
+
+      await openTenantsPageFlow(page);
+
+      await expect(page).toHaveURL(/\/super-admin\/tenants$/);
+      await expect(page.getByTestId(TENANTS_PAGE_HANDLES.PAGE)).toBeVisible();
+    },
+    { root: true },
+  );
+});

--- a/apps/web/e2e/specs/tenants/support-mode.spec.ts
+++ b/apps/web/e2e/specs/tenants/support-mode.spec.ts
@@ -7,6 +7,7 @@ import { expect, test } from "../../fixtures/test.fixture";
 import { enterSupportModeFromListFlow } from "../../flows/tenants/enter-support-mode-from-list.flow";
 import { filterTenantsFlow } from "../../flows/tenants/filter-tenants.flow";
 import { openTenantsPageFlow } from "../../flows/tenants/open-tenants-page.flow";
+import { buildLmsLocalhostTenantHost } from "../../utils/tenant-host";
 
 const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
@@ -29,10 +30,9 @@ test("managing admin can enter support mode and see the support banner", async (
       const tenantFactory = factories.createTenantFactory();
       const tenantSlug = Date.now();
       const tenantName = `support-mode-${tenantSlug}`;
-      const appProtocol = new URL(requireOrigin(origin)).protocol;
       const tenant = await tenantFactory.create({
         name: tenantName,
-        host: `${appProtocol}//support-mode-${tenantSlug}.lms.localhost`,
+        host: buildLmsLocalhostTenantHost(requireOrigin(origin), tenantName),
       });
 
       cleanup.add(async () => {
@@ -70,10 +70,9 @@ test("support mode blocks super-admin access and can be exited", async ({
       const tenantFactory = factories.createTenantFactory();
       const tenantSlug = Date.now();
       const tenantName = `support-mode-exit-${tenantSlug}`;
-      const appProtocol = new URL(requireOrigin(origin)).protocol;
       const tenant = await tenantFactory.create({
         name: tenantName,
-        host: `${appProtocol}//support-mode-exit-${tenantSlug}.lms.localhost`,
+        host: buildLmsLocalhostTenantHost(requireOrigin(origin), tenantName),
       });
 
       cleanup.add(async () => {

--- a/apps/web/e2e/utils/tenant-host.ts
+++ b/apps/web/e2e/utils/tenant-host.ts
@@ -1,0 +1,6 @@
+export const buildLmsLocalhostTenantHost = (baseURL: string, subdomain: string) => {
+  const baseUrl = new URL(baseURL);
+  const port = baseUrl.port ? `:${baseUrl.port}` : "";
+
+  return `${baseUrl.protocol}//${subdomain}.lms.localhost${port}`;
+};


### PR DESCRIPTION
## Issue(s)
- #1354 

## Overview
Adds end-to-end coverage for support mode in the web app. The new spec verifies that a managing admin can enter support mode from the tenants list, see the support banner, and exit support mode back to the super-admin area. The banner now also exposes stable test handles for the message, remaining time, and exit action.

## Business Value
This reduces the risk of regressions in a critical admin flow. Support mode is used to switch into a tenant context for troubleshooting, so validating entry, banner state, and exit behavior helps keep the workflow reliable for support and operations teams.

## Notes

- [x] Fired up e2e tests and got a positive result
