### PR TITLE
test: extend coverage with learning-based activities

### DIFF
--- a/apps/web/app/modules/Courses/Lesson/AiMentorLesson/AiMentorLesson.tsx
+++ b/apps/web/app/modules/Courses/Lesson/AiMentorLesson/AiMentorLesson.tsx
@@ -28,6 +28,8 @@ import { LessonForm } from "~/modules/Courses/Lesson/AiMentorLesson/components/L
 import RetakeModal from "~/modules/Courses/Lesson/AiMentorLesson/components/RetakeModal";
 import { stripHtmlTags } from "~/utils/stripHtmlTags";
 
+import { LEARNING_HANDLES } from "../../../../../e2e/data/learning/handles";
+
 import type { GetLessonByIdResponse } from "~/api/generated-api";
 import type { LessonPreviewUser } from "~/modules/Courses/Lesson/types";
 
@@ -191,6 +193,7 @@ const AiMentorLesson = ({ lesson, lessonLoading, previewUser }: AiMentorLessonPr
 
       {!lessonLoading && hasTaskDescription && (
         <Accordion
+          data-testid={LEARNING_HANDLES.AI_MENTOR_TASK_DESCRIPTION}
           type="single"
           collapsible
           defaultValue={isPreviewMode ? "" : "task"}
@@ -228,6 +231,7 @@ const AiMentorLesson = ({ lesson, lessonLoading, previewUser }: AiMentorLessonPr
       )}
 
       <div
+        data-testid={LEARNING_HANDLES.AI_MENTOR_MESSAGES}
         ref={messagesContainerRef}
         className="flex w-full grow max-w-full relative flex-col gap-y-4 overflow-y-scroll"
       >
@@ -272,12 +276,19 @@ const AiMentorLesson = ({ lesson, lessonLoading, previewUser }: AiMentorLessonPr
       <hr className="mt-4 w-full border-t border-[#EDEDED]" />
       <div className="mt-4 flex w-full justify-center">
         {isThreadActive && !isJudgePending ? (
-          <Button variant="primary" size="lg" className="max-w-fit gap-2" onClick={handleJudge}>
+          <Button
+            data-testid={LEARNING_HANDLES.AI_MENTOR_CHECK_BUTTON}
+            variant="primary"
+            size="lg"
+            className="max-w-fit gap-2"
+            onClick={handleJudge}
+          >
             {t("studentCourseView.lesson.aiMentorLesson.check")}
             <Icon name="ArrowRight" className="size-5" />
           </Button>
         ) : (
           <Button
+            data-testid={LEARNING_HANDLES.AI_MENTOR_RETAKE_BUTTON}
             variant="outline"
             size="lg"
             className="max-w-fit gap-2"

--- a/apps/web/app/modules/Courses/Lesson/AiMentorLesson/components/LessonComposerCenterContent.tsx
+++ b/apps/web/app/modules/Courses/Lesson/AiMentorLesson/components/LessonComposerCenterContent.tsx
@@ -12,6 +12,7 @@ type LessonComposerCenterContentProps = {
   voiceLevel: number;
   onInputChange: (e: ChangeEvent<HTMLTextAreaElement>) => void;
   onSubmit: () => void;
+  textInputTestId?: string;
 };
 
 export function LessonComposerCenterContent({
@@ -21,6 +22,7 @@ export function LessonComposerCenterContent({
   voiceLevel,
   onInputChange,
   onSubmit,
+  textInputTestId,
 }: LessonComposerCenterContentProps) {
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
@@ -61,6 +63,7 @@ export function LessonComposerCenterContent({
           <motion.textarea
             key="text-content"
             ref={textareaRef}
+            data-testid={textInputTestId}
             value={input}
             onChange={onInputChange}
             onKeyDown={(e) => {

--- a/apps/web/app/modules/Courses/Lesson/AiMentorLesson/components/LessonComposerRightControls.tsx
+++ b/apps/web/app/modules/Courses/Lesson/AiMentorLesson/components/LessonComposerRightControls.tsx
@@ -18,6 +18,7 @@ type LessonComposerRightControlsProps = {
   toggleVoiceInputLabel: string;
   startVoiceMentorLabel: string;
   stopVoiceRecordingLabel: string;
+  primaryActionTestId?: string;
 };
 
 export function LessonComposerRightControls({
@@ -34,6 +35,7 @@ export function LessonComposerRightControls({
   toggleVoiceInputLabel,
   startVoiceMentorLabel,
   stopVoiceRecordingLabel,
+  primaryActionTestId,
 }: LessonComposerRightControlsProps) {
   const buttonMode =
     isVoiceMode || isVoiceMentorMode
@@ -69,6 +71,7 @@ export function LessonComposerRightControls({
       </div>
 
       <Button
+        data-testid={primaryActionTestId}
         type="button"
         variant="primary"
         size="sm"

--- a/apps/web/app/modules/Courses/Lesson/AiMentorLesson/components/LessonForm.tsx
+++ b/apps/web/app/modules/Courses/Lesson/AiMentorLesson/components/LessonForm.tsx
@@ -11,6 +11,8 @@ import { useTranscription } from "~/modules/Voice/hooks/useTranscription";
 import { useVoiceMentor } from "~/modules/Voice/hooks/useVoiceMentor";
 import { useVoiceModeUIState } from "~/modules/Voice/hooks/useVoiceModeUIState";
 
+import { LEARNING_HANDLES } from "../../../../../../e2e/data/learning/handles";
+
 import type { Message } from "@ai-sdk/react";
 import type { ChangeEvent, Dispatch, SetStateAction } from "react";
 
@@ -229,6 +231,7 @@ export const LessonForm = ({
               voiceLevel={voiceLevel}
               onInputChange={handleInputChange as (e: ChangeEvent<HTMLTextAreaElement>) => void}
               onSubmit={handleSubmit}
+              textInputTestId={LEARNING_HANDLES.AI_MENTOR_MESSAGE_INPUT}
             />
           </div>
 
@@ -258,6 +261,7 @@ export const LessonForm = ({
               stopVoiceRecordingLabel={t(
                 "studentCourseView.lesson.aiMentorLesson.stopVoiceRecording",
               )}
+              primaryActionTestId={LEARNING_HANDLES.AI_MENTOR_MESSAGE_ACTION_BUTTON}
             />
           </div>
 

--- a/apps/web/app/modules/Courses/Lesson/LessonContent.tsx
+++ b/apps/web/app/modules/Courses/Lesson/LessonContent.tsx
@@ -18,6 +18,8 @@ import { useCourseAccessProvider } from "~/modules/Courses/context/CourseAccessP
 import { getLessonTypeTranslationKey } from "~/modules/Courses/CourseView/lessonTypes";
 import { useLanguageStore } from "~/modules/Dashboard/Settings/Language/LanguageStore";
 
+import { LEARNING_HANDLES } from "../../../../e2e/data/learning/handles";
+
 import { LessonContentRenderer } from "./LessonContentRenderer";
 import { isNextBlocked, isPreviousBlocked } from "./utils";
 
@@ -231,9 +233,11 @@ export const LessonContent = ({
               <div className="flex items-center gap-x-2">
                 <p className="body-sm-md text-neutral-800">
                   {t("studentLessonView.other.lesson")}{" "}
-                  <span data-testid="current-lesson-number">{lesson.displayOrder}</span>/
-                  <span data-testid="lessons-count">{lessonsAmount}</span> –{" "}
-                  <span data-testid="lesson-type">
+                  <span data-testid={LEARNING_HANDLES.CURRENT_LESSON_NUMBER}>
+                    {lesson.displayOrder}
+                  </span>
+                  /<span data-testid={LEARNING_HANDLES.LESSONS_COUNT}>{lessonsAmount}</span> –{" "}
+                  <span data-testid={LEARNING_HANDLES.LESSON_TYPE}>
                     {t(getLessonTypeTranslationKey(lesson.type), { defaultValue: lesson.type })}
                   </span>
                 </p>
@@ -250,7 +254,12 @@ export const LessonContent = ({
                   </Tooltip>
                 )}
               </div>
-              <p className="h4 text-neutral-950 break-words min-w-0">{lesson.title}</p>
+              <p
+                data-testid={LEARNING_HANDLES.LESSON_TITLE}
+                className="h4 text-neutral-950 break-words min-w-0"
+              >
+                {lesson.title}
+              </p>
             </div>
             {!isPreviewMode && (
               <div className="mt-4 flex flex-col gap-2 sm:ml-8 sm:mt-0 sm:items-end">
@@ -272,7 +281,7 @@ export const LessonContent = ({
                     <Icon name="ArrowRight" className="h-auto w-4 rotate-180" />
                   </Button>
                   <Button
-                    data-testid="next-lesson-button"
+                    data-testid={LEARNING_HANDLES.NEXT_LESSON_BUTTON}
                     variant="outline"
                     disabled={isNextDisabled}
                     className="w-full gap-x-1 sm:w-auto disabled:opacity-0"

--- a/apps/web/app/modules/Courses/Lesson/LessonSidebar.tsx
+++ b/apps/web/app/modules/Courses/Lesson/LessonSidebar.tsx
@@ -22,6 +22,7 @@ import {
   LessonTypesIcons,
 } from "~/modules/Courses/CourseView/lessonTypes";
 
+import { LEARNING_HANDLES } from "../../../../e2e/data/learning/handles";
 import { getChaptersWithAccess } from "../utils";
 
 import { LESSON_PROGRESS_STATUSES } from "./types";
@@ -71,7 +72,10 @@ export const LessonSidebar = ({ course, lessonId }: LessonSidebarProps) => {
   if (!course) return null;
 
   return (
-    <div className="sticky top-0 h-auto max-h-fit min-h-screen overflow-y-scroll rounded-lg bg-white">
+    <div
+      data-testid={LEARNING_HANDLES.LESSON_SIDEBAR}
+      className="sticky top-0 h-auto max-h-fit min-h-screen overflow-y-scroll rounded-lg bg-white"
+    >
       <div className="flex flex-col gap-y-12">
         <div className="flex flex-col gap-y-4 px-8 pt-8">
           <div className="flex justify-between">
@@ -144,6 +148,7 @@ export const LessonSidebar = ({ course, lessonId }: LessonSidebarProps) => {
                             <Link
                               key={id}
                               to={isBlocked ? "#" : `/course/${course.slug}/lesson/${id}`}
+                              data-testid={LEARNING_HANDLES.lessonSidebarLessonItem(id)}
                               className={cn("flex gap-x-4 px-6 py-2 hover:bg-neutral-50 pl-10", {
                                 "cursor-not-allowed hover:bg-transparent opacity-30": isBlocked,
                                 "border-l-2 border-l-primary-600 bg-primary-50 last:rounded-es-lg":
@@ -151,6 +156,11 @@ export const LessonSidebar = ({ course, lessonId }: LessonSidebarProps) => {
                               })}
                             >
                               <Badge
+                                data-testid={
+                                  isBlocked
+                                    ? LEARNING_HANDLES.lessonSidebarBlockedIndicator(id)
+                                    : undefined
+                                }
                                 variant="icon"
                                 icon={
                                   isPreviewMode

--- a/apps/web/app/modules/Courses/Lesson/Quiz.tsx
+++ b/apps/web/app/modules/Courses/Lesson/Quiz.tsx
@@ -21,6 +21,7 @@ import { toast } from "~/components/ui/use-toast";
 import { useCourseAccessProvider } from "~/modules/Courses/context/CourseAccessProvider";
 import { useLanguageStore } from "~/modules/Dashboard/Settings/Language/LanguageStore";
 
+import { LEARNING_HANDLES } from "../../../../e2e/data/learning/handles";
 import { QuizContextProvider } from "../components/QuizContextProvider";
 
 import { Questions } from "./Questions";
@@ -118,6 +119,7 @@ export const Quiz = ({ lesson, userId }: QuizProps) => {
         isQuizSubmitted={isUserSubmittedAnswer}
       >
         <form
+          data-testid={LEARNING_HANDLES.QUIZ_FORM}
           className="flex w-full flex-col gap-y-4"
           onSubmit={methods.handleSubmit(handleOnSubmit, () => {
             toast({
@@ -129,13 +131,15 @@ export const Quiz = ({ lesson, userId }: QuizProps) => {
           {!isPreviewMode && (
             <div className="flex w-full justify-between">
               <span className="group relative">
-                {t("studentLessonView.other.score", {
-                  score: lesson.quizDetails?.score ?? 0,
-                  correct: lesson.quizDetails?.correctAnswerCount ?? 0,
-                  questionsNumber: questions.length,
-                })}
+                <span data-testid={LEARNING_HANDLES.QUIZ_SCORE}>
+                  {t("studentLessonView.other.score", {
+                    score: lesson.quizDetails?.score ?? 0,
+                    correct: lesson.quizDetails?.correctAnswerCount ?? 0,
+                    questionsNumber: questions.length,
+                  })}
+                </span>
               </span>
-              <span>
+              <span data-testid={LEARNING_HANDLES.QUIZ_PASSING_THRESHOLD}>
                 {t("studentLessonView.other.passingThreshold", {
                   threshold: lesson.thresholdScore,
                   correct: requiredCorrect,
@@ -158,6 +162,7 @@ export const Quiz = ({ lesson, userId }: QuizProps) => {
                     <TooltipTrigger asChild>
                       <div className="inline-block">
                         <Button
+                          data-testid={LEARNING_HANDLES.QUIZ_RETAKE_BUTTON}
                           variant="outline"
                           type="button"
                           onClick={handleRetake}
@@ -192,6 +197,7 @@ export const Quiz = ({ lesson, userId }: QuizProps) => {
                 </TooltipProvider>
               </div>
               <Button
+                data-testid={LEARNING_HANDLES.QUIZ_SUBMIT_BUTTON}
                 type="submit"
                 className="flex items-center gap-x-2"
                 disabled={isUserSubmittedAnswer}

--- a/apps/web/e2e/data/learning/handles.ts
+++ b/apps/web/e2e/data/learning/handles.ts
@@ -1,0 +1,22 @@
+export const LEARNING_HANDLES = {
+  CURRENT_LESSON_NUMBER: "learning-current-lesson-number",
+  LESSONS_COUNT: "learning-lessons-count",
+  LESSON_TYPE: "learning-lesson-type",
+  LESSON_TITLE: "learning-lesson-title",
+  NEXT_LESSON_BUTTON: "learning-next-lesson-button",
+  QUIZ_FORM: "learning-quiz-form",
+  QUIZ_SCORE: "learning-quiz-score",
+  QUIZ_PASSING_THRESHOLD: "learning-quiz-passing-threshold",
+  QUIZ_SUBMIT_BUTTON: "learning-quiz-submit-button",
+  QUIZ_RETAKE_BUTTON: "learning-quiz-retake-button",
+  AI_MENTOR_TASK_DESCRIPTION: "learning-ai-mentor-task-description",
+  AI_MENTOR_MESSAGES: "learning-ai-mentor-messages",
+  AI_MENTOR_MESSAGE_INPUT: "learning-ai-mentor-message-input",
+  AI_MENTOR_MESSAGE_ACTION_BUTTON: "learning-ai-mentor-message-action-button",
+  AI_MENTOR_CHECK_BUTTON: "learning-ai-mentor-check-button",
+  AI_MENTOR_RETAKE_BUTTON: "learning-ai-mentor-retake-button",
+  LESSON_SIDEBAR: "learning-lesson-sidebar",
+  lessonSidebarLessonItem: (lessonId: string) => `learning-lesson-sidebar-item-${lessonId}`,
+  lessonSidebarBlockedIndicator: (lessonId: string) =>
+    `learning-lesson-sidebar-blocked-indicator-${lessonId}`,
+} as const;

--- a/apps/web/e2e/flows/learning/answer-all-rendered-quiz-question-types.flow.ts
+++ b/apps/web/e2e/flows/learning/answer-all-rendered-quiz-question-types.flow.ts
@@ -1,0 +1,42 @@
+import { expect, type Page } from "@playwright/test";
+
+type AnswerAllRenderedQuizQuestionTypesFlowInput = {
+  dndBlankAnswer: string;
+  textBlankAnswer: string;
+};
+
+export const answerAllRenderedQuizQuestionTypesFlow = async (
+  page: Page,
+  { dndBlankAnswer, textBlankAnswer }: AnswerAllRenderedQuizQuestionTypesFlowInput,
+) => {
+  await page.locator('input[name^="singleAnswerQuestions."]').first().click();
+  await page.locator('input[name^="multiAnswerQuestions."]').nth(0).click();
+  await page.locator('input[name^="multiAnswerQuestions."]').nth(1).click();
+  await page.locator('input[name^="trueOrFalseQuestions."][value="true"]').first().click();
+  await page.locator('input[name^="trueOrFalseQuestions."][value="false"]').nth(1).click();
+  await page.locator('input[name^="photoQuestionSingleChoice."]').first().click();
+  await page.locator('input[name^="photoQuestionMultipleChoice."]').nth(0).click();
+  await page.locator('input[name^="photoQuestionMultipleChoice."]').nth(1).click();
+  await page.getByTestId("text-blank-1").fill(textBlankAnswer);
+
+  const dndWord = page.getByText(dndBlankAnswer, { exact: true });
+  const dndBlank = page.getByTestId("1");
+  await dndWord.scrollIntoViewIfNeeded();
+  await dndBlank.scrollIntoViewIfNeeded();
+
+  const wordBox = await dndWord.boundingBox();
+  const blankBox = await dndBlank.boundingBox();
+
+  if (!wordBox || !blankBox) throw new Error("DND quiz answer or blank was not visible");
+
+  await page.mouse.move(wordBox.x + wordBox.width / 2, wordBox.y + wordBox.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(blankBox.x + blankBox.width / 2, blankBox.y + blankBox.height / 2, {
+    steps: 12,
+  });
+  await page.mouse.up();
+  await expect(dndBlank).toContainText(dndBlankAnswer);
+
+  await page.getByTestId("brief-response").fill("Brief answer");
+  await page.getByTestId("detailed-response").fill("Detailed answer");
+};

--- a/apps/web/e2e/flows/learning/assert-ai-mentor-entry.flow.ts
+++ b/apps/web/e2e/flows/learning/assert-ai-mentor-entry.flow.ts
@@ -1,0 +1,11 @@
+import { expect, type Page } from "@playwright/test";
+
+import { LEARNING_HANDLES } from "../../data/learning/handles";
+
+export const assertAiMentorEntryFlow = async (page: Page) => {
+  await expect(page.getByTestId(LEARNING_HANDLES.AI_MENTOR_TASK_DESCRIPTION)).toBeVisible();
+  await expect(page.getByTestId(LEARNING_HANDLES.AI_MENTOR_MESSAGES)).toBeVisible();
+  await expect(page.getByTestId(LEARNING_HANDLES.AI_MENTOR_MESSAGE_INPUT)).toBeVisible();
+  await expect(page.getByTestId(LEARNING_HANDLES.AI_MENTOR_MESSAGE_ACTION_BUTTON)).toBeVisible();
+  await expect(page.getByTestId(LEARNING_HANDLES.AI_MENTOR_CHECK_BUTTON)).toBeVisible();
+};

--- a/apps/web/e2e/flows/learning/assert-blocked-lesson-item.flow.ts
+++ b/apps/web/e2e/flows/learning/assert-blocked-lesson-item.flow.ts
@@ -1,0 +1,10 @@
+import { expect, type Page } from "@playwright/test";
+
+import { LEARNING_HANDLES } from "../../data/learning/handles";
+
+export const assertBlockedLessonItemFlow = async (page: Page, lessonId: string) => {
+  await expect(page.getByTestId(LEARNING_HANDLES.lessonSidebarLessonItem(lessonId))).toBeVisible();
+  await expect(
+    page.getByTestId(LEARNING_HANDLES.lessonSidebarBlockedIndicator(lessonId)),
+  ).toBeVisible();
+};

--- a/apps/web/e2e/flows/learning/assert-learning-progress.flow.ts
+++ b/apps/web/e2e/flows/learning/assert-learning-progress.flow.ts
@@ -1,0 +1,83 @@
+import { expect } from "@playwright/test";
+
+import type { FixtureApiClient } from "../../utils/api-client";
+
+type LessonStatusExpectation = {
+  completedLessonCount: number;
+  lessonId: string;
+  lessonStatus: string;
+};
+
+export const assertCourseLessonProgressFlow = async (
+  apiClient: FixtureApiClient,
+  courseId: string,
+  expectation: LessonStatusExpectation,
+) => {
+  await expect
+    .poll(
+      async () => {
+        const response = await apiClient.api.courseControllerGetCourse({
+          id: courseId,
+          language: "en",
+        });
+        const chapter = response.data.data.chapters[0];
+        const lesson = chapter?.lessons.find((item) => item.id === expectation.lessonId);
+
+        return {
+          completedLessonCount: chapter?.completedLessonCount ?? 0,
+          lessonStatus: lesson?.status,
+        };
+      },
+      { timeout: 15_000 },
+    )
+    .toEqual({
+      completedLessonCount: expectation.completedLessonCount,
+      lessonStatus: expectation.lessonStatus,
+    });
+};
+
+type QuizProgressExpectation = {
+  attempts: number;
+  completedLessonCount: number;
+  courseLessonStatus: string;
+  lessonCompleted: boolean;
+};
+
+export const assertQuizLessonProgressFlow = async (
+  apiClient: FixtureApiClient,
+  input: {
+    courseId: string;
+    lessonId: string;
+    studentId: string;
+    expected: QuizProgressExpectation;
+  },
+) => {
+  await expect
+    .poll(
+      async () => {
+        const [courseResponse, lessonResponse] = await Promise.all([
+          apiClient.api.courseControllerGetCourse({
+            id: input.courseId,
+            language: "en",
+          }),
+          apiClient.api.lessonControllerGetLessonById(input.lessonId, {
+            language: "en",
+            studentId: input.studentId,
+          }),
+        ]);
+
+        const chapter = courseResponse.data.data.chapters[0];
+        const lesson = chapter?.lessons.find((item) => item.id === input.lessonId);
+        const lessonData = lessonResponse.data.data;
+
+        return {
+          completedLessonCount: chapter?.completedLessonCount ?? 0,
+          courseLessonStatus: lesson?.status,
+          lessonCompleted: lessonData.lessonCompleted ?? false,
+          attempts: lessonData.attempts ?? 0,
+        };
+      },
+      { timeout: 15_000 },
+    )
+    .toEqual(input.expected);
+};

--- a/apps/web/e2e/flows/learning/go-to-next-lesson.flow.ts
+++ b/apps/web/e2e/flows/learning/go-to-next-lesson.flow.ts
@@ -1,0 +1,7 @@
+import { LEARNING_HANDLES } from "../../data/learning/handles";
+
+import type { Page } from "@playwright/test";
+
+export const goToNextLessonFlow = async (page: Page) => {
+  await page.getByTestId(LEARNING_HANDLES.NEXT_LESSON_BUTTON).click();
+};

--- a/apps/web/e2e/flows/learning/open-course-overview.flow.ts
+++ b/apps/web/e2e/flows/learning/open-course-overview.flow.ts
@@ -1,0 +1,5 @@
+import type { Page } from "@playwright/test";
+
+export const openCourseOverviewFlow = async (page: Page, courseIdOrSlug: string) => {
+  await page.goto(`/course/${courseIdOrSlug}`);
+};

--- a/apps/web/e2e/flows/learning/open-lesson-from-sidebar.flow.ts
+++ b/apps/web/e2e/flows/learning/open-lesson-from-sidebar.flow.ts
@@ -1,0 +1,7 @@
+import { LEARNING_HANDLES } from "../../data/learning/handles";
+
+import type { Page } from "@playwright/test";
+
+export const openLessonFromSidebarFlow = async (page: Page, lessonId: string) => {
+  await page.getByTestId(LEARNING_HANDLES.lessonSidebarLessonItem(lessonId)).click();
+};

--- a/apps/web/e2e/flows/learning/retake-quiz.flow.ts
+++ b/apps/web/e2e/flows/learning/retake-quiz.flow.ts
@@ -1,0 +1,7 @@
+import { LEARNING_HANDLES } from "../../data/learning/handles";
+
+import type { Page } from "@playwright/test";
+
+export const retakeQuizFlow = async (page: Page) => {
+  await page.getByTestId(LEARNING_HANDLES.QUIZ_RETAKE_BUTTON).click();
+};

--- a/apps/web/e2e/flows/learning/select-first-single-choice-answer.flow.ts
+++ b/apps/web/e2e/flows/learning/select-first-single-choice-answer.flow.ts
@@ -1,0 +1,5 @@
+import type { Page } from "@playwright/test";
+
+export const selectFirstSingleChoiceAnswerFlow = async (page: Page) => {
+  await page.locator('input[name^="singleAnswerQuestions."]').first().click();
+};

--- a/apps/web/e2e/flows/learning/start-learning.flow.ts
+++ b/apps/web/e2e/flows/learning/start-learning.flow.ts
@@ -1,0 +1,7 @@
+import { COURSE_OVERVIEW_HANDLES } from "../../data/courses/handles";
+
+import type { Page } from "@playwright/test";
+
+export const startLearningFlow = async (page: Page) => {
+  await page.getByTestId(COURSE_OVERVIEW_HANDLES.START_LEARNING_BUTTON).click();
+};

--- a/apps/web/e2e/flows/learning/submit-quiz.flow.ts
+++ b/apps/web/e2e/flows/learning/submit-quiz.flow.ts
@@ -1,0 +1,7 @@
+import { LEARNING_HANDLES } from "../../data/learning/handles";
+
+import type { Page } from "@playwright/test";
+
+export const submitQuizFlow = async (page: Page) => {
+  await page.getByTestId(LEARNING_HANDLES.QUIZ_SUBMIT_BUTTON).click();
+};

--- a/apps/web/e2e/flows/learning/wait-for-quiz-attempt-count.flow.ts
+++ b/apps/web/e2e/flows/learning/wait-for-quiz-attempt-count.flow.ts
@@ -1,0 +1,23 @@
+import { expect } from "@playwright/test";
+
+import type { FixtureApiClient } from "../../utils/api-client";
+
+export const getUserQuizAttemptCountFlow = async (apiClient: FixtureApiClient) => {
+  const response = await apiClient.api.statisticsControllerGetUserStatistics({ language: "en" });
+
+  return response.data.data.quizzes.totalAttempts;
+};
+
+export const waitForUserQuizAttemptCountFlow = async (
+  apiClient: FixtureApiClient,
+  expectedAttemptCount: number,
+) => {
+  await expect
+    .poll(
+      async () => {
+        return getUserQuizAttemptCountFlow(apiClient);
+      },
+      { timeout: 15_000 },
+    )
+    .toBeGreaterThanOrEqual(expectedAttemptCount);
+};

--- a/apps/web/e2e/specs/learning/ai-mentor-entry.spec.ts
+++ b/apps/web/e2e/specs/learning/ai-mentor-entry.spec.ts
@@ -1,0 +1,48 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { COURSE_OVERVIEW_HANDLES } from "../../data/courses/handles";
+import { LEARNING_HANDLES } from "../../data/learning/handles";
+import { expect, test } from "../../fixtures/test.fixture";
+import { assertAiMentorEntryFlow } from "../../flows/learning/assert-ai-mentor-entry.flow";
+import { openCourseOverviewFlow } from "../../flows/learning/open-course-overview.flow";
+import { startLearningFlow } from "../../flows/learning/start-learning.flow";
+
+import { createAiMentorLessonCourse } from "./learning-test-helpers";
+
+test("student can access AI mentor interaction entry points", async ({
+  cleanup,
+  factories,
+  withWorkerPage,
+}) => {
+  const enrollmentFactory = factories.createEnrollmentFactory();
+
+  const { courseId, lessons } = await createAiMentorLessonCourse({
+    cleanup,
+    factories,
+    prefix: `learning-ai-mentor-entry-${Date.now()}`,
+    withWorkerPage,
+  });
+  const { aiMentorLesson } = lessons;
+
+  await withWorkerPage(
+    USER_ROLE.student,
+    async ({ page }) => {
+      await enrollmentFactory.selfEnroll(courseId);
+
+      await openCourseOverviewFlow(page, courseId);
+      await expect(page.getByTestId(COURSE_OVERVIEW_HANDLES.START_LEARNING_BUTTON)).toBeVisible();
+
+      await startLearningFlow(page);
+
+      await expect(page).toHaveURL(new RegExp(`/course/.+/lesson/${aiMentorLesson.id}$`));
+      await expect(page.getByTestId(LEARNING_HANDLES.LESSON_TITLE)).toHaveText(
+        aiMentorLesson.title,
+      );
+
+      await assertAiMentorEntryFlow(page);
+      await expect(page.getByTestId(LEARNING_HANDLES.AI_MENTOR_CHECK_BUTTON)).toBeVisible();
+      await expect(page.getByTestId(LEARNING_HANDLES.AI_MENTOR_RETAKE_BUTTON)).toBeHidden();
+    },
+    { root: true },
+  );
+});

--- a/apps/web/e2e/specs/learning/learning-test-helpers.ts
+++ b/apps/web/e2e/specs/learning/learning-test-helpers.ts
@@ -1,0 +1,416 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import type { FixtureFactories } from "../../factories";
+import type { CurriculumCourseLessonRecord } from "../../factories/curriculum.factory";
+import type { PageHandle } from "../../fixtures/types";
+import type { UpdateCourseSettingsBody } from "~/api/generated-api";
+import type { UserRole } from "~/config/userRoles";
+
+type Cleanup = {
+  add: (task: () => Promise<void> | void) => void;
+};
+
+type WithWorkerPage = (
+  role: UserRole,
+  run: (handle: PageHandle) => Promise<void>,
+  options?: { root?: boolean },
+) => Promise<void>;
+
+type LearningCourseBuilderContext = {
+  chapterId: string;
+  courseId: string;
+  prefix: string;
+  curriculumFactory: ReturnType<FixtureFactories["createCurriculumFactory"]>;
+};
+
+type CreatePublishedLearningCourseInput<TLessons> = {
+  categoryTitle?: (prefix: string) => string;
+  cleanup: Cleanup;
+  factories: FixtureFactories;
+  prefix: string;
+  settings?: UpdateCourseSettingsBody;
+  shouldKeepCourseAfterTest?: () => boolean;
+  withWorkerPage: WithWorkerPage;
+  buildLessons: (context: LearningCourseBuilderContext) => Promise<TLessons>;
+};
+
+export type PublishedLearningCourse<TLessons> = {
+  categoryId: string;
+  courseId: string;
+  lessons: TLessons;
+};
+
+export const createPublishedLearningCourse = async <TLessons>({
+  categoryTitle = (prefix) => `Learning Category ${prefix}`,
+  cleanup,
+  factories,
+  prefix,
+  settings,
+  shouldKeepCourseAfterTest,
+  withWorkerPage,
+  buildLessons,
+}: CreatePublishedLearningCourseInput<TLessons>): Promise<PublishedLearningCourse<TLessons>> => {
+  const categoryFactory = factories.createCategoryFactory();
+  const courseFactory = factories.createCourseFactory();
+  const curriculumFactory = factories.createCurriculumFactory();
+
+  let categoryId = "";
+  let courseId = "";
+  let lessons: TLessons | undefined;
+
+  await withWorkerPage(
+    USER_ROLE.admin,
+    async () => {
+      const category = await categoryFactory.create(categoryTitle(prefix));
+      const course = await courseFactory.create({
+        title: `${prefix}-course`,
+        categoryId: category.id,
+        language: "en",
+        status: "draft",
+      });
+      const chapter = await curriculumFactory.createChapter({
+        courseId: course.id,
+        title: `${prefix}-chapter`,
+      });
+
+      categoryId = category.id;
+      courseId = course.id;
+      lessons = await buildLessons({
+        chapterId: chapter.id,
+        courseId: course.id,
+        curriculumFactory,
+        prefix,
+      });
+
+      if (settings) {
+        await courseFactory.updateSettings(course.id, settings);
+      }
+
+      await courseFactory.update(course.id, { status: "published", language: "en" });
+
+      cleanup.add(async () => {
+        await withWorkerPage(
+          USER_ROLE.admin,
+          async () => {
+            await courseFactory.update(course.id, { status: "draft", language: "en" });
+            if (shouldKeepCourseAfterTest?.()) return;
+
+            await courseFactory.delete(course.id);
+            await categoryFactory.delete(category.id);
+          },
+          { root: true },
+        );
+      });
+    },
+    { root: true },
+  );
+
+  if (!lessons) {
+    throw new Error(`Learning course ${prefix} was not created`);
+  }
+
+  return { categoryId, courseId, lessons };
+};
+
+export const createTwoContentLessonsCourse = async (
+  input: Omit<
+    CreatePublishedLearningCourseInput<{
+      firstLesson: CurriculumCourseLessonRecord;
+      secondLesson: CurriculumCourseLessonRecord;
+    }>,
+    "buildLessons"
+  >,
+) =>
+  createPublishedLearningCourse({
+    ...input,
+    buildLessons: async ({ courseId, chapterId, curriculumFactory, prefix }) => {
+      const firstLesson = await curriculumFactory.createContentLesson(courseId, {
+        chapterId,
+        title: `${prefix}-first-lesson`,
+        displayOrder: 1,
+      });
+      const secondLesson = await curriculumFactory.createContentLesson(courseId, {
+        chapterId,
+        title: `${prefix}-second-lesson`,
+        displayOrder: 2,
+      });
+
+      return { firstLesson, secondLesson };
+    },
+  });
+
+export const createThreeContentLessonsCourse = async (
+  input: Omit<
+    CreatePublishedLearningCourseInput<{
+      firstLesson: CurriculumCourseLessonRecord;
+      thirdLesson: CurriculumCourseLessonRecord;
+    }>,
+    "buildLessons"
+  >,
+) =>
+  createPublishedLearningCourse({
+    ...input,
+    settings: input.settings ?? { lessonSequenceEnabled: false },
+    buildLessons: async ({ courseId, chapterId, curriculumFactory, prefix }) => {
+      const firstLesson = await curriculumFactory.createContentLesson(courseId, {
+        chapterId,
+        title: `${prefix}-first-lesson`,
+        displayOrder: 1,
+      });
+      await curriculumFactory.createContentLesson(courseId, {
+        chapterId,
+        title: `${prefix}-second-lesson`,
+        displayOrder: 2,
+      });
+      const thirdLesson = await curriculumFactory.createContentLesson(courseId, {
+        chapterId,
+        title: `${prefix}-third-lesson`,
+        displayOrder: 3,
+      });
+
+      return { firstLesson, thirdLesson };
+    },
+  });
+
+type QuizAnswerOrder = "correct-first" | "wrong-first";
+
+export const createSingleChoiceQuizLessonCourse = async (
+  input: Omit<
+    CreatePublishedLearningCourseInput<{
+      quizLesson: CurriculumCourseLessonRecord;
+    }>,
+    "buildLessons"
+  > & {
+    answerOrder?: QuizAnswerOrder;
+    thresholdScore?: number;
+  },
+) =>
+  createPublishedLearningCourse({
+    ...input,
+    buildLessons: async ({ courseId, chapterId, curriculumFactory, prefix }) => {
+      const correctAnswer = {
+        optionText: `${prefix}-correct-answer`,
+        displayOrder: input.answerOrder === "wrong-first" ? 2 : 1,
+        isCorrect: true,
+      };
+      const wrongAnswer = {
+        optionText: `${prefix}-wrong-answer`,
+        displayOrder: input.answerOrder === "wrong-first" ? 1 : 2,
+        isCorrect: false,
+      };
+      const quizLesson = await curriculumFactory.createQuizLesson(courseId, {
+        chapterId,
+        title: `${prefix}-quiz-lesson`,
+        displayOrder: 1,
+        thresholdScore: input.thresholdScore ?? 50,
+        questions: [
+          {
+            type: "single_choice",
+            title: `${prefix}-quiz-question`,
+            displayOrder: 1,
+            options:
+              input.answerOrder === "wrong-first"
+                ? [wrongAnswer, correctAnswer]
+                : [correctAnswer, wrongAnswer],
+          },
+        ],
+      });
+
+      return { quizLesson };
+    },
+  });
+
+export const createSequencedQuizAndContentCourse = async (
+  input: Omit<
+    CreatePublishedLearningCourseInput<{
+      blockedLesson: CurriculumCourseLessonRecord;
+      quizLesson: CurriculumCourseLessonRecord;
+    }>,
+    "buildLessons" | "settings"
+  > & {
+    answerOrder?: QuizAnswerOrder;
+    thresholdScore?: number;
+  },
+) =>
+  createPublishedLearningCourse({
+    ...input,
+    settings: { lessonSequenceEnabled: true },
+    buildLessons: async ({ courseId, chapterId, curriculumFactory, prefix }) => {
+      const correctAnswer = {
+        optionText: `${prefix}-correct-answer`,
+        displayOrder: input.answerOrder === "wrong-first" ? 2 : 1,
+        isCorrect: true,
+      };
+      const wrongAnswer = {
+        optionText: `${prefix}-wrong-answer`,
+        displayOrder: input.answerOrder === "wrong-first" ? 1 : 2,
+        isCorrect: false,
+      };
+      const quizLesson = await curriculumFactory.createQuizLesson(courseId, {
+        chapterId,
+        title: `${prefix}-quiz-lesson`,
+        displayOrder: 1,
+        thresholdScore: input.thresholdScore ?? 50,
+        questions: [
+          {
+            type: "single_choice",
+            title: `${prefix}-quiz-question`,
+            displayOrder: 1,
+            options:
+              input.answerOrder === "wrong-first"
+                ? [wrongAnswer, correctAnswer]
+                : [correctAnswer, wrongAnswer],
+          },
+        ],
+      });
+      const blockedLesson = await curriculumFactory.createContentLesson(courseId, {
+        chapterId,
+        title: `${prefix}-blocked-lesson`,
+        displayOrder: 2,
+      });
+
+      return { quizLesson, blockedLesson };
+    },
+  });
+
+export const createEmbedLessonCourse = async (
+  input: Omit<
+    CreatePublishedLearningCourseInput<{
+      embedLesson: CurriculumCourseLessonRecord;
+    }>,
+    "buildLessons"
+  >,
+) =>
+  createPublishedLearningCourse({
+    ...input,
+    categoryTitle: (prefix) => `Learning Embed Category ${prefix}`,
+    buildLessons: async ({ courseId, chapterId, curriculumFactory, prefix }) => {
+      const embedLesson = await curriculumFactory.createEmbedLesson(courseId, {
+        chapterId,
+        title: `${prefix}-embed-lesson`,
+        type: "embed",
+        resources: [{ fileUrl: "https://example.com", allowFullscreen: true }],
+      });
+
+      return { embedLesson };
+    },
+  });
+
+export const createAiMentorLessonCourse = async (
+  input: Omit<
+    CreatePublishedLearningCourseInput<{
+      aiMentorLesson: CurriculumCourseLessonRecord;
+    }>,
+    "buildLessons"
+  >,
+) =>
+  createPublishedLearningCourse({
+    ...input,
+    categoryTitle: (prefix) => `Learning AI Mentor Category ${prefix}`,
+    buildLessons: async ({ courseId, chapterId, curriculumFactory, prefix }) => {
+      const aiMentorLesson = await curriculumFactory.createAiMentorLesson(courseId, {
+        chapterId,
+        title: `${prefix}-lesson`,
+        description: "<p>Practice with your AI mentor.</p>",
+        aiMentorInstructions: "<p>Ask concise questions.</p>",
+        completionConditions: "<p>Complete the mentor conversation.</p>",
+        displayOrder: 1,
+      });
+
+      return { aiMentorLesson };
+    },
+  });
+
+export const createAllRenderedQuestionTypesQuizCourse = async (
+  input: Omit<
+    CreatePublishedLearningCourseInput<{
+      dndBlankAnswer: string;
+      quizLesson: CurriculumCourseLessonRecord;
+      textBlankAnswer: string;
+    }>,
+    "buildLessons"
+  >,
+) =>
+  createPublishedLearningCourse({
+    ...input,
+    categoryTitle: (prefix) => `Learning All Quiz Types Category ${prefix}`,
+    buildLessons: async ({ courseId, chapterId, curriculumFactory, prefix }) => {
+      const textBlankAnswer = `${prefix}-text-answer`;
+      const dndBlankAnswer = `${prefix}-dnd-answer`;
+      const quizLesson = await curriculumFactory.createQuizLesson(courseId, {
+        chapterId,
+        title: `${prefix}-quiz-lesson`,
+        displayOrder: 1,
+        thresholdScore: 100,
+        questions: [
+          {
+            type: "single_choice",
+            title: `${prefix}-single-choice`,
+            displayOrder: 1,
+            options: [
+              { optionText: `${prefix}-single-correct`, displayOrder: 1, isCorrect: true },
+              { optionText: `${prefix}-single-wrong`, displayOrder: 2, isCorrect: false },
+            ],
+          },
+          {
+            type: "multiple_choice",
+            title: `${prefix}-multiple-choice`,
+            displayOrder: 2,
+            options: [
+              { optionText: `${prefix}-multi-correct-1`, displayOrder: 1, isCorrect: true },
+              { optionText: `${prefix}-multi-correct-2`, displayOrder: 2, isCorrect: true },
+              { optionText: `${prefix}-multi-wrong`, displayOrder: 3, isCorrect: false },
+            ],
+          },
+          {
+            type: "true_or_false",
+            title: `${prefix}-true-or-false`,
+            displayOrder: 3,
+            options: [
+              { optionText: `${prefix}-true-statement`, displayOrder: 1, isCorrect: true },
+              { optionText: `${prefix}-false-statement`, displayOrder: 2, isCorrect: false },
+            ],
+          },
+          {
+            type: "photo_question_single_choice",
+            title: `${prefix}-photo-single-choice`,
+            displayOrder: 4,
+            photoS3Key: null,
+            options: [
+              { optionText: `${prefix}-photo-single-correct`, displayOrder: 1, isCorrect: true },
+              { optionText: `${prefix}-photo-single-wrong`, displayOrder: 2, isCorrect: false },
+            ],
+          },
+          {
+            type: "photo_question_multiple_choice",
+            title: `${prefix}-photo-multiple-choice`,
+            displayOrder: 5,
+            photoS3Key: null,
+            options: [
+              { optionText: `${prefix}-photo-multi-correct-1`, displayOrder: 1, isCorrect: true },
+              { optionText: `${prefix}-photo-multi-correct-2`, displayOrder: 2, isCorrect: true },
+              { optionText: `${prefix}-photo-multi-wrong`, displayOrder: 3, isCorrect: false },
+            ],
+          },
+          {
+            type: "fill_in_the_blanks_text",
+            title: `${prefix}-fill-text`,
+            description: "Type the [word] answer.",
+            displayOrder: 6,
+            options: [{ optionText: textBlankAnswer, displayOrder: 1, isCorrect: true }],
+          },
+          {
+            type: "fill_in_the_blanks_dnd",
+            title: `${prefix}-fill-dnd`,
+            description: "Drag the [word] answer.",
+            displayOrder: 7,
+            options: [{ optionText: dndBlankAnswer, displayOrder: 1, isCorrect: true }],
+          },
+          { type: "brief_response", title: `${prefix}-brief-response`, displayOrder: 8 },
+          { type: "detailed_response", title: `${prefix}-detailed-response`, displayOrder: 9 },
+        ],
+      });
+
+      return { quizLesson, textBlankAnswer, dndBlankAnswer };
+    },
+  });

--- a/apps/web/e2e/specs/learning/lesson-access.spec.ts
+++ b/apps/web/e2e/specs/learning/lesson-access.spec.ts
@@ -1,0 +1,122 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { LEARNING_HANDLES } from "../../data/learning/handles";
+import { expect, test } from "../../fixtures/test.fixture";
+import { openCourseOverviewFlow } from "../../flows/learning/open-course-overview.flow";
+import { openLessonFromSidebarFlow } from "../../flows/learning/open-lesson-from-sidebar.flow";
+import { startLearningFlow } from "../../flows/learning/start-learning.flow";
+
+import { createEmbedLessonCourse, createThreeContentLessonsCourse } from "./learning-test-helpers";
+
+test("student can open lessons out of order from the sidebar when sequence is disabled", async ({
+  apiClient,
+  cleanup,
+  factories,
+  withWorkerPage,
+}) => {
+  const enrollmentFactory = factories.createEnrollmentFactory();
+
+  const { courseId, lessons } = await createThreeContentLessonsCourse({
+    cleanup,
+    factories,
+    prefix: `learning-sidebar-access-${Date.now()}`,
+    withWorkerPage,
+  });
+  const { firstLesson, thirdLesson } = lessons;
+
+  await withWorkerPage(
+    USER_ROLE.student,
+    async ({ page }) => {
+      await enrollmentFactory.selfEnroll(courseId);
+
+      await openCourseOverviewFlow(page, courseId);
+      await startLearningFlow(page);
+
+      await expect(page).toHaveURL(new RegExp(`/course/.+/lesson/${firstLesson.id}$`));
+      await expect(page.getByTestId(LEARNING_HANDLES.LESSON_SIDEBAR)).toBeVisible();
+      await expect(
+        page.getByTestId(LEARNING_HANDLES.lessonSidebarBlockedIndicator(thirdLesson.id)),
+      ).toHaveCount(0);
+
+      await openLessonFromSidebarFlow(page, thirdLesson.id);
+
+      await expect(page).toHaveURL(new RegExp(`/course/.+/lesson/${thirdLesson.id}$`));
+      await expect(page.getByTestId(LEARNING_HANDLES.LESSON_TITLE)).toHaveText(thirdLesson.title);
+      await expect(page.getByTestId(LEARNING_HANDLES.CURRENT_LESSON_NUMBER)).toHaveText("3");
+      await expect(page.getByTestId(LEARNING_HANDLES.LESSONS_COUNT)).toHaveText("3");
+
+      await expect
+        .poll(
+          async () => {
+            const response = await apiClient.api.courseControllerGetCourse({
+              id: courseId,
+              language: "en",
+            });
+            const chapter = response.data.data.chapters[0];
+            const lesson = chapter?.lessons.find((item) => item.id === thirdLesson.id);
+
+            return lesson?.status;
+          },
+          { timeout: 15_000 },
+        )
+        .toBe("completed");
+    },
+    { root: true },
+  );
+});
+
+test("student can open an embed lesson and complete it", async ({
+  apiClient,
+  cleanup,
+  factories,
+  withWorkerPage,
+}) => {
+  const enrollmentFactory = factories.createEnrollmentFactory();
+
+  const { courseId, lessons } = await createEmbedLessonCourse({
+    cleanup,
+    factories,
+    prefix: `learning-embed-${Date.now()}`,
+    withWorkerPage,
+  });
+  const { embedLesson } = lessons;
+
+  await withWorkerPage(
+    USER_ROLE.student,
+    async ({ page }) => {
+      await enrollmentFactory.selfEnroll(courseId);
+
+      await openCourseOverviewFlow(page, courseId);
+      await startLearningFlow(page);
+
+      await expect(page).toHaveURL(new RegExp(`/course/.+/lesson/${embedLesson.id}$`));
+      await expect(page.getByTestId(LEARNING_HANDLES.LESSON_TITLE)).toHaveText(embedLesson.title);
+      await expect(page.getByTestId(LEARNING_HANDLES.CURRENT_LESSON_NUMBER)).toHaveText("1");
+      await expect(page.getByTestId(LEARNING_HANDLES.LESSONS_COUNT)).toHaveText("1");
+      await expect(page.locator(`iframe[title="${embedLesson.title}"]`)).toBeVisible();
+
+      await expect
+        .poll(
+          async () => {
+            const response = await apiClient.api.courseControllerGetCourse({
+              id: courseId,
+              language: "en",
+            });
+            const chapter = response.data.data.chapters[0];
+            const lesson = chapter?.lessons.find((item) => item.id === embedLesson.id);
+
+            return {
+              completedLessonCount: chapter?.completedLessonCount ?? 0,
+              embedLessonStatus: lesson?.status,
+            };
+          },
+          { timeout: 15_000 },
+        )
+        .toEqual({
+          completedLessonCount: 1,
+          embedLessonStatus: "completed",
+        });
+    },
+    { root: true },
+  );
+});

--- a/apps/web/e2e/specs/learning/lesson-sequence.spec.ts
+++ b/apps/web/e2e/specs/learning/lesson-sequence.spec.ts
@@ -1,0 +1,187 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { LEARNING_HANDLES } from "../../data/learning/handles";
+import { expect, test } from "../../fixtures/test.fixture";
+import { assertBlockedLessonItemFlow } from "../../flows/learning/assert-blocked-lesson-item.flow";
+import { openCourseOverviewFlow } from "../../flows/learning/open-course-overview.flow";
+import { openLessonFromSidebarFlow } from "../../flows/learning/open-lesson-from-sidebar.flow";
+import { selectFirstSingleChoiceAnswerFlow } from "../../flows/learning/select-first-single-choice-answer.flow";
+import { startLearningFlow } from "../../flows/learning/start-learning.flow";
+import { submitQuizFlow } from "../../flows/learning/submit-quiz.flow";
+import {
+  getUserQuizAttemptCountFlow,
+  waitForUserQuizAttemptCountFlow,
+} from "../../flows/learning/wait-for-quiz-attempt-count.flow";
+
+import { createSequencedQuizAndContentCourse } from "./learning-test-helpers";
+
+test("student cannot skip ahead when lesson sequence is enabled", async ({
+  apiClient,
+  cleanup,
+  factories,
+  withWorkerPage,
+}) => {
+  const enrollmentFactory = factories.createEnrollmentFactory();
+
+  let quizWasSubmitted = false;
+
+  const { courseId, lessons } = await createSequencedQuizAndContentCourse({
+    cleanup,
+    factories,
+    prefix: `learning-sequence-${Date.now()}`,
+    shouldKeepCourseAfterTest: () => quizWasSubmitted,
+    withWorkerPage,
+  });
+  const { quizLesson, blockedLesson } = lessons;
+
+  await withWorkerPage(
+    USER_ROLE.student,
+    async ({ page }) => {
+      await enrollmentFactory.selfEnroll(courseId);
+
+      await openCourseOverviewFlow(page, courseId);
+      await startLearningFlow(page);
+
+      await expect(page).toHaveURL(new RegExp(`/course/.+/lesson/${quizLesson.id}$`));
+      await expect(page.getByTestId(LEARNING_HANDLES.LESSON_TITLE)).toHaveText(quizLesson.title);
+      await expect(page.getByTestId(LEARNING_HANDLES.QUIZ_FORM)).toBeVisible();
+      await expect(page.getByTestId(LEARNING_HANDLES.NEXT_LESSON_BUTTON)).toBeDisabled();
+      await assertBlockedLessonItemFlow(page, blockedLesson.id);
+
+      await page.getByTestId(LEARNING_HANDLES.lessonSidebarLessonItem(blockedLesson.id)).click();
+      await expect(page).toHaveURL(new RegExp(`/course/.+/lesson/${quizLesson.id}#?$`));
+
+      const expectedQuizAttemptCount = (await getUserQuizAttemptCountFlow(apiClient)) + 1;
+
+      await selectFirstSingleChoiceAnswerFlow(page);
+      await submitQuizFlow(page);
+      quizWasSubmitted = true;
+
+      await expect
+        .poll(
+          async () => {
+            const response = await apiClient.api.courseControllerGetCourse({
+              id: courseId,
+              language: "en",
+            });
+            const chapter = response.data.data.chapters[0];
+            const courseQuizLesson = chapter?.lessons.find((lesson) => lesson.id === quizLesson.id);
+            const nextLesson = chapter?.lessons.find((lesson) => lesson.id === blockedLesson.id);
+
+            return {
+              quizLessonStatus: courseQuizLesson?.status,
+              nextLessonStatus: nextLesson?.status,
+            };
+          },
+          { timeout: 15_000 },
+        )
+        .toEqual({
+          quizLessonStatus: "completed",
+          nextLessonStatus: "not_started",
+        });
+
+      await waitForUserQuizAttemptCountFlow(apiClient, expectedQuizAttemptCount);
+
+      await expect(page.getByTestId(LEARNING_HANDLES.NEXT_LESSON_BUTTON)).toBeEnabled();
+      await expect(
+        page.getByTestId(LEARNING_HANDLES.lessonSidebarBlockedIndicator(blockedLesson.id)),
+      ).toHaveCount(0);
+
+      await openLessonFromSidebarFlow(page, blockedLesson.id);
+
+      await expect(page).toHaveURL(new RegExp(`/course/.+/lesson/${blockedLesson.id}$`));
+      await expect(page.getByTestId(LEARNING_HANDLES.LESSON_TITLE)).toHaveText(blockedLesson.title);
+    },
+    { root: true },
+  );
+});
+
+test("student does not unlock the next lesson after failing a required quiz", async ({
+  apiClient,
+  cleanup,
+  factories,
+  withWorkerPage,
+}) => {
+  const enrollmentFactory = factories.createEnrollmentFactory();
+
+  let quizWasSubmitted = false;
+
+  const { courseId, lessons } = await createSequencedQuizAndContentCourse({
+    answerOrder: "wrong-first",
+    cleanup,
+    factories,
+    prefix: `learning-sequence-failed-quiz-${Date.now()}`,
+    shouldKeepCourseAfterTest: () => quizWasSubmitted,
+    thresholdScore: 100,
+    withWorkerPage,
+  });
+  const { quizLesson, blockedLesson } = lessons;
+
+  await withWorkerPage(
+    USER_ROLE.student,
+    async ({ page }) => {
+      await enrollmentFactory.selfEnroll(courseId);
+      const studentId = await enrollmentFactory.getCurrentUserId();
+
+      await openCourseOverviewFlow(page, courseId);
+      await startLearningFlow(page);
+
+      await expect(page).toHaveURL(new RegExp(`/course/.+/lesson/${quizLesson.id}$`));
+      await expect(page.getByTestId(LEARNING_HANDLES.LESSON_TITLE)).toHaveText(quizLesson.title);
+      await expect(page.getByTestId(LEARNING_HANDLES.QUIZ_FORM)).toBeVisible();
+      await expect(page.getByTestId(LEARNING_HANDLES.NEXT_LESSON_BUTTON)).toBeDisabled();
+      await assertBlockedLessonItemFlow(page, blockedLesson.id);
+
+      const expectedQuizAttemptCount = (await getUserQuizAttemptCountFlow(apiClient)) + 1;
+
+      await selectFirstSingleChoiceAnswerFlow(page);
+      await submitQuizFlow(page);
+      quizWasSubmitted = true;
+
+      await expect(page.getByTestId(LEARNING_HANDLES.QUIZ_SUBMIT_BUTTON)).toBeDisabled();
+      await expect(page.getByTestId(LEARNING_HANDLES.QUIZ_RETAKE_BUTTON)).toBeEnabled();
+      await expect(page.getByTestId(LEARNING_HANDLES.NEXT_LESSON_BUTTON)).toBeDisabled();
+      await assertBlockedLessonItemFlow(page, blockedLesson.id);
+
+      await page.getByTestId(LEARNING_HANDLES.lessonSidebarLessonItem(blockedLesson.id)).click();
+      await expect(page).toHaveURL(new RegExp(`/course/.+/lesson/${quizLesson.id}#?$`));
+
+      await expect
+        .poll(
+          async () => {
+            const [courseResponse, lessonResponse] = await Promise.all([
+              apiClient.api.courseControllerGetCourse({
+                id: courseId,
+                language: "en",
+              }),
+              apiClient.api.lessonControllerGetLessonById(quizLesson.id, {
+                language: "en",
+                studentId,
+              }),
+            ]);
+
+            const chapter = courseResponse.data.data.chapters[0];
+            const nextLesson = chapter?.lessons.find((lesson) => lesson.id === blockedLesson.id);
+            const lessonData = lessonResponse.data.data;
+
+            return {
+              completedLessonCount: chapter?.completedLessonCount ?? 0,
+              nextLessonStatus: nextLesson?.status,
+              lessonCompleted: lessonData.lessonCompleted ?? false,
+              attempts: lessonData.attempts ?? 0,
+            };
+          },
+          { timeout: 15_000 },
+        )
+        .toEqual({
+          completedLessonCount: 0,
+          nextLessonStatus: "not_started",
+          lessonCompleted: true,
+          attempts: 1,
+        });
+
+      await waitForUserQuizAttemptCountFlow(apiClient, expectedQuizAttemptCount);
+    },
+    { root: true },
+  );
+});

--- a/apps/web/e2e/specs/learning/quiz-all-question-types.spec.ts
+++ b/apps/web/e2e/specs/learning/quiz-all-question-types.spec.ts
@@ -1,0 +1,100 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { LEARNING_HANDLES } from "../../data/learning/handles";
+import { expect, test } from "../../fixtures/test.fixture";
+import { answerAllRenderedQuizQuestionTypesFlow } from "../../flows/learning/answer-all-rendered-quiz-question-types.flow";
+import { openCourseOverviewFlow } from "../../flows/learning/open-course-overview.flow";
+import { startLearningFlow } from "../../flows/learning/start-learning.flow";
+import { submitQuizFlow } from "../../flows/learning/submit-quiz.flow";
+import {
+  getUserQuizAttemptCountFlow,
+  waitForUserQuizAttemptCountFlow,
+} from "../../flows/learning/wait-for-quiz-attempt-count.flow";
+
+import { createAllRenderedQuestionTypesQuizCourse } from "./learning-test-helpers";
+
+test("student can submit a quiz containing every rendered question type", async ({
+  apiClient,
+  cleanup,
+  factories,
+  withWorkerPage,
+}) => {
+  const enrollmentFactory = factories.createEnrollmentFactory();
+
+  let quizWasSubmitted = false;
+
+  const { courseId, lessons } = await createAllRenderedQuestionTypesQuizCourse({
+    cleanup,
+    factories,
+    prefix: `learning-all-quiz-types-${Date.now()}`,
+    shouldKeepCourseAfterTest: () => quizWasSubmitted,
+    withWorkerPage,
+  });
+  const { quizLesson, textBlankAnswer, dndBlankAnswer } = lessons;
+
+  await withWorkerPage(
+    USER_ROLE.student,
+    async ({ page }) => {
+      await enrollmentFactory.selfEnroll(courseId);
+      const studentId = await enrollmentFactory.getCurrentUserId();
+
+      await openCourseOverviewFlow(page, courseId);
+      await startLearningFlow(page);
+
+      await expect(page).toHaveURL(new RegExp(`/course/.+/lesson/${quizLesson.id}$`));
+      await expect(page.getByTestId(LEARNING_HANDLES.LESSON_TITLE)).toHaveText(quizLesson.title);
+      await expect(page.getByTestId(LEARNING_HANDLES.QUIZ_FORM)).toBeVisible();
+
+      const expectedQuizAttemptCount = (await getUserQuizAttemptCountFlow(apiClient)) + 1;
+
+      await answerAllRenderedQuizQuestionTypesFlow(page, { dndBlankAnswer, textBlankAnswer });
+
+      await submitQuizFlow(page);
+      quizWasSubmitted = true;
+
+      await expect(page.getByTestId(LEARNING_HANDLES.QUIZ_SUBMIT_BUTTON)).toBeDisabled();
+      await expect(page.getByTestId(LEARNING_HANDLES.QUIZ_RETAKE_BUTTON)).toBeEnabled();
+
+      await expect
+        .poll(
+          async () => {
+            const [courseResponse, lessonResponse] = await Promise.all([
+              apiClient.api.courseControllerGetCourse({
+                id: courseId,
+                language: "en",
+              }),
+              apiClient.api.lessonControllerGetLessonById(quizLesson.id, {
+                language: "en",
+                studentId,
+              }),
+            ]);
+
+            const chapter = courseResponse.data.data.chapters[0];
+            const courseLesson = chapter?.lessons.find((lesson) => lesson.id === quizLesson.id);
+            const lessonData = lessonResponse.data.data;
+
+            return {
+              completedLessonCount: chapter?.completedLessonCount ?? 0,
+              courseLessonStatus: courseLesson?.status,
+              lessonCompleted: lessonData.lessonCompleted ?? false,
+              attempts: lessonData.attempts ?? 0,
+              correctAnswerCount: lessonData.quizDetails?.correctAnswerCount ?? 0,
+              score: lessonData.quizDetails?.score ?? 0,
+            };
+          },
+          { timeout: 15_000 },
+        )
+        .toEqual({
+          completedLessonCount: 1,
+          courseLessonStatus: "completed",
+          lessonCompleted: true,
+          attempts: 1,
+          correctAnswerCount: 9,
+          score: 100,
+        });
+
+      await waitForUserQuizAttemptCountFlow(apiClient, expectedQuizAttemptCount);
+    },
+    { root: true },
+  );
+});

--- a/apps/web/e2e/specs/learning/quiz-retake.spec.ts
+++ b/apps/web/e2e/specs/learning/quiz-retake.spec.ts
@@ -1,0 +1,124 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { LEARNING_HANDLES } from "../../data/learning/handles";
+import { expect, test } from "../../fixtures/test.fixture";
+import { assertQuizLessonProgressFlow } from "../../flows/learning/assert-learning-progress.flow";
+import { openCourseOverviewFlow } from "../../flows/learning/open-course-overview.flow";
+import { retakeQuizFlow } from "../../flows/learning/retake-quiz.flow";
+import { selectFirstSingleChoiceAnswerFlow } from "../../flows/learning/select-first-single-choice-answer.flow";
+import { startLearningFlow } from "../../flows/learning/start-learning.flow";
+import { submitQuizFlow } from "../../flows/learning/submit-quiz.flow";
+import {
+  getUserQuizAttemptCountFlow,
+  waitForUserQuizAttemptCountFlow,
+} from "../../flows/learning/wait-for-quiz-attempt-count.flow";
+
+import { createSingleChoiceQuizLessonCourse } from "./learning-test-helpers";
+
+test("student can submit and retake a quiz lesson", async ({
+  apiClient,
+  cleanup,
+  factories,
+  withWorkerPage,
+}) => {
+  const enrollmentFactory = factories.createEnrollmentFactory();
+
+  let quizWasSubmitted = false;
+
+  const { courseId, lessons } = await createSingleChoiceQuizLessonCourse({
+    cleanup,
+    factories,
+    prefix: `learning-quiz-retake-${Date.now()}`,
+    shouldKeepCourseAfterTest: () => quizWasSubmitted,
+    withWorkerPage,
+  });
+  const { quizLesson } = lessons;
+
+  await withWorkerPage(
+    USER_ROLE.student,
+    async ({ page }) => {
+      await enrollmentFactory.selfEnroll(courseId);
+      const studentId = await enrollmentFactory.getCurrentUserId();
+
+      await openCourseOverviewFlow(page, courseId);
+      await startLearningFlow(page);
+
+      await expect(page).toHaveURL(new RegExp(`/course/.+/lesson/${quizLesson.id}$`));
+      await expect(page.getByTestId(LEARNING_HANDLES.LESSON_TITLE)).toHaveText(quizLesson.title);
+      await expect(page.getByTestId(LEARNING_HANDLES.CURRENT_LESSON_NUMBER)).toHaveText("1");
+      await expect(page.getByTestId(LEARNING_HANDLES.LESSONS_COUNT)).toHaveText("1");
+      await expect(page.getByTestId(LEARNING_HANDLES.QUIZ_FORM)).toBeVisible();
+
+      const initialQuizAttemptCount = await getUserQuizAttemptCountFlow(apiClient);
+
+      await selectFirstSingleChoiceAnswerFlow(page);
+      await submitQuizFlow(page);
+      quizWasSubmitted = true;
+      const firstExpectedQuizAttemptCount = initialQuizAttemptCount + 1;
+
+      await expect(page.getByTestId(LEARNING_HANDLES.QUIZ_SUBMIT_BUTTON)).toBeDisabled();
+      await expect(page.getByTestId(LEARNING_HANDLES.QUIZ_RETAKE_BUTTON)).toBeEnabled();
+
+      await assertQuizLessonProgressFlow(apiClient, {
+        courseId,
+        lessonId: quizLesson.id,
+        studentId,
+        expected: {
+          completedLessonCount: 1,
+          courseLessonStatus: "completed",
+          lessonCompleted: true,
+          attempts: 1,
+        },
+      });
+
+      await waitForUserQuizAttemptCountFlow(apiClient, firstExpectedQuizAttemptCount);
+
+      await retakeQuizFlow(page);
+
+      await expect(page.getByTestId(LEARNING_HANDLES.QUIZ_SUBMIT_BUTTON)).toBeEnabled();
+      await expect(page.getByTestId(LEARNING_HANDLES.QUIZ_RETAKE_BUTTON)).toBeDisabled();
+
+      await expect
+        .poll(
+          async () => {
+            const { data } = await apiClient.api.lessonControllerGetLessonById(quizLesson.id, {
+              language: "en",
+              studentId,
+            });
+
+            const lessonData = data.data;
+
+            return {
+              attempts: lessonData.attempts ?? 0,
+            };
+          },
+          { timeout: 15_000 },
+        )
+        .toEqual({
+          attempts: 2,
+        });
+
+      await selectFirstSingleChoiceAnswerFlow(page);
+      await submitQuizFlow(page);
+      const secondExpectedQuizAttemptCount = initialQuizAttemptCount + 2;
+
+      await expect(page.getByTestId(LEARNING_HANDLES.QUIZ_SUBMIT_BUTTON)).toBeDisabled();
+      await expect(page.getByTestId(LEARNING_HANDLES.QUIZ_RETAKE_BUTTON)).toBeEnabled();
+
+      await assertQuizLessonProgressFlow(apiClient, {
+        courseId,
+        lessonId: quizLesson.id,
+        studentId,
+        expected: {
+          completedLessonCount: 1,
+          courseLessonStatus: "completed",
+          lessonCompleted: true,
+          attempts: 2,
+        },
+      });
+
+      await waitForUserQuizAttemptCountFlow(apiClient, secondExpectedQuizAttemptCount);
+    },
+    { root: true },
+  );
+});

--- a/apps/web/e2e/specs/learning/start-learning.spec.ts
+++ b/apps/web/e2e/specs/learning/start-learning.spec.ts
@@ -1,0 +1,71 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { COURSE_OVERVIEW_HANDLES } from "../../data/courses/handles";
+import { LEARNING_HANDLES } from "../../data/learning/handles";
+import { expect, test } from "../../fixtures/test.fixture";
+import { assertCourseLessonProgressFlow } from "../../flows/learning/assert-learning-progress.flow";
+import { goToNextLessonFlow } from "../../flows/learning/go-to-next-lesson.flow";
+import { openCourseOverviewFlow } from "../../flows/learning/open-course-overview.flow";
+import { startLearningFlow } from "../../flows/learning/start-learning.flow";
+
+import { createTwoContentLessonsCourse } from "./learning-test-helpers";
+
+test("student can start learning and continue to the next content lesson", async ({
+  apiClient,
+  cleanup,
+  factories,
+  withWorkerPage,
+}) => {
+  const enrollmentFactory = factories.createEnrollmentFactory();
+
+  const { courseId, lessons } = await createTwoContentLessonsCourse({
+    cleanup,
+    factories,
+    prefix: `learning-${Date.now()}`,
+    withWorkerPage,
+  });
+  const { firstLesson, secondLesson } = lessons;
+
+  await withWorkerPage(
+    USER_ROLE.student,
+    async ({ page }) => {
+      await enrollmentFactory.selfEnroll(courseId);
+
+      await openCourseOverviewFlow(page, courseId);
+      await expect(page.getByTestId(COURSE_OVERVIEW_HANDLES.START_LEARNING_BUTTON)).toBeVisible();
+
+      await startLearningFlow(page);
+
+      await expect(page).toHaveURL(new RegExp(`/course/.+/lesson/${firstLesson.id}$`));
+      await expect(page.getByTestId(LEARNING_HANDLES.LESSON_TITLE)).toHaveText(firstLesson.title);
+      await expect(page.getByTestId(LEARNING_HANDLES.CURRENT_LESSON_NUMBER)).toHaveText("1");
+      await expect(page.getByTestId(LEARNING_HANDLES.LESSONS_COUNT)).toHaveText("2");
+      await expect(page.getByTestId(LEARNING_HANDLES.LESSON_TYPE)).toBeVisible();
+
+      await assertCourseLessonProgressFlow(apiClient, courseId, {
+        completedLessonCount: 1,
+        lessonId: firstLesson.id,
+        lessonStatus: "completed",
+      });
+
+      await expect(page.getByTestId(LEARNING_HANDLES.NEXT_LESSON_BUTTON)).toBeEnabled();
+      await goToNextLessonFlow(page);
+
+      await expect(page).toHaveURL(new RegExp(`/course/.+/lesson/${secondLesson.id}$`));
+      await expect(page.getByTestId(LEARNING_HANDLES.LESSON_TITLE)).toHaveText(secondLesson.title);
+
+      await assertCourseLessonProgressFlow(apiClient, courseId, {
+        completedLessonCount: 2,
+        lessonId: secondLesson.id,
+        lessonStatus: "completed",
+      });
+
+      await openCourseOverviewFlow(page, courseId);
+      await expect(page.getByTestId(COURSE_OVERVIEW_HANDLES.START_LEARNING_BUTTON)).toBeVisible();
+      await startLearningFlow(page);
+
+      await expect(page).toHaveURL(new RegExp(`/course/.+/lesson/${firstLesson.id}$`));
+    },
+    { root: true },
+  );
+});

--- a/apps/web/e2e/strategy.md
+++ b/apps/web/e2e/strategy.md
@@ -341,7 +341,7 @@ Based on `playwright-strategy/03-capability-coverage.md`:
   - authenticated visibility
   - manage/super-admin visibility
   - invalid-route redirects
-- Learning
+- Learning -- DONE
   - lesson open
   - next lesson progression
   - mark complete
@@ -376,9 +376,9 @@ Based on `playwright-strategy/03-capability-coverage.md`:
   - feature toggles
 - Certificates
   - view/download/share link/share render
-- Onboarding
+- Onboarding -- SKIP
   - progression/completion/reset
-- Support Mode
+- Support Mode -- DONE
   - entry/exit
   - visibility/badge behavior
 - i18n -- DONE


### PR DESCRIPTION
## Issue(s)
- #1354

## Overview
Extended learning E2E coverage and make specs easier to read and maintain.

Coverage includes:
  - start learning and next lesson progression
  - lesson sequence enforcement and blocked access
  - quiz submit and retake
  - quiz submit with all rendered question types
  - AI mentor entry
  - embed lesson access

## Business Value
Keeps learning flows covered end to end and reduces regression risk around course progression, quiz handling, and blocked lesson access.

### Notes

- [x] Fired up e2e tests and got a positive result