### PR TITLE
test: extend statistics test coverage

### DIFF
--- a/apps/api/src/swagger/api-schema.json
+++ b/apps/api/src/swagger/api-schema.json
@@ -6942,6 +6942,27 @@
         }
       }
     },
+    "/api/test-config/ai-mentor-statistics-progress": {
+      "post": {
+        "operationId": "TestConfigController_prepareAiMentorStatisticsProgress",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PrepareAiMentorStatisticsProgressBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        }
+      }
+    },
     "/api/category": {
       "get": {
         "operationId": "CategoryController_getAllCategories",
@@ -26288,6 +26309,48 @@
         },
         "required": [
           "data"
+        ]
+      },
+      "PrepareAiMentorStatisticsProgressBody": {
+        "type": "object",
+        "properties": {
+          "lessonId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "studentId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "language": {
+            "default": "en",
+            "anyOf": [
+              {
+                "const": "en",
+                "type": "string"
+              },
+              {
+                "const": "pl",
+                "type": "string"
+              },
+              {
+                "const": "de",
+                "type": "string"
+              },
+              {
+                "const": "lt",
+                "type": "string"
+              },
+              {
+                "const": "cs",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "required": [
+          "lessonId",
+          "studentId"
         ]
       },
       "GetAllCategoriesResponse": {

--- a/apps/api/src/test-config/api/test-config.controller.ts
+++ b/apps/api/src/test-config/api/test-config.controller.ts
@@ -1,9 +1,26 @@
-import { Controller, Post } from "@nestjs/common";
+import { Body, Controller, Post } from "@nestjs/common";
+import { PERMISSIONS, SUPPORTED_LANGUAGES } from "@repo/shared";
+import { Type } from "@sinclair/typebox";
+import { Validate } from "nestjs-typebox";
 
+import { UUIDSchema } from "src/common";
 import { Public } from "src/common/decorators/public.decorator";
+import { RequirePermission } from "src/common/decorators/require-permission.decorator";
 import { OnlyStaging } from "src/common/decorators/staging.decorator";
+import { CurrentUser } from "src/common/decorators/user.decorator";
+import { CurrentUserType } from "src/common/types/current-user.type";
+import { supportedLanguagesSchema } from "src/courses/schemas/course.schema";
 
 import { TestConfigService } from "../test-config.service";
+
+import type { Static } from "@sinclair/typebox";
+
+const prepareAiMentorStatisticsProgressSchema = Type.Object({
+  lessonId: UUIDSchema,
+  studentId: UUIDSchema,
+  language: Type.Optional(supportedLanguagesSchema),
+});
+type PrepareAiMentorStatisticsProgressBody = Static<typeof prepareAiMentorStatisticsProgressSchema>;
 
 @Controller("test-config")
 export class TestConfigController {
@@ -20,5 +37,22 @@ export class TestConfigController {
   @OnlyStaging()
   async teardown(): Promise<void> {
     return this.testConfigService.teardown();
+  }
+
+  @Post("ai-mentor-statistics-progress")
+  @RequirePermission(PERMISSIONS.COURSE_STATISTICS)
+  @Validate({
+    request: [{ type: "body", schema: prepareAiMentorStatisticsProgressSchema }],
+  })
+  async prepareAiMentorStatisticsProgress(
+    @Body() body: PrepareAiMentorStatisticsProgressBody,
+    @CurrentUser() currentUser: CurrentUserType,
+  ): Promise<void> {
+    return this.testConfigService.prepareAiMentorStatisticsProgress({
+      language: body.language ?? SUPPORTED_LANGUAGES.EN,
+      lessonId: body.lessonId,
+      studentId: body.studentId,
+      actor: currentUser,
+    });
   }
 }

--- a/apps/api/src/test-config/test-config.module.ts
+++ b/apps/api/src/test-config/test-config.module.ts
@@ -1,10 +1,12 @@
 import { Module } from "@nestjs/common";
 
+import { StudentLessonProgressModule } from "src/studentLessonProgress/studentLessonProgress.module";
+
 import { TestConfigController } from "./api/test-config.controller";
 import { TestConfigService } from "./test-config.service";
 
 @Module({
-  imports: [],
+  imports: [StudentLessonProgressModule],
   controllers: [TestConfigController],
   providers: [TestConfigService],
   exports: [],

--- a/apps/api/src/test-config/test-config.service.ts
+++ b/apps/api/src/test-config/test-config.service.ts
@@ -1,8 +1,15 @@
-import { Injectable, NotImplementedException } from "@nestjs/common";
+import { ForbiddenException, Injectable, NotImplementedException } from "@nestjs/common";
+import { SUPPORTED_LANGUAGES } from "@repo/shared";
+
+import { StudentLessonProgressService } from "src/studentLessonProgress/studentLessonProgress.service";
+
+import type { SupportedLanguages } from "@repo/shared";
+import type { UUIDType } from "src/common";
+import type { CurrentUserType } from "src/common/types/current-user.type";
 
 @Injectable()
 export class TestConfigService {
-  constructor() {}
+  constructor(private readonly studentLessonProgressService: StudentLessonProgressService) {}
 
   public async setup() {
     throw new NotImplementedException();
@@ -10,5 +17,41 @@ export class TestConfigService {
 
   public async teardown() {
     throw new NotImplementedException();
+  }
+
+  public async prepareAiMentorStatisticsProgress({
+    actor,
+    language = SUPPORTED_LANGUAGES.EN,
+    lessonId,
+    studentId,
+  }: {
+    actor: CurrentUserType;
+    language?: SupportedLanguages;
+    lessonId: UUIDType;
+    studentId: UUIDType;
+  }) {
+    this.ensureTestConfigWritesAllowed();
+
+    await this.studentLessonProgressService.markLessonAsCompleted({
+      actor,
+      aiMentorLessonData: {
+        maxScore: 10,
+        minScore: 5,
+        passed: true,
+        percentage: 80,
+        score: 8,
+        summary: "Prepared AI mentor statistics progress for E2E.",
+      },
+      id: lessonId,
+      language,
+      studentId,
+      userPermissions: [],
+    });
+  }
+
+  private ensureTestConfigWritesAllowed() {
+    if (process.env.NODE_ENV === "test" || process.env.NODE_ENV === "staging") return;
+
+    throw new ForbiddenException("Test config writes are disabled outside test and staging");
   }
 }

--- a/apps/web/app/api/generated-api.ts
+++ b/apps/web/app/api/generated-api.ts
@@ -3323,6 +3323,15 @@ export interface UpdatePromotionCodeResponse {
   };
 }
 
+export interface PrepareAiMentorStatisticsProgressBody {
+  /** @format uuid */
+  lessonId: string;
+  /** @format uuid */
+  studentId: string;
+  /** @default "en" */
+  language?: "en" | "pl" | "de" | "lt" | "cs";
+}
+
 export interface GetAllCategoriesResponse {
   data: {
     /** @format uuid */
@@ -8269,6 +8278,24 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       this.request<void, any>({
         path: `/api/test-config/teardown`,
         method: "POST",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @name TestConfigControllerPrepareAiMentorStatisticsProgress
+     * @request POST:/api/test-config/ai-mentor-statistics-progress
+     */
+    testConfigControllerPrepareAiMentorStatisticsProgress: (
+      data: PrepareAiMentorStatisticsProgressBody,
+      params: RequestParams = {},
+    ) =>
+      this.request<void, any>({
+        path: `/api/test-config/ai-mentor-statistics-progress`,
+        method: "POST",
+        body: data,
+        type: ContentType.Json,
         ...params,
       }),
 

--- a/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/CourseAdminStatistics.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/CourseAdminStatistics.tsx
@@ -26,6 +26,8 @@ import {
 } from "~/modules/common/SearchFilter/SearchFilter";
 import { CourseStudentsLearningTimeTable } from "~/modules/Courses/CourseView/CourseAdminStatistics/components/CourseStudentsLearningTimeTable";
 
+import { COURSE_STATISTICS_HANDLES } from "../../../../../e2e/data/statistics/handles";
+
 import {
   CourseAdminStatisticsCard,
   CourseStatusDistributionChart,
@@ -142,6 +144,7 @@ export function CourseAdminStatistics({ course }: CourseAdminStatisticsProps) {
     {
       name: "search",
       type: "text",
+      testId: COURSE_STATISTICS_HANDLES.DETAILS_SEARCH_INPUT,
     },
   ];
 
@@ -154,6 +157,8 @@ export function CourseAdminStatistics({ course }: CourseAdminStatisticsProps) {
         value: group.id,
       })),
       placeholder: t("adminCourseView.statistics.groupFilter.placeholder"),
+      testId: COURSE_STATISTICS_HANDLES.GROUP_FILTER,
+      optionTestId: (option) => COURSE_STATISTICS_HANDLES.groupFilterOption(option.value),
     },
   ];
 
@@ -254,7 +259,7 @@ export function CourseAdminStatistics({ course }: CourseAdminStatisticsProps) {
 
   return (
     <TooltipProvider>
-      <Card>
+      <Card data-testid={COURSE_STATISTICS_HANDLES.ROOT}>
         <CardHeader>
           <h6 className="h6">{t("adminCourseView.statistics.title")}</h6>
           <p className="body-base-md title-neutral-800">
@@ -275,17 +280,20 @@ export function CourseAdminStatistics({ course }: CourseAdminStatisticsProps) {
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3 grid-rows-auto md:grid-rows-4">
             <CourseAdminStatisticsCard
+              data-testid={COURSE_STATISTICS_HANDLES.OVERVIEW_ENROLLED_COUNT_CARD}
               title={t("adminCourseView.statistics.overview.enrolledCount")}
               tooltipText={t("adminCourseView.statistics.overview.enrolledCountTooltip")}
               statistic={courseStatistics?.enrolledCount ?? 0}
             />
             <CourseAdminStatisticsCard
+              data-testid={COURSE_STATISTICS_HANDLES.OVERVIEW_COMPLETION_RATE_CARD}
               title={t("adminCourseView.statistics.overview.completionRate")}
               tooltipText={t("adminCourseView.statistics.overview.completionRateTooltip")}
               statistic={courseStatistics?.completionPercentage ?? 0}
               type="percentage"
             />
             <CourseAdminStatisticsCard
+              data-testid={COURSE_STATISTICS_HANDLES.OVERVIEW_AVERAGE_COMPLETION_CARD}
               title={t("adminCourseView.statistics.overview.averageCompletionPercentage")}
               tooltipText={t(
                 "adminCourseView.statistics.overview.averageCompletionPercentageTooltip",
@@ -294,6 +302,7 @@ export function CourseAdminStatistics({ course }: CourseAdminStatisticsProps) {
               type="percentage"
             />
             <CourseAdminStatisticsCard
+              data-testid={COURSE_STATISTICS_HANDLES.OVERVIEW_AVERAGE_LEARNING_TIME_CARD}
               title={t("adminCourseView.statistics.overview.averageLearningTime")}
               tooltipText={t("adminCourseView.statistics.overview.averageLearningTimeTooltip")}
               statistic={formatLearningTime(courseStatistics?.averageSeconds ?? 0)}
@@ -327,15 +336,25 @@ export function CourseAdminStatistics({ course }: CourseAdminStatisticsProps) {
                         value={(quizSearchParams.quizId as string) || "all"}
                         onValueChange={(value) => handleQuizFilterChange("quizId", value)}
                       >
-                        <SelectTrigger className="max-w-52">
+                        <SelectTrigger
+                          data-testid={COURSE_STATISTICS_HANDLES.QUIZ_FILTER}
+                          className="max-w-52"
+                        >
                           <SelectValue placeholder={t("adminCourseView.statistics.filterByQuiz")} />
                         </SelectTrigger>
                         <SelectContent>
-                          <SelectItem value="all">
+                          <SelectItem
+                            data-testid={COURSE_STATISTICS_HANDLES.quizFilterOption("all")}
+                            value="all"
+                          >
                             {t("adminCourseView.statistics.allQuizzes")}
                           </SelectItem>
                           {quizOptions.map((quiz) => (
-                            <SelectItem key={quiz.id} value={quiz.id}>
+                            <SelectItem
+                              key={quiz.id}
+                              data-testid={COURSE_STATISTICS_HANDLES.quizFilterOption(quiz.id)}
+                              value={quiz.id}
+                            >
                               {quiz.title}
                             </SelectItem>
                           ))}
@@ -347,17 +366,31 @@ export function CourseAdminStatistics({ course }: CourseAdminStatisticsProps) {
                         value={(aiMentorSearchParams.lessonId as string) || "all"}
                         onValueChange={(value) => handleAiMentorFilterChange("lessonId", value)}
                       >
-                        <SelectTrigger className="max-w-52">
+                        <SelectTrigger
+                          data-testid={COURSE_STATISTICS_HANDLES.AI_MENTOR_LESSON_FILTER}
+                          className="max-w-52"
+                        >
                           <SelectValue
                             placeholder={t("adminCourseView.statistics.filterByLesson")}
                           />
                         </SelectTrigger>
                         <SelectContent>
-                          <SelectItem value="all">
+                          <SelectItem
+                            data-testid={COURSE_STATISTICS_HANDLES.aiMentorLessonFilterOption(
+                              "all",
+                            )}
+                            value="all"
+                          >
                             {t("adminCourseView.statistics.allLessons")}
                           </SelectItem>
                           {aiMentorLessons.map((aiMentorLesson) => (
-                            <SelectItem key={aiMentorLesson.id} value={aiMentorLesson.id}>
+                            <SelectItem
+                              key={aiMentorLesson.id}
+                              data-testid={COURSE_STATISTICS_HANDLES.aiMentorLessonFilterOption(
+                                aiMentorLesson.id,
+                              )}
+                              value={aiMentorLesson.id}
+                            >
                               {aiMentorLesson.title}
                             </SelectItem>
                           ))}
@@ -370,6 +403,14 @@ export function CourseAdminStatistics({ course }: CourseAdminStatisticsProps) {
                   {Object.values(StatisticsTabs).map((tab) => (
                     <TabsTrigger
                       key={tab}
+                      data-testid={
+                        {
+                          progress: COURSE_STATISTICS_HANDLES.PROGRESS_TAB,
+                          quizResults: COURSE_STATISTICS_HANDLES.QUIZ_RESULTS_TAB,
+                          aiMentorResults: COURSE_STATISTICS_HANDLES.AI_MENTOR_RESULTS_TAB,
+                          learningTime: COURSE_STATISTICS_HANDLES.LEARNING_TIME_TAB,
+                        }[tab]
+                      }
                       className="h-full grow md:w-fit"
                       value={tab}
                       onClick={() => setActiveTab(tab)}

--- a/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/components/CourseAdminStatisticsCard.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/components/CourseAdminStatisticsCard.tsx
@@ -2,6 +2,7 @@ import { Info } from "~/assets/svgs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "~/components/ui/tooltip";
 
 interface CourseAdminStatisticsCardProps {
+  "data-testid"?: string;
   title: string;
   statistic: number | string;
   tooltipText: string;
@@ -9,6 +10,7 @@ interface CourseAdminStatisticsCardProps {
 }
 
 export function CourseAdminStatisticsCard({
+  "data-testid": testId,
   title,
   statistic,
   tooltipText,
@@ -22,7 +24,10 @@ export function CourseAdminStatisticsCard({
   };
 
   return (
-    <div className="rounded-sm p-6 outline outline-1 outline-neutral-200 flex flex-col justify-center">
+    <div
+      data-testid={testId}
+      className="rounded-sm p-6 outline outline-1 outline-neutral-200 flex flex-col justify-center"
+    >
       <div className="flex items-center gap-2">
         <p className="body-sm-md">{title}</p>
         <Tooltip>

--- a/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/components/CourseStudentsAiMentorResults.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/components/CourseStudentsAiMentorResults.tsx
@@ -23,6 +23,8 @@ import { usePermissions } from "~/hooks/usePermissions";
 import { cn } from "~/lib/utils";
 import { tanstackSortingToParam } from "~/utils/tanstackSortingToParam";
 
+import { COURSE_STATISTICS_HANDLES } from "../../../../../../e2e/data/statistics/handles";
+
 import LessonPreviewDialog from "./LessonPreviewDialog";
 
 import type { ColumnDef, SortingState } from "@tanstack/react-table";
@@ -145,6 +147,10 @@ export function CourseStudentsAiMentorResultsTable({
         cell: ({ row }) => (
           <div className="flex justify-center">
             <Button
+              data-testid={COURSE_STATISTICS_HANDLES.aiMentorResultsPreviewButton(
+                row.original.studentId,
+                row.original.lessonId,
+              )}
               variant="outline"
               size="icon"
               onClick={() => {
@@ -191,6 +197,7 @@ export function CourseStudentsAiMentorResultsTable({
 
   return (
     <div
+      data-testid={COURSE_STATISTICS_HANDLES.AI_MENTOR_RESULTS_TABLE}
       className={cn(
         "rounded-lg overflow-hidden border border-neutral-200 relative",
         isFetching && "shimmer-45",
@@ -212,6 +219,10 @@ export function CourseStudentsAiMentorResultsTable({
           {table.getRowModel().rows.map((row) => (
             <TableRow
               key={row.id}
+              data-testid={COURSE_STATISTICS_HANDLES.aiMentorResultsRow(
+                row.original.studentId,
+                row.original.lessonId,
+              )}
               data-state={row.getIsSelected() && "selected"}
               className="cursor-pointer hover:bg-neutral-100"
             >

--- a/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/components/CourseStudentsLearningTimeTable.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/components/CourseStudentsLearningTimeTable.tsx
@@ -22,6 +22,8 @@ import { cn } from "~/lib/utils";
 import { formatLearningTime } from "~/modules/Courses/CourseView/CourseAdminStatistics/CourseAdminStatistics";
 import { tanstackSortingToParam } from "~/utils/tanstackSortingToParam";
 
+import { COURSE_STATISTICS_HANDLES } from "../../../../../../e2e/data/statistics/handles";
+
 import type { ColumnDef, SortingState } from "@tanstack/react-table";
 import type { GetCourseLearningTimeStatisticsResponse } from "~/api/generated-api";
 import type { CourseLearningTimeFilterQuery } from "~/api/queries/admin/useCourseLearningTimeStatistics";
@@ -181,6 +183,7 @@ export function CourseStudentsLearningTimeTable({
 
   return (
     <div
+      data-testid={COURSE_STATISTICS_HANDLES.LEARNING_TIME_TABLE}
       className={cn(
         "rounded-lg overflow-hidden border border-neutral-200 relative",
         isFetching && "shimmer-45",
@@ -202,6 +205,7 @@ export function CourseStudentsLearningTimeTable({
           {table.getRowModel().rows.map((row) => (
             <TableRow
               key={row.id}
+              data-testid={COURSE_STATISTICS_HANDLES.learningTimeRow(row.original.id)}
               data-course-id={row.original.id}
               data-state={row.getIsSelected() && "selected"}
               className="cursor-pointer hover:bg-neutral-100"

--- a/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/components/CourseStudentsProgressTable.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/components/CourseStudentsProgressTable.tsx
@@ -24,6 +24,8 @@ import { cn } from "~/lib/utils";
 import { useLanguageStore } from "~/modules/Dashboard/Settings/Language/LanguageStore";
 import { tanstackSortingToParam } from "~/utils/tanstackSortingToParam";
 
+import { COURSE_STATISTICS_HANDLES } from "../../../../../../e2e/data/statistics/handles";
+
 import type { ColumnDef, SortingState } from "@tanstack/react-table";
 import type { GetCourseStudentsProgressResponse } from "~/api/generated-api";
 import type { CourseStudentsProgressQueryParams } from "~/api/queries/admin/useCourseStudentsProgress";
@@ -230,6 +232,7 @@ export function CourseStudentsProgressTable({
 
   return (
     <div
+      data-testid={COURSE_STATISTICS_HANDLES.PROGRESS_TABLE}
       className={cn(
         "rounded-lg overflow-hidden border border-neutral-200 relative",
         isFetching && "shimmer-45",
@@ -251,6 +254,7 @@ export function CourseStudentsProgressTable({
           {table.getRowModel().rows.map((row) => (
             <TableRow
               key={row.id}
+              data-testid={COURSE_STATISTICS_HANDLES.progressRow(row.original.studentId)}
               data-course-id={row.original.studentId}
               data-state={row.getIsSelected() && "selected"}
               className="cursor-pointer hover:bg-neutral-100"

--- a/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/components/CourseStudentsQuizResultsTable.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/components/CourseStudentsQuizResultsTable.tsx
@@ -24,6 +24,8 @@ import { cn } from "~/lib/utils";
 import Loader from "~/modules/common/Loader/Loader";
 import { tanstackSortingToParam } from "~/utils/tanstackSortingToParam";
 
+import { COURSE_STATISTICS_HANDLES } from "../../../../../../e2e/data/statistics/handles";
+
 import LessonPreviewDialog from "./LessonPreviewDialog";
 
 import type { ColumnDef, SortingState } from "@tanstack/react-table";
@@ -153,6 +155,10 @@ export function CourseStudentsQuizResultsTable({
         cell: ({ row }) => (
           <div className="flex justify-center">
             <Button
+              data-testid={COURSE_STATISTICS_HANDLES.quizResultsPreviewButton(
+                row.original.studentId,
+                row.original.lessonId,
+              )}
               variant="outline"
               size="icon"
               onClick={() => {
@@ -207,6 +213,7 @@ export function CourseStudentsQuizResultsTable({
 
   return (
     <div
+      data-testid={COURSE_STATISTICS_HANDLES.QUIZ_RESULTS_TABLE}
       className={cn(
         "rounded-lg overflow-hidden border border-neutral-200 relative",
         isFetching && "shimmer-45",
@@ -228,6 +235,10 @@ export function CourseStudentsQuizResultsTable({
           {table.getRowModel().rows.map((row) => (
             <TableRow
               key={row.id}
+              data-testid={COURSE_STATISTICS_HANDLES.quizResultsRow(
+                row.original.studentId,
+                row.original.lessonId,
+              )}
               data-state={row.getIsSelected() && "selected"}
               className="cursor-pointer hover:bg-neutral-100"
             >

--- a/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/components/LessonPreviewDialog.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/components/LessonPreviewDialog.tsx
@@ -14,6 +14,8 @@ import { CourseAccessProvider } from "~/modules/Courses/context/CourseAccessProv
 import { LessonContent } from "~/modules/Courses/Lesson/LessonContent";
 import { useLanguageStore } from "~/modules/Dashboard/Settings/Language/LanguageStore";
 
+import { COURSE_STATISTICS_HANDLES } from "../../../../../../e2e/data/statistics/handles";
+
 import type { GetCourseResponse } from "~/api/generated-api";
 
 interface LessonPreviewDialogProps {
@@ -79,6 +81,7 @@ export default function LessonPreviewDialog({
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent
+        data-testid={COURSE_STATISTICS_HANDLES.LESSON_PREVIEW_DIALOG}
         className="max-h-[90vh] w-[90%] max-w-screen-2xl 3xl:max-w-[1024px] p-0 gap-0 flex flex-col"
         noCloseButton
       >

--- a/apps/web/app/modules/Courses/CourseView/CourseView.page.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseView.page.tsx
@@ -19,6 +19,8 @@ import { LearningModeBanner } from "~/modules/Courses/Lesson/LearningModeBanner"
 import { useLanguageStore } from "~/modules/Dashboard/Settings/Language/LanguageStore";
 import { isSupportedLanguage } from "~/utils/browser-language";
 
+import { COURSE_STATISTICS_HANDLES } from "../../../../e2e/data/statistics/handles";
+
 import { ChapterListOverview } from "./components/ChapterListOverview";
 import { CourseAdminStatistics } from "./CourseAdminStatistics/CourseAdminStatistics";
 import CourseCertificate from "./CourseCertificate";
@@ -100,6 +102,7 @@ export default function CourseViewPage() {
   const courseViewTabs = useMemo(
     () => [
       {
+        key: "chapters",
         title: t("studentCourseView.tabs.chapters"),
         itemCount: course?.chapters?.length,
         content: <ChapterListOverview />,
@@ -107,6 +110,7 @@ export default function CourseViewPage() {
         isForUnregistered: true,
       },
       {
+        key: "moreFromAuthor",
         title: t("studentCourseView.tabs.moreFromAuthor"),
         content: (
           <div className="flex flex-col gap-6">
@@ -118,6 +122,7 @@ export default function CourseViewPage() {
         isForUnregistered: false,
       },
       {
+        key: "statistics",
         title: t("studentCourseView.tabs.statistics"),
         content: <CourseAdminStatistics course={course} />,
         isForAdminLike: true,
@@ -157,13 +162,18 @@ export default function CourseViewPage() {
               <Tabs defaultValue={courseViewTabs[0].title} className="w-full">
                 <TabsList className="bg-card w-full justify-start gap-4 p-0 overflow-hidden">
                   {courseViewTabs.map((tab) => {
-                    const { title, isForAdminLike, isForUnregistered } = tab;
+                    const { key, title, isForAdminLike, isForUnregistered } = tab;
 
                     if (!canView(isForAdminLike, isForUnregistered)) return null;
 
                     return (
                       <TabsTrigger
                         key={title}
+                        data-testid={
+                          key === "statistics"
+                            ? COURSE_STATISTICS_HANDLES.COURSE_VIEW_STATISTICS_TAB
+                            : undefined
+                        }
                         value={title}
                         className="flex h-full rounded-none items-center gap-1.5 data-[state=active]:shadow-none text-neutral-900 data-[state=active]:text-primary-700 data-[state=active]:border-b-2 data-[state=active]:border-b-primary-700"
                       >

--- a/apps/web/app/modules/Statistics/Admin/AdminStatistics.tsx
+++ b/apps/web/app/modules/Statistics/Admin/AdminStatistics.tsx
@@ -10,6 +10,8 @@ import { ConversionsAfterFreemiumLessonChart } from "~/modules/Statistics/Admin/
 import { EnrollmentChart } from "~/modules/Statistics/Admin/components/EnrollmentChart";
 import { useDownloadSummaryReport } from "~/modules/Statistics/Admin/hooks/useDownloadSummaryReport";
 
+import { ADMIN_STATISTICS_HANDLES } from "../../../../e2e/data/statistics/handles";
+
 import { CourseCompletionPercentageChart, FiveMostPopularCoursesChart } from "./components";
 
 import type { ChartConfig } from "~/components/ui/chart";
@@ -119,39 +121,56 @@ export const AdminStatistics = () => {
       className="flex flex-col gap-y-6 xl:!h-full xl:gap-y-8 2xl:!h-auto"
     >
       <div className="flex items-center justify-end gap-x-4">
-        <Button onClick={downloadReport} disabled={isDownloading}>
+        <Button
+          data-testid={ADMIN_STATISTICS_HANDLES.DOWNLOAD_REPORT_BUTTON}
+          onClick={downloadReport}
+          disabled={isDownloading}
+        >
           {isDownloading
             ? t("adminStatisticsView.other.downloadingReport")
             : t("adminStatisticsView.other.downloadReport")}
         </Button>
       </div>
-      <div className="grid grid-cols-1 gap-y-4 md:grid-cols-2 md:gap-x-4 md:gap-y-6 xl:h-full xl:grid-cols-4 xl:grid-rows-[minmax(min-content,_auto)]">
-        <FiveMostPopularCoursesChart
-          data={statistics?.fiveMostPopularCourses}
-          isLoading={isLoading}
-        />
-        <CourseCompletionPercentageChart
-          isLoading={isLoading}
-          label={`${statistics?.totalCoursesCompletionStats.completionPercentage}`}
-          title={t("adminStatisticsView.other.courseCompletionPercentage")}
-          chartConfig={coursesCompletionChartConfig}
-          chartData={coursesCompletionChartData}
-        />
-        <ConversionsAfterFreemiumLessonChart
-          isLoading={isLoading}
-          label={`${statistics?.conversionAfterFreemiumLesson.conversionPercentage}`}
-          title={t("adminStatisticsView.other.conversionsAfterFreemiumLesson")}
-          chartConfig={conversionsChartConfig}
-          chartData={conversionsChartData}
-        />
-        <EnrollmentChart isLoading={isLoading} data={statistics?.courseStudentsStats} />
-        <AvgScoreAcrossAllQuizzesChart
-          isLoading={isLoading}
-          label={`${correctAnswers}/${totalAnswers}`}
-          title={t("adminStatisticsView.other.avgQuizScore")}
-          chartConfig={avgQuizScoreChartConfig}
-          chartData={avgQuizScoreChartData}
-        />
+      <div
+        data-testid={ADMIN_STATISTICS_HANDLES.PAGE}
+        className="grid grid-cols-1 gap-y-4 md:grid-cols-2 md:gap-x-4 md:gap-y-6 xl:h-full xl:grid-cols-4 xl:grid-rows-[minmax(min-content,_auto)]"
+      >
+        <div data-testid={ADMIN_STATISTICS_HANDLES.MOST_POPULAR_COURSES_CHART}>
+          <FiveMostPopularCoursesChart
+            data={statistics?.fiveMostPopularCourses}
+            isLoading={isLoading}
+          />
+        </div>
+        <div data-testid={ADMIN_STATISTICS_HANDLES.COURSE_COMPLETION_CHART}>
+          <CourseCompletionPercentageChart
+            isLoading={isLoading}
+            label={`${statistics?.totalCoursesCompletionStats.completionPercentage}`}
+            title={t("adminStatisticsView.other.courseCompletionPercentage")}
+            chartConfig={coursesCompletionChartConfig}
+            chartData={coursesCompletionChartData}
+          />
+        </div>
+        <div data-testid={ADMIN_STATISTICS_HANDLES.FREEMIUM_CONVERSION_CHART}>
+          <ConversionsAfterFreemiumLessonChart
+            isLoading={isLoading}
+            label={`${statistics?.conversionAfterFreemiumLesson.conversionPercentage}`}
+            title={t("adminStatisticsView.other.conversionsAfterFreemiumLesson")}
+            chartConfig={conversionsChartConfig}
+            chartData={conversionsChartData}
+          />
+        </div>
+        <div data-testid={ADMIN_STATISTICS_HANDLES.ENROLLMENT_CHART}>
+          <EnrollmentChart isLoading={isLoading} data={statistics?.courseStudentsStats} />
+        </div>
+        <div data-testid={ADMIN_STATISTICS_HANDLES.AVERAGE_QUIZ_SCORE_CHART}>
+          <AvgScoreAcrossAllQuizzesChart
+            isLoading={isLoading}
+            label={`${correctAnswers}/${totalAnswers}`}
+            title={t("adminStatisticsView.other.avgQuizScore")}
+            chartConfig={avgQuizScoreChartConfig}
+            chartData={avgQuizScoreChartData}
+          />
+        </div>
       </div>
     </PageWrapper>
   );

--- a/apps/web/e2e/data/learning/handles.ts
+++ b/apps/web/e2e/data/learning/handles.ts
@@ -15,7 +15,6 @@ export const LEARNING_HANDLES = {
   AI_MENTOR_MESSAGE_INPUT: "learning-ai-mentor-message-input",
   AI_MENTOR_MESSAGE_ACTION_BUTTON: "learning-ai-mentor-message-action-button",
   AI_MENTOR_MIC_BUTTON: "learning-ai-mentor-mic-button",
-  AI_MENTOR_MESSAGE: "learning-ai-mentor-message",
   aiMentorMessage: (messageId: string) => `learning-ai-mentor-message-${messageId}`,
   aiMentorMessageRole: (role: "assistant" | "user" | "data" | "system") =>
     `learning-ai-mentor-message-${role}`,

--- a/apps/web/e2e/data/learning/handles.ts
+++ b/apps/web/e2e/data/learning/handles.ts
@@ -11,6 +11,7 @@ export const LEARNING_HANDLES = {
   QUIZ_RETAKE_BUTTON: "learning-quiz-retake-button",
   AI_MENTOR_TASK_DESCRIPTION: "learning-ai-mentor-task-description",
   AI_MENTOR_MESSAGES: "learning-ai-mentor-messages",
+  AI_MENTOR_MESSAGE: "learning-ai-mentor-message",
   AI_MENTOR_MESSAGE_INPUT: "learning-ai-mentor-message-input",
   AI_MENTOR_MESSAGE_ACTION_BUTTON: "learning-ai-mentor-message-action-button",
   AI_MENTOR_MIC_BUTTON: "learning-ai-mentor-mic-button",

--- a/apps/web/e2e/data/statistics/handles.ts
+++ b/apps/web/e2e/data/statistics/handles.ts
@@ -1,0 +1,45 @@
+export const COURSE_STATISTICS_HANDLES = {
+  COURSE_VIEW_STATISTICS_TAB: "course-view-statistics-tab",
+  ROOT: "course-statistics-root",
+  GROUP_FILTER: "course-statistics-group-filter",
+  groupFilterOption: (groupId: string) => `course-statistics-group-filter-option-${groupId}`,
+  OVERVIEW_ENROLLED_COUNT_CARD: "course-statistics-overview-enrolled-count-card",
+  OVERVIEW_COMPLETION_RATE_CARD: "course-statistics-overview-completion-rate-card",
+  OVERVIEW_AVERAGE_COMPLETION_CARD: "course-statistics-overview-average-completion-card",
+  OVERVIEW_AVERAGE_LEARNING_TIME_CARD: "course-statistics-overview-average-learning-time-card",
+  DETAILS_SEARCH_INPUT: "course-statistics-details-search-input",
+  PROGRESS_TAB: "course-statistics-progress-tab",
+  QUIZ_RESULTS_TAB: "course-statistics-quiz-results-tab",
+  AI_MENTOR_RESULTS_TAB: "course-statistics-ai-mentor-results-tab",
+  LEARNING_TIME_TAB: "course-statistics-learning-time-tab",
+  PROGRESS_TABLE: "course-statistics-progress-table",
+  QUIZ_RESULTS_TABLE: "course-statistics-quiz-results-table",
+  AI_MENTOR_RESULTS_TABLE: "course-statistics-ai-mentor-results-table",
+  LEARNING_TIME_TABLE: "course-statistics-learning-time-table",
+  QUIZ_FILTER: "course-statistics-quiz-filter",
+  quizFilterOption: (quizId: string) => `course-statistics-quiz-filter-option-${quizId}`,
+  AI_MENTOR_LESSON_FILTER: "course-statistics-ai-mentor-lesson-filter",
+  aiMentorLessonFilterOption: (lessonId: string) =>
+    `course-statistics-ai-mentor-lesson-filter-option-${lessonId}`,
+  progressRow: (studentId: string) => `course-statistics-progress-row-${studentId}`,
+  quizResultsRow: (studentId: string, lessonId: string) =>
+    `course-statistics-quiz-results-row-${studentId}-${lessonId}`,
+  quizResultsPreviewButton: (studentId: string, lessonId: string) =>
+    `course-statistics-quiz-results-preview-button-${studentId}-${lessonId}`,
+  aiMentorResultsRow: (studentId: string, lessonId: string) =>
+    `course-statistics-ai-mentor-results-row-${studentId}-${lessonId}`,
+  aiMentorResultsPreviewButton: (studentId: string, lessonId: string) =>
+    `course-statistics-ai-mentor-results-preview-button-${studentId}-${lessonId}`,
+  learningTimeRow: (studentId: string) => `course-statistics-learning-time-row-${studentId}`,
+  LESSON_PREVIEW_DIALOG: "course-statistics-lesson-preview-dialog",
+} as const;
+
+export const ADMIN_STATISTICS_HANDLES = {
+  PAGE: "admin-statistics-page",
+  DOWNLOAD_REPORT_BUTTON: "admin-statistics-download-report-button",
+  MOST_POPULAR_COURSES_CHART: "admin-statistics-most-popular-courses-chart",
+  COURSE_COMPLETION_CHART: "admin-statistics-course-completion-chart",
+  FREEMIUM_CONVERSION_CHART: "admin-statistics-freemium-conversion-chart",
+  ENROLLMENT_CHART: "admin-statistics-enrollment-chart",
+  AVERAGE_QUIZ_SCORE_CHART: "admin-statistics-average-quiz-score-chart",
+} as const;

--- a/apps/web/e2e/flows/statistics/open-admin-statistics.flow.ts
+++ b/apps/web/e2e/flows/statistics/open-admin-statistics.flow.ts
@@ -1,0 +1,8 @@
+import { ADMIN_STATISTICS_HANDLES } from "../../data/statistics/handles";
+
+import type { Page } from "@playwright/test";
+
+export const openAdminStatisticsFlow = async (page: Page) => {
+  await page.goto("/admin/analytics");
+  await page.getByTestId(ADMIN_STATISTICS_HANDLES.PAGE).waitFor();
+};

--- a/apps/web/e2e/flows/statistics/open-course-statistics-tab.flow.ts
+++ b/apps/web/e2e/flows/statistics/open-course-statistics-tab.flow.ts
@@ -1,0 +1,16 @@
+import { COURSE_STATISTICS_HANDLES } from "../../data/statistics/handles";
+
+import type { Page } from "@playwright/test";
+
+type CourseStatisticsTab = "progress" | "quizResults" | "aiMentorResults" | "learningTime";
+
+const tabHandleByValue: Record<CourseStatisticsTab, string> = {
+  progress: COURSE_STATISTICS_HANDLES.PROGRESS_TAB,
+  quizResults: COURSE_STATISTICS_HANDLES.QUIZ_RESULTS_TAB,
+  aiMentorResults: COURSE_STATISTICS_HANDLES.AI_MENTOR_RESULTS_TAB,
+  learningTime: COURSE_STATISTICS_HANDLES.LEARNING_TIME_TAB,
+};
+
+export const openCourseStatisticsTabFlow = async (page: Page, tab: CourseStatisticsTab) => {
+  await page.getByTestId(tabHandleByValue[tab]).click();
+};

--- a/apps/web/e2e/flows/statistics/open-course-statistics.flow.ts
+++ b/apps/web/e2e/flows/statistics/open-course-statistics.flow.ts
@@ -1,0 +1,14 @@
+import { expect, type Page } from "@playwright/test";
+
+import { COURSE_STATISTICS_HANDLES } from "../../data/statistics/handles";
+
+export const openCourseStatisticsFlow = async (page: Page, courseId: string) => {
+  await page.goto(`/course/${courseId}`);
+
+  const statisticsTab = page.getByTestId(COURSE_STATISTICS_HANDLES.COURSE_VIEW_STATISTICS_TAB);
+
+  await statisticsTab.waitFor({ state: "visible" });
+  await statisticsTab.click();
+  await expect(statisticsTab).toHaveAttribute("data-state", "active");
+  await page.getByTestId(COURSE_STATISTICS_HANDLES.ROOT).waitFor({ state: "visible" });
+};

--- a/apps/web/e2e/flows/statistics/search-course-statistics.flow.ts
+++ b/apps/web/e2e/flows/statistics/search-course-statistics.flow.ts
@@ -1,0 +1,7 @@
+import { COURSE_STATISTICS_HANDLES } from "../../data/statistics/handles";
+
+import type { Page } from "@playwright/test";
+
+export const searchCourseStatisticsFlow = async (page: Page, search: string) => {
+  await page.getByTestId(COURSE_STATISTICS_HANDLES.DETAILS_SEARCH_INPUT).fill(search);
+};

--- a/apps/web/e2e/specs/statistics/admin-analytics.spec.ts
+++ b/apps/web/e2e/specs/statistics/admin-analytics.spec.ts
@@ -1,0 +1,43 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { ADMIN_STATISTICS_HANDLES } from "../../data/statistics/handles";
+import { expect, test } from "../../fixtures/test.fixture";
+import { openAdminStatisticsFlow } from "../../flows/statistics/open-admin-statistics.flow";
+
+test("admin can view analytics dashboard charts", async ({ withReadonlyPage }) => {
+  await withReadonlyPage(USER_ROLE.admin, async ({ page }) => {
+    await openAdminStatisticsFlow(page);
+
+    await expect(
+      page.getByTestId(ADMIN_STATISTICS_HANDLES.MOST_POPULAR_COURSES_CHART),
+    ).toBeVisible();
+    await expect(page.getByTestId(ADMIN_STATISTICS_HANDLES.COURSE_COMPLETION_CHART)).toBeVisible();
+    await expect(
+      page.getByTestId(ADMIN_STATISTICS_HANDLES.FREEMIUM_CONVERSION_CHART),
+    ).toBeVisible();
+    await expect(page.getByTestId(ADMIN_STATISTICS_HANDLES.ENROLLMENT_CHART)).toBeVisible();
+    await expect(page.getByTestId(ADMIN_STATISTICS_HANDLES.AVERAGE_QUIZ_SCORE_CHART)).toBeVisible();
+  });
+});
+
+test("admin can download analytics summary report", async ({ withReadonlyPage }) => {
+  await withReadonlyPage(USER_ROLE.admin, async ({ page }) => {
+    await openAdminStatisticsFlow(page);
+
+    await page.route("**/api/report/summary?**", async (route) => {
+      await route.fulfill({
+        body: "summary",
+        contentType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      });
+    });
+
+    const reportResponse = page.waitForResponse((response) =>
+      response.url().includes("/api/report/summary"),
+    );
+
+    await page.getByTestId(ADMIN_STATISTICS_HANDLES.DOWNLOAD_REPORT_BUTTON).click();
+
+    await expect((await reportResponse).ok()).toBe(true);
+    await expect(page.getByTestId(ADMIN_STATISTICS_HANDLES.DOWNLOAD_REPORT_BUTTON)).toBeEnabled();
+  });
+});

--- a/apps/web/e2e/specs/statistics/ai-mentor-statistics.spec.ts
+++ b/apps/web/e2e/specs/statistics/ai-mentor-statistics.spec.ts
@@ -1,0 +1,90 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { COURSE_STATISTICS_HANDLES } from "../../data/statistics/handles";
+import { expect, test } from "../../fixtures/test.fixture";
+import { openCourseStatisticsTabFlow } from "../../flows/statistics/open-course-statistics-tab.flow";
+import { openCourseStatisticsFlow } from "../../flows/statistics/open-course-statistics.flow";
+import { createAiMentorLessonCourse } from "../learning/learning-test-helpers";
+
+test("admin can view AI mentor statistics after prepared mentor progress", async ({
+  apiClient,
+  cleanup,
+  factories,
+  withWorkerPage,
+}) => {
+  const enrollmentFactory = factories.createEnrollmentFactory();
+  const { courseId, lessons } = await createAiMentorLessonCourse({
+    cleanup,
+    factories,
+    prefix: `statistics-ai-mentor-${Date.now()}`,
+    shouldKeepCourseAfterTest: () => true,
+    withWorkerPage,
+  });
+  const { aiMentorLesson } = lessons;
+
+  let studentId = "";
+
+  await withWorkerPage(
+    USER_ROLE.student,
+    async () => {
+      await enrollmentFactory.selfEnroll(courseId);
+      studentId = await enrollmentFactory.getCurrentUserId();
+    },
+    { root: true },
+  );
+
+  await withWorkerPage(
+    USER_ROLE.admin,
+    async ({ page }) => {
+      await apiClient.prepareAiMentorStatisticsProgress({
+        language: "en",
+        lessonId: aiMentorLesson.id,
+        studentId,
+      });
+
+      await expect
+        .poll(
+          async () => {
+            const response = await apiClient.api.courseControllerGetCourseStudentsAiMentorResults(
+              courseId,
+              {
+                language: "en",
+                perPage: 100,
+              },
+            );
+
+            return response.data.data.some(
+              (row) => row.studentId === studentId && row.lessonId === aiMentorLesson.id,
+            );
+          },
+          { timeout: 30_000 },
+        )
+        .toBe(true);
+
+      await openCourseStatisticsFlow(page, courseId);
+      await openCourseStatisticsTabFlow(page, "aiMentorResults");
+
+      await expect(
+        page.getByTestId(
+          COURSE_STATISTICS_HANDLES.aiMentorResultsRow(studentId, aiMentorLesson.id),
+        ),
+      ).toBeVisible();
+      await expect(
+        page.getByTestId(
+          COURSE_STATISTICS_HANDLES.aiMentorResultsPreviewButton(studentId, aiMentorLesson.id),
+        ),
+      ).toBeVisible();
+
+      await page.getByTestId(COURSE_STATISTICS_HANDLES.AI_MENTOR_LESSON_FILTER).click();
+      await page
+        .getByTestId(COURSE_STATISTICS_HANDLES.aiMentorLessonFilterOption(aiMentorLesson.id))
+        .click();
+      await expect(
+        page.getByTestId(
+          COURSE_STATISTICS_HANDLES.aiMentorResultsRow(studentId, aiMentorLesson.id),
+        ),
+      ).toBeVisible();
+    },
+    { root: true },
+  );
+});

--- a/apps/web/e2e/specs/statistics/course-statistics.spec.ts
+++ b/apps/web/e2e/specs/statistics/course-statistics.spec.ts
@@ -1,0 +1,180 @@
+import { SYSTEM_ROLE_SLUGS } from "@repo/shared";
+
+import { USER_ROLE } from "~/config/userRoles";
+
+import { COURSE_STATISTICS_HANDLES } from "../../data/statistics/handles";
+import { expect, test } from "../../fixtures/test.fixture";
+import { openCourseOverviewFlow } from "../../flows/learning/open-course-overview.flow";
+import { selectFirstSingleChoiceAnswerFlow } from "../../flows/learning/select-first-single-choice-answer.flow";
+import { startLearningFlow } from "../../flows/learning/start-learning.flow";
+import { submitQuizFlow } from "../../flows/learning/submit-quiz.flow";
+import { waitForUserQuizAttemptCountFlow } from "../../flows/learning/wait-for-quiz-attempt-count.flow";
+import { openCourseStatisticsTabFlow } from "../../flows/statistics/open-course-statistics-tab.flow";
+import { openCourseStatisticsFlow } from "../../flows/statistics/open-course-statistics.flow";
+import { searchCourseStatisticsFlow } from "../../flows/statistics/search-course-statistics.flow";
+import { createSingleChoiceQuizLessonCourse } from "../learning/learning-test-helpers";
+
+test("admin can view course statistics overview, progress, quiz results and filters", async ({
+  apiClient,
+  cleanup,
+  factories,
+  withWorkerPage,
+}) => {
+  const enrollmentFactory = factories.createEnrollmentFactory();
+  const groupFactory = factories.createGroupFactory();
+  const userFactory = factories.createUserFactory();
+  let quizWasSubmitted = false;
+
+  const { courseId, lessons } = await createSingleChoiceQuizLessonCourse({
+    cleanup,
+    factories,
+    prefix: `statistics-course-${Date.now()}`,
+    shouldKeepCourseAfterTest: () => quizWasSubmitted,
+    withWorkerPage,
+  });
+  const { quizLesson } = lessons;
+
+  let studentId = "";
+  let studentName = "";
+
+  await withWorkerPage(
+    USER_ROLE.student,
+    async ({ page }) => {
+      await enrollmentFactory.selfEnroll(courseId);
+      const currentUser = (await apiClient.api.authControllerCurrentUser()).data.data;
+      studentId = currentUser.id;
+      studentName = `${currentUser.firstName} ${currentUser.lastName}`;
+
+      await openCourseOverviewFlow(page, courseId);
+      await startLearningFlow(page);
+      await selectFirstSingleChoiceAnswerFlow(page);
+      await submitQuizFlow(page);
+      quizWasSubmitted = true;
+
+      await waitForUserQuizAttemptCountFlow(apiClient, 1);
+    },
+    { root: true },
+  );
+
+  await withWorkerPage(
+    USER_ROLE.admin,
+    async ({ page }) => {
+      const group = await groupFactory.create({
+        name: `statistics-group-${Date.now()}`,
+      });
+
+      cleanup.add(async () => {
+        await withWorkerPage(
+          USER_ROLE.admin,
+          async () => {
+            await enrollmentFactory.unenrollGroups(courseId, [group.id]);
+            await userFactory.update(studentId, {
+              groups: [],
+              roleSlugs: [SYSTEM_ROLE_SLUGS.STUDENT],
+            });
+            await groupFactory.delete(group.id);
+          },
+          { root: true },
+        );
+      });
+
+      await userFactory.update(studentId, {
+        groups: [group.id],
+        roleSlugs: [SYSTEM_ROLE_SLUGS.STUDENT],
+      });
+      await enrollmentFactory.enrollGroups(courseId, [
+        { id: group.id, isMandatory: false, dueDate: null },
+      ]);
+
+      await expect
+        .poll(async () => {
+          const [overview, progress, groupProgress, quizResults] = await Promise.all([
+            apiClient.api.courseControllerGetCourseStatistics(courseId),
+            apiClient.api.courseControllerGetCourseStudentsProgress(courseId, {
+              language: "en",
+              perPage: 100,
+            }),
+            apiClient.api.courseControllerGetCourseStudentsProgress(courseId, {
+              groupId: group.id,
+              language: "en",
+              perPage: 100,
+            }),
+            apiClient.api.courseControllerGetCourseStudentsQuizResults(courseId, {
+              language: "en",
+              perPage: 100,
+            }),
+          ]);
+
+          return {
+            enrolledCount: overview.data.data.enrolledCount,
+            progressRow: progress.data.data.some((row) => row.studentId === studentId),
+            groupProgressRow: groupProgress.data.data.some((row) => row.studentId === studentId),
+            quizRow: quizResults.data.data.some(
+              (row) => row.studentId === studentId && row.lessonId === quizLesson.id,
+            ),
+          };
+        })
+        .toEqual({
+          enrolledCount: 1,
+          progressRow: true,
+          groupProgressRow: true,
+          quizRow: true,
+        });
+
+      await openCourseStatisticsFlow(page, courseId);
+
+      await expect(
+        page.getByTestId(COURSE_STATISTICS_HANDLES.OVERVIEW_ENROLLED_COUNT_CARD),
+      ).toContainText("1");
+      await expect(
+        page.getByTestId(COURSE_STATISTICS_HANDLES.OVERVIEW_COMPLETION_RATE_CARD),
+      ).toContainText("100%");
+      await expect(
+        page.getByTestId(COURSE_STATISTICS_HANDLES.progressRow(studentId)),
+      ).toBeVisible();
+      await expect(
+        page.getByTestId(COURSE_STATISTICS_HANDLES.progressRow(studentId)),
+      ).toContainText(studentName);
+
+      await page.getByTestId(COURSE_STATISTICS_HANDLES.GROUP_FILTER).click();
+      await page.getByTestId(COURSE_STATISTICS_HANDLES.groupFilterOption(group.id)).click();
+      await expect(
+        page.getByTestId(COURSE_STATISTICS_HANDLES.progressRow(studentId)),
+      ).toBeVisible();
+
+      await page.getByTestId(COURSE_STATISTICS_HANDLES.GROUP_FILTER).click();
+      await page.getByTestId(COURSE_STATISTICS_HANDLES.groupFilterOption("all")).click();
+      await expect(
+        page.getByTestId(COURSE_STATISTICS_HANDLES.progressRow(studentId)),
+      ).toBeVisible();
+
+      await searchCourseStatisticsFlow(page, studentName);
+      await expect(
+        page.getByTestId(COURSE_STATISTICS_HANDLES.progressRow(studentId)),
+      ).toBeVisible();
+
+      await openCourseStatisticsTabFlow(page, "quizResults");
+      await expect(
+        page.getByTestId(COURSE_STATISTICS_HANDLES.quizResultsRow(studentId, quizLesson.id)),
+      ).toBeVisible();
+      await expect(
+        page.getByTestId(COURSE_STATISTICS_HANDLES.quizResultsRow(studentId, quizLesson.id)),
+      ).toContainText(quizLesson.title);
+
+      await page.getByTestId(COURSE_STATISTICS_HANDLES.QUIZ_FILTER).click();
+      await page.getByTestId(COURSE_STATISTICS_HANDLES.quizFilterOption(quizLesson.id)).click();
+      await expect(
+        page.getByTestId(COURSE_STATISTICS_HANDLES.quizResultsRow(studentId, quizLesson.id)),
+      ).toBeVisible();
+      await expect(
+        page.getByTestId(
+          COURSE_STATISTICS_HANDLES.quizResultsPreviewButton(studentId, quizLesson.id),
+        ),
+      ).toBeVisible();
+
+      await openCourseStatisticsTabFlow(page, "learningTime");
+      await expect(page.getByTestId(COURSE_STATISTICS_HANDLES.LEARNING_TIME_TABLE)).toBeVisible();
+    },
+    { root: true },
+  );
+});

--- a/apps/web/e2e/specs/statistics/role-access.spec.ts
+++ b/apps/web/e2e/specs/statistics/role-access.spec.ts
@@ -1,0 +1,41 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { COURSE_STATISTICS_HANDLES } from "../../data/statistics/handles";
+import { expect, test } from "../../fixtures/test.fixture";
+import { openCourseOverviewFlow } from "../../flows/learning/open-course-overview.flow";
+import { createSingleChoiceQuizLessonCourse } from "../learning/learning-test-helpers";
+
+test("course statistics tab is visible for admin and hidden for student", async ({
+  cleanup,
+  factories,
+  withWorkerPage,
+}) => {
+  const { courseId } = await createSingleChoiceQuizLessonCourse({
+    cleanup,
+    factories,
+    prefix: `statistics-role-access-${Date.now()}`,
+    withWorkerPage,
+  });
+
+  await withWorkerPage(
+    USER_ROLE.admin,
+    async ({ page }) => {
+      await openCourseOverviewFlow(page, courseId);
+      await expect(
+        page.getByTestId(COURSE_STATISTICS_HANDLES.COURSE_VIEW_STATISTICS_TAB),
+      ).toBeVisible();
+    },
+    { root: true },
+  );
+
+  await withWorkerPage(
+    USER_ROLE.student,
+    async ({ page }) => {
+      await openCourseOverviewFlow(page, courseId);
+      await expect(
+        page.getByTestId(COURSE_STATISTICS_HANDLES.COURSE_VIEW_STATISTICS_TAB),
+      ).toHaveCount(0);
+    },
+    { root: true },
+  );
+});

--- a/apps/web/e2e/utils/api-client.ts
+++ b/apps/web/e2e/utils/api-client.ts
@@ -3,6 +3,7 @@ import { AxiosHeaders } from "axios";
 import { API } from "~/api/generated-api";
 
 import type { BrowserContext, Cookie } from "@playwright/test";
+import type { PrepareAiMentorStatisticsProgressBody } from "~/api/generated-api";
 
 const DEFAULT_API_URL = "http://localhost:3000";
 
@@ -67,6 +68,10 @@ export class FixtureApiClient {
   async syncFromContext(context: BrowserContext, origin: string) {
     this.syncTenantOrigin(origin);
     this.syncCookies(await context.cookies());
+  }
+
+  async prepareAiMentorStatisticsProgress(input: PrepareAiMentorStatisticsProgressBody) {
+    await this.api.testConfigControllerPrepareAiMentorStatisticsProgress(input);
   }
 
   clearCookies() {


### PR DESCRIPTION
<!--
 1. Make sure you have correct branch name i.e. `ab_prefix_123_task_name`, where `123` is a issue ID, and `ab` is an author
 2. Make sure you have meaningful title related to task with correct prefix: feat/fix/chore/style/docs/refactor
 3. Reference multiple issues in one PR by listing them in the issues section
 4. Make sure all necessary sections are filled, remove obsolete sections
 5. Do a self review first
 6. Check if your PR includes only code related to your task
 7. `Notes` is used for additional info but also to notify if any action is required
-->

## Issue(s)
[1354](https://github.com/Selleo/mentingo/issues/1354)

 ## Overview
  <!--
  General description what it does
  -->

  Extends E2E coverage for statistics across admin analytics and course-level statistics.

  Adds statistics-specific handles, flows, and specs covering:

  - Admin analytics dashboard chart rendering.
  - Admin analytics summary report download.
  - Course statistics role access, with admin visibility and student restriction.
  - Course statistics overview, student progress, search, group filtering, quiz results, quiz
    filtering, and learning-time table visibility.
  - AI mentor statistics using prepared mentor progress through a test-config fixture endpoint
    instead of real AI chat/judge calls.

  Adds stable data-testid hooks across course statistics tables, filters, overview cards, preview
  actions, lesson preview dialog, course statistics tab, AI mentor messages, and admin analytics
  charts. Also adds a typed generated API client path for preparing deterministic AI mentor
  statistics data in tests.

  ## Business Value
  <!--
  Why are we doing this from a business perspective? What value does this bring to the project
  from end-users perspective?
  -->

  Improves confidence that admins can access and use statistics dashboards reliably, including
  course progress, quiz results, AI mentor results, filters, and report downloads.

  The deterministic AI mentor statistics setup avoids spending time and money on real AI calls in
  E2E while still validating the statistics UI and backend integration path.
