### PR TITLE
fix: one command application setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The setup script will automatically:
 - ✓ Set up environment files (.env)
 - ✓ Start Docker containers
 - ✓ Run database migrations
-- ✓ Seed the database with test data
+- ✓ Seed the database
 
 > [!NOTE]
 > On Linux, Caddy needs permission to bind to port 443. The script will automatically handle this, but you may be prompted for your sudo password.
@@ -134,31 +134,26 @@ The setup script will automatically:
 
 After setup completes, the following default accounts are available:
 
-| Role            | Email                      | Password |
-| --------------- | -------------------------- | -------- |
-| Admin           | admin@example.com          | password |
-| Student         | user@example.com           | password |
-| Content Creator | contentcreator@example.com | password |
+| Role            | Email                              | Password |
+| --------------- | ---------------------------------- | -------- |
+| Admin           | admin+tenant1@example.com          | password |
+| Student         | student+tenant1@example.com        | password |
+| Content Creator | contentcreator+tenant1@example.com | password |
 
 > [!NOTE]
-> The setup script creates a minimal production-like environment with only these three essential accounts.
+> The setup script seeds the default multi-tenant development environment. The primary tenant uses the accounts above.
+
+> Default tenant hosts:
+>
+> - `https://tenant1.lms.localhost`
+> - `https://tenant2.lms.localhost`
+> - `https://tenant3.lms.localhost`
+
+> [!TIP]
+> If you open one of the other seeded hosts, log in with `admin+tenant<number>@example.com` and the same password.
 
 > [!TIP]
 > If you need a populated environment with sample courses, lessons, and additional test users for development, you can run the development seed instead:
->
-> ```bash
-> pnpm db:seed
-> ```
->
-> This will create accounts:
->
-> | Role            | Email                       | Password |
-> | --------------- | --------------------------- | -------- |
-> | Student         | student@example.com         | password |
-> | Student         | student2@example.com        | password |
-> | Content Creator | contentcreator@example.com  | password |
-> | Content Creator | contentcreator2@example.com | password |
-> | Admin           | admin@example.com           | password |
 
 > [!NOTE]
 > All accounts are intended for development and testing purposes only.

--- a/apps/api/src/seed/seed-prod.ts
+++ b/apps/api/src/seed/seed-prod.ts
@@ -14,6 +14,7 @@ import {
   ensureSeedTenant,
   seedSystemRolesForTenant,
   seedTruncateAllTables,
+  seedUserRoleGrantSql,
 } from "./seed-helpers";
 
 import type { DatabasePg, UUIDType } from "../common";
@@ -83,6 +84,8 @@ async function insertCredential(userId: UUIDType, tenantId: UUIDType, password: 
 }
 
 export async function seedProduction() {
+  await seedUserRoleGrantSql(db);
+
   await seedTruncateAllTables(db);
 
   try {

--- a/setup.sh
+++ b/setup.sh
@@ -11,6 +11,18 @@ YELLOW='\033[1;33m'
 RED='\033[0;31m'
 NC='\033[0m' # No Color
 
+read_env_value() {
+    local key="$1"
+    local file="$2"
+    local value
+
+    value=$(grep -E "^${key}=" "$file" | tail -n1 | cut -d= -f2- || true)
+    value="${value%\"}"
+    value="${value#\"}"
+
+    echo "$value"
+}
+
 # Determine the script's directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
@@ -350,7 +362,7 @@ echo ""
 
 #  Seed the database
 echo -e "${GREEN}[10/11]${NC} Seeding the database..."
-if ! pnpm --filter=api run db:seed-prod > /dev/null 2>&1; then
+if ! pnpm --filter=api run db:seed > /dev/null 2>&1; then
     echo -e "${RED}✗ Failed to seed database${NC}"
     exit 1
 fi
@@ -382,30 +394,62 @@ echo ""
 trap - ERR
 
 # Display success message with credentials
+DEV_TENANT_ORIGINS=$(read_env_value "DEV_TENANT_ORIGINS" "apps/api/.env")
+IFS=',' read -r -a TENANT_HOSTS_RAW <<< "$DEV_TENANT_ORIGINS"
+
+TENANT_HOSTS=()
+for host in "${TENANT_HOSTS_RAW[@]}"; do
+    host="${host//[[:space:]]/}"
+    if [ -n "$host" ]; then
+        TENANT_HOSTS+=("$host")
+    fi
+done
+
+PRIMARY_HOST="https://tenant1.lms.localhost"
+if [ "${#TENANT_HOSTS[@]}" -gt 0 ]; then
+    PRIMARY_HOST="${TENANT_HOSTS[0]}"
+fi
+
+OTHER_HOSTS=()
+if [ "${#TENANT_HOSTS[@]}" -gt 1 ]; then
+    OTHER_HOSTS=("${TENANT_HOSTS[@]:1}")
+fi
+
 echo ""
 echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 echo -e "${GREEN}✓ Setup completed successfully!${NC}"
 echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 echo ""
-echo -e "${YELLOW}Created user accounts (default tenant):${NC}"
-echo -e "  ${BLUE}Primary host:${NC} ${GREEN}https://tenant1.lms.localhost${NC}"
+echo -e "${YELLOW}Created tenant hosts:${NC}"
+echo -e "  ${BLUE}Primary host:${NC} ${GREEN}${PRIMARY_HOST}${NC}"
+
+if [ "${#OTHER_HOSTS[@]}" -gt 0 ]; then
+    echo -e "  ${BLUE}Other hosts:${NC}"
+    for host in "${OTHER_HOSTS[@]}"; do
+        echo -e "    ${GREEN}${host}${NC}"
+    done
+    echo -e "  ${BLUE}Other host login:${NC} ${GREEN}admin+tenant<number>@example.com${NC}"
+fi
+
+echo ""
+echo -e "${YELLOW}Created user accounts (primary tenant):${NC}"
 echo ""
 echo -e "  ${BLUE}Admin User:${NC}"
-echo -e "    Email:    ${GREEN}admin@example.com${NC}"
+echo -e "    Email:    ${GREEN}admin+tenant1@example.com${NC}"
 echo -e "    Password: ${GREEN}password${NC}"
 echo ""
 echo -e "  ${BLUE}Student User:${NC}"
-echo -e "    Email:    ${GREEN}user@example.com${NC}"
+echo -e "    Email:    ${GREEN}user+tenant1@example.com${NC}"
 echo -e "    Password: ${GREEN}password${NC}"
 echo ""
 echo -e "  ${BLUE}Content Creator:${NC}"
-echo -e "    Email:    ${GREEN}contentcreator@example.com${NC}"
+echo -e "    Email:    ${GREEN}contentcreator+tenant1@example.com${NC}"
 echo -e "    Password: ${GREEN}password${NC}"
 echo ""
 echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 echo ""
 echo -e "${YELLOW}Next steps:${NC}"
 echo -e "  1. Run ${GREEN}pnpm dev${NC} to start the development servers"
-echo -e "  2. Open ${GREEN}https://tenant1.lms.localhost${NC} in your browser"
+echo -e "  2. Open ${GREEN}${PRIMARY_HOST}${NC} in your browser"
 echo -e "  3. Log in with one of the accounts above"
 echo ""


### PR DESCRIPTION
## Overview

Update the README setup documentation to match the current default seed flow:

- Clarify that setup seeds the normal multi-tenant development environment
- Replace the default account table with the primary tenant credentials
- Document the default tenant hosts created during setup
- Explain how to log in on the other seeded hosts

## Business Value

This reduces onboarding friction for developers and QA by making the setup output and the README match the real seeded environment. It removes ambiguity around which credentials and tenant URLs to use after running the setup script.