### PR TITLE
Chatingo

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -40,6 +40,7 @@ import { EmailModule } from "./common/emails/emails.module";
 import { JwtAuthGuard } from "./common/guards/jwt-auth.guard";
 import { PermissionsGuard } from "./common/guards/permissions.guard";
 import { StagingGuard } from "./common/guards/staging.guard";
+import { CourseChatModule } from "./course-chat/course-chat.module";
 import { CourseModule } from "./courses/course.module";
 import { EventsModule } from "./events/events.module";
 import { FileModule } from "./file/files.module";
@@ -130,6 +131,7 @@ import type { RedisClient } from "src/redis";
     CategoryModule,
     ConditionalModule.registerWhen(ScheduleModule.forRoot(), (env) => !env.JEST_WORKER_ID),
     CourseModule,
+    CourseChatModule,
     GroupModule,
     LessonModule,
     QuestionsModule,

--- a/apps/api/src/common/emails/translations.ts
+++ b/apps/api/src/common/emails/translations.ts
@@ -92,6 +92,13 @@ export const EMAIL_SUBJECTS_TRANSLATIONS = {
     lt: "Prisijungimo nuoroda",
     cs: "Přihlašovací odkaz",
   },
+  courseChatMentionEmail: {
+    en: "You were mentioned in {{courseName}}",
+    pl: "Oznaczono Cię w kursie {{courseName}}",
+    de: "Du wurdest in {{courseName}} erwähnt",
+    lt: "Buvote paminėti kurse {{courseName}}",
+    cs: "Byl(a) jste zmíněn(a) v kurzu {{courseName}}",
+  },
 } as const;
 
 export type EmailSubjectKey = keyof typeof EMAIL_SUBJECTS_TRANSLATIONS;

--- a/apps/api/src/course-chat/__tests__/course-chat.gateway.spec.ts
+++ b/apps/api/src/course-chat/__tests__/course-chat.gateway.spec.ts
@@ -1,0 +1,82 @@
+import { WsException } from "@nestjs/websockets";
+
+import { CourseChatGateway } from "src/course-chat/course-chat.gateway";
+
+import type { CourseChatPresenceService } from "src/course-chat/course-chat-presence.service";
+import type { CourseChatService } from "src/course-chat/course-chat.service";
+import type { TenantDbRunnerService } from "src/storage/db/tenant-db-runner.service";
+import type { AuthenticatedSocket } from "src/websocket/websocket.types";
+
+const userId = "00000000-0000-0000-0000-000000000001";
+const courseId = "00000000-0000-0000-0000-000000000002";
+const tenantId = "00000000-0000-0000-0000-000000000003";
+
+describe("CourseChatGateway", () => {
+  let courseChatService: jest.Mocked<CourseChatService>;
+  let courseChatPresenceService: jest.Mocked<CourseChatPresenceService>;
+  let tenantDbRunnerService: jest.Mocked<TenantDbRunnerService>;
+  let gateway: CourseChatGateway;
+  let socket: AuthenticatedSocket;
+
+  beforeEach(() => {
+    courseChatService = {
+      assertUserEnrolledInCourse: jest.fn(),
+    } as unknown as jest.Mocked<CourseChatService>;
+
+    courseChatPresenceService = {
+      join: jest.fn().mockReturnValue({ courseId, userId, isOnline: true }),
+      leave: jest.fn(),
+      disconnect: jest.fn().mockReturnValue([]),
+      isOnline: jest.fn(),
+    } as unknown as jest.Mocked<CourseChatPresenceService>;
+
+    tenantDbRunnerService = {
+      runWithTenant: jest.fn((_tenantId, fn) => fn()),
+    } as unknown as jest.Mocked<TenantDbRunnerService>;
+
+    gateway = new CourseChatGateway(
+      courseChatService,
+      courseChatPresenceService,
+      tenantDbRunnerService,
+    );
+    gateway.server = { to: jest.fn().mockReturnValue({ emit: jest.fn() }) } as never;
+    socket = {
+      id: "socket-1",
+      data: {
+        user: {
+          userId,
+          email: "student@example.com",
+          roleSlugs: [],
+          permissions: [],
+          tenantId,
+        },
+      },
+      join: jest.fn(),
+      leave: jest.fn(),
+    } as unknown as AuthenticatedSocket;
+  });
+
+  it("joins the course chat room for enrolled users", async () => {
+    courseChatService.assertUserEnrolledInCourse.mockResolvedValue(undefined);
+
+    const result = await gateway.handleJoinCourseChat(socket, { courseId });
+
+    expect(tenantDbRunnerService.runWithTenant).toHaveBeenCalledWith(
+      tenantId,
+      expect.any(Function),
+    );
+    expect(courseChatService.assertUserEnrolledInCourse).toHaveBeenCalledWith(courseId, userId);
+    expect(socket.join).toHaveBeenCalledWith(`course-chat:${courseId}`);
+    expect(courseChatPresenceService.join).toHaveBeenCalledWith(courseId, userId, "socket-1");
+    expect(result).toEqual({ success: true, room: `course-chat:${courseId}` });
+  });
+
+  it("rejects room joins for users without enrollment", async () => {
+    courseChatService.assertUserEnrolledInCourse.mockRejectedValue(new Error("forbidden"));
+
+    await expect(gateway.handleJoinCourseChat(socket, { courseId })).rejects.toBeInstanceOf(
+      WsException,
+    );
+    expect(socket.join).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/course-chat/__tests__/course-chat.service.spec.ts
+++ b/apps/api/src/course-chat/__tests__/course-chat.service.spec.ts
@@ -35,6 +35,7 @@ const message: CourseChatMessageResponse = {
   createdAt: "2026-04-29T12:00:00.000Z",
   updatedAt: "2026-04-29T12:00:00.000Z",
   user,
+  reactions: [],
 };
 
 const thread: CourseChatThreadResponse = {
@@ -69,6 +70,9 @@ describe("CourseChatService", () => {
       messageBelongsToThread: jest.fn(),
       getMentionEmailRecipients: jest.fn(),
       getCourseEmailContext: jest.fn(),
+      getMessageContext: jest.fn(),
+      toggleMessageReaction: jest.fn(),
+      getMessageReactions: jest.fn(),
     } as unknown as jest.Mocked<CourseChatRepository>;
 
     presenceService = {
@@ -173,6 +177,34 @@ describe("CourseChatService", () => {
         subject: "You were mentioned in Algorithms",
       }),
       { tenantId: "00000000-0000-0000-0000-000000000006" },
+    );
+  });
+
+  it("toggles message reactions for enrolled users", async () => {
+    repository.getMessageContext.mockResolvedValue({ id: messageId, threadId, courseId });
+    repository.isUserEnrolledInCourse.mockResolvedValue(true);
+    repository.getMessageReactions.mockResolvedValue([
+      { reaction: "👍", count: 1, reactedByCurrentUser: true },
+    ]);
+
+    const result = await service.toggleMessageReaction(messageId, userId, { reaction: "👍" });
+
+    expect(repository.toggleMessageReaction).toHaveBeenCalledWith({
+      messageId,
+      courseId,
+      userId,
+      reaction: "👍",
+    });
+    expect(result.data).toEqual({
+      courseId,
+      threadId,
+      messageId,
+      reactions: [{ reaction: "👍", count: 1, reactedByCurrentUser: true }],
+    });
+    expect(realtimePublisher.emitToRoom).toHaveBeenCalledWith(
+      "course-chat:message-reactions-updated",
+      `course-chat:${courseId}`,
+      result.data,
     );
   });
 });

--- a/apps/api/src/course-chat/__tests__/course-chat.service.spec.ts
+++ b/apps/api/src/course-chat/__tests__/course-chat.service.spec.ts
@@ -1,0 +1,178 @@
+import { ForbiddenException } from "@nestjs/common";
+
+import { CourseChatService } from "src/course-chat/course-chat.service";
+
+import type { EmailService } from "src/common/emails/emails.service";
+import type { CourseChatPresenceService } from "src/course-chat/course-chat-presence.service";
+import type { CourseChatRepository } from "src/course-chat/course-chat.repository";
+import type {
+  CourseChatMessageResponse,
+  CourseChatThreadResponse,
+} from "src/course-chat/schemas/course-chat.schema";
+import type { RealtimePublisher } from "src/websocket/realtime.publisher";
+
+const userId = "00000000-0000-0000-0000-000000000001";
+const courseId = "00000000-0000-0000-0000-000000000002";
+const threadId = "00000000-0000-0000-0000-000000000003";
+const messageId = "00000000-0000-0000-0000-000000000004";
+const mentionedUserId = "00000000-0000-0000-0000-000000000005";
+
+const user = {
+  id: userId,
+  firstName: "Ada",
+  lastName: "Lovelace",
+  avatarReference: null,
+};
+
+const message: CourseChatMessageResponse = {
+  id: messageId,
+  threadId,
+  courseId,
+  userId,
+  content: "Hello course",
+  parentMessageId: null,
+  deletedAt: null,
+  createdAt: "2026-04-29T12:00:00.000Z",
+  updatedAt: "2026-04-29T12:00:00.000Z",
+  user,
+};
+
+const thread: CourseChatThreadResponse = {
+  id: threadId,
+  courseId,
+  createdByUserId: userId,
+  archived: false,
+  createdAt: "2026-04-29T12:00:00.000Z",
+  updatedAt: "2026-04-29T12:00:00.000Z",
+  messageCount: 1,
+  createdBy: user,
+  rootMessage: message,
+  latestMessage: message,
+};
+
+describe("CourseChatService", () => {
+  let repository: jest.Mocked<CourseChatRepository>;
+  let presenceService: jest.Mocked<CourseChatPresenceService>;
+  let emailService: jest.Mocked<EmailService>;
+  let realtimePublisher: jest.Mocked<RealtimePublisher>;
+  let service: CourseChatService;
+
+  beforeEach(() => {
+    repository = {
+      isUserEnrolledInCourse: jest.fn(),
+      getThreads: jest.fn(),
+      getThreadById: jest.fn(),
+      getMessages: jest.fn(),
+      getMessageById: jest.fn(),
+      createThreadWithMessage: jest.fn(),
+      createMessage: jest.fn(),
+      messageBelongsToThread: jest.fn(),
+      getMentionEmailRecipients: jest.fn(),
+      getCourseEmailContext: jest.fn(),
+    } as unknown as jest.Mocked<CourseChatRepository>;
+
+    presenceService = {
+      isOnline: jest.fn(),
+    } as unknown as jest.Mocked<CourseChatPresenceService>;
+
+    emailService = {
+      getDefaultEmailProperties: jest.fn().mockResolvedValue({
+        primaryColor: "#4796FD",
+        companyName: "Mentingo",
+        language: "en",
+      }),
+      sendEmailWithLogo: jest.fn(),
+    } as unknown as jest.Mocked<EmailService>;
+
+    realtimePublisher = {
+      emitToRoom: jest.fn(),
+      emitToRoomWithAck: jest.fn(),
+    };
+
+    service = new CourseChatService(repository, presenceService, emailService, realtimePublisher);
+  });
+
+  it("blocks users who are not enrolled in the course", async () => {
+    repository.isUserEnrolledInCourse.mockResolvedValue(false);
+
+    await expect(service.getThreads({ courseId, userId })).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+
+  it("creates a thread with a trimmed first message for enrolled users", async () => {
+    repository.isUserEnrolledInCourse.mockResolvedValue(true);
+    repository.createThreadWithMessage.mockResolvedValue({ threadId, messageId });
+    repository.getThreadById.mockResolvedValue(thread);
+    repository.getMessageById.mockResolvedValue(message);
+
+    const result = await service.createThread(courseId, userId, { content: "  Hello course  " });
+
+    expect(repository.createThreadWithMessage).toHaveBeenCalledWith(
+      courseId,
+      userId,
+      "Hello course",
+    );
+    expect(result.data).toEqual({ thread, message });
+    expect(realtimePublisher.emitToRoom).toHaveBeenCalledWith(
+      "course-chat:thread-created",
+      `course-chat:${courseId}`,
+      { thread, message },
+    );
+  });
+
+  it("adds replies to the course that owns the thread", async () => {
+    repository.getThreadById.mockResolvedValue(thread);
+    repository.isUserEnrolledInCourse.mockResolvedValue(true);
+    repository.createMessage.mockResolvedValue(messageId);
+    repository.getMessageById.mockResolvedValue(message);
+
+    await service.createMessage(threadId, userId, { content: "Reply" });
+
+    expect(repository.createMessage).toHaveBeenCalledWith({
+      threadId,
+      courseId,
+      userId,
+      content: "Reply",
+      parentMessageId: undefined,
+    });
+  });
+
+  it("notifies enrolled users mentioned in a message", async () => {
+    repository.getThreadById.mockResolvedValue(thread);
+    repository.isUserEnrolledInCourse.mockResolvedValue(true);
+    repository.createMessage.mockResolvedValue(messageId);
+    repository.getMessageById.mockResolvedValue(message);
+    repository.getMentionEmailRecipients.mockResolvedValue([
+      {
+        id: mentionedUserId,
+        email: "mentioned@example.com",
+        firstName: "Grace",
+        tenantId: "00000000-0000-0000-0000-000000000006",
+      },
+    ]);
+    repository.getCourseEmailContext.mockResolvedValue({
+      title: { en: "Algorithms" },
+      baseLanguage: "en",
+    });
+
+    await service.createMessage(threadId, userId, {
+      content: `Hi @Ada Lovelace`,
+      mentionedUserIds: [mentionedUserId, userId, mentionedUserId],
+    });
+
+    expect(repository.getMentionEmailRecipients).toHaveBeenCalledWith(courseId, [mentionedUserId]);
+    expect(realtimePublisher.emitToRoom).toHaveBeenCalledWith(
+      "course-chat:user-mentioned",
+      `user:${mentionedUserId}`,
+      { courseId, message },
+    );
+    expect(emailService.sendEmailWithLogo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "mentioned@example.com",
+        subject: "You were mentioned in Algorithms",
+      }),
+      { tenantId: "00000000-0000-0000-0000-000000000006" },
+    );
+  });
+});

--- a/apps/api/src/course-chat/course-chat-presence.service.ts
+++ b/apps/api/src/course-chat/course-chat-presence.service.ts
@@ -1,0 +1,101 @@
+import { Injectable } from "@nestjs/common";
+
+import type { UUIDType } from "src/common";
+
+type PresenceChange = {
+  courseId: UUIDType;
+  userId: UUIDType;
+  isOnline: boolean;
+};
+
+@Injectable()
+export class CourseChatPresenceService {
+  private readonly courseUsers = new Map<UUIDType, Map<UUIDType, Set<string>>>();
+  private readonly socketMemberships = new Map<string, Set<string>>();
+
+  join(courseId: UUIDType, userId: UUIDType, socketId: string): PresenceChange | null {
+    const userSockets = this.getUserSockets(courseId, userId);
+    const wasOnline = userSockets.size > 0;
+
+    userSockets.add(socketId);
+    this.getSocketMemberships(socketId).add(this.getMembershipKey(courseId, userId));
+
+    if (wasOnline) return null;
+
+    return { courseId, userId, isOnline: true };
+  }
+
+  leave(courseId: UUIDType, userId: UUIDType, socketId: string): PresenceChange | null {
+    const userSockets = this.courseUsers.get(courseId)?.get(userId);
+    if (!userSockets?.has(socketId)) return null;
+
+    userSockets.delete(socketId);
+    this.socketMemberships.get(socketId)?.delete(this.getMembershipKey(courseId, userId));
+    this.cleanupSocket(socketId);
+
+    if (userSockets.size > 0) return null;
+
+    this.courseUsers.get(courseId)?.delete(userId);
+    this.cleanupCourse(courseId);
+
+    return { courseId, userId, isOnline: false };
+  }
+
+  disconnect(socketId: string): PresenceChange[] {
+    const memberships = Array.from(this.socketMemberships.get(socketId) ?? []);
+    const changes: PresenceChange[] = [];
+
+    for (const membership of memberships) {
+      const [courseId, userId] = membership.split(":") as [UUIDType, UUIDType];
+      const change = this.leave(courseId, userId, socketId);
+      if (change) changes.push(change);
+    }
+
+    this.socketMemberships.delete(socketId);
+    return changes;
+  }
+
+  isOnline(courseId: UUIDType, userId: UUIDType): boolean {
+    return Boolean(this.courseUsers.get(courseId)?.get(userId)?.size);
+  }
+
+  private getUserSockets(courseId: UUIDType, userId: UUIDType) {
+    let users = this.courseUsers.get(courseId);
+    if (!users) {
+      users = new Map();
+      this.courseUsers.set(courseId, users);
+    }
+
+    let sockets = users.get(userId);
+    if (!sockets) {
+      sockets = new Set();
+      users.set(userId, sockets);
+    }
+
+    return sockets;
+  }
+
+  private getSocketMemberships(socketId: string) {
+    let memberships = this.socketMemberships.get(socketId);
+    if (!memberships) {
+      memberships = new Set();
+      this.socketMemberships.set(socketId, memberships);
+    }
+
+    return memberships;
+  }
+
+  private getMembershipKey(courseId: UUIDType, userId: UUIDType) {
+    return `${courseId}:${userId}`;
+  }
+
+  private cleanupSocket(socketId: string) {
+    const memberships = this.socketMemberships.get(socketId);
+    if (memberships && memberships.size === 0) this.socketMemberships.delete(socketId);
+  }
+
+  private cleanupCourse(courseId: UUIDType) {
+    const users = this.courseUsers.get(courseId);
+    if (users && users.size === 0) this.courseUsers.delete(courseId);
+  }
+}

--- a/apps/api/src/course-chat/course-chat.constants.ts
+++ b/apps/api/src/course-chat/course-chat.constants.ts
@@ -5,6 +5,9 @@ export const COURSE_CHAT_SOCKET_EVENTS = {
   THREAD_CREATED: "course-chat:thread-created",
   USER_PRESENCE_CHANGED: "course-chat:user-presence-changed",
   USER_MENTIONED: "course-chat:user-mentioned",
+  MESSAGE_REACTIONS_UPDATED: "course-chat:message-reactions-updated",
 } as const;
+
+export const COURSE_CHAT_ALLOWED_REACTIONS = ["👍", "❤️", "😂", "🎉", "😮"] as const;
 
 export const getCourseChatRoom = (courseId: string) => `course-chat:${courseId}`;

--- a/apps/api/src/course-chat/course-chat.constants.ts
+++ b/apps/api/src/course-chat/course-chat.constants.ts
@@ -1,0 +1,10 @@
+export const COURSE_CHAT_SOCKET_EVENTS = {
+  JOIN: "join:course-chat",
+  LEAVE: "leave:course-chat",
+  MESSAGE_CREATED: "course-chat:message-created",
+  THREAD_CREATED: "course-chat:thread-created",
+  USER_PRESENCE_CHANGED: "course-chat:user-presence-changed",
+  USER_MENTIONED: "course-chat:user-mentioned",
+} as const;
+
+export const getCourseChatRoom = (courseId: string) => `course-chat:${courseId}`;

--- a/apps/api/src/course-chat/course-chat.controller.ts
+++ b/apps/api/src/course-chat/course-chat.controller.ts
@@ -13,6 +13,7 @@ import { CurrentUser } from "src/common/decorators/user.decorator";
 import { CourseChatService } from "src/course-chat/course-chat.service";
 import {
   courseChatMessageSchema,
+  courseChatMessageReactionsUpdatedSchema,
   courseChatMessagesResponseSchema,
   courseChatPaginationQuerySchema,
   courseChatThreadsResponseSchema,
@@ -20,12 +21,15 @@ import {
   createCourseChatMessageSchema,
   createCourseChatThreadResponseSchema,
   createCourseChatThreadSchema,
+  toggleCourseChatMessageReactionSchema,
   type CourseChatMessageResponse,
+  type CourseChatMessageReactionsUpdatedResponse,
   type CourseChatThreadResponse,
   type CourseChatUserResponse,
   type CreateCourseChatMessageBody,
   type CreateCourseChatThreadBody,
   type CreateCourseChatThreadResponse,
+  type ToggleCourseChatMessageReactionBody,
 } from "src/course-chat/schemas/course-chat.schema";
 
 @Controller("course-chat")
@@ -110,5 +114,21 @@ export class CourseChatController {
     @CurrentUser("userId") userId: UUIDType,
   ): Promise<BaseResponse<CourseChatMessageResponse>> {
     return this.courseChatService.createMessage(threadId, userId, body);
+  }
+
+  @Post("messages/:messageId/reactions")
+  @Validate({
+    request: [
+      { type: "param", name: "messageId", schema: UUIDSchema },
+      { type: "body", schema: toggleCourseChatMessageReactionSchema },
+    ],
+    response: baseResponse(courseChatMessageReactionsUpdatedSchema),
+  })
+  async toggleMessageReaction(
+    @Param("messageId") messageId: UUIDType,
+    @Body() body: ToggleCourseChatMessageReactionBody,
+    @CurrentUser("userId") userId: UUIDType,
+  ): Promise<BaseResponse<CourseChatMessageReactionsUpdatedResponse>> {
+    return this.courseChatService.toggleMessageReaction(messageId, userId, body);
   }
 }

--- a/apps/api/src/course-chat/course-chat.controller.ts
+++ b/apps/api/src/course-chat/course-chat.controller.ts
@@ -1,0 +1,114 @@
+import { Body, Controller, Get, Param, Post, Query } from "@nestjs/common";
+import { Validate } from "nestjs-typebox";
+
+import {
+  baseResponse,
+  paginatedResponse,
+  UUIDSchema,
+  UUIDType,
+  type BaseResponse,
+  type PaginatedResponse,
+} from "src/common";
+import { CurrentUser } from "src/common/decorators/user.decorator";
+import { CourseChatService } from "src/course-chat/course-chat.service";
+import {
+  courseChatMessageSchema,
+  courseChatMessagesResponseSchema,
+  courseChatPaginationQuerySchema,
+  courseChatThreadsResponseSchema,
+  courseChatUsersResponseSchema,
+  createCourseChatMessageSchema,
+  createCourseChatThreadResponseSchema,
+  createCourseChatThreadSchema,
+  type CourseChatMessageResponse,
+  type CourseChatThreadResponse,
+  type CourseChatUserResponse,
+  type CreateCourseChatMessageBody,
+  type CreateCourseChatThreadBody,
+  type CreateCourseChatThreadResponse,
+} from "src/course-chat/schemas/course-chat.schema";
+
+@Controller("course-chat")
+export class CourseChatController {
+  constructor(private readonly courseChatService: CourseChatService) {}
+
+  @Get(":courseId/threads")
+  @Validate({
+    request: [
+      { type: "param", name: "courseId", schema: UUIDSchema },
+      { type: "query", name: "page", schema: courseChatPaginationQuerySchema },
+      { type: "query", name: "perPage", schema: courseChatPaginationQuerySchema },
+    ],
+    response: paginatedResponse(courseChatThreadsResponseSchema),
+  })
+  async getThreads(
+    @Param("courseId") courseId: UUIDType,
+    @Query("page") page: number | undefined,
+    @Query("perPage") perPage: number | undefined,
+    @CurrentUser("userId") userId: UUIDType,
+  ): Promise<PaginatedResponse<CourseChatThreadResponse[]>> {
+    return this.courseChatService.getThreads({ courseId, userId, page, perPage });
+  }
+
+  @Get(":courseId/users")
+  @Validate({
+    request: [{ type: "param", name: "courseId", schema: UUIDSchema }],
+    response: baseResponse(courseChatUsersResponseSchema),
+  })
+  async getUsers(
+    @Param("courseId") courseId: UUIDType,
+    @CurrentUser("userId") userId: UUIDType,
+  ): Promise<BaseResponse<CourseChatUserResponse[]>> {
+    return this.courseChatService.getUsers(courseId, userId);
+  }
+
+  @Post(":courseId/threads")
+  @Validate({
+    request: [
+      { type: "param", name: "courseId", schema: UUIDSchema },
+      { type: "body", schema: createCourseChatThreadSchema },
+    ],
+    response: baseResponse(createCourseChatThreadResponseSchema),
+  })
+  async createThread(
+    @Param("courseId") courseId: UUIDType,
+    @Body() body: CreateCourseChatThreadBody,
+    @CurrentUser("userId") userId: UUIDType,
+  ): Promise<BaseResponse<CreateCourseChatThreadResponse>> {
+    return this.courseChatService.createThread(courseId, userId, body);
+  }
+
+  @Get("threads/:threadId/messages")
+  @Validate({
+    request: [
+      { type: "param", name: "threadId", schema: UUIDSchema },
+      { type: "query", name: "page", schema: courseChatPaginationQuerySchema },
+      { type: "query", name: "perPage", schema: courseChatPaginationQuerySchema },
+    ],
+    response: paginatedResponse(courseChatMessagesResponseSchema),
+  })
+  async getMessages(
+    @Param("threadId") threadId: UUIDType,
+    @Query("page") page: number | undefined,
+    @Query("perPage") perPage: number | undefined,
+    @CurrentUser("userId") userId: UUIDType,
+  ): Promise<PaginatedResponse<CourseChatMessageResponse[]>> {
+    return this.courseChatService.getMessages({ threadId, userId, page, perPage });
+  }
+
+  @Post("threads/:threadId/messages")
+  @Validate({
+    request: [
+      { type: "param", name: "threadId", schema: UUIDSchema },
+      { type: "body", schema: createCourseChatMessageSchema },
+    ],
+    response: baseResponse(courseChatMessageSchema),
+  })
+  async createMessage(
+    @Param("threadId") threadId: UUIDType,
+    @Body() body: CreateCourseChatMessageBody,
+    @CurrentUser("userId") userId: UUIDType,
+  ): Promise<BaseResponse<CourseChatMessageResponse>> {
+    return this.courseChatService.createMessage(threadId, userId, body);
+  }
+}

--- a/apps/api/src/course-chat/course-chat.gateway.ts
+++ b/apps/api/src/course-chat/course-chat.gateway.ts
@@ -1,0 +1,119 @@
+import { Logger, UseGuards } from "@nestjs/common";
+import {
+  ConnectedSocket,
+  MessageBody,
+  SubscribeMessage,
+  WebSocketGateway,
+  WebSocketServer,
+  WsException,
+} from "@nestjs/websockets";
+import { Server } from "socket.io";
+
+import { CourseChatPresenceService } from "src/course-chat/course-chat-presence.service";
+import {
+  COURSE_CHAT_SOCKET_EVENTS,
+  getCourseChatRoom,
+} from "src/course-chat/course-chat.constants";
+import { CourseChatService } from "src/course-chat/course-chat.service";
+import { TenantDbRunnerService } from "src/storage/db/tenant-db-runner.service";
+import { WsJwtGuard } from "src/websocket/guards/ws-jwt.guard";
+import { AuthenticatedSocket } from "src/websocket/websocket.types";
+
+import type { OnGatewayDisconnect } from "@nestjs/websockets";
+import type { UUIDType } from "src/common";
+
+type CourseChatRoomPayload = {
+  courseId: UUIDType;
+};
+
+@WebSocketGateway({
+  namespace: "/ws",
+  path: "/api/ws",
+  transports: ["websocket", "polling"],
+})
+export class CourseChatGateway implements OnGatewayDisconnect {
+  @WebSocketServer()
+  server!: Server;
+
+  private readonly logger = new Logger(CourseChatGateway.name);
+
+  constructor(
+    private readonly courseChatService: CourseChatService,
+    private readonly courseChatPresenceService: CourseChatPresenceService,
+    private readonly tenantDbRunnerService: TenantDbRunnerService,
+  ) {}
+
+  handleDisconnect(client: AuthenticatedSocket) {
+    const changes = this.courseChatPresenceService.disconnect(client.id);
+    for (const change of changes) {
+      this.emitPresenceChange(change.courseId, change.userId, change.isOnline);
+    }
+  }
+
+  @UseGuards(WsJwtGuard)
+  @SubscribeMessage(COURSE_CHAT_SOCKET_EVENTS.JOIN)
+  async handleJoinCourseChat(
+    @ConnectedSocket() client: AuthenticatedSocket,
+    @MessageBody() payload: CourseChatRoomPayload,
+  ) {
+    const { courseId } = payload;
+    const user = client.data.user;
+
+    if (!courseId) throw new WsException("courseChat.errors.courseIdRequired");
+
+    try {
+      await this.tenantDbRunnerService.runWithTenant(user.tenantId, () =>
+        this.courseChatService.assertUserEnrolledInCourse(courseId, user.userId),
+      );
+    } catch (error) {
+      this.logger.debug(`Course chat join rejected for user ${user.userId}: ${error}`);
+      throw new WsException("courseChat.errors.notEnrolled");
+    }
+
+    const room = getCourseChatRoom(courseId);
+    await client.join(room);
+    const presenceChange = this.courseChatPresenceService.join(courseId, user.userId, client.id);
+    if (presenceChange) {
+      this.emitPresenceChange(courseId, user.userId, presenceChange.isOnline);
+    }
+
+    this.logger.debug(`User ${user.userId} joined course chat room: ${room}`);
+
+    return { success: true, room };
+  }
+
+  @UseGuards(WsJwtGuard)
+  @SubscribeMessage(COURSE_CHAT_SOCKET_EVENTS.LEAVE)
+  async handleLeaveCourseChat(
+    @ConnectedSocket() client: AuthenticatedSocket,
+    @MessageBody() payload: CourseChatRoomPayload,
+  ) {
+    const { courseId } = payload;
+    if (!courseId) throw new WsException("courseChat.errors.courseIdRequired");
+
+    const room = getCourseChatRoom(courseId);
+    await client.leave(room);
+    const presenceChange = this.courseChatPresenceService.leave(
+      courseId,
+      client.data.user.userId,
+      client.id,
+    );
+    if (presenceChange) {
+      this.emitPresenceChange(courseId, client.data.user.userId, presenceChange.isOnline);
+    }
+
+    this.logger.debug(`User ${client.data.user.userId} left course chat room: ${room}`);
+
+    return { success: true };
+  }
+
+  private emitPresenceChange(courseId: UUIDType, userId: UUIDType, isOnline: boolean) {
+    this.server
+      .to(getCourseChatRoom(courseId))
+      .emit(COURSE_CHAT_SOCKET_EVENTS.USER_PRESENCE_CHANGED, {
+        courseId,
+        userId,
+        isOnline,
+      });
+  }
+}

--- a/apps/api/src/course-chat/course-chat.module.ts
+++ b/apps/api/src/course-chat/course-chat.module.ts
@@ -1,0 +1,21 @@
+import { Module } from "@nestjs/common";
+
+import { EmailModule } from "src/common/emails/emails.module";
+import { CourseChatPresenceService } from "src/course-chat/course-chat-presence.service";
+import { CourseChatController } from "src/course-chat/course-chat.controller";
+import { CourseChatGateway } from "src/course-chat/course-chat.gateway";
+import { CourseChatRepository } from "src/course-chat/course-chat.repository";
+import { CourseChatService } from "src/course-chat/course-chat.service";
+
+@Module({
+  imports: [EmailModule],
+  controllers: [CourseChatController],
+  providers: [
+    CourseChatService,
+    CourseChatRepository,
+    CourseChatPresenceService,
+    CourseChatGateway,
+  ],
+  exports: [CourseChatService],
+})
+export class CourseChatModule {}

--- a/apps/api/src/course-chat/course-chat.repository.ts
+++ b/apps/api/src/course-chat/course-chat.repository.ts
@@ -1,0 +1,420 @@
+import { Inject, Injectable } from "@nestjs/common";
+import { COURSE_ENROLLMENT } from "@repo/shared";
+import { and, count, desc, eq, inArray, isNull, sql } from "drizzle-orm";
+
+import { DatabasePg } from "src/common";
+import { DEFAULT_PAGE_SIZE } from "src/common/pagination";
+import {
+  courses,
+  courseChatMessages,
+  courseChatThreads,
+  studentCourses,
+  users,
+} from "src/storage/schema";
+
+import type { UUIDType } from "src/common";
+import type {
+  CourseChatMessageResponse,
+  CourseChatThreadResponse,
+  CourseChatUserResponse,
+} from "src/course-chat/schemas/course-chat.schema";
+
+type CourseChatMessageRow = {
+  id: UUIDType;
+  threadId: UUIDType;
+  courseId: UUIDType;
+  userId: UUIDType;
+  content: string;
+  parentMessageId: UUIDType | null;
+  deletedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  userIdForProfile: UUIDType;
+  userFirstName: string;
+  userLastName: string;
+  userAvatarReference: string | null;
+};
+
+export type CourseChatMentionEmailRecipient = {
+  id: UUIDType;
+  email: string;
+  firstName: string;
+  tenantId: UUIDType;
+};
+
+export type CourseChatEmailContext = {
+  title: Record<string, string>;
+  baseLanguage: string;
+};
+
+@Injectable()
+export class CourseChatRepository {
+  constructor(@Inject("DB") private readonly db: DatabasePg) {}
+
+  async isUserEnrolledInCourse(courseId: UUIDType, userId: UUIDType): Promise<boolean> {
+    const [enrollment] = await this.db
+      .select({ id: studentCourses.id })
+      .from(studentCourses)
+      .where(
+        and(
+          eq(studentCourses.courseId, courseId),
+          eq(studentCourses.studentId, userId),
+          eq(studentCourses.status, COURSE_ENROLLMENT.ENROLLED),
+        ),
+      )
+      .limit(1);
+
+    return Boolean(enrollment);
+  }
+
+  async getThreads(courseId: UUIDType, page = 1, perPage = DEFAULT_PAGE_SIZE) {
+    const data = await this.db
+      .select({
+        id: courseChatThreads.id,
+        courseId: courseChatThreads.courseId,
+        createdByUserId: courseChatThreads.createdByUserId,
+        archived: courseChatThreads.archived,
+        createdAt: courseChatThreads.createdAt,
+        updatedAt: courseChatThreads.updatedAt,
+        messageCount: sql<number>`(
+          SELECT COUNT(*)::int
+          FROM ${courseChatMessages}
+          WHERE ${courseChatMessages.threadId} = ${courseChatThreads.id}
+            AND ${courseChatMessages.deletedAt} IS NULL
+        )`,
+        createdById: users.id,
+        createdByFirstName: users.firstName,
+        createdByLastName: users.lastName,
+        createdByAvatarReference: users.avatarReference,
+      })
+      .from(courseChatThreads)
+      .innerJoin(users, eq(users.id, courseChatThreads.createdByUserId))
+      .where(and(eq(courseChatThreads.courseId, courseId), eq(courseChatThreads.archived, false)))
+      .orderBy(courseChatThreads.createdAt)
+      .limit(perPage)
+      .offset((page - 1) * perPage);
+
+    const [{ totalItems }] = await this.db
+      .select({ totalItems: count() })
+      .from(courseChatThreads)
+      .where(and(eq(courseChatThreads.courseId, courseId), eq(courseChatThreads.archived, false)));
+
+    const threads = await Promise.all(
+      data.map(async (thread): Promise<CourseChatThreadResponse> => {
+        const [rootMessage, latestMessage] = await Promise.all([
+          this.getRootMessage(thread.id),
+          this.getLatestMessage(thread.id),
+        ]);
+
+        if (!rootMessage) {
+          throw new Error(`Course chat thread ${thread.id} has no root message`);
+        }
+
+        return this.mapThread(thread, rootMessage, latestMessage);
+      }),
+    );
+
+    return {
+      data: threads,
+      pagination: { totalItems, page, perPage },
+    };
+  }
+
+  async getEnrolledUsers(courseId: UUIDType): Promise<Omit<CourseChatUserResponse, "isOnline">[]> {
+    return this.db
+      .select({
+        id: users.id,
+        firstName: users.firstName,
+        lastName: users.lastName,
+        avatarReference: users.avatarReference,
+      })
+      .from(studentCourses)
+      .innerJoin(users, eq(users.id, studentCourses.studentId))
+      .where(
+        and(
+          eq(studentCourses.courseId, courseId),
+          eq(studentCourses.status, COURSE_ENROLLMENT.ENROLLED),
+          isNull(users.deletedAt),
+        ),
+      )
+      .orderBy(users.firstName, users.lastName);
+  }
+
+  async getEnrolledUserIds(courseId: UUIDType, userIds: UUIDType[]): Promise<UUIDType[]> {
+    if (!userIds.length) return [];
+
+    const rows = await this.db
+      .select({ userId: studentCourses.studentId })
+      .from(studentCourses)
+      .where(
+        and(
+          eq(studentCourses.courseId, courseId),
+          eq(studentCourses.status, COURSE_ENROLLMENT.ENROLLED),
+          inArray(studentCourses.studentId, userIds),
+        ),
+      );
+
+    return rows.map(({ userId }) => userId);
+  }
+
+  async getMentionEmailRecipients(
+    courseId: UUIDType,
+    userIds: UUIDType[],
+  ): Promise<CourseChatMentionEmailRecipient[]> {
+    if (!userIds.length) return [];
+
+    return this.db
+      .select({
+        id: users.id,
+        email: users.email,
+        firstName: users.firstName,
+        tenantId: users.tenantId,
+      })
+      .from(studentCourses)
+      .innerJoin(users, eq(users.id, studentCourses.studentId))
+      .where(
+        and(
+          eq(studentCourses.courseId, courseId),
+          eq(studentCourses.status, COURSE_ENROLLMENT.ENROLLED),
+          inArray(studentCourses.studentId, userIds),
+          isNull(users.deletedAt),
+        ),
+      );
+  }
+
+  async getCourseEmailContext(courseId: UUIDType): Promise<CourseChatEmailContext | null> {
+    const [course] = await this.db
+      .select({
+        title: courses.title,
+        baseLanguage: courses.baseLanguage,
+      })
+      .from(courses)
+      .where(eq(courses.id, courseId))
+      .limit(1);
+
+    return course ? (course as CourseChatEmailContext) : null;
+  }
+
+  async getThreadById(threadId: UUIDType): Promise<CourseChatThreadResponse | null> {
+    const [thread] = await this.db
+      .select({
+        id: courseChatThreads.id,
+        courseId: courseChatThreads.courseId,
+        createdByUserId: courseChatThreads.createdByUserId,
+        archived: courseChatThreads.archived,
+        createdAt: courseChatThreads.createdAt,
+        updatedAt: courseChatThreads.updatedAt,
+        messageCount: sql<number>`(
+          SELECT COUNT(*)::int
+          FROM ${courseChatMessages}
+          WHERE ${courseChatMessages.threadId} = ${courseChatThreads.id}
+            AND ${courseChatMessages.deletedAt} IS NULL
+        )`,
+        createdById: users.id,
+        createdByFirstName: users.firstName,
+        createdByLastName: users.lastName,
+        createdByAvatarReference: users.avatarReference,
+      })
+      .from(courseChatThreads)
+      .innerJoin(users, eq(users.id, courseChatThreads.createdByUserId))
+      .where(eq(courseChatThreads.id, threadId))
+      .limit(1);
+
+    if (!thread) return null;
+
+    const [rootMessage, latestMessage] = await Promise.all([
+      this.getRootMessage(thread.id),
+      this.getLatestMessage(thread.id),
+    ]);
+
+    if (!rootMessage) {
+      throw new Error(`Course chat thread ${thread.id} has no root message`);
+    }
+
+    return this.mapThread(thread, rootMessage, latestMessage);
+  }
+
+  async getMessages(threadId: UUIDType, page = 1, perPage = DEFAULT_PAGE_SIZE) {
+    const data = await this.db
+      .select(this.messageSelect())
+      .from(courseChatMessages)
+      .innerJoin(users, eq(users.id, courseChatMessages.userId))
+      .where(and(eq(courseChatMessages.threadId, threadId), isNull(courseChatMessages.deletedAt)))
+      .orderBy(courseChatMessages.createdAt)
+      .limit(perPage)
+      .offset((page - 1) * perPage);
+
+    const [{ totalItems }] = await this.db
+      .select({ totalItems: count() })
+      .from(courseChatMessages)
+      .where(and(eq(courseChatMessages.threadId, threadId), isNull(courseChatMessages.deletedAt)));
+
+    return {
+      data: data.map((message) => this.mapMessage(message)),
+      pagination: { totalItems, page, perPage },
+    };
+  }
+
+  async getMessageById(messageId: UUIDType): Promise<CourseChatMessageResponse | null> {
+    const [message] = await this.db
+      .select(this.messageSelect())
+      .from(courseChatMessages)
+      .innerJoin(users, eq(users.id, courseChatMessages.userId))
+      .where(eq(courseChatMessages.id, messageId))
+      .limit(1);
+
+    return message ? this.mapMessage(message) : null;
+  }
+
+  async createThreadWithMessage(courseId: UUIDType, userId: UUIDType, content: string) {
+    return this.db.transaction(async (trx) => {
+      const [thread] = await trx
+        .insert(courseChatThreads)
+        .values({ courseId, createdByUserId: userId })
+        .returning({ id: courseChatThreads.id });
+
+      const [message] = await trx
+        .insert(courseChatMessages)
+        .values({ threadId: thread.id, courseId, userId, content })
+        .returning({ id: courseChatMessages.id });
+
+      return { threadId: thread.id, messageId: message.id };
+    });
+  }
+
+  async createMessage(params: {
+    threadId: UUIDType;
+    courseId: UUIDType;
+    userId: UUIDType;
+    content: string;
+    parentMessageId?: UUIDType;
+  }) {
+    return this.db.transaction(async (trx) => {
+      const [message] = await trx
+        .insert(courseChatMessages)
+        .values(params)
+        .returning({ id: courseChatMessages.id });
+
+      await trx
+        .update(courseChatThreads)
+        .set({ updatedAt: sql`CURRENT_TIMESTAMP` })
+        .where(eq(courseChatThreads.id, params.threadId));
+
+      return message.id;
+    });
+  }
+
+  async messageBelongsToThread(messageId: UUIDType, threadId: UUIDType): Promise<boolean> {
+    const [message] = await this.db
+      .select({ id: courseChatMessages.id })
+      .from(courseChatMessages)
+      .where(
+        and(
+          eq(courseChatMessages.id, messageId),
+          eq(courseChatMessages.threadId, threadId),
+          isNull(courseChatMessages.deletedAt),
+        ),
+      )
+      .limit(1);
+
+    return Boolean(message);
+  }
+
+  private async getLatestMessage(threadId: UUIDType): Promise<CourseChatMessageResponse | null> {
+    const [message] = await this.db
+      .select(this.messageSelect())
+      .from(courseChatMessages)
+      .innerJoin(users, eq(users.id, courseChatMessages.userId))
+      .where(and(eq(courseChatMessages.threadId, threadId), isNull(courseChatMessages.deletedAt)))
+      .orderBy(desc(courseChatMessages.createdAt))
+      .limit(1);
+
+    return message ? this.mapMessage(message) : null;
+  }
+
+  private async getRootMessage(threadId: UUIDType): Promise<CourseChatMessageResponse | null> {
+    const [message] = await this.db
+      .select(this.messageSelect())
+      .from(courseChatMessages)
+      .innerJoin(users, eq(users.id, courseChatMessages.userId))
+      .where(and(eq(courseChatMessages.threadId, threadId), isNull(courseChatMessages.deletedAt)))
+      .orderBy(courseChatMessages.createdAt)
+      .limit(1);
+
+    return message ? this.mapMessage(message) : null;
+  }
+
+  private messageSelect() {
+    return {
+      id: courseChatMessages.id,
+      threadId: courseChatMessages.threadId,
+      courseId: courseChatMessages.courseId,
+      userId: courseChatMessages.userId,
+      content: courseChatMessages.content,
+      parentMessageId: courseChatMessages.parentMessageId,
+      deletedAt: courseChatMessages.deletedAt,
+      createdAt: courseChatMessages.createdAt,
+      updatedAt: courseChatMessages.updatedAt,
+      userIdForProfile: users.id,
+      userFirstName: users.firstName,
+      userLastName: users.lastName,
+      userAvatarReference: users.avatarReference,
+    };
+  }
+
+  private mapThread(
+    thread: {
+      id: UUIDType;
+      courseId: UUIDType;
+      createdByUserId: UUIDType;
+      archived: boolean;
+      createdAt: string;
+      updatedAt: string;
+      messageCount: number;
+      createdById: UUIDType;
+      createdByFirstName: string;
+      createdByLastName: string;
+      createdByAvatarReference: string | null;
+    },
+    rootMessage: CourseChatMessageResponse,
+    latestMessage: CourseChatMessageResponse | null,
+  ): CourseChatThreadResponse {
+    return {
+      id: thread.id,
+      courseId: thread.courseId,
+      createdByUserId: thread.createdByUserId,
+      archived: thread.archived,
+      createdAt: thread.createdAt,
+      updatedAt: thread.updatedAt,
+      messageCount: thread.messageCount,
+      createdBy: {
+        id: thread.createdById,
+        firstName: thread.createdByFirstName,
+        lastName: thread.createdByLastName,
+        avatarReference: thread.createdByAvatarReference,
+      },
+      rootMessage,
+      latestMessage,
+    };
+  }
+
+  private mapMessage(message: CourseChatMessageRow): CourseChatMessageResponse {
+    return {
+      id: message.id,
+      threadId: message.threadId,
+      courseId: message.courseId,
+      userId: message.userId,
+      content: message.content,
+      parentMessageId: message.parentMessageId,
+      deletedAt: message.deletedAt,
+      createdAt: message.createdAt,
+      updatedAt: message.updatedAt,
+      user: {
+        id: message.userIdForProfile,
+        firstName: message.userFirstName,
+        lastName: message.userLastName,
+        avatarReference: message.userAvatarReference,
+      },
+    };
+  }
+}

--- a/apps/api/src/course-chat/course-chat.repository.ts
+++ b/apps/api/src/course-chat/course-chat.repository.ts
@@ -6,6 +6,7 @@ import { DatabasePg } from "src/common";
 import { DEFAULT_PAGE_SIZE } from "src/common/pagination";
 import {
   courses,
+  courseChatMessageReactions,
   courseChatMessages,
   courseChatThreads,
   studentCourses,
@@ -15,6 +16,7 @@ import {
 import type { UUIDType } from "src/common";
 import type {
   CourseChatMessageResponse,
+  CourseChatMessageReactionResponse,
   CourseChatThreadResponse,
   CourseChatUserResponse,
 } from "src/course-chat/schemas/course-chat.schema";
@@ -47,6 +49,12 @@ export type CourseChatEmailContext = {
   baseLanguage: string;
 };
 
+export type CourseChatMessageContext = {
+  id: UUIDType;
+  threadId: UUIDType;
+  courseId: UUIDType;
+};
+
 @Injectable()
 export class CourseChatRepository {
   constructor(@Inject("DB") private readonly db: DatabasePg) {}
@@ -67,7 +75,12 @@ export class CourseChatRepository {
     return Boolean(enrollment);
   }
 
-  async getThreads(courseId: UUIDType, page = 1, perPage = DEFAULT_PAGE_SIZE) {
+  async getThreads(
+    courseId: UUIDType,
+    viewerUserId: UUIDType,
+    page = 1,
+    perPage = DEFAULT_PAGE_SIZE,
+  ) {
     const data = await this.db
       .select({
         id: courseChatThreads.id,
@@ -102,8 +115,8 @@ export class CourseChatRepository {
     const threads = await Promise.all(
       data.map(async (thread): Promise<CourseChatThreadResponse> => {
         const [rootMessage, latestMessage] = await Promise.all([
-          this.getRootMessage(thread.id),
-          this.getLatestMessage(thread.id),
+          this.getRootMessage(thread.id, viewerUserId),
+          this.getLatestMessage(thread.id, viewerUserId),
         ]);
 
         if (!rootMessage) {
@@ -195,7 +208,10 @@ export class CourseChatRepository {
     return course ? (course as CourseChatEmailContext) : null;
   }
 
-  async getThreadById(threadId: UUIDType): Promise<CourseChatThreadResponse | null> {
+  async getThreadById(
+    threadId: UUIDType,
+    viewerUserId: UUIDType,
+  ): Promise<CourseChatThreadResponse | null> {
     const [thread] = await this.db
       .select({
         id: courseChatThreads.id,
@@ -223,8 +239,8 @@ export class CourseChatRepository {
     if (!thread) return null;
 
     const [rootMessage, latestMessage] = await Promise.all([
-      this.getRootMessage(thread.id),
-      this.getLatestMessage(thread.id),
+      this.getRootMessage(thread.id, viewerUserId),
+      this.getLatestMessage(thread.id, viewerUserId),
     ]);
 
     if (!rootMessage) {
@@ -234,7 +250,12 @@ export class CourseChatRepository {
     return this.mapThread(thread, rootMessage, latestMessage);
   }
 
-  async getMessages(threadId: UUIDType, page = 1, perPage = DEFAULT_PAGE_SIZE) {
+  async getMessages(
+    threadId: UUIDType,
+    viewerUserId: UUIDType,
+    page = 1,
+    perPage = DEFAULT_PAGE_SIZE,
+  ) {
     const data = await this.db
       .select(this.messageSelect())
       .from(courseChatMessages)
@@ -250,12 +271,15 @@ export class CourseChatRepository {
       .where(and(eq(courseChatMessages.threadId, threadId), isNull(courseChatMessages.deletedAt)));
 
     return {
-      data: data.map((message) => this.mapMessage(message)),
+      data: await Promise.all(data.map((message) => this.mapMessage(message, viewerUserId))),
       pagination: { totalItems, page, perPage },
     };
   }
 
-  async getMessageById(messageId: UUIDType): Promise<CourseChatMessageResponse | null> {
+  async getMessageById(
+    messageId: UUIDType,
+    viewerUserId: UUIDType,
+  ): Promise<CourseChatMessageResponse | null> {
     const [message] = await this.db
       .select(this.messageSelect())
       .from(courseChatMessages)
@@ -263,7 +287,7 @@ export class CourseChatRepository {
       .where(eq(courseChatMessages.id, messageId))
       .limit(1);
 
-    return message ? this.mapMessage(message) : null;
+    return message ? this.mapMessage(message, viewerUserId) : null;
   }
 
   async createThreadWithMessage(courseId: UUIDType, userId: UUIDType, content: string) {
@@ -320,7 +344,64 @@ export class CourseChatRepository {
     return Boolean(message);
   }
 
-  private async getLatestMessage(threadId: UUIDType): Promise<CourseChatMessageResponse | null> {
+  async getMessageContext(messageId: UUIDType): Promise<CourseChatMessageContext | null> {
+    const [message] = await this.db
+      .select({
+        id: courseChatMessages.id,
+        threadId: courseChatMessages.threadId,
+        courseId: courseChatMessages.courseId,
+      })
+      .from(courseChatMessages)
+      .where(and(eq(courseChatMessages.id, messageId), isNull(courseChatMessages.deletedAt)))
+      .limit(1);
+
+    return message ?? null;
+  }
+
+  async toggleMessageReaction(params: {
+    messageId: UUIDType;
+    courseId: UUIDType;
+    userId: UUIDType;
+    reaction: string;
+  }) {
+    await this.db.transaction(async (trx) => {
+      const deleted = await trx
+        .delete(courseChatMessageReactions)
+        .where(
+          and(
+            eq(courseChatMessageReactions.messageId, params.messageId),
+            eq(courseChatMessageReactions.userId, params.userId),
+            eq(courseChatMessageReactions.reaction, params.reaction),
+          ),
+        )
+        .returning({ id: courseChatMessageReactions.id });
+
+      if (deleted.length) return;
+
+      await trx.insert(courseChatMessageReactions).values(params);
+    });
+  }
+
+  async getMessageReactions(
+    messageId: UUIDType,
+    viewerUserId: UUIDType,
+  ): Promise<CourseChatMessageReactionResponse[]> {
+    return this.db
+      .select({
+        reaction: courseChatMessageReactions.reaction,
+        count: sql<number>`COUNT(*)::int`,
+        reactedByCurrentUser: sql<boolean>`BOOL_OR(${courseChatMessageReactions.userId} = ${viewerUserId})`,
+      })
+      .from(courseChatMessageReactions)
+      .where(eq(courseChatMessageReactions.messageId, messageId))
+      .groupBy(courseChatMessageReactions.reaction)
+      .orderBy(courseChatMessageReactions.reaction);
+  }
+
+  private async getLatestMessage(
+    threadId: UUIDType,
+    viewerUserId: UUIDType,
+  ): Promise<CourseChatMessageResponse | null> {
     const [message] = await this.db
       .select(this.messageSelect())
       .from(courseChatMessages)
@@ -329,10 +410,13 @@ export class CourseChatRepository {
       .orderBy(desc(courseChatMessages.createdAt))
       .limit(1);
 
-    return message ? this.mapMessage(message) : null;
+    return message ? this.mapMessage(message, viewerUserId) : null;
   }
 
-  private async getRootMessage(threadId: UUIDType): Promise<CourseChatMessageResponse | null> {
+  private async getRootMessage(
+    threadId: UUIDType,
+    viewerUserId: UUIDType,
+  ): Promise<CourseChatMessageResponse | null> {
     const [message] = await this.db
       .select(this.messageSelect())
       .from(courseChatMessages)
@@ -341,7 +425,7 @@ export class CourseChatRepository {
       .orderBy(courseChatMessages.createdAt)
       .limit(1);
 
-    return message ? this.mapMessage(message) : null;
+    return message ? this.mapMessage(message, viewerUserId) : null;
   }
 
   private messageSelect() {
@@ -398,7 +482,10 @@ export class CourseChatRepository {
     };
   }
 
-  private mapMessage(message: CourseChatMessageRow): CourseChatMessageResponse {
+  private async mapMessage(
+    message: CourseChatMessageRow,
+    viewerUserId: UUIDType,
+  ): Promise<CourseChatMessageResponse> {
     return {
       id: message.id,
       threadId: message.threadId,
@@ -415,6 +502,7 @@ export class CourseChatRepository {
         lastName: message.userLastName,
         avatarReference: message.userAvatarReference,
       },
+      reactions: await this.getMessageReactions(message.id, viewerUserId),
     };
   }
 }

--- a/apps/api/src/course-chat/course-chat.service.ts
+++ b/apps/api/src/course-chat/course-chat.service.ts
@@ -13,6 +13,7 @@ import { EmailService } from "src/common/emails/emails.service";
 import { getEmailSubject } from "src/common/emails/translations";
 import { CourseChatPresenceService } from "src/course-chat/course-chat-presence.service";
 import {
+  COURSE_CHAT_ALLOWED_REACTIONS,
   COURSE_CHAT_SOCKET_EVENTS,
   getCourseChatRoom,
 } from "src/course-chat/course-chat.constants";
@@ -28,6 +29,7 @@ import type {
   CreateCourseChatMessageBody,
   CreateCourseChatThreadBody,
   CreateCourseChatThreadResponse,
+  ToggleCourseChatMessageReactionBody,
 } from "src/course-chat/schemas/course-chat.schema";
 
 type CourseChatRealtimePublisher = {
@@ -61,6 +63,7 @@ export class CourseChatService {
 
     const threads = await this.courseChatRepository.getThreads(
       params.courseId,
+      params.userId,
       params.page,
       params.perPage,
     );
@@ -77,6 +80,7 @@ export class CourseChatService {
     const thread = await this.getAccessibleThread(params.threadId, params.userId);
     const messages = await this.courseChatRepository.getMessages(
       thread.id,
+      params.userId,
       params.page,
       params.perPage,
     );
@@ -115,8 +119,8 @@ export class CourseChatService {
     );
 
     const [thread, message] = await Promise.all([
-      this.courseChatRepository.getThreadById(threadId),
-      this.courseChatRepository.getMessageById(messageId),
+      this.courseChatRepository.getThreadById(threadId, userId),
+      this.courseChatRepository.getMessageById(messageId, userId),
     ]);
 
     if (!thread || !message) throw new NotFoundException("courseChat.errors.notFound");
@@ -161,7 +165,7 @@ export class CourseChatService {
       parentMessageId: body.parentMessageId,
     });
 
-    const message = await this.courseChatRepository.getMessageById(messageId);
+    const message = await this.courseChatRepository.getMessageById(messageId, userId);
     if (!message) throw new NotFoundException("courseChat.errors.notFound");
 
     this.realtimePublisher.emitToRoom(
@@ -179,8 +183,46 @@ export class CourseChatService {
     return new BaseResponse(message);
   }
 
+  async toggleMessageReaction(
+    messageId: UUIDType,
+    userId: UUIDType,
+    body: ToggleCourseChatMessageReactionBody,
+  ) {
+    if (!this.isAllowedReaction(body.reaction)) {
+      throw new BadRequestException("courseChat.errors.invalidReaction");
+    }
+
+    const message = await this.courseChatRepository.getMessageContext(messageId);
+    if (!message) throw new NotFoundException("courseChat.errors.messageNotFound");
+
+    await this.assertUserEnrolledInCourse(message.courseId, userId);
+
+    await this.courseChatRepository.toggleMessageReaction({
+      messageId,
+      courseId: message.courseId,
+      userId,
+      reaction: body.reaction,
+    });
+
+    const reactions = await this.courseChatRepository.getMessageReactions(messageId, userId);
+    const payload = {
+      courseId: message.courseId,
+      threadId: message.threadId,
+      messageId,
+      reactions,
+    };
+
+    this.realtimePublisher.emitToRoom(
+      COURSE_CHAT_SOCKET_EVENTS.MESSAGE_REACTIONS_UPDATED,
+      getCourseChatRoom(message.courseId),
+      payload,
+    );
+
+    return new BaseResponse(payload);
+  }
+
   private async getAccessibleThread(threadId: UUIDType, userId: UUIDType) {
-    const thread = await this.courseChatRepository.getThreadById(threadId);
+    const thread = await this.courseChatRepository.getThreadById(threadId, userId);
 
     if (!thread || thread.archived) {
       throw new NotFoundException("courseChat.errors.threadNotFound");
@@ -199,6 +241,10 @@ export class CourseChatService {
     }
 
     return normalized;
+  }
+
+  private isAllowedReaction(reaction: string) {
+    return (COURSE_CHAT_ALLOWED_REACTIONS as readonly string[]).includes(reaction);
   }
 
   private async emitMentionNotifications(params: {

--- a/apps/api/src/course-chat/course-chat.service.ts
+++ b/apps/api/src/course-chat/course-chat.service.ts
@@ -1,0 +1,340 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Inject,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
+import { BaseEmailTemplate } from "@repo/email-templates";
+import { SUPPORTED_LANGUAGES } from "@repo/shared";
+
+import { BaseResponse, PaginatedResponse } from "src/common";
+import { EmailService } from "src/common/emails/emails.service";
+import { getEmailSubject } from "src/common/emails/translations";
+import { CourseChatPresenceService } from "src/course-chat/course-chat-presence.service";
+import {
+  COURSE_CHAT_SOCKET_EVENTS,
+  getCourseChatRoom,
+} from "src/course-chat/course-chat.constants";
+import { CourseChatRepository } from "src/course-chat/course-chat.repository";
+import { REALTIME_PUBLISHER } from "src/websocket/realtime.publisher";
+
+import type { SupportedLanguages } from "@repo/shared";
+import type { UUIDType } from "src/common";
+import type {
+  CourseChatMessageResponse,
+  CourseChatThreadResponse,
+  CourseChatUserResponse,
+  CreateCourseChatMessageBody,
+  CreateCourseChatThreadBody,
+  CreateCourseChatThreadResponse,
+} from "src/course-chat/schemas/course-chat.schema";
+
+type CourseChatRealtimePublisher = {
+  emitToRoom(event: string, roomId: string, payload: unknown): void;
+};
+
+@Injectable()
+export class CourseChatService {
+  constructor(
+    private readonly courseChatRepository: CourseChatRepository,
+    private readonly courseChatPresenceService: CourseChatPresenceService,
+    private readonly emailService: EmailService,
+    @Inject(REALTIME_PUBLISHER) private readonly realtimePublisher: CourseChatRealtimePublisher,
+  ) {}
+
+  async assertUserEnrolledInCourse(courseId: UUIDType, userId: UUIDType) {
+    const isEnrolled = await this.courseChatRepository.isUserEnrolledInCourse(courseId, userId);
+
+    if (!isEnrolled) {
+      throw new ForbiddenException("courseChat.errors.notEnrolled");
+    }
+  }
+
+  async getThreads(params: {
+    courseId: UUIDType;
+    userId: UUIDType;
+    page?: number;
+    perPage?: number;
+  }): Promise<PaginatedResponse<CourseChatThreadResponse[]>> {
+    await this.assertUserEnrolledInCourse(params.courseId, params.userId);
+
+    const threads = await this.courseChatRepository.getThreads(
+      params.courseId,
+      params.page,
+      params.perPage,
+    );
+
+    return new PaginatedResponse(threads);
+  }
+
+  async getMessages(params: {
+    threadId: UUIDType;
+    userId: UUIDType;
+    page?: number;
+    perPage?: number;
+  }): Promise<PaginatedResponse<CourseChatMessageResponse[]>> {
+    const thread = await this.getAccessibleThread(params.threadId, params.userId);
+    const messages = await this.courseChatRepository.getMessages(
+      thread.id,
+      params.page,
+      params.perPage,
+    );
+
+    return new PaginatedResponse(messages);
+  }
+
+  async getUsers(
+    courseId: UUIDType,
+    userId: UUIDType,
+  ): Promise<BaseResponse<CourseChatUserResponse[]>> {
+    await this.assertUserEnrolledInCourse(courseId, userId);
+
+    const users = await this.courseChatRepository.getEnrolledUsers(courseId);
+
+    return new BaseResponse(
+      users.map((user) => ({
+        ...user,
+        isOnline: this.courseChatPresenceService.isOnline(courseId, user.id),
+      })),
+    );
+  }
+
+  async createThread(
+    courseId: UUIDType,
+    userId: UUIDType,
+    body: CreateCourseChatThreadBody,
+  ): Promise<BaseResponse<CreateCourseChatThreadResponse>> {
+    await this.assertUserEnrolledInCourse(courseId, userId);
+
+    const content = this.normalizeContent(body.content);
+    const { threadId, messageId } = await this.courseChatRepository.createThreadWithMessage(
+      courseId,
+      userId,
+      content,
+    );
+
+    const [thread, message] = await Promise.all([
+      this.courseChatRepository.getThreadById(threadId),
+      this.courseChatRepository.getMessageById(messageId),
+    ]);
+
+    if (!thread || !message) throw new NotFoundException("courseChat.errors.notFound");
+
+    const payload = { thread, message };
+    const room = getCourseChatRoom(courseId);
+    this.realtimePublisher.emitToRoom(COURSE_CHAT_SOCKET_EVENTS.THREAD_CREATED, room, payload);
+    this.realtimePublisher.emitToRoom(COURSE_CHAT_SOCKET_EVENTS.MESSAGE_CREATED, room, message);
+    await this.emitMentionNotifications({
+      courseId,
+      actorUserId: userId,
+      message,
+      mentionedUserIds: body.mentionedUserIds,
+    });
+
+    return new BaseResponse(payload);
+  }
+
+  async createMessage(
+    threadId: UUIDType,
+    userId: UUIDType,
+    body: CreateCourseChatMessageBody,
+  ): Promise<BaseResponse<CourseChatMessageResponse>> {
+    const thread = await this.getAccessibleThread(threadId, userId);
+
+    if (body.parentMessageId) {
+      const parentBelongsToThread = await this.courseChatRepository.messageBelongsToThread(
+        body.parentMessageId,
+        thread.id,
+      );
+
+      if (!parentBelongsToThread) {
+        throw new BadRequestException("courseChat.errors.invalidParentMessage");
+      }
+    }
+
+    const messageId = await this.courseChatRepository.createMessage({
+      threadId: thread.id,
+      courseId: thread.courseId,
+      userId,
+      content: this.normalizeContent(body.content),
+      parentMessageId: body.parentMessageId,
+    });
+
+    const message = await this.courseChatRepository.getMessageById(messageId);
+    if (!message) throw new NotFoundException("courseChat.errors.notFound");
+
+    this.realtimePublisher.emitToRoom(
+      COURSE_CHAT_SOCKET_EVENTS.MESSAGE_CREATED,
+      getCourseChatRoom(thread.courseId),
+      message,
+    );
+    await this.emitMentionNotifications({
+      courseId: thread.courseId,
+      actorUserId: userId,
+      message,
+      mentionedUserIds: body.mentionedUserIds,
+    });
+
+    return new BaseResponse(message);
+  }
+
+  private async getAccessibleThread(threadId: UUIDType, userId: UUIDType) {
+    const thread = await this.courseChatRepository.getThreadById(threadId);
+
+    if (!thread || thread.archived) {
+      throw new NotFoundException("courseChat.errors.threadNotFound");
+    }
+
+    await this.assertUserEnrolledInCourse(thread.courseId, userId);
+
+    return thread;
+  }
+
+  private normalizeContent(content: string) {
+    const normalized = content.trim();
+
+    if (!normalized) {
+      throw new BadRequestException("courseChat.errors.emptyMessage");
+    }
+
+    return normalized;
+  }
+
+  private async emitMentionNotifications(params: {
+    courseId: UUIDType;
+    actorUserId: UUIDType;
+    message: CourseChatMessageResponse;
+    mentionedUserIds?: UUIDType[];
+  }) {
+    const uniqueMentionedUserIds = Array.from(new Set(params.mentionedUserIds ?? [])).filter(
+      (mentionedUserId) => mentionedUserId !== params.actorUserId,
+    );
+
+    if (!uniqueMentionedUserIds.length) return;
+
+    const [recipients, courseContext] = await Promise.all([
+      this.courseChatRepository.getMentionEmailRecipients(params.courseId, uniqueMentionedUserIds),
+      this.courseChatRepository.getCourseEmailContext(params.courseId),
+    ]);
+
+    for (const recipient of recipients) {
+      this.realtimePublisher.emitToRoom(
+        COURSE_CHAT_SOCKET_EVENTS.USER_MENTIONED,
+        `user:${recipient.id}`,
+        {
+          courseId: params.courseId,
+          message: params.message,
+        },
+      );
+    }
+
+    if (!courseContext) return;
+
+    await Promise.allSettled(
+      recipients.map(async (recipient) => {
+        const defaultEmailSettings = await this.emailService.getDefaultEmailProperties(
+          recipient.tenantId,
+          recipient.id,
+        );
+        const courseName = this.getLocalizedCourseTitle(
+          courseContext.title,
+          defaultEmailSettings.language,
+          courseContext.baseLanguage,
+        );
+        const authorName = `${params.message.user.firstName} ${params.message.user.lastName}`;
+        const { text, html } = new BaseEmailTemplate({
+          heading: this.getMentionEmailHeading(defaultEmailSettings.language),
+          paragraphs: this.getMentionEmailParagraphs(defaultEmailSettings.language, {
+            recipientName: recipient.firstName,
+            authorName,
+            courseName,
+            messageContent: params.message.content,
+          }),
+          buttonText: this.getMentionEmailButtonText(defaultEmailSettings.language),
+          buttonLink: `${process.env.CORS_ORIGIN}/course/${params.courseId}`,
+          ...defaultEmailSettings,
+        });
+
+        await this.emailService.sendEmailWithLogo(
+          {
+            to: recipient.email,
+            subject: getEmailSubject("courseChatMentionEmail", defaultEmailSettings.language, {
+              courseName,
+            }),
+            text,
+            html,
+          },
+          { tenantId: recipient.tenantId },
+        );
+      }),
+    );
+  }
+
+  private getLocalizedCourseTitle(
+    title: Record<string, string>,
+    language: SupportedLanguages,
+    baseLanguage: string,
+  ) {
+    return title[language] ?? title[baseLanguage] ?? title[SUPPORTED_LANGUAGES.EN] ?? "Course";
+  }
+
+  private getMentionEmailHeading(language: SupportedLanguages) {
+    return (
+      {
+        en: "You were mentioned in course chat",
+        pl: "Oznaczono Cię na czacie kursu",
+        de: "Du wurdest im Kurschat erwähnt",
+        lt: "Buvote paminėti kurso pokalbyje",
+        cs: "Byl(a) jste zmíněn(a) v chatu kurzu",
+      } satisfies Record<SupportedLanguages, string>
+    )[language];
+  }
+
+  private getMentionEmailButtonText(language: SupportedLanguages) {
+    return (
+      {
+        en: "Open course chat",
+        pl: "Otwórz czat kursu",
+        de: "Kurschat öffnen",
+        lt: "Atidaryti kurso pokalbį",
+        cs: "Otevřít chat kurzu",
+      } satisfies Record<SupportedLanguages, string>
+    )[language];
+  }
+
+  private getMentionEmailParagraphs(
+    language: SupportedLanguages,
+    params: {
+      recipientName: string;
+      authorName: string;
+      courseName: string;
+      messageContent: string;
+    },
+  ) {
+    const translations = {
+      en: [
+        `Hi ${params.recipientName}, ${params.authorName} mentioned you in ${params.courseName}.`,
+        `"${params.messageContent}"`,
+      ],
+      pl: [
+        `Cześć ${params.recipientName}, ${params.authorName} oznaczył(a) Cię w kursie ${params.courseName}.`,
+        `"${params.messageContent}"`,
+      ],
+      de: [
+        `Hallo ${params.recipientName}, ${params.authorName} hat dich in ${params.courseName} erwähnt.`,
+        `"${params.messageContent}"`,
+      ],
+      lt: [
+        `Sveiki, ${params.recipientName}, ${params.authorName} paminėjo jus kurse ${params.courseName}.`,
+        `"${params.messageContent}"`,
+      ],
+      cs: [
+        `Ahoj ${params.recipientName}, ${params.authorName} vás zmínil(a) v kurzu ${params.courseName}.`,
+        `"${params.messageContent}"`,
+      ],
+    } satisfies Record<SupportedLanguages, string[]>;
+
+    return translations[language];
+  }
+}

--- a/apps/api/src/course-chat/schemas/course-chat.schema.ts
+++ b/apps/api/src/course-chat/schemas/course-chat.schema.ts
@@ -11,6 +11,12 @@ const userSchema = Type.Object({
   avatarReference: Type.Union([Type.String(), Type.Null()]),
 });
 
+export const courseChatMessageReactionSchema = Type.Object({
+  reaction: Type.String(),
+  count: Type.Number(),
+  reactedByCurrentUser: Type.Boolean(),
+});
+
 export const courseChatMessageSchema = Type.Object({
   id: UUIDSchema,
   threadId: UUIDSchema,
@@ -22,6 +28,7 @@ export const courseChatMessageSchema = Type.Object({
   createdAt: Type.String(),
   updatedAt: Type.String(),
   user: userSchema,
+  reactions: Type.Array(courseChatMessageReactionSchema),
 });
 
 export const courseChatThreadSchema = Type.Object({
@@ -56,6 +63,17 @@ export const createCourseChatMessageSchema = Type.Object({
   mentionedUserIds: Type.Optional(Type.Array(UUIDSchema)),
 });
 
+export const toggleCourseChatMessageReactionSchema = Type.Object({
+  reaction: Type.String({ minLength: 1, maxLength: 16 }),
+});
+
+export const courseChatMessageReactionsUpdatedSchema = Type.Object({
+  courseId: UUIDSchema,
+  threadId: UUIDSchema,
+  messageId: UUIDSchema,
+  reactions: Type.Array(courseChatMessageReactionSchema),
+});
+
 export const courseChatPaginationQuerySchema = Type.Optional(Type.Number({ minimum: 1 }));
 
 export const courseChatThreadsResponseSchema = Type.Array(courseChatThreadSchema);
@@ -68,8 +86,15 @@ export const createCourseChatThreadResponseSchema = Type.Object({
 });
 
 export type CourseChatMessageResponse = Static<typeof courseChatMessageSchema>;
+export type CourseChatMessageReactionResponse = Static<typeof courseChatMessageReactionSchema>;
+export type CourseChatMessageReactionsUpdatedResponse = Static<
+  typeof courseChatMessageReactionsUpdatedSchema
+>;
 export type CourseChatThreadResponse = Static<typeof courseChatThreadSchema>;
 export type CourseChatUserResponse = Static<typeof courseChatUserSchema>;
 export type CreateCourseChatThreadBody = Static<typeof createCourseChatThreadSchema>;
 export type CreateCourseChatMessageBody = Static<typeof createCourseChatMessageSchema>;
+export type ToggleCourseChatMessageReactionBody = Static<
+  typeof toggleCourseChatMessageReactionSchema
+>;
 export type CreateCourseChatThreadResponse = Static<typeof createCourseChatThreadResponseSchema>;

--- a/apps/api/src/course-chat/schemas/course-chat.schema.ts
+++ b/apps/api/src/course-chat/schemas/course-chat.schema.ts
@@ -1,0 +1,75 @@
+import { Type } from "@sinclair/typebox";
+
+import { UUIDSchema } from "src/common";
+
+import type { Static } from "@sinclair/typebox";
+
+const userSchema = Type.Object({
+  id: UUIDSchema,
+  firstName: Type.String(),
+  lastName: Type.String(),
+  avatarReference: Type.Union([Type.String(), Type.Null()]),
+});
+
+export const courseChatMessageSchema = Type.Object({
+  id: UUIDSchema,
+  threadId: UUIDSchema,
+  courseId: UUIDSchema,
+  userId: UUIDSchema,
+  content: Type.String(),
+  parentMessageId: Type.Union([UUIDSchema, Type.Null()]),
+  deletedAt: Type.Union([Type.String(), Type.Null()]),
+  createdAt: Type.String(),
+  updatedAt: Type.String(),
+  user: userSchema,
+});
+
+export const courseChatThreadSchema = Type.Object({
+  id: UUIDSchema,
+  courseId: UUIDSchema,
+  createdByUserId: UUIDSchema,
+  archived: Type.Boolean(),
+  createdAt: Type.String(),
+  updatedAt: Type.String(),
+  messageCount: Type.Number(),
+  createdBy: userSchema,
+  rootMessage: courseChatMessageSchema,
+  latestMessage: Type.Union([courseChatMessageSchema, Type.Null()]),
+});
+
+export const courseChatUserSchema = Type.Object({
+  id: UUIDSchema,
+  firstName: Type.String(),
+  lastName: Type.String(),
+  avatarReference: Type.Union([Type.String(), Type.Null()]),
+  isOnline: Type.Boolean(),
+});
+
+export const createCourseChatThreadSchema = Type.Object({
+  content: Type.String({ minLength: 1, maxLength: 5000 }),
+  mentionedUserIds: Type.Optional(Type.Array(UUIDSchema)),
+});
+
+export const createCourseChatMessageSchema = Type.Object({
+  content: Type.String({ minLength: 1, maxLength: 5000 }),
+  parentMessageId: Type.Optional(UUIDSchema),
+  mentionedUserIds: Type.Optional(Type.Array(UUIDSchema)),
+});
+
+export const courseChatPaginationQuerySchema = Type.Optional(Type.Number({ minimum: 1 }));
+
+export const courseChatThreadsResponseSchema = Type.Array(courseChatThreadSchema);
+export const courseChatMessagesResponseSchema = Type.Array(courseChatMessageSchema);
+export const courseChatUsersResponseSchema = Type.Array(courseChatUserSchema);
+
+export const createCourseChatThreadResponseSchema = Type.Object({
+  thread: courseChatThreadSchema,
+  message: courseChatMessageSchema,
+});
+
+export type CourseChatMessageResponse = Static<typeof courseChatMessageSchema>;
+export type CourseChatThreadResponse = Static<typeof courseChatThreadSchema>;
+export type CourseChatUserResponse = Static<typeof courseChatUserSchema>;
+export type CreateCourseChatThreadBody = Static<typeof createCourseChatThreadSchema>;
+export type CreateCourseChatMessageBody = Static<typeof createCourseChatMessageSchema>;
+export type CreateCourseChatThreadResponse = Static<typeof createCourseChatThreadResponseSchema>;

--- a/apps/api/src/storage/migrations/0110_add_chat_to_course.sql
+++ b/apps/api/src/storage/migrations/0110_add_chat_to_course.sql
@@ -1,0 +1,98 @@
+CREATE TABLE IF NOT EXISTS "course_chat_messages" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"created_at" timestamp(3) with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	"updated_at" timestamp(3) with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	"thread_id" uuid NOT NULL,
+	"course_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"content" text NOT NULL,
+	"parent_message_id" uuid,
+	"deleted_at" timestamp(3) with time zone,
+	"tenant_id" uuid DEFAULT current_setting('app.tenant_id', true)::uuid NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "course_chat_threads" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"created_at" timestamp(3) with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	"updated_at" timestamp(3) with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	"course_id" uuid NOT NULL,
+	"created_by_user_id" uuid NOT NULL,
+	"archived" boolean DEFAULT false NOT NULL,
+	"tenant_id" uuid DEFAULT current_setting('app.tenant_id', true)::uuid NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "course_chat_messages" ADD CONSTRAINT "course_chat_messages_thread_id_course_chat_threads_id_fk" FOREIGN KEY ("thread_id") REFERENCES "public"."course_chat_threads"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "course_chat_messages" ADD CONSTRAINT "course_chat_messages_course_id_courses_id_fk" FOREIGN KEY ("course_id") REFERENCES "public"."courses"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "course_chat_messages" ADD CONSTRAINT "course_chat_messages_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "course_chat_messages" ADD CONSTRAINT "course_chat_messages_parent_message_id_course_chat_messages_id_fk" FOREIGN KEY ("parent_message_id") REFERENCES "public"."course_chat_messages"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "course_chat_messages" ADD CONSTRAINT "course_chat_messages_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "course_chat_threads" ADD CONSTRAINT "course_chat_threads_course_id_courses_id_fk" FOREIGN KEY ("course_id") REFERENCES "public"."courses"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "course_chat_threads" ADD CONSTRAINT "course_chat_threads_created_by_user_id_users_id_fk" FOREIGN KEY ("created_by_user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "course_chat_threads" ADD CONSTRAINT "course_chat_threads_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "course_chat_messages_tenant_id_idx" ON "course_chat_messages" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "course_chat_messages_course_id_created_at_idx" ON "course_chat_messages" USING btree ("course_id","created_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "course_chat_messages_thread_id_created_at_idx" ON "course_chat_messages" USING btree ("thread_id","created_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "course_chat_threads_tenant_id_idx" ON "course_chat_threads" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "course_chat_threads_course_id_created_at_idx" ON "course_chat_threads" USING btree ("course_id","created_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "course_chat_threads_course_id_updated_at_idx" ON "course_chat_threads" USING btree ("course_id","updated_at");--> statement-breakpoint
+DO $$
+DECLARE
+  r record;
+BEGIN
+  FOR r IN
+    SELECT table_schema, table_name
+    FROM information_schema.columns
+    WHERE column_name = 'tenant_id'
+      AND table_schema = 'public'
+      AND table_name IN ('course_chat_threads', 'course_chat_messages')
+  LOOP
+    EXECUTE format('ALTER TABLE %I.%I ENABLE ROW LEVEL SECURITY', r.table_schema, r.table_name);
+    EXECUTE format(
+      'CREATE POLICY %I ON %I.%I USING (tenant_id = current_setting(''app.tenant_id'', true)::uuid) WITH CHECK (tenant_id = current_setting(''app.tenant_id'', true)::uuid)',
+      concat(r.table_name, '_tenant_isolation'),
+      r.table_schema,
+      r.table_name
+    );
+  END LOOP;
+END
+$$;

--- a/apps/api/src/storage/migrations/0111_add_course_chat_reactions.sql
+++ b/apps/api/src/storage/migrations/0111_add_course_chat_reactions.sql
@@ -1,0 +1,44 @@
+CREATE TABLE IF NOT EXISTS "course_chat_message_reactions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"created_at" timestamp(3) with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	"updated_at" timestamp(3) with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	"message_id" uuid NOT NULL,
+	"course_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"reaction" text NOT NULL,
+	"tenant_id" uuid DEFAULT current_setting('app.tenant_id', true)::uuid NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "course_chat_message_reactions" ADD CONSTRAINT "course_chat_message_reactions_message_id_course_chat_messages_id_fk" FOREIGN KEY ("message_id") REFERENCES "public"."course_chat_messages"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "course_chat_message_reactions" ADD CONSTRAINT "course_chat_message_reactions_course_id_courses_id_fk" FOREIGN KEY ("course_id") REFERENCES "public"."courses"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "course_chat_message_reactions" ADD CONSTRAINT "course_chat_message_reactions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "course_chat_message_reactions" ADD CONSTRAINT "course_chat_message_reactions_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "course_chat_message_reactions_tenant_id_idx" ON "course_chat_message_reactions" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "course_chat_message_reactions_message_id_reaction_idx" ON "course_chat_message_reactions" USING btree ("message_id","reaction");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "course_chat_message_reactions_user_message_reaction_unique_idx" ON "course_chat_message_reactions" USING btree ("user_id","message_id","reaction");--> statement-breakpoint
+ALTER TABLE "course_chat_message_reactions" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE POLICY "course_chat_message_reactions_tenant_isolation" ON "course_chat_message_reactions" USING (tenant_id = current_setting('app.tenant_id', true)::uuid) WITH CHECK (tenant_id = current_setting('app.tenant_id', true)::uuid);
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/apps/api/src/storage/migrations/meta/0110_snapshot.json
+++ b/apps/api/src/storage/migrations/meta/0110_snapshot.json
@@ -1,0 +1,8739 @@
+{
+  "id": "0e9f526b-4feb-409f-be97-c726e3adfcaa",
+  "prevId": "c61a324c-0742-40f9-a238-a328fdddc555",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_logs": {
+      "name": "activity_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_role": {
+          "name": "actor_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "activity_log_action_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "activity_logs_tenant_id_idx": {
+          "name": "activity_logs_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_logs_actor_idx": {
+          "name": "activity_logs_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_logs_action_idx": {
+          "name": "activity_logs_action_idx",
+          "columns": [
+            {
+              "expression": "action_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_logs_timeframe_idx": {
+          "name": "activity_logs_timeframe_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_logs_resource_idx": {
+          "name": "activity_logs_resource_idx",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_logs_actor_id_users_id_fk": {
+          "name": "activity_logs_actor_id_users_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "activity_logs_tenant_id_tenants_id_fk": {
+          "name": "activity_logs_tenant_id_tenants_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.ai_mentor_lessons": {
+      "name": "ai_mentor_lessons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_mentor_instructions": {
+          "name": "ai_mentor_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completion_conditions": {
+          "name": "completion_conditions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'AI Mentor'"
+        },
+        "avatar_reference": {
+          "name": "avatar_reference",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mentor'"
+        },
+        "voice_mode": {
+          "name": "voice_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'preset'"
+        },
+        "tts_preset": {
+          "name": "tts_preset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'male'"
+        },
+        "custom_tts_reference": {
+          "name": "custom_tts_reference",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "ai_mentor_lessons_tenant_id_idx": {
+          "name": "ai_mentor_lessons_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_mentor_lessons_lesson_id_lessons_id_fk": {
+          "name": "ai_mentor_lessons_lesson_id_lessons_id_fk",
+          "tableFrom": "ai_mentor_lessons",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_mentor_lessons_tenant_id_tenants_id_fk": {
+          "name": "ai_mentor_lessons_tenant_id_tenants_id_fk",
+          "tableFrom": "ai_mentor_lessons",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.ai_mentor_student_lesson_progress": {
+      "name": "ai_mentor_student_lesson_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "student_lesson_progress_id": {
+          "name": "student_lesson_progress_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_score": {
+          "name": "min_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_score": {
+          "name": "max_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percentage": {
+          "name": "percentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passed": {
+          "name": "passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "ai_mentor_student_lesson_progress_tenant_id_idx": {
+          "name": "ai_mentor_student_lesson_progress_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_mentor_student_lesson_progress_student_lesson_progress_id_student_lesson_progress_id_fk": {
+          "name": "ai_mentor_student_lesson_progress_student_lesson_progress_id_student_lesson_progress_id_fk",
+          "tableFrom": "ai_mentor_student_lesson_progress",
+          "tableTo": "student_lesson_progress",
+          "columnsFrom": [
+            "student_lesson_progress_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_mentor_student_lesson_progress_tenant_id_tenants_id_fk": {
+          "name": "ai_mentor_student_lesson_progress_tenant_id_tenants_id_fk",
+          "tableFrom": "ai_mentor_student_lesson_progress",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.ai_mentor_thread_messages": {
+      "name": "ai_mentor_thread_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "ai_mentor_thread_messages_tenant_id_idx": {
+          "name": "ai_mentor_thread_messages_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_mentor_thread_messages_thread_id_ai_mentor_threads_id_fk": {
+          "name": "ai_mentor_thread_messages_thread_id_ai_mentor_threads_id_fk",
+          "tableFrom": "ai_mentor_thread_messages",
+          "tableTo": "ai_mentor_threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_mentor_thread_messages_tenant_id_tenants_id_fk": {
+          "name": "ai_mentor_thread_messages_tenant_id_tenants_id_fk",
+          "tableFrom": "ai_mentor_thread_messages",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.ai_mentor_threads": {
+      "name": "ai_mentor_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_mentor_lesson_id": {
+          "name": "ai_mentor_lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "user_language": {
+          "name": "user_language",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "ai_mentor_threads_tenant_id_idx": {
+          "name": "ai_mentor_threads_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_mentor_threads_user_id_users_id_fk": {
+          "name": "ai_mentor_threads_user_id_users_id_fk",
+          "tableFrom": "ai_mentor_threads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_mentor_threads_ai_mentor_lesson_id_ai_mentor_lessons_id_fk": {
+          "name": "ai_mentor_threads_ai_mentor_lesson_id_ai_mentor_lessons_id_fk",
+          "tableFrom": "ai_mentor_threads",
+          "tableTo": "ai_mentor_lessons",
+          "columnsFrom": [
+            "ai_mentor_lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_mentor_threads_tenant_id_tenants_id_fk": {
+          "name": "ai_mentor_threads_tenant_id_tenants_id_fk",
+          "tableFrom": "ai_mentor_threads",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.announcements": {
+      "name": "announcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_everyone": {
+          "name": "is_everyone",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "announcements_tenant_id_idx": {
+          "name": "announcements_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "announcements_author_id_users_id_fk": {
+          "name": "announcements_author_id_users_id_fk",
+          "tableFrom": "announcements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "announcements_tenant_id_tenants_id_fk": {
+          "name": "announcements_tenant_id_tenants_id_fk",
+          "tableFrom": "announcements",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.article_sections": {
+      "name": "article_sections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "title": {
+          "name": "title",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "base_language": {
+          "name": "base_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "available_locales": {
+          "name": "available_locales",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['en']::text[]"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "article_sections_tenant_id_idx": {
+          "name": "article_sections_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "article_sections_tenant_id_tenants_id_fk": {
+          "name": "article_sections_tenant_id_tenants_id_fk",
+          "tableFrom": "article_sections",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.articles": {
+      "name": "articles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "title": {
+          "name": "title",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "article_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "base_language": {
+          "name": "base_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "available_locales": {
+          "name": "available_locales",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['en']::text[]"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "article_section_id": {
+          "name": "article_section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_id": {
+          "name": "updated_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "articles_tenant_id_idx": {
+          "name": "articles_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "article_section_idx": {
+          "name": "article_section_idx",
+          "columns": [
+            {
+              "expression": "article_section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "articles_article_section_id_article_sections_id_fk": {
+          "name": "articles_article_section_id_article_sections_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "article_sections",
+          "columnsFrom": [
+            "article_section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "articles_author_id_users_id_fk": {
+          "name": "articles_author_id_users_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "articles_updated_by_id_users_id_fk": {
+          "name": "articles_updated_by_id_users_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "articles_tenant_id_tenants_id_fk": {
+          "name": "articles_tenant_id_tenants_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "categories_tenant_id_idx": {
+          "name": "categories_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_tenant_id_title_unique": {
+          "name": "categories_tenant_id_title_unique",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "categories_tenant_id_tenants_id_fk": {
+          "name": "categories_tenant_id_tenants_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.certificates": {
+      "name": "certificates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "certificates_tenant_id_idx": {
+          "name": "certificates_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "certificates_user_id_users_id_fk": {
+          "name": "certificates_user_id_users_id_fk",
+          "tableFrom": "certificates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "certificates_course_id_courses_id_fk": {
+          "name": "certificates_course_id_courses_id_fk",
+          "tableFrom": "certificates",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "certificates_tenant_id_tenants_id_fk": {
+          "name": "certificates_tenant_id_tenants_id_fk",
+          "tableFrom": "certificates",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "certificates_user_id_course_id_unique": {
+          "name": "certificates_user_id_course_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "course_id"
+          ]
+        }
+      }
+    },
+    "public.chapters": {
+      "name": "chapters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "title": {
+          "name": "title",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_freemium": {
+          "name": "is_freemium",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lesson_count": {
+          "name": "lesson_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "chapters_tenant_id_idx": {
+          "name": "chapters_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chapters_course_id_courses_id_fk": {
+          "name": "chapters_course_id_courses_id_fk",
+          "tableFrom": "chapters",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chapters_author_id_users_id_fk": {
+          "name": "chapters_author_id_users_id_fk",
+          "tableFrom": "chapters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "chapters_tenant_id_tenants_id_fk": {
+          "name": "chapters_tenant_id_tenants_id_fk",
+          "tableFrom": "chapters",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.course_chat_messages": {
+      "name": "course_chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_message_id": {
+          "name": "parent_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "course_chat_messages_tenant_id_idx": {
+          "name": "course_chat_messages_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "course_chat_messages_course_id_created_at_idx": {
+          "name": "course_chat_messages_course_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "course_chat_messages_thread_id_created_at_idx": {
+          "name": "course_chat_messages_thread_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_chat_messages_thread_id_course_chat_threads_id_fk": {
+          "name": "course_chat_messages_thread_id_course_chat_threads_id_fk",
+          "tableFrom": "course_chat_messages",
+          "tableTo": "course_chat_threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course_chat_messages_course_id_courses_id_fk": {
+          "name": "course_chat_messages_course_id_courses_id_fk",
+          "tableFrom": "course_chat_messages",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course_chat_messages_user_id_users_id_fk": {
+          "name": "course_chat_messages_user_id_users_id_fk",
+          "tableFrom": "course_chat_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course_chat_messages_parent_message_id_course_chat_messages_id_fk": {
+          "name": "course_chat_messages_parent_message_id_course_chat_messages_id_fk",
+          "tableFrom": "course_chat_messages",
+          "tableTo": "course_chat_messages",
+          "columnsFrom": [
+            "parent_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "course_chat_messages_tenant_id_tenants_id_fk": {
+          "name": "course_chat_messages_tenant_id_tenants_id_fk",
+          "tableFrom": "course_chat_messages",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.course_chat_threads": {
+      "name": "course_chat_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "course_chat_threads_tenant_id_idx": {
+          "name": "course_chat_threads_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "course_chat_threads_course_id_created_at_idx": {
+          "name": "course_chat_threads_course_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "course_chat_threads_course_id_updated_at_idx": {
+          "name": "course_chat_threads_course_id_updated_at_idx",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_chat_threads_course_id_courses_id_fk": {
+          "name": "course_chat_threads_course_id_courses_id_fk",
+          "tableFrom": "course_chat_threads",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course_chat_threads_created_by_user_id_users_id_fk": {
+          "name": "course_chat_threads_created_by_user_id_users_id_fk",
+          "tableFrom": "course_chat_threads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course_chat_threads_tenant_id_tenants_id_fk": {
+          "name": "course_chat_threads_tenant_id_tenants_id_fk",
+          "tableFrom": "course_chat_threads",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.course_slugs": {
+      "name": "course_slugs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_short_id": {
+          "name": "course_short_id",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lang": {
+          "name": "lang",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "course_slugs_tenant_id_idx": {
+          "name": "course_slugs_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "course_slug_course_short_id_lang_unique_idx": {
+          "name": "course_slug_course_short_id_lang_unique_idx",
+          "columns": [
+            {
+              "expression": "course_short_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lang",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_slugs_course_short_id_courses_short_id_fk": {
+          "name": "course_slugs_course_short_id_courses_short_id_fk",
+          "tableFrom": "course_slugs",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_short_id"
+          ],
+          "columnsTo": [
+            "short_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "course_slugs_tenant_id_tenants_id_fk": {
+          "name": "course_slugs_tenant_id_tenants_id_fk",
+          "tableFrom": "course_slugs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.course_student_mode": {
+      "name": "course_student_mode",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "course_student_mode_tenant_id_idx": {
+          "name": "course_student_mode_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_student_mode_user_id_users_id_fk": {
+          "name": "course_student_mode_user_id_users_id_fk",
+          "tableFrom": "course_student_mode",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course_student_mode_course_id_courses_id_fk": {
+          "name": "course_student_mode_course_id_courses_id_fk",
+          "tableFrom": "course_student_mode",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course_student_mode_tenant_id_tenants_id_fk": {
+          "name": "course_student_mode_tenant_id_tenants_id_fk",
+          "tableFrom": "course_student_mode",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "course_student_mode_user_id_course_id_unique": {
+          "name": "course_student_mode_user_id_course_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "course_id"
+          ]
+        }
+      }
+    },
+    "public.course_students_stats": {
+      "name": "course_students_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_students_count": {
+          "name": "new_students_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "course_students_stats_tenant_id_idx": {
+          "name": "course_students_stats_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_students_stats_course_id_courses_id_fk": {
+          "name": "course_students_stats_course_id_courses_id_fk",
+          "tableFrom": "course_students_stats",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course_students_stats_author_id_users_id_fk": {
+          "name": "course_students_stats_author_id_users_id_fk",
+          "tableFrom": "course_students_stats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course_students_stats_tenant_id_tenants_id_fk": {
+          "name": "course_students_stats_tenant_id_tenants_id_fk",
+          "tableFrom": "course_students_stats",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "course_students_stats_course_id_month_year_unique": {
+          "name": "course_students_stats_course_id_month_year_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "course_id",
+            "month",
+            "year"
+          ]
+        }
+      }
+    },
+    "public.courses": {
+      "name": "courses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "short_id": {
+          "name": "short_id",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "title": {
+          "name": "title",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "description": {
+          "name": "description",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "thumbnail_s3_key": {
+          "name": "thumbnail_s3_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "has_certificate": {
+          "name": "has_certificate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "price_in_cents": {
+          "name": "price_in_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "chapter_count": {
+          "name": "chapter_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_scorm": {
+          "name": "is_scorm",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_type": {
+          "name": "origin_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'regular'"
+        },
+        "source_course_id": {
+          "name": "source_course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_tenant_id": {
+          "name": "source_tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"lessonSequenceEnabled\":false,\"quizFeedbackEnabled\":true,\"certificateSignature\":null,\"certificateFontColor\":null}'::jsonb"
+        },
+        "base_language": {
+          "name": "base_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "available_locales": {
+          "name": "available_locales",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['en']::text[]"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "courses_tenant_id_idx": {
+          "name": "courses_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "courses_short_id_unique_idx": {
+          "name": "courses_short_id_unique_idx",
+          "columns": [
+            {
+              "expression": "short_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "courses_author_id_users_id_fk": {
+          "name": "courses_author_id_users_id_fk",
+          "tableFrom": "courses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "courses_category_id_categories_id_fk": {
+          "name": "courses_category_id_categories_id_fk",
+          "tableFrom": "courses",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "courses_tenant_id_tenants_id_fk": {
+          "name": "courses_tenant_id_tenants_id_fk",
+          "tableFrom": "courses",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.courses_summary_stats": {
+      "name": "courses_summary_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "free_purchased_count": {
+          "name": "free_purchased_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "paid_purchased_count": {
+          "name": "paid_purchased_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "paid_purchased_after_freemium_count": {
+          "name": "paid_purchased_after_freemium_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completed_freemium_student_count": {
+          "name": "completed_freemium_student_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completed_course_student_count": {
+          "name": "completed_course_student_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "courses_summary_stats_tenant_id_idx": {
+          "name": "courses_summary_stats_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "courses_summary_stats_course_id_courses_id_fk": {
+          "name": "courses_summary_stats_course_id_courses_id_fk",
+          "tableFrom": "courses_summary_stats",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "courses_summary_stats_author_id_users_id_fk": {
+          "name": "courses_summary_stats_author_id_users_id_fk",
+          "tableFrom": "courses_summary_stats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "courses_summary_stats_tenant_id_tenants_id_fk": {
+          "name": "courses_summary_stats_tenant_id_tenants_id_fk",
+          "tableFrom": "courses_summary_stats",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "courses_summary_stats_course_id_unique": {
+          "name": "courses_summary_stats_course_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "course_id"
+          ]
+        }
+      }
+    },
+    "public.create_tokens": {
+      "name": "create_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiry_date": {
+          "name": "expiry_date",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reminder_count": {
+          "name": "reminder_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "create_tokens_tenant_id_idx": {
+          "name": "create_tokens_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "create_tokens_token_hash_idx": {
+          "name": "create_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "create_tokens_user_id_users_id_fk": {
+          "name": "create_tokens_user_id_users_id_fk",
+          "tableFrom": "create_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "create_tokens_tenant_id_tenants_id_fk": {
+          "name": "create_tokens_tenant_id_tenants_id_fk",
+          "tableFrom": "create_tokens",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.credentials": {
+      "name": "credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "credentials_tenant_id_idx": {
+          "name": "credentials_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credentials_user_id_users_id_fk": {
+          "name": "credentials_user_id_users_id_fk",
+          "tableFrom": "credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "credentials_tenant_id_tenants_id_fk": {
+          "name": "credentials_tenant_id_tenants_id_fk",
+          "tableFrom": "credentials",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.doc_chunks": {
+      "name": "doc_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "doc_chunks_tenant_id_idx": {
+          "name": "doc_chunks_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "doc_chunks_document_id_documents_id_fk": {
+          "name": "doc_chunks_document_id_documents_id_fk",
+          "tableFrom": "doc_chunks",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "doc_chunks_tenant_id_tenants_id_fk": {
+          "name": "doc_chunks_tenant_id_tenants_id_fk",
+          "tableFrom": "doc_chunks",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.document_to_ai_mentor_lesson": {
+      "name": "document_to_ai_mentor_lesson",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_mentor_lesson_id": {
+          "name": "ai_mentor_lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "document_to_ai_mentor_lesson_tenant_id_idx": {
+          "name": "document_to_ai_mentor_lesson_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_to_ai_mentor_lesson_document_id_documents_id_fk": {
+          "name": "document_to_ai_mentor_lesson_document_id_documents_id_fk",
+          "tableFrom": "document_to_ai_mentor_lesson",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "document_to_ai_mentor_lesson_ai_mentor_lesson_id_ai_mentor_lessons_id_fk": {
+          "name": "document_to_ai_mentor_lesson_ai_mentor_lesson_id_ai_mentor_lessons_id_fk",
+          "tableFrom": "document_to_ai_mentor_lesson",
+          "tableTo": "ai_mentor_lessons",
+          "columnsFrom": [
+            "ai_mentor_lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "document_to_ai_mentor_lesson_tenant_id_tenants_id_fk": {
+          "name": "document_to_ai_mentor_lesson_tenant_id_tenants_id_fk",
+          "tableFrom": "document_to_ai_mentor_lesson",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "document_to_ai_mentor_lesson_document_id_ai_mentor_lesson_id_unique": {
+          "name": "document_to_ai_mentor_lesson_document_id_ai_mentor_lesson_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "document_id",
+            "ai_mentor_lesson_id"
+          ]
+        }
+      }
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_sum": {
+          "name": "check_sum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "documents_tenant_id_idx": {
+          "name": "documents_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "documents_tenant_id_tenants_id_fk": {
+          "name": "documents_tenant_id_tenants_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "documents_check_sum_unique": {
+          "name": "documents_check_sum_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "check_sum"
+          ]
+        }
+      }
+    },
+    "public.form_field_answers": {
+      "name": "form_field_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "form_field_id": {
+          "name": "form_field_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_snapshot": {
+          "name": "label_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "answered_language": {
+          "name": "answered_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "form_field_answers_tenant_id_idx": {
+          "name": "form_field_answers_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_field_answers_user_id_form_field_id_unique": {
+          "name": "form_field_answers_user_id_form_field_id_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "form_field_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_field_answers_user_id_idx": {
+          "name": "form_field_answers_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_field_answers_form_field_id_form_fields_id_fk": {
+          "name": "form_field_answers_form_field_id_form_fields_id_fk",
+          "tableFrom": "form_field_answers",
+          "tableTo": "form_fields",
+          "columnsFrom": [
+            "form_field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "form_field_answers_user_id_users_id_fk": {
+          "name": "form_field_answers_user_id_users_id_fk",
+          "tableFrom": "form_field_answers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_field_answers_tenant_id_tenants_id_fk": {
+          "name": "form_field_answers_tenant_id_tenants_id_fk",
+          "tableFrom": "form_field_answers",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.form_fields": {
+      "name": "form_fields",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "base_language": {
+          "name": "base_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "available_locales": {
+          "name": "available_locales",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['en']::text[]"
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "form_fields_tenant_id_idx": {
+          "name": "form_fields_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_fields_form_id_display_order_idx": {
+          "name": "form_fields_form_id_display_order_idx",
+          "columns": [
+            {
+              "expression": "form_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_fields_form_id_forms_id_fk": {
+          "name": "form_fields_form_id_forms_id_fk",
+          "tableFrom": "form_fields",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_fields_tenant_id_tenants_id_fk": {
+          "name": "form_fields_tenant_id_tenants_id_fk",
+          "tableFrom": "form_fields",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.forms": {
+      "name": "forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "forms_tenant_id_idx": {
+          "name": "forms_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forms_tenant_id_type_unique_idx": {
+          "name": "forms_tenant_id_type_unique_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forms_tenant_id_tenants_id_fk": {
+          "name": "forms_tenant_id_tenants_id_fk",
+          "tableFrom": "forms",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.group_announcements": {
+      "name": "group_announcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "announcement_id": {
+          "name": "announcement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "group_announcements_tenant_id_idx": {
+          "name": "group_announcements_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_announcements_group_id_groups_id_fk": {
+          "name": "group_announcements_group_id_groups_id_fk",
+          "tableFrom": "group_announcements",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_announcements_announcement_id_announcements_id_fk": {
+          "name": "group_announcements_announcement_id_announcements_id_fk",
+          "tableFrom": "group_announcements",
+          "tableTo": "announcements",
+          "columnsFrom": [
+            "announcement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_announcements_tenant_id_tenants_id_fk": {
+          "name": "group_announcements_tenant_id_tenants_id_fk",
+          "tableFrom": "group_announcements",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "group_announcements_group_id_announcement_id_unique": {
+          "name": "group_announcements_group_id_announcement_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "announcement_id"
+          ]
+        }
+      }
+    },
+    "public.group_courses": {
+      "name": "group_courses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrolled_by": {
+          "name": "enrolled_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_mandatory": {
+          "name": "is_mandatory",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "group_courses_tenant_id_idx": {
+          "name": "group_courses_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_courses_group_id_groups_id_fk": {
+          "name": "group_courses_group_id_groups_id_fk",
+          "tableFrom": "group_courses",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_courses_course_id_courses_id_fk": {
+          "name": "group_courses_course_id_courses_id_fk",
+          "tableFrom": "group_courses",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_courses_enrolled_by_users_id_fk": {
+          "name": "group_courses_enrolled_by_users_id_fk",
+          "tableFrom": "group_courses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "enrolled_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "group_courses_tenant_id_tenants_id_fk": {
+          "name": "group_courses_tenant_id_tenants_id_fk",
+          "tableFrom": "group_courses",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "group_courses_group_id_course_id_unique": {
+          "name": "group_courses_group_id_course_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "course_id"
+          ]
+        }
+      }
+    },
+    "public.group_users": {
+      "name": "group_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "group_users_tenant_id_idx": {
+          "name": "group_users_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_users_user_id_users_id_fk": {
+          "name": "group_users_user_id_users_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_users_group_id_groups_id_fk": {
+          "name": "group_users_group_id_groups_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_users_tenant_id_tenants_id_fk": {
+          "name": "group_users_tenant_id_tenants_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "group_users_user_id_group_id_unique": {
+          "name": "group_users_user_id_group_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "group_id"
+          ]
+        }
+      }
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "characteristic": {
+          "name": "characteristic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "groups_tenant_id_idx": {
+          "name": "groups_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_tenant_id_tenants_id_fk": {
+          "name": "groups_tenant_id_tenants_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.integration_api_keys": {
+      "name": "integration_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "integration_api_keys_tenant_id_idx": {
+          "name": "integration_api_keys_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_api_keys_key_prefix_idx": {
+          "name": "integration_api_keys_key_prefix_idx",
+          "columns": [
+            {
+              "expression": "key_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_api_keys_created_by_idx": {
+          "name": "integration_api_keys_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_api_keys_created_by_user_id_users_id_fk": {
+          "name": "integration_api_keys_created_by_user_id_users_id_fk",
+          "tableFrom": "integration_api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_api_keys_tenant_id_tenants_id_fk": {
+          "name": "integration_api_keys_tenant_id_tenants_id_fk",
+          "tableFrom": "integration_api_keys",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.lesson_learning_time": {
+      "name": "lesson_learning_time",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_seconds": {
+          "name": "total_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "lesson_learning_time_tenant_id_idx": {
+          "name": "lesson_learning_time_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lesson_learning_time_user_course_idx": {
+          "name": "lesson_learning_time_user_course_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lesson_learning_time_user_id_users_id_fk": {
+          "name": "lesson_learning_time_user_id_users_id_fk",
+          "tableFrom": "lesson_learning_time",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lesson_learning_time_lesson_id_lessons_id_fk": {
+          "name": "lesson_learning_time_lesson_id_lessons_id_fk",
+          "tableFrom": "lesson_learning_time",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lesson_learning_time_course_id_courses_id_fk": {
+          "name": "lesson_learning_time_course_id_courses_id_fk",
+          "tableFrom": "lesson_learning_time",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lesson_learning_time_tenant_id_tenants_id_fk": {
+          "name": "lesson_learning_time_tenant_id_tenants_id_fk",
+          "tableFrom": "lesson_learning_time",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lesson_learning_time_user_id_lesson_id_unique": {
+          "name": "lesson_learning_time_user_id_lesson_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "lesson_id"
+          ]
+        }
+      }
+    },
+    "public.lessons": {
+      "name": "lessons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "description": {
+          "name": "description",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "threshold_score": {
+          "name": "threshold_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts_limit": {
+          "name": "attempts_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quiz_cooldown_in_hours": {
+          "name": "quiz_cooldown_in_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_s3_key": {
+          "name": "file_s3_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_external": {
+          "name": "is_external",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "lessons_tenant_id_idx": {
+          "name": "lessons_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lessons_chapter_id_chapters_id_fk": {
+          "name": "lessons_chapter_id_chapters_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lessons_tenant_id_tenants_id_fk": {
+          "name": "lessons_tenant_id_tenants_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.magic_link_tokens": {
+      "name": "magic_link_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiry_date": {
+          "name": "expiry_date",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "magic_link_tokens_tenant_id_idx": {
+          "name": "magic_link_tokens_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "magic_link_tokens_token_hash_idx": {
+          "name": "magic_link_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "magic_link_tokens_user_id_users_id_fk": {
+          "name": "magic_link_tokens_user_id_users_id_fk",
+          "tableFrom": "magic_link_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "magic_link_tokens_tenant_id_tenants_id_fk": {
+          "name": "magic_link_tokens_tenant_id_tenants_id_fk",
+          "tableFrom": "magic_link_tokens",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.master_course_entity_map": {
+      "name": "master_course_entity_map",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "export_id": {
+          "name": "export_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_entity_id": {
+          "name": "source_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_entity_id": {
+          "name": "target_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "master_course_entity_map_export_idx": {
+          "name": "master_course_entity_map_export_idx",
+          "columns": [
+            {
+              "expression": "export_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "master_course_entity_map_source_entity_idx": {
+          "name": "master_course_entity_map_source_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "master_course_entity_map_source_unique_idx": {
+          "name": "master_course_entity_map_source_unique_idx",
+          "columns": [
+            {
+              "expression": "export_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "master_course_entity_map_export_id_master_course_exports_id_fk": {
+          "name": "master_course_entity_map_export_id_master_course_exports_id_fk",
+          "tableFrom": "master_course_entity_map",
+          "tableTo": "master_course_exports",
+          "columnsFrom": [
+            "export_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.master_course_exports": {
+      "name": "master_course_exports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "source_tenant_id": {
+          "name": "source_tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_course_id": {
+          "name": "source_course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_tenant_id": {
+          "name": "target_tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_course_id": {
+          "name": "target_course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "master_course_exports_source_course_idx": {
+          "name": "master_course_exports_source_course_idx",
+          "columns": [
+            {
+              "expression": "source_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "master_course_exports_target_course_idx": {
+          "name": "master_course_exports_target_course_idx",
+          "columns": [
+            {
+              "expression": "target_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "master_course_exports_source_target_unique_idx": {
+          "name": "master_course_exports_source_target_unique_idx",
+          "columns": [
+            {
+              "expression": "source_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "master_course_exports_source_tenant_id_tenants_id_fk": {
+          "name": "master_course_exports_source_tenant_id_tenants_id_fk",
+          "tableFrom": "master_course_exports",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "source_tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "master_course_exports_source_course_id_courses_id_fk": {
+          "name": "master_course_exports_source_course_id_courses_id_fk",
+          "tableFrom": "master_course_exports",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "source_course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "master_course_exports_target_tenant_id_tenants_id_fk": {
+          "name": "master_course_exports_target_tenant_id_tenants_id_fk",
+          "tableFrom": "master_course_exports",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "target_tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "master_course_exports_target_course_id_courses_id_fk": {
+          "name": "master_course_exports_target_course_id_courses_id_fk",
+          "tableFrom": "master_course_exports",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "target_course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.news": {
+      "name": "news",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "title": {
+          "name": "title",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "news_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "base_language": {
+          "name": "base_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "available_locales": {
+          "name": "available_locales",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['en']::text[]"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "news_tenant_id_idx": {
+          "name": "news_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "news_author_id_users_id_fk": {
+          "name": "news_author_id_users_id_fk",
+          "tableFrom": "news",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "news_tenant_id_tenants_id_fk": {
+          "name": "news_tenant_id_tenants_id_fk",
+          "tableFrom": "news",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.outbox_events": {
+      "name": "outbox_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "outbox_events_tenant_id_idx": {
+          "name": "outbox_events_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outbox_events_poll_idx": {
+          "name": "outbox_events_poll_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "outbox_events_tenant_id_tenants_id_fk": {
+          "name": "outbox_events_tenant_id_tenants_id_fk",
+          "tableFrom": "outbox_events",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.permission_role_rule_sets": {
+      "name": "permission_role_rule_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_set_id": {
+          "name": "rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "permission_role_rule_sets_tenant_id_idx": {
+          "name": "permission_role_rule_sets_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "permission_role_rule_sets_role_id_rule_set_id_unique": {
+          "name": "permission_role_rule_sets_role_id_rule_set_id_unique",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "permission_role_rule_sets_role_id_permission_roles_id_fk": {
+          "name": "permission_role_rule_sets_role_id_permission_roles_id_fk",
+          "tableFrom": "permission_role_rule_sets",
+          "tableTo": "permission_roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "permission_role_rule_sets_rule_set_id_permission_rule_sets_id_fk": {
+          "name": "permission_role_rule_sets_rule_set_id_permission_rule_sets_id_fk",
+          "tableFrom": "permission_role_rule_sets",
+          "tableTo": "permission_rule_sets",
+          "columnsFrom": [
+            "rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "permission_role_rule_sets_tenant_id_tenants_id_fk": {
+          "name": "permission_role_rule_sets_tenant_id_tenants_id_fk",
+          "tableFrom": "permission_role_rule_sets",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.permission_roles": {
+      "name": "permission_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "permission_roles_tenant_id_idx": {
+          "name": "permission_roles_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "permission_roles_tenant_id_slug_unique": {
+          "name": "permission_roles_tenant_id_slug_unique",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "permission_roles_tenant_id_tenants_id_fk": {
+          "name": "permission_roles_tenant_id_tenants_id_fk",
+          "tableFrom": "permission_roles",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.permission_rule_set_permissions": {
+      "name": "permission_rule_set_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "rule_set_id": {
+          "name": "rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "permission_rule_set_permissions_tenant_id_idx": {
+          "name": "permission_rule_set_permissions_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "permission_rule_set_permissions_rule_set_id_permission_unique": {
+          "name": "permission_rule_set_permissions_rule_set_id_permission_unique",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "permission",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "permission_rule_set_permissions_rule_set_id_permission_rule_sets_id_fk": {
+          "name": "permission_rule_set_permissions_rule_set_id_permission_rule_sets_id_fk",
+          "tableFrom": "permission_rule_set_permissions",
+          "tableTo": "permission_rule_sets",
+          "columnsFrom": [
+            "rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "permission_rule_set_permissions_tenant_id_tenants_id_fk": {
+          "name": "permission_rule_set_permissions_tenant_id_tenants_id_fk",
+          "tableFrom": "permission_rule_set_permissions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.permission_rule_sets": {
+      "name": "permission_rule_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "permission_rule_sets_tenant_id_idx": {
+          "name": "permission_rule_sets_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "permission_rule_sets_tenant_id_slug_unique": {
+          "name": "permission_rule_sets_tenant_id_slug_unique",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "permission_rule_sets_tenant_id_tenants_id_fk": {
+          "name": "permission_rule_sets_tenant_id_tenants_id_fk",
+          "tableFrom": "permission_rule_sets",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.permission_user_roles": {
+      "name": "permission_user_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "permission_user_roles_tenant_id_idx": {
+          "name": "permission_user_roles_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "permission_user_roles_user_id_role_id_unique": {
+          "name": "permission_user_roles_user_id_role_id_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "permission_user_roles_user_id_users_id_fk": {
+          "name": "permission_user_roles_user_id_users_id_fk",
+          "tableFrom": "permission_user_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "permission_user_roles_role_id_permission_roles_id_fk": {
+          "name": "permission_user_roles_role_id_permission_roles_id_fk",
+          "tableFrom": "permission_user_roles",
+          "tableTo": "permission_roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "permission_user_roles_tenant_id_tenants_id_fk": {
+          "name": "permission_user_roles_tenant_id_tenants_id_fk",
+          "tableFrom": "permission_user_roles",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.question_answer_options": {
+      "name": "question_answer_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_text": {
+          "name": "option_text",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matched_word": {
+          "name": "matched_word",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scale_answer": {
+          "name": "scale_answer",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "question_answer_options_tenant_id_idx": {
+          "name": "question_answer_options_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "question_answer_options_question_id_questions_id_fk": {
+          "name": "question_answer_options_question_id_questions_id_fk",
+          "tableFrom": "question_answer_options",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "question_answer_options_tenant_id_tenants_id_fk": {
+          "name": "question_answer_options_tenant_id_tenants_id_fk",
+          "tableFrom": "question_answer_options",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_s3_key": {
+          "name": "photo_s3_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "solution_explanation": {
+          "name": "solution_explanation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "questions_tenant_id_idx": {
+          "name": "questions_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "questions_lesson_id_lessons_id_fk": {
+          "name": "questions_lesson_id_lessons_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "questions_author_id_users_id_fk": {
+          "name": "questions_author_id_users_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "questions_tenant_id_tenants_id_fk": {
+          "name": "questions_tenant_id_tenants_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.questions_and_answers": {
+      "name": "questions_and_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "title": {
+          "name": "title",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "description": {
+          "name": "description",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "base_language": {
+          "name": "base_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "available_locales": {
+          "name": "available_locales",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['en']::text[]"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "questions_and_answers_tenant_id_idx": {
+          "name": "questions_and_answers_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "questions_and_answers_tenant_id_tenants_id_fk": {
+          "name": "questions_and_answers_tenant_id_tenants_id_fk",
+          "tableFrom": "questions_and_answers",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.quiz_attempts": {
+      "name": "quiz_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct_answers": {
+          "name": "correct_answers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrong_answers": {
+          "name": "wrong_answers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "quiz_attempts_tenant_id_idx": {
+          "name": "quiz_attempts_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quiz_attempts_user_id_users_id_fk": {
+          "name": "quiz_attempts_user_id_users_id_fk",
+          "tableFrom": "quiz_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quiz_attempts_course_id_courses_id_fk": {
+          "name": "quiz_attempts_course_id_courses_id_fk",
+          "tableFrom": "quiz_attempts",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quiz_attempts_lesson_id_lessons_id_fk": {
+          "name": "quiz_attempts_lesson_id_lessons_id_fk",
+          "tableFrom": "quiz_attempts",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quiz_attempts_tenant_id_tenants_id_fk": {
+          "name": "quiz_attempts_tenant_id_tenants_id_fk",
+          "tableFrom": "quiz_attempts",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.reset_tokens": {
+      "name": "reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiry_date": {
+          "name": "expiry_date",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "reset_tokens_tenant_id_idx": {
+          "name": "reset_tokens_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reset_tokens_token_hash_idx": {
+          "name": "reset_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reset_tokens_user_id_users_id_fk": {
+          "name": "reset_tokens_user_id_users_id_fk",
+          "tableFrom": "reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reset_tokens_tenant_id_tenants_id_fk": {
+          "name": "reset_tokens_tenant_id_tenants_id_fk",
+          "tableFrom": "reset_tokens",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.resource_entity": {
+      "name": "resource_entity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship_type": {
+          "name": "relationship_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'attachment'"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "resource_entity_tenant_id_idx": {
+          "name": "resource_entity_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "resource_entity_resource_idx": {
+          "name": "resource_entity_resource_idx",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "resource_entity_entity_idx": {
+          "name": "resource_entity_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "resource_entity_relationship_idx": {
+          "name": "resource_entity_relationship_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relationship_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "resource_entity_resource_id_resources_id_fk": {
+          "name": "resource_entity_resource_id_resources_id_fk",
+          "tableFrom": "resource_entity",
+          "tableTo": "resources",
+          "columnsFrom": [
+            "resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "resource_entity_tenant_id_tenants_id_fk": {
+          "name": "resource_entity_tenant_id_tenants_id_fk",
+          "tableFrom": "resource_entity",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "resource_entity_resource_id_entity_id_entity_type_relationship_type_unique": {
+          "name": "resource_entity_resource_id_entity_id_entity_type_relationship_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "resource_id",
+            "entity_id",
+            "entity_type",
+            "relationship_type"
+          ]
+        }
+      }
+    },
+    "public.resources": {
+      "name": "resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "title": {
+          "name": "title",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "description": {
+          "name": "description",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "reference": {
+          "name": "reference",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "uploaded_by_id": {
+          "name": "uploaded_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "resources_tenant_id_idx": {
+          "name": "resources_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "resources_uploaded_by_id_users_id_fk": {
+          "name": "resources_uploaded_by_id_users_id_fk",
+          "tableFrom": "resources",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "resources_tenant_id_tenants_id_fk": {
+          "name": "resources_tenant_id_tenants_id_fk",
+          "tableFrom": "resources",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.scorm_files": {
+      "name": "scorm_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key_path": {
+          "name": "s3_key_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "scorm_files_tenant_id_idx": {
+          "name": "scorm_files_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scorm_files_tenant_id_tenants_id_fk": {
+          "name": "scorm_files_tenant_id_tenants_id_fk",
+          "tableFrom": "scorm_files",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.scorm_metadata": {
+      "name": "scorm_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_point": {
+          "name": "entry_point",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "scorm_metadata_tenant_id_idx": {
+          "name": "scorm_metadata_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scorm_metadata_course_id_courses_id_fk": {
+          "name": "scorm_metadata_course_id_courses_id_fk",
+          "tableFrom": "scorm_metadata",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "scorm_metadata_file_id_scorm_files_id_fk": {
+          "name": "scorm_metadata_file_id_scorm_files_id_fk",
+          "tableFrom": "scorm_metadata",
+          "tableTo": "scorm_files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "scorm_metadata_tenant_id_tenants_id_fk": {
+          "name": "scorm_metadata_tenant_id_tenants_id_fk",
+          "tableFrom": "scorm_metadata",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.secrets": {
+      "name": "secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "secret_name": {
+          "name": "secret_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_dek": {
+          "name": "encrypted_dek",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_dek_iv": {
+          "name": "encrypted_dek_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_dek_tag": {
+          "name": "encrypted_dek_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alg": {
+          "name": "alg",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'AES-256-GCM'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "secrets_tenant_id_idx": {
+          "name": "secrets_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "secrets_tenant_secret_name_uq": {
+          "name": "secrets_tenant_secret_name_uq",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "secret_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "secrets_name_idx": {
+          "name": "secrets_name_idx",
+          "columns": [
+            {
+              "expression": "secret_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "secrets_tenant_id_tenants_id_fk": {
+          "name": "secrets_tenant_id_tenants_id_fk",
+          "tableFrom": "secrets",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "settings_tenant_id_idx": {
+          "name": "settings_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "settings_user_id_users_id_fk": {
+          "name": "settings_user_id_users_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "settings_tenant_id_tenants_id_fk": {
+          "name": "settings_tenant_id_tenants_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.student_chapter_progress": {
+      "name": "student_chapter_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_lesson_count": {
+          "name": "completed_lesson_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_as_freemium": {
+          "name": "completed_as_freemium",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "student_chapter_progress_tenant_id_idx": {
+          "name": "student_chapter_progress_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_chapter_progress_student_id_users_id_fk": {
+          "name": "student_chapter_progress_student_id_users_id_fk",
+          "tableFrom": "student_chapter_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "student_chapter_progress_course_id_courses_id_fk": {
+          "name": "student_chapter_progress_course_id_courses_id_fk",
+          "tableFrom": "student_chapter_progress",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "student_chapter_progress_chapter_id_chapters_id_fk": {
+          "name": "student_chapter_progress_chapter_id_chapters_id_fk",
+          "tableFrom": "student_chapter_progress",
+          "tableTo": "chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "student_chapter_progress_tenant_id_tenants_id_fk": {
+          "name": "student_chapter_progress_tenant_id_tenants_id_fk",
+          "tableFrom": "student_chapter_progress",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "student_chapter_progress_student_id_course_id_chapter_id_unique": {
+          "name": "student_chapter_progress_student_id_course_id_chapter_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "student_id",
+            "course_id",
+            "chapter_id"
+          ]
+        }
+      }
+    },
+    "public.student_courses": {
+      "name": "student_courses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "finished_chapter_count": {
+          "name": "finished_chapter_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_completion_metadata": {
+          "name": "course_completion_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enrolled'"
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrolled_by_group_id": {
+          "name": "enrolled_by_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "student_courses_tenant_id_idx": {
+          "name": "student_courses_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_courses_student_id_users_id_fk": {
+          "name": "student_courses_student_id_users_id_fk",
+          "tableFrom": "student_courses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "student_courses_course_id_courses_id_fk": {
+          "name": "student_courses_course_id_courses_id_fk",
+          "tableFrom": "student_courses",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "student_courses_enrolled_by_group_id_groups_id_fk": {
+          "name": "student_courses_enrolled_by_group_id_groups_id_fk",
+          "tableFrom": "student_courses",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "enrolled_by_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "student_courses_tenant_id_tenants_id_fk": {
+          "name": "student_courses_tenant_id_tenants_id_fk",
+          "tableFrom": "student_courses",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "student_courses_student_id_course_id_unique": {
+          "name": "student_courses_student_id_course_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "student_id",
+            "course_id"
+          ]
+        }
+      }
+    },
+    "public.student_lesson_progress": {
+      "name": "student_lesson_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_question_count": {
+          "name": "completed_question_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "quiz_score": {
+          "name": "quiz_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_quiz_passed": {
+          "name": "is_quiz_passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_started": {
+          "name": "is_started",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language_answered": {
+          "name": "language_answered",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'en'"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "student_lesson_progress_tenant_id_idx": {
+          "name": "student_lesson_progress_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_lesson_progress_student_id_users_id_fk": {
+          "name": "student_lesson_progress_student_id_users_id_fk",
+          "tableFrom": "student_lesson_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "student_lesson_progress_chapter_id_chapters_id_fk": {
+          "name": "student_lesson_progress_chapter_id_chapters_id_fk",
+          "tableFrom": "student_lesson_progress",
+          "tableTo": "chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_lesson_progress_lesson_id_lessons_id_fk": {
+          "name": "student_lesson_progress_lesson_id_lessons_id_fk",
+          "tableFrom": "student_lesson_progress",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_lesson_progress_tenant_id_tenants_id_fk": {
+          "name": "student_lesson_progress_tenant_id_tenants_id_fk",
+          "tableFrom": "student_lesson_progress",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "student_lesson_progress_student_id_lesson_id_chapter_id_unique": {
+          "name": "student_lesson_progress_student_id_lesson_id_chapter_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "student_id",
+            "lesson_id",
+            "chapter_id"
+          ]
+        }
+      }
+    },
+    "public.student_question_answers": {
+      "name": "student_question_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer": {
+          "name": "answer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "student_question_answers_tenant_id_idx": {
+          "name": "student_question_answers_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_question_answers_question_id_questions_id_fk": {
+          "name": "student_question_answers_question_id_questions_id_fk",
+          "tableFrom": "student_question_answers",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_question_answers_student_id_users_id_fk": {
+          "name": "student_question_answers_student_id_users_id_fk",
+          "tableFrom": "student_question_answers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_question_answers_tenant_id_tenants_id_fk": {
+          "name": "student_question_answers_tenant_id_tenants_id_fk",
+          "tableFrom": "student_question_answers",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "student_question_answers_question_id_student_id_unique": {
+          "name": "student_question_answers_question_id_student_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "question_id",
+            "student_id"
+          ]
+        }
+      }
+    },
+    "public.support_sessions": {
+      "name": "support_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "original_user_id": {
+          "name": "original_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_tenant_id": {
+          "name": "original_tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_tenant_id": {
+          "name": "target_tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_grant_token": {
+          "name": "hashed_grant_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grant_expires_at": {
+          "name": "grant_expires_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "return_url": {
+          "name": "return_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "support_sessions_hashed_grant_token_unique": {
+          "name": "support_sessions_hashed_grant_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_grant_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "support_sessions_status_idx": {
+          "name": "support_sessions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "support_sessions_original_user_idx": {
+          "name": "support_sessions_original_user_idx",
+          "columns": [
+            {
+              "expression": "original_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "support_sessions_target_tenant_idx": {
+          "name": "support_sessions_target_tenant_idx",
+          "columns": [
+            {
+              "expression": "target_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "support_sessions_original_user_id_users_id_fk": {
+          "name": "support_sessions_original_user_id_users_id_fk",
+          "tableFrom": "support_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "original_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "support_sessions_original_tenant_id_tenants_id_fk": {
+          "name": "support_sessions_original_tenant_id_tenants_id_fk",
+          "tableFrom": "support_sessions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "original_tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "support_sessions_target_tenant_id_tenants_id_fk": {
+          "name": "support_sessions_target_tenant_id_tenants_id_fk",
+          "tableFrom": "support_sessions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "target_tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "is_managing": {
+          "name": "is_managing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "unique_host_idx": {
+          "name": "unique_host_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.user_announcements": {
+      "name": "user_announcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "announcement_id": {
+          "name": "announcement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "user_announcements_tenant_id_idx": {
+          "name": "user_announcements_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_announcements_user_id_users_id_fk": {
+          "name": "user_announcements_user_id_users_id_fk",
+          "tableFrom": "user_announcements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_announcements_announcement_id_announcements_id_fk": {
+          "name": "user_announcements_announcement_id_announcements_id_fk",
+          "tableFrom": "user_announcements",
+          "tableTo": "announcements",
+          "columnsFrom": [
+            "announcement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_announcements_tenant_id_tenants_id_fk": {
+          "name": "user_announcements_tenant_id_tenants_id_fk",
+          "tableFrom": "user_announcements",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_announcements_user_id_announcement_id_unique": {
+          "name": "user_announcements_user_id_announcement_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "announcement_id"
+          ]
+        }
+      }
+    },
+    "public.user_details": {
+      "name": "user_details",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone_number": {
+          "name": "contact_phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_title": {
+          "name": "job_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "user_details_tenant_id_idx": {
+          "name": "user_details_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_details_user_id_users_id_fk": {
+          "name": "user_details_user_id_users_id_fk",
+          "tableFrom": "user_details",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_details_tenant_id_tenants_id_fk": {
+          "name": "user_details_tenant_id_tenants_id_fk",
+          "tableFrom": "user_details",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_details_user_id_unique": {
+          "name": "user_details_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      }
+    },
+    "public.user_onboarding": {
+      "name": "user_onboarding",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dashboard": {
+          "name": "dashboard",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "courses": {
+          "name": "courses",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "announcements": {
+          "name": "announcements",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "profile": {
+          "name": "profile",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "provider_information": {
+          "name": "provider_information",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "user_onboarding_tenant_id_idx": {
+          "name": "user_onboarding_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_onboarding_user_id_users_id_fk": {
+          "name": "user_onboarding_user_id_users_id_fk",
+          "tableFrom": "user_onboarding",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_onboarding_tenant_id_tenants_id_fk": {
+          "name": "user_onboarding_tenant_id_tenants_id_fk",
+          "tableFrom": "user_onboarding",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_onboarding_user_id_unique": {
+          "name": "user_onboarding_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      }
+    },
+    "public.user_statistics": {
+      "name": "user_statistics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_streak": {
+          "name": "current_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "longest_streak": {
+          "name": "longest_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_activity_date": {
+          "name": "last_activity_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_history": {
+          "name": "activity_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "user_statistics_tenant_id_idx": {
+          "name": "user_statistics_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_statistics_user_id_users_id_fk": {
+          "name": "user_statistics_user_id_users_id_fk",
+          "tableFrom": "user_statistics",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_statistics_tenant_id_tenants_id_fk": {
+          "name": "user_statistics_tenant_id_tenants_id_fk",
+          "tableFrom": "user_statistics",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_statistics_user_id_unique": {
+          "name": "user_statistics_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      }
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_reference": {
+          "name": "avatar_reference",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "current_setting('app.tenant_id', true)::uuid"
+        }
+      },
+      "indexes": {
+        "users_tenant_id_idx": {
+          "name": "users_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_tenant_id_tenants_id_fk": {
+          "name": "users_tenant_id_tenants_id_fk",
+          "tableFrom": "users",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "public.activity_log_action_type": {
+      "name": "activity_log_action_type",
+      "schema": "public",
+      "values": [
+        "create",
+        "update",
+        "delete",
+        "login",
+        "login_failed",
+        "logout",
+        "enroll_course",
+        "unenroll_course",
+        "start_course",
+        "group_assignment",
+        "complete_lesson",
+        "complete_course",
+        "complete_chapter",
+        "view_announcement"
+      ]
+    },
+    "public.article_status": {
+      "name": "article_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.status": {
+      "name": "status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "private"
+      ]
+    },
+    "public.news_status": {
+      "name": "news_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/src/storage/migrations/meta/_journal.json
+++ b/apps/api/src/storage/migrations/meta/_journal.json
@@ -771,6 +771,13 @@
       "when": 1777303796631,
       "tag": "0109_secret_name_unique_per_tenant",
       "breakpoints": true
+    },
+    {
+      "idx": 110,
+      "version": "7",
+      "when": 1777464066471,
+      "tag": "0110_add_chat_to_course",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/storage/migrations/meta/_journal.json
+++ b/apps/api/src/storage/migrations/meta/_journal.json
@@ -778,6 +778,13 @@
       "when": 1777464066471,
       "tag": "0110_add_chat_to_course",
       "breakpoints": true
+    },
+    {
+      "idx": 111,
+      "version": "7",
+      "when": 1777465560000,
+      "tag": "0111_add_course_chat_reactions",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/storage/schema/index.ts
+++ b/apps/api/src/storage/schema/index.ts
@@ -436,6 +436,34 @@ export const courseChatMessages = pgTable(
   })),
 );
 
+export const courseChatMessageReactions = pgTable(
+  "course_chat_message_reactions",
+  {
+    ...id,
+    ...timestamps,
+    messageId: uuid("message_id")
+      .references(() => courseChatMessages.id, { onDelete: "cascade" })
+      .notNull(),
+    courseId: uuid("course_id")
+      .references(() => courses.id, { onDelete: "cascade" })
+      .notNull(),
+    userId: uuid("user_id")
+      .references(() => users.id, { onDelete: "cascade" })
+      .notNull(),
+    reaction: text("reaction").notNull(),
+    tenantId,
+  },
+  withTenantIdIndex("course_chat_message_reactions", (table) => ({
+    messageReactionIdx: index("course_chat_message_reactions_message_id_reaction_idx").on(
+      table.messageId,
+      table.reaction,
+    ),
+    userMessageReactionUniqueIdx: uniqueIndex(
+      "course_chat_message_reactions_user_message_reaction_unique_idx",
+    ).on(table.userId, table.messageId, table.reaction),
+  })),
+);
+
 export const questions = pgTable(
   "questions",
   {

--- a/apps/api/src/storage/schema/index.ts
+++ b/apps/api/src/storage/schema/index.ts
@@ -18,6 +18,7 @@ import {
   timestamp,
   unique,
   uniqueIndex,
+  type AnyPgColumn,
   uuid,
   varchar,
   vector,
@@ -369,6 +370,70 @@ export const aiMentorThreadMessages = pgTable(
     tenantId,
   },
   withTenantIdIndex("ai_mentor_thread_messages"),
+);
+
+export const courseChatThreads = pgTable(
+  "course_chat_threads",
+  {
+    ...id,
+    ...timestamps,
+    courseId: uuid("course_id")
+      .references(() => courses.id, { onDelete: "cascade" })
+      .notNull(),
+    createdByUserId: uuid("created_by_user_id")
+      .references(() => users.id, { onDelete: "cascade" })
+      .notNull(),
+    archived,
+    tenantId,
+  },
+  withTenantIdIndex("course_chat_threads", (table) => ({
+    courseCreatedAtIdx: index("course_chat_threads_course_id_created_at_idx").on(
+      table.courseId,
+      table.createdAt,
+    ),
+    courseUpdatedAtIdx: index("course_chat_threads_course_id_updated_at_idx").on(
+      table.courseId,
+      table.updatedAt,
+    ),
+  })),
+);
+
+export const courseChatMessages = pgTable(
+  "course_chat_messages",
+  {
+    ...id,
+    ...timestamps,
+    threadId: uuid("thread_id")
+      .references(() => courseChatThreads.id, { onDelete: "cascade" })
+      .notNull(),
+    courseId: uuid("course_id")
+      .references(() => courses.id, { onDelete: "cascade" })
+      .notNull(),
+    userId: uuid("user_id")
+      .references(() => users.id, { onDelete: "cascade" })
+      .notNull(),
+    content: text("content").notNull(),
+    parentMessageId: uuid("parent_message_id").references(
+      (): AnyPgColumn => courseChatMessages.id,
+      { onDelete: "set null" },
+    ),
+    deletedAt: timestamp("deleted_at", {
+      mode: "string",
+      withTimezone: true,
+      precision: 3,
+    }),
+    tenantId,
+  },
+  withTenantIdIndex("course_chat_messages", (table) => ({
+    courseCreatedAtIdx: index("course_chat_messages_course_id_created_at_idx").on(
+      table.courseId,
+      table.createdAt,
+    ),
+    threadCreatedAtIdx: index("course_chat_messages_thread_id_created_at_idx").on(
+      table.threadId,
+      table.createdAt,
+    ),
+  })),
 );
 
 export const questions = pgTable(

--- a/apps/api/src/swagger/api-schema.json
+++ b/apps/api/src/swagger/api-schema.json
@@ -7158,6 +7158,230 @@
         }
       }
     },
+    "/api/course-chat/{courseId}/threads": {
+      "get": {
+        "operationId": "CourseChatController_getThreads",
+        "parameters": [
+          {
+            "name": "courseId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "minimum": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "perPage",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "minimum": 1,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetThreadsResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "CourseChatController_createThread",
+        "parameters": [
+          {
+            "name": "courseId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateThreadBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateThreadResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/course-chat/{courseId}/users": {
+      "get": {
+        "operationId": "CourseChatController_getUsers",
+        "parameters": [
+          {
+            "name": "courseId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetUsersResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/course-chat/threads/{threadId}/messages": {
+      "get": {
+        "operationId": "CourseChatController_getMessages",
+        "parameters": [
+          {
+            "name": "threadId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "minimum": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "perPage",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "minimum": 1,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetMessagesResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "CourseChatController_createMessage",
+        "parameters": [
+          {
+            "name": "threadId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateMessageBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateMessageResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/course-chat/messages/{messageId}/reactions": {
+      "post": {
+        "operationId": "CourseChatController_toggleMessageReaction",
+        "parameters": [
+          {
+            "name": "messageId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ToggleMessageReactionBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ToggleMessageReactionResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/report/summary": {
       "get": {
         "operationId": "ReportController_downloadSummaryReport",
@@ -26545,6 +26769,1192 @@
             },
             "required": [
               "message"
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "GetThreadsResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "courseId": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "createdByUserId": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "archived": {
+                  "type": "boolean"
+                },
+                "createdAt": {
+                  "type": "string"
+                },
+                "updatedAt": {
+                  "type": "string"
+                },
+                "messageCount": {
+                  "type": "number"
+                },
+                "createdBy": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "firstName": {
+                      "type": "string"
+                    },
+                    "lastName": {
+                      "type": "string"
+                    },
+                    "avatarReference": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "firstName",
+                    "lastName",
+                    "avatarReference"
+                  ]
+                },
+                "rootMessage": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "threadId": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "courseId": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "userId": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "content": {
+                      "type": "string"
+                    },
+                    "parentMessageId": {
+                      "anyOf": [
+                        {
+                          "format": "uuid",
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "deletedAt": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "createdAt": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    },
+                    "user": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "format": "uuid",
+                          "type": "string"
+                        },
+                        "firstName": {
+                          "type": "string"
+                        },
+                        "lastName": {
+                          "type": "string"
+                        },
+                        "avatarReference": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "firstName",
+                        "lastName",
+                        "avatarReference"
+                      ]
+                    },
+                    "reactions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "reaction": {
+                            "type": "string"
+                          },
+                          "count": {
+                            "type": "number"
+                          },
+                          "reactedByCurrentUser": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "reaction",
+                          "count",
+                          "reactedByCurrentUser"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "threadId",
+                    "courseId",
+                    "userId",
+                    "content",
+                    "parentMessageId",
+                    "deletedAt",
+                    "createdAt",
+                    "updatedAt",
+                    "user",
+                    "reactions"
+                  ]
+                },
+                "latestMessage": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "format": "uuid",
+                          "type": "string"
+                        },
+                        "threadId": {
+                          "format": "uuid",
+                          "type": "string"
+                        },
+                        "courseId": {
+                          "format": "uuid",
+                          "type": "string"
+                        },
+                        "userId": {
+                          "format": "uuid",
+                          "type": "string"
+                        },
+                        "content": {
+                          "type": "string"
+                        },
+                        "parentMessageId": {
+                          "anyOf": [
+                            {
+                              "format": "uuid",
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "deletedAt": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "updatedAt": {
+                          "type": "string"
+                        },
+                        "user": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "format": "uuid",
+                              "type": "string"
+                            },
+                            "firstName": {
+                              "type": "string"
+                            },
+                            "lastName": {
+                              "type": "string"
+                            },
+                            "avatarReference": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "firstName",
+                            "lastName",
+                            "avatarReference"
+                          ]
+                        },
+                        "reactions": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "reaction": {
+                                "type": "string"
+                              },
+                              "count": {
+                                "type": "number"
+                              },
+                              "reactedByCurrentUser": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "reaction",
+                              "count",
+                              "reactedByCurrentUser"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "threadId",
+                        "courseId",
+                        "userId",
+                        "content",
+                        "parentMessageId",
+                        "deletedAt",
+                        "createdAt",
+                        "updatedAt",
+                        "user",
+                        "reactions"
+                      ]
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "id",
+                "courseId",
+                "createdByUserId",
+                "archived",
+                "createdAt",
+                "updatedAt",
+                "messageCount",
+                "createdBy",
+                "rootMessage",
+                "latestMessage"
+              ]
+            }
+          },
+          "pagination": {
+            "type": "object",
+            "properties": {
+              "totalItems": {
+                "type": "number"
+              },
+              "page": {
+                "type": "number"
+              },
+              "perPage": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "totalItems",
+              "page",
+              "perPage"
+            ]
+          },
+          "appliedFilters": {
+            "type": "object",
+            "patternProperties": {
+              "^(.*)$": {}
+            }
+          }
+        },
+        "required": [
+          "data",
+          "pagination"
+        ]
+      },
+      "CreateThreadBody": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "minLength": 1,
+            "maxLength": 5000,
+            "type": "string"
+          },
+          "mentionedUserIds": {
+            "type": "array",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "content"
+        ]
+      },
+      "CreateThreadResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "thread": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "courseId": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "createdByUserId": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "archived": {
+                    "type": "boolean"
+                  },
+                  "createdAt": {
+                    "type": "string"
+                  },
+                  "updatedAt": {
+                    "type": "string"
+                  },
+                  "messageCount": {
+                    "type": "number"
+                  },
+                  "createdBy": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "format": "uuid",
+                        "type": "string"
+                      },
+                      "firstName": {
+                        "type": "string"
+                      },
+                      "lastName": {
+                        "type": "string"
+                      },
+                      "avatarReference": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "firstName",
+                      "lastName",
+                      "avatarReference"
+                    ]
+                  },
+                  "rootMessage": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "format": "uuid",
+                        "type": "string"
+                      },
+                      "threadId": {
+                        "format": "uuid",
+                        "type": "string"
+                      },
+                      "courseId": {
+                        "format": "uuid",
+                        "type": "string"
+                      },
+                      "userId": {
+                        "format": "uuid",
+                        "type": "string"
+                      },
+                      "content": {
+                        "type": "string"
+                      },
+                      "parentMessageId": {
+                        "anyOf": [
+                          {
+                            "format": "uuid",
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "deletedAt": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "createdAt": {
+                        "type": "string"
+                      },
+                      "updatedAt": {
+                        "type": "string"
+                      },
+                      "user": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "format": "uuid",
+                            "type": "string"
+                          },
+                          "firstName": {
+                            "type": "string"
+                          },
+                          "lastName": {
+                            "type": "string"
+                          },
+                          "avatarReference": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "firstName",
+                          "lastName",
+                          "avatarReference"
+                        ]
+                      },
+                      "reactions": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "reaction": {
+                              "type": "string"
+                            },
+                            "count": {
+                              "type": "number"
+                            },
+                            "reactedByCurrentUser": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "reaction",
+                            "count",
+                            "reactedByCurrentUser"
+                          ]
+                        }
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "threadId",
+                      "courseId",
+                      "userId",
+                      "content",
+                      "parentMessageId",
+                      "deletedAt",
+                      "createdAt",
+                      "updatedAt",
+                      "user",
+                      "reactions"
+                    ]
+                  },
+                  "latestMessage": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "format": "uuid",
+                            "type": "string"
+                          },
+                          "threadId": {
+                            "format": "uuid",
+                            "type": "string"
+                          },
+                          "courseId": {
+                            "format": "uuid",
+                            "type": "string"
+                          },
+                          "userId": {
+                            "format": "uuid",
+                            "type": "string"
+                          },
+                          "content": {
+                            "type": "string"
+                          },
+                          "parentMessageId": {
+                            "anyOf": [
+                              {
+                                "format": "uuid",
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "deletedAt": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "updatedAt": {
+                            "type": "string"
+                          },
+                          "user": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "format": "uuid",
+                                "type": "string"
+                              },
+                              "firstName": {
+                                "type": "string"
+                              },
+                              "lastName": {
+                                "type": "string"
+                              },
+                              "avatarReference": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "firstName",
+                              "lastName",
+                              "avatarReference"
+                            ]
+                          },
+                          "reactions": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "reaction": {
+                                  "type": "string"
+                                },
+                                "count": {
+                                  "type": "number"
+                                },
+                                "reactedByCurrentUser": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "reaction",
+                                "count",
+                                "reactedByCurrentUser"
+                              ]
+                            }
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "threadId",
+                          "courseId",
+                          "userId",
+                          "content",
+                          "parentMessageId",
+                          "deletedAt",
+                          "createdAt",
+                          "updatedAt",
+                          "user",
+                          "reactions"
+                        ]
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "id",
+                  "courseId",
+                  "createdByUserId",
+                  "archived",
+                  "createdAt",
+                  "updatedAt",
+                  "messageCount",
+                  "createdBy",
+                  "rootMessage",
+                  "latestMessage"
+                ]
+              },
+              "message": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "threadId": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "courseId": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "userId": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "content": {
+                    "type": "string"
+                  },
+                  "parentMessageId": {
+                    "anyOf": [
+                      {
+                        "format": "uuid",
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "deletedAt": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "createdAt": {
+                    "type": "string"
+                  },
+                  "updatedAt": {
+                    "type": "string"
+                  },
+                  "user": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "format": "uuid",
+                        "type": "string"
+                      },
+                      "firstName": {
+                        "type": "string"
+                      },
+                      "lastName": {
+                        "type": "string"
+                      },
+                      "avatarReference": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "firstName",
+                      "lastName",
+                      "avatarReference"
+                    ]
+                  },
+                  "reactions": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "reaction": {
+                          "type": "string"
+                        },
+                        "count": {
+                          "type": "number"
+                        },
+                        "reactedByCurrentUser": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "reaction",
+                        "count",
+                        "reactedByCurrentUser"
+                      ]
+                    }
+                  }
+                },
+                "required": [
+                  "id",
+                  "threadId",
+                  "courseId",
+                  "userId",
+                  "content",
+                  "parentMessageId",
+                  "deletedAt",
+                  "createdAt",
+                  "updatedAt",
+                  "user",
+                  "reactions"
+                ]
+              }
+            },
+            "required": [
+              "thread",
+              "message"
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "GetMessagesResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "threadId": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "courseId": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "userId": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "content": {
+                  "type": "string"
+                },
+                "parentMessageId": {
+                  "anyOf": [
+                    {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "deletedAt": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "createdAt": {
+                  "type": "string"
+                },
+                "updatedAt": {
+                  "type": "string"
+                },
+                "user": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "firstName": {
+                      "type": "string"
+                    },
+                    "lastName": {
+                      "type": "string"
+                    },
+                    "avatarReference": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "firstName",
+                    "lastName",
+                    "avatarReference"
+                  ]
+                },
+                "reactions": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "reaction": {
+                        "type": "string"
+                      },
+                      "count": {
+                        "type": "number"
+                      },
+                      "reactedByCurrentUser": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "reaction",
+                      "count",
+                      "reactedByCurrentUser"
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "id",
+                "threadId",
+                "courseId",
+                "userId",
+                "content",
+                "parentMessageId",
+                "deletedAt",
+                "createdAt",
+                "updatedAt",
+                "user",
+                "reactions"
+              ]
+            }
+          },
+          "pagination": {
+            "type": "object",
+            "properties": {
+              "totalItems": {
+                "type": "number"
+              },
+              "page": {
+                "type": "number"
+              },
+              "perPage": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "totalItems",
+              "page",
+              "perPage"
+            ]
+          },
+          "appliedFilters": {
+            "type": "object",
+            "patternProperties": {
+              "^(.*)$": {}
+            }
+          }
+        },
+        "required": [
+          "data",
+          "pagination"
+        ]
+      },
+      "CreateMessageBody": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "minLength": 1,
+            "maxLength": 5000,
+            "type": "string"
+          },
+          "parentMessageId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "mentionedUserIds": {
+            "type": "array",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "content"
+        ]
+      },
+      "CreateMessageResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "format": "uuid",
+                "type": "string"
+              },
+              "threadId": {
+                "format": "uuid",
+                "type": "string"
+              },
+              "courseId": {
+                "format": "uuid",
+                "type": "string"
+              },
+              "userId": {
+                "format": "uuid",
+                "type": "string"
+              },
+              "content": {
+                "type": "string"
+              },
+              "parentMessageId": {
+                "anyOf": [
+                  {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "deletedAt": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "createdAt": {
+                "type": "string"
+              },
+              "updatedAt": {
+                "type": "string"
+              },
+              "user": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "firstName": {
+                    "type": "string"
+                  },
+                  "lastName": {
+                    "type": "string"
+                  },
+                  "avatarReference": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "id",
+                  "firstName",
+                  "lastName",
+                  "avatarReference"
+                ]
+              },
+              "reactions": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "reaction": {
+                      "type": "string"
+                    },
+                    "count": {
+                      "type": "number"
+                    },
+                    "reactedByCurrentUser": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "reaction",
+                    "count",
+                    "reactedByCurrentUser"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "id",
+              "threadId",
+              "courseId",
+              "userId",
+              "content",
+              "parentMessageId",
+              "deletedAt",
+              "createdAt",
+              "updatedAt",
+              "user",
+              "reactions"
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "ToggleMessageReactionBody": {
+        "type": "object",
+        "properties": {
+          "reaction": {
+            "minLength": 1,
+            "maxLength": 16,
+            "type": "string"
+          }
+        },
+        "required": [
+          "reaction"
+        ]
+      },
+      "ToggleMessageReactionResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "courseId": {
+                "format": "uuid",
+                "type": "string"
+              },
+              "threadId": {
+                "format": "uuid",
+                "type": "string"
+              },
+              "messageId": {
+                "format": "uuid",
+                "type": "string"
+              },
+              "reactions": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "reaction": {
+                      "type": "string"
+                    },
+                    "count": {
+                      "type": "number"
+                    },
+                    "reactedByCurrentUser": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "reaction",
+                    "count",
+                    "reactedByCurrentUser"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "courseId",
+              "threadId",
+              "messageId",
+              "reactions"
             ]
           }
         },

--- a/apps/api/src/websocket/websocket.module.ts
+++ b/apps/api/src/websocket/websocket.module.ts
@@ -13,6 +13,6 @@ import { WsGateway } from "src/websocket/websocket.gateway";
     SocketRealtimePublisher,
     { provide: REALTIME_PUBLISHER, useExisting: SocketRealtimePublisher },
   ],
-  exports: [WsGateway, REALTIME_PUBLISHER],
+  exports: [WsGateway, WsJwtGuard, REALTIME_PUBLISHER],
 })
 export class WebSocketModule {}

--- a/apps/web/app/api/generated-api.ts
+++ b/apps/web/app/api/generated-api.ts
@@ -3392,6 +3392,242 @@ export interface DeleteManyCategoriesResponse {
   };
 }
 
+export interface GetThreadsResponse {
+  data: {
+    /** @format uuid */
+    id: string;
+    /** @format uuid */
+    courseId: string;
+    /** @format uuid */
+    createdByUserId: string;
+    archived: boolean;
+    createdAt: string;
+    updatedAt: string;
+    messageCount: number;
+    createdBy: {
+      /** @format uuid */
+      id: string;
+      firstName: string;
+      lastName: string;
+      avatarReference: string | null;
+    };
+    rootMessage: {
+      /** @format uuid */
+      id: string;
+      /** @format uuid */
+      threadId: string;
+      /** @format uuid */
+      courseId: string;
+      /** @format uuid */
+      userId: string;
+      content: string;
+      parentMessageId: string | null;
+      deletedAt: string | null;
+      createdAt: string;
+      updatedAt: string;
+      user: {
+        /** @format uuid */
+        id: string;
+        firstName: string;
+        lastName: string;
+        avatarReference: string | null;
+      };
+    };
+    latestMessage: {
+      /** @format uuid */
+      id: string;
+      /** @format uuid */
+      threadId: string;
+      /** @format uuid */
+      courseId: string;
+      /** @format uuid */
+      userId: string;
+      content: string;
+      parentMessageId: string | null;
+      deletedAt: string | null;
+      createdAt: string;
+      updatedAt: string;
+      user: {
+        /** @format uuid */
+        id: string;
+        firstName: string;
+        lastName: string;
+        avatarReference: string | null;
+      };
+    } | null;
+  }[];
+  pagination: {
+    totalItems: number;
+    page: number;
+    perPage: number;
+  };
+  appliedFilters?: object;
+}
+
+export interface CreateThreadBody {
+  /**
+   * @minLength 1
+   * @maxLength 5000
+   */
+  content: string;
+}
+
+export interface CreateThreadResponse {
+  data: {
+    thread: {
+      /** @format uuid */
+      id: string;
+      /** @format uuid */
+      courseId: string;
+      /** @format uuid */
+      createdByUserId: string;
+      archived: boolean;
+      createdAt: string;
+      updatedAt: string;
+      messageCount: number;
+      createdBy: {
+        /** @format uuid */
+        id: string;
+        firstName: string;
+        lastName: string;
+        avatarReference: string | null;
+      };
+      rootMessage: {
+        /** @format uuid */
+        id: string;
+        /** @format uuid */
+        threadId: string;
+        /** @format uuid */
+        courseId: string;
+        /** @format uuid */
+        userId: string;
+        content: string;
+        parentMessageId: string | null;
+        deletedAt: string | null;
+        createdAt: string;
+        updatedAt: string;
+        user: {
+          /** @format uuid */
+          id: string;
+          firstName: string;
+          lastName: string;
+          avatarReference: string | null;
+        };
+      };
+      latestMessage: {
+        /** @format uuid */
+        id: string;
+        /** @format uuid */
+        threadId: string;
+        /** @format uuid */
+        courseId: string;
+        /** @format uuid */
+        userId: string;
+        content: string;
+        parentMessageId: string | null;
+        deletedAt: string | null;
+        createdAt: string;
+        updatedAt: string;
+        user: {
+          /** @format uuid */
+          id: string;
+          firstName: string;
+          lastName: string;
+          avatarReference: string | null;
+        };
+      } | null;
+    };
+    message: {
+      /** @format uuid */
+      id: string;
+      /** @format uuid */
+      threadId: string;
+      /** @format uuid */
+      courseId: string;
+      /** @format uuid */
+      userId: string;
+      content: string;
+      parentMessageId: string | null;
+      deletedAt: string | null;
+      createdAt: string;
+      updatedAt: string;
+      user: {
+        /** @format uuid */
+        id: string;
+        firstName: string;
+        lastName: string;
+        avatarReference: string | null;
+      };
+    };
+  };
+}
+
+export interface GetMessagesResponse {
+  data: {
+    /** @format uuid */
+    id: string;
+    /** @format uuid */
+    threadId: string;
+    /** @format uuid */
+    courseId: string;
+    /** @format uuid */
+    userId: string;
+    content: string;
+    parentMessageId: string | null;
+    deletedAt: string | null;
+    createdAt: string;
+    updatedAt: string;
+    user: {
+      /** @format uuid */
+      id: string;
+      firstName: string;
+      lastName: string;
+      avatarReference: string | null;
+    };
+  }[];
+  pagination: {
+    totalItems: number;
+    page: number;
+    perPage: number;
+  };
+  appliedFilters?: object;
+}
+
+export interface CreateMessageBody {
+  /**
+   * @minLength 1
+   * @maxLength 5000
+   */
+  content: string;
+  /** @format uuid */
+  parentMessageId?: string;
+}
+
+export interface CreateMessageResponse {
+  data: {
+    /** @format uuid */
+    id: string;
+    /** @format uuid */
+    threadId: string;
+    /** @format uuid */
+    courseId: string;
+    /** @format uuid */
+    userId: string;
+    content: string;
+    parentMessageId: string | null;
+    deletedAt: string | null;
+    createdAt: string;
+    updatedAt: string;
+    user: {
+      /** @format uuid */
+      id: string;
+      firstName: string;
+      lastName: string;
+      avatarReference: string | null;
+    };
+  };
+}
+
 export interface UploadScormPackageResponse {
   data: {
     message: string;
@@ -8374,6 +8610,94 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       this.request<DeleteManyCategoriesResponse, any>({
         path: `/api/category/deleteManyCategories`,
         method: "DELETE",
+        body: data,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @name CourseChatControllerGetThreads
+     * @request GET:/api/course-chat/{courseId}/threads
+     */
+    courseChatControllerGetThreads: (
+      courseId: string,
+      query?: {
+        /** @min 1 */
+        page?: number;
+        /** @min 1 */
+        perPage?: number;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<GetThreadsResponse, any>({
+        path: `/api/course-chat/${courseId}/threads`,
+        method: "GET",
+        query: query,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @name CourseChatControllerCreateThread
+     * @request POST:/api/course-chat/{courseId}/threads
+     */
+    courseChatControllerCreateThread: (
+      courseId: string,
+      data: CreateThreadBody,
+      params: RequestParams = {},
+    ) =>
+      this.request<CreateThreadResponse, any>({
+        path: `/api/course-chat/${courseId}/threads`,
+        method: "POST",
+        body: data,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @name CourseChatControllerGetMessages
+     * @request GET:/api/course-chat/threads/{threadId}/messages
+     */
+    courseChatControllerGetMessages: (
+      threadId: string,
+      query?: {
+        /** @min 1 */
+        page?: number;
+        /** @min 1 */
+        perPage?: number;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<GetMessagesResponse, any>({
+        path: `/api/course-chat/threads/${threadId}/messages`,
+        method: "GET",
+        query: query,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @name CourseChatControllerCreateMessage
+     * @request POST:/api/course-chat/threads/{threadId}/messages
+     */
+    courseChatControllerCreateMessage: (
+      threadId: string,
+      data: CreateMessageBody,
+      params: RequestParams = {},
+    ) =>
+      this.request<CreateMessageResponse, any>({
+        path: `/api/course-chat/threads/${threadId}/messages`,
+        method: "POST",
         body: data,
         type: ContentType.Json,
         format: "json",

--- a/apps/web/app/api/queries/course-chat/useCourseChat.ts
+++ b/apps/web/app/api/queries/course-chat/useCourseChat.ts
@@ -10,6 +10,12 @@ export type CourseChatUserProfile = {
   avatarReference: string | null;
 };
 
+export type CourseChatMessageReaction = {
+  reaction: string;
+  count: number;
+  reactedByCurrentUser: boolean;
+};
+
 export type CourseChatMessage = {
   id: string;
   threadId: string;
@@ -21,6 +27,7 @@ export type CourseChatMessage = {
   createdAt: string;
   updatedAt: string;
   user: CourseChatUserProfile;
+  reactions?: CourseChatMessageReaction[];
 };
 
 export type CourseChatThread = {
@@ -62,6 +69,15 @@ export type CreateCourseChatPayload = {
   content: string;
   mentionedUserIds?: string[];
 };
+
+export type CourseChatMessageReactionsUpdated = {
+  courseId: string;
+  threadId: string;
+  messageId: string;
+  reactions: CourseChatMessageReaction[];
+};
+
+export const COURSE_CHAT_REACTIONS = ["👍", "❤️", "😂", "🎉", "😮"] as const;
 
 export const COURSE_CHAT_THREADS_QUERY_KEY = ["course-chat", "threads"];
 export const COURSE_CHAT_MESSAGES_QUERY_KEY = ["course-chat", "messages"];
@@ -182,6 +198,27 @@ export function useCreateCourseChatMessage(threadId?: string) {
   });
 }
 
+export function useToggleCourseChatMessageReaction() {
+  return useMutation({
+    mutationFn: async ({ messageId, reaction }: { messageId: string; reaction: string }) => {
+      const response = await ApiClient.request<
+        BaseResponse<CourseChatMessageReactionsUpdated>,
+        unknown
+      >({
+        path: `/api/course-chat/messages/${messageId}/reactions`,
+        method: "POST",
+        body: { reaction },
+        secure: true,
+      });
+
+      return response.data.data;
+    },
+    onSuccess: (payload) => {
+      updateMessageReactionsInCache(payload);
+    },
+  });
+}
+
 export function upsertThreadInCache(thread: CourseChatThread) {
   queryClient.setQueryData<Paginated<CourseChatThread[]>>(
     getCourseChatThreadsQueryKey(thread.courseId),
@@ -260,5 +297,42 @@ export function updateCourseChatUserPresence(params: {
       current?.map((user) =>
         user.id === params.userId ? { ...user, isOnline: params.isOnline } : user,
       ),
+  );
+}
+
+export function updateMessageReactionsInCache(payload: CourseChatMessageReactionsUpdated) {
+  const updateMessage = (message: CourseChatMessage): CourseChatMessage =>
+    message.id === payload.messageId ? { ...message, reactions: payload.reactions } : message;
+
+  queryClient.setQueryData<Paginated<CourseChatMessage[]>>(
+    getCourseChatMessagesQueryKey(payload.threadId),
+    (current) =>
+      current
+        ? {
+            ...current,
+            data: current.data.map(updateMessage),
+          }
+        : current,
+  );
+
+  queryClient.setQueryData<Paginated<CourseChatThread[]>>(
+    getCourseChatThreadsQueryKey(payload.courseId),
+    (current) =>
+      current
+        ? {
+            ...current,
+            data: current.data.map((thread) =>
+              thread.id === payload.threadId
+                ? {
+                    ...thread,
+                    rootMessage: updateMessage(thread.rootMessage),
+                    latestMessage: thread.latestMessage
+                      ? updateMessage(thread.latestMessage)
+                      : null,
+                  }
+                : thread,
+            ),
+          }
+        : current,
   );
 }

--- a/apps/web/app/api/queries/course-chat/useCourseChat.ts
+++ b/apps/web/app/api/queries/course-chat/useCourseChat.ts
@@ -1,0 +1,264 @@
+import { queryOptions, useMutation, useQuery } from "@tanstack/react-query";
+
+import { ApiClient } from "~/api/api-client";
+import { queryClient } from "~/api/queryClient";
+
+export type CourseChatUserProfile = {
+  id: string;
+  firstName: string;
+  lastName: string;
+  avatarReference: string | null;
+};
+
+export type CourseChatMessage = {
+  id: string;
+  threadId: string;
+  courseId: string;
+  userId: string;
+  content: string;
+  parentMessageId: string | null;
+  deletedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  user: CourseChatUserProfile;
+};
+
+export type CourseChatThread = {
+  id: string;
+  courseId: string;
+  createdByUserId: string;
+  archived: boolean;
+  createdAt: string;
+  updatedAt: string;
+  messageCount: number;
+  createdBy: CourseChatUserProfile;
+  rootMessage: CourseChatMessage;
+  latestMessage: CourseChatMessage | null;
+};
+
+export type CourseChatUser = CourseChatUserProfile & {
+  isOnline: boolean;
+};
+
+type Paginated<T> = {
+  data: T;
+  pagination: {
+    totalItems: number;
+    page: number;
+    perPage: number;
+  };
+};
+
+type BaseResponse<T> = {
+  data: T;
+};
+
+export type CreateCourseChatThreadResponse = {
+  thread: CourseChatThread;
+  message: CourseChatMessage;
+};
+
+export type CreateCourseChatPayload = {
+  content: string;
+  mentionedUserIds?: string[];
+};
+
+export const COURSE_CHAT_THREADS_QUERY_KEY = ["course-chat", "threads"];
+export const COURSE_CHAT_MESSAGES_QUERY_KEY = ["course-chat", "messages"];
+export const COURSE_CHAT_USERS_QUERY_KEY = ["course-chat", "users"];
+
+export const getCourseChatThreadsQueryKey = (courseId: string) => [
+  ...COURSE_CHAT_THREADS_QUERY_KEY,
+  courseId,
+];
+
+export const getCourseChatMessagesQueryKey = (threadId: string) => [
+  ...COURSE_CHAT_MESSAGES_QUERY_KEY,
+  threadId,
+];
+
+export const getCourseChatUsersQueryKey = (courseId: string) => [
+  ...COURSE_CHAT_USERS_QUERY_KEY,
+  courseId,
+];
+
+export const courseChatThreadsQueryOptions = (courseId: string) =>
+  queryOptions({
+    enabled: Boolean(courseId),
+    queryKey: getCourseChatThreadsQueryKey(courseId),
+    queryFn: async () => {
+      const response = await ApiClient.request<Paginated<CourseChatThread[]>, unknown>({
+        path: `/api/course-chat/${courseId}/threads`,
+        method: "GET",
+        query: { page: 1, perPage: 50 },
+        secure: true,
+      });
+
+      return response.data;
+    },
+  });
+
+export const courseChatMessagesQueryOptions = (threadId?: string) =>
+  queryOptions({
+    enabled: Boolean(threadId),
+    queryKey: getCourseChatMessagesQueryKey(threadId ?? ""),
+    queryFn: async () => {
+      const response = await ApiClient.request<Paginated<CourseChatMessage[]>, unknown>({
+        path: `/api/course-chat/threads/${threadId}/messages`,
+        method: "GET",
+        query: { page: 1, perPage: 100 },
+        secure: true,
+      });
+
+      return response.data;
+    },
+  });
+
+export const courseChatUsersQueryOptions = (courseId: string) =>
+  queryOptions({
+    enabled: Boolean(courseId),
+    queryKey: getCourseChatUsersQueryKey(courseId),
+    queryFn: async () => {
+      const response = await ApiClient.request<BaseResponse<CourseChatUser[]>, unknown>({
+        path: `/api/course-chat/${courseId}/users`,
+        method: "GET",
+        secure: true,
+      });
+
+      return response.data.data;
+    },
+  });
+
+export function useCourseChatThreads(courseId: string) {
+  return useQuery(courseChatThreadsQueryOptions(courseId));
+}
+
+export function useCourseChatThreadMessages(threadId?: string) {
+  return useQuery(courseChatMessagesQueryOptions(threadId));
+}
+
+export function useCourseChatUsers(courseId: string) {
+  return useQuery(courseChatUsersQueryOptions(courseId));
+}
+
+export function useCreateCourseChatThread(courseId: string) {
+  return useMutation({
+    mutationFn: async (payload: CreateCourseChatPayload) => {
+      const response = await ApiClient.request<
+        BaseResponse<CreateCourseChatThreadResponse>,
+        unknown
+      >({
+        path: `/api/course-chat/${courseId}/threads`,
+        method: "POST",
+        body: payload,
+        secure: true,
+      });
+
+      return response.data.data;
+    },
+    onSuccess: ({ thread }) => {
+      upsertThreadInCache(thread);
+    },
+  });
+}
+
+export function useCreateCourseChatMessage(threadId?: string) {
+  return useMutation({
+    mutationFn: async (payload: CreateCourseChatPayload) => {
+      if (!threadId) throw new Error("Missing threadId");
+
+      const response = await ApiClient.request<BaseResponse<CourseChatMessage>, unknown>({
+        path: `/api/course-chat/threads/${threadId}/messages`,
+        method: "POST",
+        body: payload,
+        secure: true,
+      });
+
+      return response.data.data;
+    },
+    onSuccess: (message) => {
+      upsertMessageInCache(message);
+    },
+  });
+}
+
+export function upsertThreadInCache(thread: CourseChatThread) {
+  queryClient.setQueryData<Paginated<CourseChatThread[]>>(
+    getCourseChatThreadsQueryKey(thread.courseId),
+    (current) => {
+      if (!current) return current;
+
+      const existing = current.data.some((item) => item.id === thread.id);
+      const data = existing
+        ? current.data.map((item) => (item.id === thread.id ? thread : item))
+        : [...current.data, thread];
+
+      return {
+        ...current,
+        data,
+        pagination: {
+          ...current.pagination,
+          totalItems: existing ? current.pagination.totalItems : current.pagination.totalItems + 1,
+        },
+      };
+    },
+  );
+}
+
+export function upsertMessageInCache(message: CourseChatMessage) {
+  queryClient.setQueryData<Paginated<CourseChatMessage[]>>(
+    getCourseChatMessagesQueryKey(message.threadId),
+    (current) => {
+      if (!current) return current;
+
+      const exists = current.data.some((item) => item.id === message.id);
+      const data = exists ? current.data : [...current.data, message];
+
+      return {
+        ...current,
+        data,
+        pagination: {
+          ...current.pagination,
+          totalItems: exists ? current.pagination.totalItems : current.pagination.totalItems + 1,
+        },
+      };
+    },
+  );
+
+  queryClient.setQueryData<Paginated<CourseChatThread[]>>(
+    getCourseChatThreadsQueryKey(message.courseId),
+    (current) => {
+      if (!current) return current;
+
+      const data = current.data.map((thread) =>
+        thread.id === message.threadId
+          ? {
+              ...thread,
+              latestMessage: message,
+              messageCount:
+                thread.latestMessage?.id === message.id
+                  ? thread.messageCount
+                  : thread.messageCount + 1,
+              updatedAt: message.createdAt,
+            }
+          : thread,
+      );
+
+      return { ...current, data };
+    },
+  );
+}
+
+export function updateCourseChatUserPresence(params: {
+  courseId: string;
+  userId: string;
+  isOnline: boolean;
+}) {
+  queryClient.setQueryData<CourseChatUser[]>(
+    getCourseChatUsersQueryKey(params.courseId),
+    (current) =>
+      current?.map((user) =>
+        user.id === params.userId ? { ...user, isOnline: params.isOnline } : user,
+      ),
+  );
+}

--- a/apps/web/app/api/queries/index.ts
+++ b/apps/web/app/api/queries/index.ts
@@ -37,3 +37,11 @@ export {
 export { newsQueryOptions, useNews, useNewsSuspense, NEWS_QUERY_KEY } from "./useNews";
 export { articleQueryOptions, useArticle, useArticleSuspense } from "./useArticle";
 export { articlesTocQueryOptions, useArticlesToc, useArticlesTocSuspense } from "./useArticlesToc";
+export {
+  courseChatMessagesQueryOptions,
+  courseChatThreadsQueryOptions,
+  useCourseChatThreadMessages,
+  useCourseChatThreads,
+  useCreateCourseChatMessage,
+  useCreateCourseChatThread,
+} from "./course-chat/useCourseChat";

--- a/apps/web/app/locales/cs/translation.json
+++ b/apps/web/app/locales/cs/translation.json
@@ -2099,8 +2099,29 @@
     },
     "tabs": {
       "chapters": "Kapitoly",
+      "chat": "Chat",
       "moreFromAuthor": "Více od autora",
       "statistics": "Statistika"
+    },
+    "courseChat": {
+      "title": "Chat kurzu",
+      "newThreadPlaceholder": "Zahajte novou diskuzi...",
+      "startThread": "Zahájit vlákno",
+      "messagesTitle": "Zprávy",
+      "noThreadSelected": "Vyberte vlákno",
+      "emptyThreads": "Zatím zde nejsou žádné konverzace. Zahajte první vlákno.",
+      "emptyMessages": "Zatím zde nejsou žádné zprávy.",
+      "replyPlaceholder": "Napište odpověď...",
+      "reply": "Odpovědět",
+      "repliesCount": "{{count}} odpovědí",
+      "send": "Odeslat",
+      "selectThread": "Vyberte vlákno pro čtení zpráv.",
+      "users": "Uživatelé",
+      "onlineCount": "{{online}}/{{total}} online",
+      "online": "Online",
+      "offline": "Offline",
+      "emptyUsers": "Zatím nejsou zapsáni žádní uživatelé.",
+      "mentionedToast": "Někdo vás zmínil v chatu kurzu."
     }
   },
   "studentChapterView": {

--- a/apps/web/app/locales/de/translation.json
+++ b/apps/web/app/locales/de/translation.json
@@ -2099,8 +2099,29 @@
     },
     "tabs": {
       "chapters": "Kapitel",
+      "chat": "Chat",
       "moreFromAuthor": "Mehr vom Autor",
       "statistics": "Statistiken"
+    },
+    "courseChat": {
+      "title": "Kurschat",
+      "newThreadPlaceholder": "Neue Diskussion starten...",
+      "startThread": "Thread starten",
+      "messagesTitle": "Nachrichten",
+      "noThreadSelected": "Thread auswählen",
+      "emptyThreads": "Noch keine Gespräche. Starten Sie den ersten Thread.",
+      "emptyMessages": "Noch keine Nachrichten.",
+      "replyPlaceholder": "Antwort schreiben...",
+      "reply": "Antworten",
+      "repliesCount": "{{count}} Antworten",
+      "send": "Senden",
+      "selectThread": "Wählen Sie einen Thread, um Nachrichten zu lesen.",
+      "users": "Benutzer",
+      "onlineCount": "{{online}}/{{total}} online",
+      "online": "Online",
+      "offline": "Offline",
+      "emptyUsers": "Noch keine eingeschriebenen Benutzer.",
+      "mentionedToast": "Jemand hat Sie im Kurschat erwähnt."
     }
   },
   "studentChapterView": {

--- a/apps/web/app/locales/en/translation.json
+++ b/apps/web/app/locales/en/translation.json
@@ -2152,8 +2152,29 @@
     },
     "tabs": {
       "chapters": "Chapters",
+      "chat": "Chat",
       "moreFromAuthor": "More from author",
       "statistics": "Statistics"
+    },
+    "courseChat": {
+      "title": "Course chat",
+      "newThreadPlaceholder": "Start a new discussion...",
+      "startThread": "Start thread",
+      "messagesTitle": "Messages",
+      "noThreadSelected": "Select a thread",
+      "emptyThreads": "No conversations yet. Start the first thread.",
+      "emptyMessages": "No messages yet.",
+      "replyPlaceholder": "Write a reply...",
+      "reply": "Reply",
+      "repliesCount": "{{count}} replies",
+      "send": "Send",
+      "selectThread": "Select a thread to read messages.",
+      "users": "Users",
+      "onlineCount": "{{online}}/{{total}} online",
+      "online": "Online",
+      "offline": "Offline",
+      "emptyUsers": "No enrolled users yet.",
+      "mentionedToast": "Someone mentioned you in course chat."
     }
   },
   "studentChapterView": {

--- a/apps/web/app/locales/lt/translation.json
+++ b/apps/web/app/locales/lt/translation.json
@@ -2099,8 +2099,29 @@
     },
     "tabs": {
       "chapters": "Skyriai",
+      "chat": "Pokalbis",
       "moreFromAuthor": "Daugiau iš autoriaus",
       "statistics": "Statistika"
+    },
+    "courseChat": {
+      "title": "Kurso pokalbis",
+      "newThreadPlaceholder": "Pradėkite naują diskusiją...",
+      "startThread": "Pradėti temą",
+      "messagesTitle": "Žinutės",
+      "noThreadSelected": "Pasirinkite temą",
+      "emptyThreads": "Pokalbių dar nėra. Pradėkite pirmą temą.",
+      "emptyMessages": "Žinučių dar nėra.",
+      "replyPlaceholder": "Parašykite atsakymą...",
+      "reply": "Atsakyti",
+      "repliesCount": "{{count}} atsakymai",
+      "send": "Siųsti",
+      "selectThread": "Pasirinkite temą, kad skaitytumėte žinutes.",
+      "users": "Vartotojai",
+      "onlineCount": "{{online}}/{{total}} online",
+      "online": "Online",
+      "offline": "Offline",
+      "emptyUsers": "Dar nėra užsiregistravusių vartotojų.",
+      "mentionedToast": "Kažkas paminėjo jus kurso pokalbyje."
     }
   },
   "studentChapterView": {

--- a/apps/web/app/locales/pl/translation.json
+++ b/apps/web/app/locales/pl/translation.json
@@ -2154,8 +2154,29 @@
     },
     "tabs": {
       "chapters": "Rozdziały",
+      "chat": "Chat",
       "moreFromAuthor": "Więcej od autora",
       "statistics": "Statystyki"
+    },
+    "courseChat": {
+      "title": "Chat kursu",
+      "newThreadPlaceholder": "Rozpocznij nową dyskusję...",
+      "startThread": "Rozpocznij wątek",
+      "messagesTitle": "Wiadomości",
+      "noThreadSelected": "Wybierz wątek",
+      "emptyThreads": "Nie ma jeszcze rozmów. Rozpocznij pierwszy wątek.",
+      "emptyMessages": "Nie ma jeszcze wiadomości.",
+      "replyPlaceholder": "Napisz odpowiedź...",
+      "reply": "Odpowiedz",
+      "repliesCount": "{{count}} odpowiedzi",
+      "send": "Wyślij",
+      "selectThread": "Wybierz wątek, aby przeczytać wiadomości.",
+      "users": "Użytkownicy",
+      "onlineCount": "{{online}}/{{total}} online",
+      "online": "Online",
+      "offline": "Offline",
+      "emptyUsers": "Brak zapisanych użytkowników.",
+      "mentionedToast": "Ktoś oznaczył Cię na czacie kursu."
     }
   },
   "studentChapterView": {

--- a/apps/web/app/modules/Courses/CourseView/CourseChat/ChatMessage.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseChat/ChatMessage.tsx
@@ -1,0 +1,75 @@
+import { format } from "date-fns";
+
+import {
+  COURSE_CHAT_REACTIONS,
+  type CourseChatMessage as CourseChatMessageType,
+  type CourseChatUser,
+  useToggleCourseChatMessageReaction,
+} from "~/api/queries/course-chat/useCourseChat";
+import { UserAvatar } from "~/components/UserProfile/UserAvatar";
+
+import { renderMessageContent } from "./courseChatUtils";
+import { ReactionButton } from "./ReactionButton";
+
+type ChatMessageProps = {
+  message: CourseChatMessageType;
+  users: CourseChatUser[];
+};
+
+export function ChatMessage({ message, users }: ChatMessageProps) {
+  const authorName = `${message.user.firstName} ${message.user.lastName}`;
+  const toggleReaction = useToggleCourseChatMessageReaction();
+  const reactions = message.reactions ?? [];
+
+  return (
+    <div className="group flex gap-3">
+      <UserAvatar
+        className="size-9"
+        userName={authorName}
+        profilePictureUrl={message.user.avatarReference}
+      />
+      <div className="min-w-0 flex-1">
+        <div className="mb-1 flex flex-wrap items-center gap-x-2 gap-y-1">
+          <span className="body-sm-md text-neutral-950">{authorName}</span>
+          <span className="caption text-neutral-500">
+            {format(new Date(message.createdAt), "dd.MM.yyyy HH:mm")}
+          </span>
+        </div>
+        <div className="rounded-xl bg-neutral-100 px-4 py-3 text-neutral-950">
+          <p className="body-sm whitespace-pre-wrap break-words">
+            {renderMessageContent(message.content, users)}
+          </p>
+        </div>
+        <div className="mt-2 flex flex-wrap items-center gap-1">
+          {reactions.map((reactionSummary) => (
+            <ReactionButton
+              key={reactionSummary.reaction}
+              reaction={reactionSummary.reaction}
+              count={reactionSummary.count}
+              reactedByCurrentUser={reactionSummary.reactedByCurrentUser}
+              disabled={toggleReaction.isPending}
+              onClick={() =>
+                toggleReaction.mutate({
+                  messageId: message.id,
+                  reaction: reactionSummary.reaction,
+                })
+              }
+            />
+          ))}
+          <div className="flex gap-1 opacity-0 transition group-hover:opacity-100 group-focus-within:opacity-100">
+            {COURSE_CHAT_REACTIONS.filter(
+              (reaction) => !reactions.some((item) => item.reaction === reaction),
+            ).map((reaction) => (
+              <ReactionButton
+                key={reaction}
+                reaction={reaction}
+                disabled={toggleReaction.isPending}
+                onClick={() => toggleReaction.mutate({ messageId: message.id, reaction })}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/modules/Courses/CourseView/CourseChat/ChatUsersPanel.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseChat/ChatUsersPanel.tsx
@@ -1,0 +1,82 @@
+import { useTranslation } from "react-i18next";
+
+import { Skeleton } from "~/components/ui/skeleton";
+import { UserAvatar } from "~/components/UserProfile/UserAvatar";
+import { cn } from "~/lib/utils";
+
+import { EmptyState } from "./CourseChatStates";
+
+import type { CourseChatUser } from "~/api/queries/course-chat/useCourseChat";
+
+type ChatUsersPanelProps = {
+  users: CourseChatUser[];
+  isLoading: boolean;
+};
+
+export function ChatUsersPanel({ users, isLoading }: ChatUsersPanelProps) {
+  const { t } = useTranslation();
+  const onlineCount = users.filter((user) => user.isOnline).length;
+
+  return (
+    <aside className="border-t border-neutral-200 bg-background p-4 lg:w-72 lg:border-l lg:border-t-0">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <div>
+          <h3 className="body-base-md text-neutral-950">
+            {t("studentCourseView.courseChat.users")}
+          </h3>
+          <p className="caption text-neutral-500">
+            {t("studentCourseView.courseChat.onlineCount", {
+              online: onlineCount,
+              total: users.length,
+            })}
+          </p>
+        </div>
+      </div>
+
+      <div className="flex max-h-[560px] flex-col gap-2 overflow-y-auto">
+        {isLoading ? (
+          <>
+            <Skeleton className="h-12 w-full" />
+            <Skeleton className="h-12 w-full" />
+            <Skeleton className="h-12 w-full" />
+          </>
+        ) : users.length ? (
+          users.map((user) => {
+            const userName = `${user.firstName} ${user.lastName}`;
+
+            return (
+              <div
+                key={user.id}
+                className="flex items-center gap-3 rounded-lg p-2 hover:bg-neutral-50"
+              >
+                <div className="relative">
+                  <UserAvatar
+                    className="size-9"
+                    userName={userName}
+                    profilePictureUrl={user.avatarReference}
+                  />
+                  <span
+                    className={cn(
+                      "absolute bottom-0 right-0 size-3 rounded-full border-2 border-background",
+                      user.isOnline ? "bg-green-500" : "bg-neutral-300",
+                    )}
+                  />
+                </div>
+                <div className="min-w-0">
+                  <p className="body-sm-md truncate text-neutral-950">{userName}</p>
+                  <p className="caption text-neutral-500">
+                    {user.isOnline
+                      ? t("studentCourseView.courseChat.online")
+                      : t("studentCourseView.courseChat.offline")}
+                  </p>
+                </div>
+              </div>
+            );
+          })
+        ) : (
+          <EmptyState text={t("studentCourseView.courseChat.emptyUsers")} />
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/app/modules/Courses/CourseView/CourseChat/CourseChatStates.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseChat/CourseChatStates.tsx
@@ -1,0 +1,28 @@
+import { Skeleton } from "~/components/ui/skeleton";
+
+export function EmptyState({ text }: { text: string }) {
+  return (
+    <div className="rounded-lg border border-dashed border-neutral-300 bg-background p-6 text-center">
+      <p className="body-sm text-neutral-600">{text}</p>
+    </div>
+  );
+}
+
+export function MainFeedSkeleton() {
+  return (
+    <>
+      <Skeleton className="h-28 w-full" />
+      <Skeleton className="h-28 w-full" />
+      <Skeleton className="h-28 w-full" />
+    </>
+  );
+}
+
+export function MessagesSkeleton() {
+  return (
+    <>
+      <Skeleton className="h-16 w-3/4" />
+      <Skeleton className="ml-auto h-16 w-2/3" />
+    </>
+  );
+}

--- a/apps/web/app/modules/Courses/CourseView/CourseChat/CourseChatTab.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseChat/CourseChatTab.tsx
@@ -1,12 +1,8 @@
-import { format } from "date-fns";
-import { MessageSquare, MessagesSquare, PanelRightClose, PanelRightOpen, Send } from "lucide-react";
+import { MessageSquare, PanelRightClose, PanelRightOpen, Send } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import {
-  type CourseChatMessage,
-  type CourseChatThread,
-  type CourseChatUser,
   useCourseChatThreadMessages,
   useCourseChatThreads,
   useCourseChatUsers,
@@ -15,12 +11,13 @@ import {
 } from "~/api/queries/course-chat/useCourseChat";
 import { Button } from "~/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
-import { Skeleton } from "~/components/ui/skeleton";
-import { Textarea } from "~/components/ui/textarea";
 import { useToast } from "~/components/ui/use-toast";
-import { UserAvatar } from "~/components/UserProfile/UserAvatar";
-import { cn } from "~/lib/utils";
 
+import { ChatUsersPanel } from "./ChatUsersPanel";
+import { EmptyState, MainFeedSkeleton } from "./CourseChatStates";
+import { getMentionedUserIds } from "./courseChatUtils";
+import { MainThreadMessage } from "./MainThreadMessage";
+import { MentionTextarea } from "./MentionTextarea";
 import { useCourseChatSocket } from "./useCourseChatSocket";
 
 import type { FormEvent, KeyboardEvent } from "react";
@@ -92,6 +89,13 @@ export function CourseChatTab({ courseId, currentUserId }: CourseChatTabProps) {
     setReplyContent("");
   };
 
+  const handleNewThreadKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key !== "Enter" || event.shiftKey) return;
+
+    event.preventDefault();
+    event.currentTarget.form?.requestSubmit();
+  };
+
   return (
     <Card className="overflow-hidden">
       <CardHeader className="border-b border-neutral-200">
@@ -153,6 +157,7 @@ export function CourseChatTab({ courseId, currentUserId }: CourseChatTabProps) {
               <MentionTextarea
                 value={newThreadContent}
                 onChange={setNewThreadContent}
+                onKeyDown={handleNewThreadKeyDown}
                 users={mentionableUsers}
                 placeholder={t("studentCourseView.courseChat.newThreadPlaceholder")}
                 maxLength={5000}
@@ -173,360 +178,5 @@ export function CourseChatTab({ courseId, currentUserId }: CourseChatTabProps) {
         {isRosterOpen && <ChatUsersPanel users={chatUsers} isLoading={isLoadingUsers} />}
       </CardContent>
     </Card>
-  );
-}
-
-function ChatUsersPanel({ users, isLoading }: { users: CourseChatUser[]; isLoading: boolean }) {
-  const { t } = useTranslation();
-  const onlineCount = users.filter((user) => user.isOnline).length;
-
-  return (
-    <aside className="border-t border-neutral-200 bg-background p-4 lg:w-72 lg:border-l lg:border-t-0">
-      <div className="mb-4 flex items-center justify-between gap-3">
-        <div>
-          <h3 className="body-base-md text-neutral-950">
-            {t("studentCourseView.courseChat.users")}
-          </h3>
-          <p className="caption text-neutral-500">
-            {t("studentCourseView.courseChat.onlineCount", {
-              online: onlineCount,
-              total: users.length,
-            })}
-          </p>
-        </div>
-      </div>
-
-      <div className="flex max-h-[560px] flex-col gap-2 overflow-y-auto">
-        {isLoading ? (
-          <>
-            <Skeleton className="h-12 w-full" />
-            <Skeleton className="h-12 w-full" />
-            <Skeleton className="h-12 w-full" />
-          </>
-        ) : users.length ? (
-          users.map((user) => {
-            const userName = `${user.firstName} ${user.lastName}`;
-
-            return (
-              <div
-                key={user.id}
-                className="flex items-center gap-3 rounded-lg p-2 hover:bg-neutral-50"
-              >
-                <div className="relative">
-                  <UserAvatar
-                    className="size-9"
-                    userName={userName}
-                    profilePictureUrl={user.avatarReference}
-                  />
-                  <span
-                    className={cn(
-                      "absolute bottom-0 right-0 size-3 rounded-full border-2 border-background",
-                      user.isOnline ? "bg-green-500" : "bg-neutral-300",
-                    )}
-                  />
-                </div>
-                <div className="min-w-0">
-                  <p className="body-sm-md truncate text-neutral-950">{userName}</p>
-                  <p className="caption text-neutral-500">
-                    {user.isOnline
-                      ? t("studentCourseView.courseChat.online")
-                      : t("studentCourseView.courseChat.offline")}
-                  </p>
-                </div>
-              </div>
-            );
-          })
-        ) : (
-          <EmptyState text={t("studentCourseView.courseChat.emptyUsers")} />
-        )}
-      </div>
-    </aside>
-  );
-}
-
-function MainThreadMessage({
-  thread,
-  isOpen,
-  isLoadingReplies,
-  replies,
-  users,
-  mentionableUsers,
-  replyContent,
-  isSendingReply,
-  onToggle,
-  onReplyChange,
-  onReplySubmit,
-}: {
-  thread: CourseChatThread;
-  isOpen: boolean;
-  isLoadingReplies: boolean;
-  replies: CourseChatMessage[];
-  users: CourseChatUser[];
-  mentionableUsers: CourseChatUser[];
-  replyContent: string;
-  isSendingReply: boolean;
-  onToggle: () => void;
-  onReplyChange: (value: string) => void;
-  onReplySubmit: (event: FormEvent<HTMLFormElement>) => void;
-}) {
-  const { t } = useTranslation();
-  const replyCount = Math.max(thread.messageCount - 1, 0);
-
-  return (
-    <article className="rounded-xl border border-neutral-200 bg-background p-4 shadow-sm">
-      <ChatMessage message={thread.rootMessage} users={users} />
-
-      <div className="mt-3 flex flex-wrap items-center gap-3 pl-11">
-        <Button type="button" variant="ghost" size="sm" className="gap-2" onClick={onToggle}>
-          <MessagesSquare className="size-4" />
-          {replyCount
-            ? t("studentCourseView.courseChat.repliesCount", { count: replyCount })
-            : t("studentCourseView.courseChat.reply")}
-        </Button>
-        {thread.latestMessage && thread.latestMessage.id !== thread.rootMessage.id && (
-          <span className="caption text-neutral-500">
-            {format(new Date(thread.latestMessage.createdAt), "dd.MM.yyyy HH:mm")}
-          </span>
-        )}
-      </div>
-
-      {isOpen && (
-        <div className="mt-4 border-l-2 border-primary-100 pl-4 md:ml-11">
-          <div className="flex flex-col gap-4">
-            {isLoadingReplies ? (
-              <MessagesSkeleton />
-            ) : replies.length ? (
-              replies.map((message) => (
-                <ChatMessage key={message.id} message={message} users={users} />
-              ))
-            ) : (
-              <EmptyState text={t("studentCourseView.courseChat.emptyMessages")} />
-            )}
-
-            <form className="flex flex-col gap-3" onSubmit={onReplySubmit}>
-              <MentionTextarea
-                value={replyContent}
-                onChange={onReplyChange}
-                users={mentionableUsers}
-                placeholder={t("studentCourseView.courseChat.replyPlaceholder")}
-                maxLength={5000}
-                className="min-h-[80px] resize-none"
-              />
-              <Button
-                type="submit"
-                className="self-end gap-2"
-                disabled={!replyContent.trim() || isSendingReply}
-              >
-                <Send className="size-4" />
-                {t("studentCourseView.courseChat.send")}
-              </Button>
-            </form>
-          </div>
-        </div>
-      )}
-    </article>
-  );
-}
-
-function MentionTextarea({
-  value,
-  onChange,
-  users,
-  placeholder,
-  maxLength,
-  className,
-}: {
-  value: string;
-  onChange: (value: string) => void;
-  users: CourseChatUser[];
-  placeholder: string;
-  maxLength: number;
-  className?: string;
-}) {
-  const [highlightedIndex, setHighlightedIndex] = useState(0);
-  const [isPickerDismissed, setIsPickerDismissed] = useState(false);
-  const mentionQuery = getActiveMentionQuery(value);
-  const matchingUsers = useMemo(() => {
-    if (mentionQuery === null || isPickerDismissed) return [];
-
-    const normalizedQuery = mentionQuery.toLowerCase();
-
-    return users
-      .filter((user) => getUserDisplayName(user).toLowerCase().includes(normalizedQuery))
-      .slice(0, 6);
-  }, [isPickerDismissed, mentionQuery, users]);
-
-  useEffect(() => {
-    setHighlightedIndex(0);
-    setIsPickerDismissed(false);
-  }, [mentionQuery]);
-
-  const insertMention = (user: CourseChatUser) => {
-    const mention = `@${getUserDisplayName(user)} `;
-    const nextValue = value.replace(/(^|\s)@([^\s@]*)$/, `$1${mention}`);
-    onChange(nextValue);
-  };
-
-  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (!matchingUsers.length) return;
-
-    if (event.key === "ArrowDown") {
-      event.preventDefault();
-      setHighlightedIndex((current) => (current + 1) % matchingUsers.length);
-      return;
-    }
-
-    if (event.key === "ArrowUp") {
-      event.preventDefault();
-      setHighlightedIndex((current) => (current - 1 + matchingUsers.length) % matchingUsers.length);
-      return;
-    }
-
-    if (event.key === "Enter" || event.key === "Tab") {
-      event.preventDefault();
-      insertMention(matchingUsers[highlightedIndex]);
-      return;
-    }
-
-    if (event.key === "Escape") {
-      event.preventDefault();
-      setIsPickerDismissed(true);
-    }
-  };
-
-  return (
-    <div className="relative">
-      <Textarea
-        value={value}
-        onChange={(event) => onChange(event.target.value)}
-        onKeyDown={handleKeyDown}
-        placeholder={placeholder}
-        maxLength={maxLength}
-        className={className}
-      />
-      {matchingUsers.length > 0 && (
-        <div className="absolute bottom-full left-0 z-10 mb-2 w-72 rounded-xl border border-neutral-200 bg-background p-2 shadow-lg">
-          {matchingUsers.map((user, index) => {
-            const userName = getUserDisplayName(user);
-
-            return (
-              <button
-                key={user.id}
-                type="button"
-                className={cn(
-                  "flex w-full items-center gap-3 rounded-lg p-2 text-left hover:bg-neutral-50",
-                  index === highlightedIndex && "bg-neutral-50",
-                )}
-                onMouseDown={(event) => {
-                  event.preventDefault();
-                  insertMention(user);
-                }}
-              >
-                <UserAvatar
-                  className="size-8"
-                  userName={userName}
-                  profilePictureUrl={user.avatarReference}
-                />
-                <span className="body-sm-md truncate text-neutral-950">{userName}</span>
-              </button>
-            );
-          })}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function ChatMessage({ message, users }: { message: CourseChatMessage; users: CourseChatUser[] }) {
-  const authorName = `${message.user.firstName} ${message.user.lastName}`;
-
-  return (
-    <div className="flex gap-3">
-      <UserAvatar
-        className="size-9"
-        userName={authorName}
-        profilePictureUrl={message.user.avatarReference}
-      />
-      <div className="min-w-0 flex-1">
-        <div className="mb-1 flex flex-wrap items-center gap-x-2 gap-y-1">
-          <span className="body-sm-md text-neutral-950">{authorName}</span>
-          <span className="caption text-neutral-500">
-            {format(new Date(message.createdAt), "dd.MM.yyyy HH:mm")}
-          </span>
-        </div>
-        <div className="rounded-xl bg-neutral-100 px-4 py-3 text-neutral-950">
-          <p className="body-sm whitespace-pre-wrap break-words">
-            {renderMessageContent(message.content, users)}
-          </p>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function getUserDisplayName(user: CourseChatUser) {
-  return `${user.firstName} ${user.lastName}`;
-}
-
-function getActiveMentionQuery(value: string) {
-  const match = value.match(/(^|\s)@([^\s@]*)$/);
-
-  return match?.[2] ?? null;
-}
-
-function getMentionedUserIds(content: string, users: CourseChatUser[]) {
-  return users
-    .filter((user) => content.includes(`@${getUserDisplayName(user)}`))
-    .map((user) => user.id);
-}
-
-function renderMessageContent(content: string, users: CourseChatUser[]) {
-  const mentionLabels = users
-    .map((user) => `@${getUserDisplayName(user)}`)
-    .sort((a, b) => b.length - a.length);
-
-  if (!mentionLabels.length) return content;
-
-  const mentionRegex = new RegExp(`(${mentionLabels.map(escapeRegExp).join("|")})`, "g");
-
-  return content.split(mentionRegex).map((part, index) =>
-    mentionLabels.includes(part) ? (
-      <span key={`${part}-${index}`} className="font-medium text-primary-700">
-        {part}
-      </span>
-    ) : (
-      part
-    ),
-  );
-}
-
-function escapeRegExp(value: string) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function EmptyState({ text }: { text: string }) {
-  return (
-    <div className="rounded-lg border border-dashed border-neutral-300 bg-background p-6 text-center">
-      <p className="body-sm text-neutral-600">{text}</p>
-    </div>
-  );
-}
-
-function MainFeedSkeleton() {
-  return (
-    <>
-      <Skeleton className="h-28 w-full" />
-      <Skeleton className="h-28 w-full" />
-      <Skeleton className="h-28 w-full" />
-    </>
-  );
-}
-
-function MessagesSkeleton() {
-  return (
-    <>
-      <Skeleton className="h-16 w-3/4" />
-      <Skeleton className="ml-auto h-16 w-2/3" />
-    </>
   );
 }

--- a/apps/web/app/modules/Courses/CourseView/CourseChat/CourseChatTab.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseChat/CourseChatTab.tsx
@@ -1,0 +1,532 @@
+import { format } from "date-fns";
+import { MessageSquare, MessagesSquare, PanelRightClose, PanelRightOpen, Send } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import {
+  type CourseChatMessage,
+  type CourseChatThread,
+  type CourseChatUser,
+  useCourseChatThreadMessages,
+  useCourseChatThreads,
+  useCourseChatUsers,
+  useCreateCourseChatMessage,
+  useCreateCourseChatThread,
+} from "~/api/queries/course-chat/useCourseChat";
+import { Button } from "~/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+import { Skeleton } from "~/components/ui/skeleton";
+import { Textarea } from "~/components/ui/textarea";
+import { useToast } from "~/components/ui/use-toast";
+import { UserAvatar } from "~/components/UserProfile/UserAvatar";
+import { cn } from "~/lib/utils";
+
+import { useCourseChatSocket } from "./useCourseChatSocket";
+
+import type { FormEvent, KeyboardEvent } from "react";
+
+type CourseChatTabProps = {
+  courseId: string;
+  currentUserId: string;
+};
+
+export function CourseChatTab({ courseId, currentUserId }: CourseChatTabProps) {
+  const { t } = useTranslation();
+  const { toast } = useToast();
+  const [openThreadId, setOpenThreadId] = useState<string | undefined>();
+  const [isRosterOpen, setIsRosterOpen] = useState(true);
+  const [newThreadContent, setNewThreadContent] = useState("");
+  const [replyContent, setReplyContent] = useState("");
+
+  const { data: threadsResponse, isLoading: isLoadingThreads } = useCourseChatThreads(courseId);
+  const { data: chatUsers = [], isLoading: isLoadingUsers } = useCourseChatUsers(courseId);
+  const mentionableUsers = useMemo(
+    () => chatUsers.filter((user) => user.id !== currentUserId),
+    [chatUsers, currentUserId],
+  );
+  const threads = useMemo(() => threadsResponse?.data ?? [], [threadsResponse?.data]);
+  const openThread = threads.find((thread) => thread.id === openThreadId);
+
+  const { data: messagesResponse, isLoading: isLoadingMessages } =
+    useCourseChatThreadMessages(openThreadId);
+  const replies =
+    messagesResponse?.data.filter((message) => message.id !== openThread?.rootMessage.id) ?? [];
+
+  const createThread = useCreateCourseChatThread(courseId);
+  const createMessage = useCreateCourseChatMessage(openThreadId);
+
+  const handleMentioned = useCallback(() => {
+    toast({ description: t("studentCourseView.courseChat.mentionedToast") });
+  }, [t, toast]);
+
+  useCourseChatSocket({ courseId, enabled: Boolean(courseId), onMentioned: handleMentioned });
+
+  useEffect(() => {
+    if (openThreadId && !threads.some((thread) => thread.id === openThreadId)) {
+      setOpenThreadId(undefined);
+    }
+  }, [openThreadId, threads]);
+
+  const handleCreateThread = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const content = newThreadContent.trim();
+    if (!content) return;
+
+    const result = await createThread.mutateAsync({
+      content,
+      mentionedUserIds: getMentionedUserIds(content, mentionableUsers),
+    });
+    setNewThreadContent("");
+    setOpenThreadId(result.thread.id);
+  };
+
+  const handleCreateMessage = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const content = replyContent.trim();
+    if (!content || !openThreadId) return;
+
+    await createMessage.mutateAsync({
+      content,
+      mentionedUserIds: getMentionedUserIds(content, mentionableUsers),
+    });
+    setReplyContent("");
+  };
+
+  return (
+    <Card className="overflow-hidden">
+      <CardHeader className="border-b border-neutral-200">
+        <div className="flex items-center justify-between gap-3">
+          <CardTitle className="h5 flex items-center gap-2">
+            <MessageSquare className="size-5 text-primary-700" />
+            {t("studentCourseView.courseChat.title")}
+          </CardTitle>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="gap-2"
+            onClick={() => setIsRosterOpen((current) => !current)}
+          >
+            {isRosterOpen ? (
+              <PanelRightClose className="size-4" />
+            ) : (
+              <PanelRightOpen className="size-4" />
+            )}
+            {t("studentCourseView.courseChat.users")}
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="grid min-h-[640px] bg-neutral-50 p-0 lg:grid-cols-[minmax(0,1fr)_auto]">
+        <div className="flex min-w-0 flex-col gap-6">
+          <div className="flex flex-1 flex-col gap-4 overflow-y-auto px-4 py-6 md:px-6">
+            {isLoadingThreads ? (
+              <MainFeedSkeleton />
+            ) : threads.length ? (
+              threads.map((thread) => (
+                <MainThreadMessage
+                  key={thread.id}
+                  thread={thread}
+                  isOpen={thread.id === openThreadId}
+                  isLoadingReplies={isLoadingMessages && thread.id === openThreadId}
+                  replies={thread.id === openThreadId ? replies : []}
+                  users={chatUsers}
+                  mentionableUsers={mentionableUsers}
+                  replyContent={thread.id === openThreadId ? replyContent : ""}
+                  isSendingReply={createMessage.isPending && thread.id === openThreadId}
+                  onToggle={() =>
+                    setOpenThreadId((current) => (current === thread.id ? undefined : thread.id))
+                  }
+                  onReplyChange={setReplyContent}
+                  onReplySubmit={handleCreateMessage}
+                />
+              ))
+            ) : (
+              <EmptyState text={t("studentCourseView.courseChat.emptyThreads")} />
+            )}
+          </div>
+
+          <form
+            className="border-t border-neutral-200 bg-background p-4 md:p-6"
+            onSubmit={handleCreateThread}
+          >
+            <div className="flex flex-col gap-3 rounded-xl border border-neutral-200 bg-background p-3 shadow-sm">
+              <MentionTextarea
+                value={newThreadContent}
+                onChange={setNewThreadContent}
+                users={mentionableUsers}
+                placeholder={t("studentCourseView.courseChat.newThreadPlaceholder")}
+                maxLength={5000}
+                className="min-h-[96px] resize-none border-0 px-0 shadow-none focus-visible:ring-0"
+              />
+              <Button
+                type="submit"
+                className="self-end gap-2"
+                disabled={!newThreadContent.trim() || createThread.isPending}
+              >
+                <Send className="size-4" />
+                {t("studentCourseView.courseChat.send")}
+              </Button>
+            </div>
+          </form>
+        </div>
+
+        {isRosterOpen && <ChatUsersPanel users={chatUsers} isLoading={isLoadingUsers} />}
+      </CardContent>
+    </Card>
+  );
+}
+
+function ChatUsersPanel({ users, isLoading }: { users: CourseChatUser[]; isLoading: boolean }) {
+  const { t } = useTranslation();
+  const onlineCount = users.filter((user) => user.isOnline).length;
+
+  return (
+    <aside className="border-t border-neutral-200 bg-background p-4 lg:w-72 lg:border-l lg:border-t-0">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <div>
+          <h3 className="body-base-md text-neutral-950">
+            {t("studentCourseView.courseChat.users")}
+          </h3>
+          <p className="caption text-neutral-500">
+            {t("studentCourseView.courseChat.onlineCount", {
+              online: onlineCount,
+              total: users.length,
+            })}
+          </p>
+        </div>
+      </div>
+
+      <div className="flex max-h-[560px] flex-col gap-2 overflow-y-auto">
+        {isLoading ? (
+          <>
+            <Skeleton className="h-12 w-full" />
+            <Skeleton className="h-12 w-full" />
+            <Skeleton className="h-12 w-full" />
+          </>
+        ) : users.length ? (
+          users.map((user) => {
+            const userName = `${user.firstName} ${user.lastName}`;
+
+            return (
+              <div
+                key={user.id}
+                className="flex items-center gap-3 rounded-lg p-2 hover:bg-neutral-50"
+              >
+                <div className="relative">
+                  <UserAvatar
+                    className="size-9"
+                    userName={userName}
+                    profilePictureUrl={user.avatarReference}
+                  />
+                  <span
+                    className={cn(
+                      "absolute bottom-0 right-0 size-3 rounded-full border-2 border-background",
+                      user.isOnline ? "bg-green-500" : "bg-neutral-300",
+                    )}
+                  />
+                </div>
+                <div className="min-w-0">
+                  <p className="body-sm-md truncate text-neutral-950">{userName}</p>
+                  <p className="caption text-neutral-500">
+                    {user.isOnline
+                      ? t("studentCourseView.courseChat.online")
+                      : t("studentCourseView.courseChat.offline")}
+                  </p>
+                </div>
+              </div>
+            );
+          })
+        ) : (
+          <EmptyState text={t("studentCourseView.courseChat.emptyUsers")} />
+        )}
+      </div>
+    </aside>
+  );
+}
+
+function MainThreadMessage({
+  thread,
+  isOpen,
+  isLoadingReplies,
+  replies,
+  users,
+  mentionableUsers,
+  replyContent,
+  isSendingReply,
+  onToggle,
+  onReplyChange,
+  onReplySubmit,
+}: {
+  thread: CourseChatThread;
+  isOpen: boolean;
+  isLoadingReplies: boolean;
+  replies: CourseChatMessage[];
+  users: CourseChatUser[];
+  mentionableUsers: CourseChatUser[];
+  replyContent: string;
+  isSendingReply: boolean;
+  onToggle: () => void;
+  onReplyChange: (value: string) => void;
+  onReplySubmit: (event: FormEvent<HTMLFormElement>) => void;
+}) {
+  const { t } = useTranslation();
+  const replyCount = Math.max(thread.messageCount - 1, 0);
+
+  return (
+    <article className="rounded-xl border border-neutral-200 bg-background p-4 shadow-sm">
+      <ChatMessage message={thread.rootMessage} users={users} />
+
+      <div className="mt-3 flex flex-wrap items-center gap-3 pl-11">
+        <Button type="button" variant="ghost" size="sm" className="gap-2" onClick={onToggle}>
+          <MessagesSquare className="size-4" />
+          {replyCount
+            ? t("studentCourseView.courseChat.repliesCount", { count: replyCount })
+            : t("studentCourseView.courseChat.reply")}
+        </Button>
+        {thread.latestMessage && thread.latestMessage.id !== thread.rootMessage.id && (
+          <span className="caption text-neutral-500">
+            {format(new Date(thread.latestMessage.createdAt), "dd.MM.yyyy HH:mm")}
+          </span>
+        )}
+      </div>
+
+      {isOpen && (
+        <div className="mt-4 border-l-2 border-primary-100 pl-4 md:ml-11">
+          <div className="flex flex-col gap-4">
+            {isLoadingReplies ? (
+              <MessagesSkeleton />
+            ) : replies.length ? (
+              replies.map((message) => (
+                <ChatMessage key={message.id} message={message} users={users} />
+              ))
+            ) : (
+              <EmptyState text={t("studentCourseView.courseChat.emptyMessages")} />
+            )}
+
+            <form className="flex flex-col gap-3" onSubmit={onReplySubmit}>
+              <MentionTextarea
+                value={replyContent}
+                onChange={onReplyChange}
+                users={mentionableUsers}
+                placeholder={t("studentCourseView.courseChat.replyPlaceholder")}
+                maxLength={5000}
+                className="min-h-[80px] resize-none"
+              />
+              <Button
+                type="submit"
+                className="self-end gap-2"
+                disabled={!replyContent.trim() || isSendingReply}
+              >
+                <Send className="size-4" />
+                {t("studentCourseView.courseChat.send")}
+              </Button>
+            </form>
+          </div>
+        </div>
+      )}
+    </article>
+  );
+}
+
+function MentionTextarea({
+  value,
+  onChange,
+  users,
+  placeholder,
+  maxLength,
+  className,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  users: CourseChatUser[];
+  placeholder: string;
+  maxLength: number;
+  className?: string;
+}) {
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+  const [isPickerDismissed, setIsPickerDismissed] = useState(false);
+  const mentionQuery = getActiveMentionQuery(value);
+  const matchingUsers = useMemo(() => {
+    if (mentionQuery === null || isPickerDismissed) return [];
+
+    const normalizedQuery = mentionQuery.toLowerCase();
+
+    return users
+      .filter((user) => getUserDisplayName(user).toLowerCase().includes(normalizedQuery))
+      .slice(0, 6);
+  }, [isPickerDismissed, mentionQuery, users]);
+
+  useEffect(() => {
+    setHighlightedIndex(0);
+    setIsPickerDismissed(false);
+  }, [mentionQuery]);
+
+  const insertMention = (user: CourseChatUser) => {
+    const mention = `@${getUserDisplayName(user)} `;
+    const nextValue = value.replace(/(^|\s)@([^\s@]*)$/, `$1${mention}`);
+    onChange(nextValue);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (!matchingUsers.length) return;
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setHighlightedIndex((current) => (current + 1) % matchingUsers.length);
+      return;
+    }
+
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setHighlightedIndex((current) => (current - 1 + matchingUsers.length) % matchingUsers.length);
+      return;
+    }
+
+    if (event.key === "Enter" || event.key === "Tab") {
+      event.preventDefault();
+      insertMention(matchingUsers[highlightedIndex]);
+      return;
+    }
+
+    if (event.key === "Escape") {
+      event.preventDefault();
+      setIsPickerDismissed(true);
+    }
+  };
+
+  return (
+    <div className="relative">
+      <Textarea
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        maxLength={maxLength}
+        className={className}
+      />
+      {matchingUsers.length > 0 && (
+        <div className="absolute bottom-full left-0 z-10 mb-2 w-72 rounded-xl border border-neutral-200 bg-background p-2 shadow-lg">
+          {matchingUsers.map((user, index) => {
+            const userName = getUserDisplayName(user);
+
+            return (
+              <button
+                key={user.id}
+                type="button"
+                className={cn(
+                  "flex w-full items-center gap-3 rounded-lg p-2 text-left hover:bg-neutral-50",
+                  index === highlightedIndex && "bg-neutral-50",
+                )}
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                  insertMention(user);
+                }}
+              >
+                <UserAvatar
+                  className="size-8"
+                  userName={userName}
+                  profilePictureUrl={user.avatarReference}
+                />
+                <span className="body-sm-md truncate text-neutral-950">{userName}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ChatMessage({ message, users }: { message: CourseChatMessage; users: CourseChatUser[] }) {
+  const authorName = `${message.user.firstName} ${message.user.lastName}`;
+
+  return (
+    <div className="flex gap-3">
+      <UserAvatar
+        className="size-9"
+        userName={authorName}
+        profilePictureUrl={message.user.avatarReference}
+      />
+      <div className="min-w-0 flex-1">
+        <div className="mb-1 flex flex-wrap items-center gap-x-2 gap-y-1">
+          <span className="body-sm-md text-neutral-950">{authorName}</span>
+          <span className="caption text-neutral-500">
+            {format(new Date(message.createdAt), "dd.MM.yyyy HH:mm")}
+          </span>
+        </div>
+        <div className="rounded-xl bg-neutral-100 px-4 py-3 text-neutral-950">
+          <p className="body-sm whitespace-pre-wrap break-words">
+            {renderMessageContent(message.content, users)}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function getUserDisplayName(user: CourseChatUser) {
+  return `${user.firstName} ${user.lastName}`;
+}
+
+function getActiveMentionQuery(value: string) {
+  const match = value.match(/(^|\s)@([^\s@]*)$/);
+
+  return match?.[2] ?? null;
+}
+
+function getMentionedUserIds(content: string, users: CourseChatUser[]) {
+  return users
+    .filter((user) => content.includes(`@${getUserDisplayName(user)}`))
+    .map((user) => user.id);
+}
+
+function renderMessageContent(content: string, users: CourseChatUser[]) {
+  const mentionLabels = users
+    .map((user) => `@${getUserDisplayName(user)}`)
+    .sort((a, b) => b.length - a.length);
+
+  if (!mentionLabels.length) return content;
+
+  const mentionRegex = new RegExp(`(${mentionLabels.map(escapeRegExp).join("|")})`, "g");
+
+  return content.split(mentionRegex).map((part, index) =>
+    mentionLabels.includes(part) ? (
+      <span key={`${part}-${index}`} className="font-medium text-primary-700">
+        {part}
+      </span>
+    ) : (
+      part
+    ),
+  );
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function EmptyState({ text }: { text: string }) {
+  return (
+    <div className="rounded-lg border border-dashed border-neutral-300 bg-background p-6 text-center">
+      <p className="body-sm text-neutral-600">{text}</p>
+    </div>
+  );
+}
+
+function MainFeedSkeleton() {
+  return (
+    <>
+      <Skeleton className="h-28 w-full" />
+      <Skeleton className="h-28 w-full" />
+      <Skeleton className="h-28 w-full" />
+    </>
+  );
+}
+
+function MessagesSkeleton() {
+  return (
+    <>
+      <Skeleton className="h-16 w-3/4" />
+      <Skeleton className="ml-auto h-16 w-2/3" />
+    </>
+  );
+}

--- a/apps/web/app/modules/Courses/CourseView/CourseChat/MainThreadMessage.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseChat/MainThreadMessage.tsx
@@ -1,0 +1,100 @@
+import { format } from "date-fns";
+import { MessagesSquare, Send } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { Button } from "~/components/ui/button";
+
+import { ChatMessage } from "./ChatMessage";
+import { MessagesSkeleton } from "./CourseChatStates";
+import { MentionTextarea } from "./MentionTextarea";
+
+import type { FormEvent } from "react";
+import type {
+  CourseChatMessage as CourseChatMessageType,
+  CourseChatThread,
+  CourseChatUser,
+} from "~/api/queries/course-chat/useCourseChat";
+
+type MainThreadMessageProps = {
+  thread: CourseChatThread;
+  isOpen: boolean;
+  isLoadingReplies: boolean;
+  replies: CourseChatMessageType[];
+  users: CourseChatUser[];
+  mentionableUsers: CourseChatUser[];
+  replyContent: string;
+  isSendingReply: boolean;
+  onToggle: () => void;
+  onReplyChange: (value: string) => void;
+  onReplySubmit: (event: FormEvent<HTMLFormElement>) => void;
+};
+
+export function MainThreadMessage({
+  thread,
+  isOpen,
+  isLoadingReplies,
+  replies,
+  users,
+  mentionableUsers,
+  replyContent,
+  isSendingReply,
+  onToggle,
+  onReplyChange,
+  onReplySubmit,
+}: MainThreadMessageProps) {
+  const { t } = useTranslation();
+  const replyCount = Math.max(thread.messageCount - 1, 0);
+
+  return (
+    <article className="rounded-xl border border-neutral-200 bg-background p-4 shadow-sm">
+      <ChatMessage message={thread.rootMessage} users={users} />
+
+      <div className="mt-3 flex flex-wrap items-center gap-3 pl-11">
+        <Button type="button" variant="ghost" size="sm" className="gap-2" onClick={onToggle}>
+          <MessagesSquare className="size-4" />
+          {replyCount
+            ? t("studentCourseView.courseChat.repliesCount", { count: replyCount })
+            : t("studentCourseView.courseChat.reply")}
+        </Button>
+        {thread.latestMessage && thread.latestMessage.id !== thread.rootMessage.id && (
+          <span className="caption text-neutral-500">
+            {format(new Date(thread.latestMessage.createdAt), "dd.MM.yyyy HH:mm")}
+          </span>
+        )}
+      </div>
+
+      {isOpen && (
+        <div className="mt-4 border-l-2 border-primary-100 pl-4 md:ml-11">
+          <div className="flex flex-col gap-4">
+            {isLoadingReplies ? (
+              <MessagesSkeleton />
+            ) : replies.length ? (
+              replies.map((message) => (
+                <ChatMessage key={message.id} message={message} users={users} />
+              ))
+            ) : null}
+
+            <form className="flex flex-col gap-3" onSubmit={onReplySubmit}>
+              <MentionTextarea
+                value={replyContent}
+                onChange={onReplyChange}
+                users={mentionableUsers}
+                placeholder={t("studentCourseView.courseChat.replyPlaceholder")}
+                maxLength={5000}
+                className="min-h-[80px] resize-none"
+              />
+              <Button
+                type="submit"
+                className="self-end gap-2"
+                disabled={!replyContent.trim() || isSendingReply}
+              >
+                <Send className="size-4" />
+                {t("studentCourseView.courseChat.send")}
+              </Button>
+            </form>
+          </div>
+        </div>
+      )}
+    </article>
+  );
+}

--- a/apps/web/app/modules/Courses/CourseView/CourseChat/MentionTextarea.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseChat/MentionTextarea.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { Textarea } from "~/components/ui/textarea";
+import { UserAvatar } from "~/components/UserProfile/UserAvatar";
+import { cn } from "~/lib/utils";
+
+import { getActiveMentionQuery, getUserDisplayName } from "./courseChatUtils";
+
+import type { KeyboardEvent } from "react";
+import type { CourseChatUser } from "~/api/queries/course-chat/useCourseChat";
+
+type MentionTextareaProps = {
+  value: string;
+  onChange: (value: string) => void;
+  onKeyDown?: (event: KeyboardEvent<HTMLTextAreaElement>) => void;
+  users: CourseChatUser[];
+  placeholder: string;
+  maxLength: number;
+  className?: string;
+};
+
+export function MentionTextarea({
+  value,
+  onChange,
+  onKeyDown,
+  users,
+  placeholder,
+  maxLength,
+  className,
+}: MentionTextareaProps) {
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+  const [isPickerDismissed, setIsPickerDismissed] = useState(false);
+  const mentionQuery = getActiveMentionQuery(value);
+  const matchingUsers = useMemo(() => {
+    if (mentionQuery === null || isPickerDismissed) return [];
+
+    const normalizedQuery = mentionQuery.toLowerCase();
+
+    return users
+      .filter((user) => getUserDisplayName(user).toLowerCase().includes(normalizedQuery))
+      .slice(0, 6);
+  }, [isPickerDismissed, mentionQuery, users]);
+
+  useEffect(() => {
+    setHighlightedIndex(0);
+    setIsPickerDismissed(false);
+  }, [mentionQuery]);
+
+  const insertMention = (user: CourseChatUser) => {
+    const mention = `@${getUserDisplayName(user)} `;
+    const nextValue = value.replace(/(^|\s)@([^\s@]*)$/, `$1${mention}`);
+    onChange(nextValue);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    onKeyDown?.(event);
+    if (event.defaultPrevented) return;
+
+    if (!matchingUsers.length) return;
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setHighlightedIndex((current) => (current + 1) % matchingUsers.length);
+      return;
+    }
+
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setHighlightedIndex((current) => (current - 1 + matchingUsers.length) % matchingUsers.length);
+      return;
+    }
+
+    if (event.key === "Enter" || event.key === "Tab") {
+      event.preventDefault();
+      insertMention(matchingUsers[highlightedIndex]);
+      return;
+    }
+
+    if (event.key === "Escape") {
+      event.preventDefault();
+      setIsPickerDismissed(true);
+    }
+  };
+
+  return (
+    <div className="relative">
+      <Textarea
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        maxLength={maxLength}
+        className={className}
+      />
+      {matchingUsers.length > 0 && (
+        <div className="absolute bottom-full left-0 z-10 mb-2 w-72 rounded-xl border border-neutral-200 bg-background p-2 shadow-lg">
+          {matchingUsers.map((user, index) => {
+            const userName = getUserDisplayName(user);
+
+            return (
+              <button
+                key={user.id}
+                type="button"
+                className={cn(
+                  "flex w-full items-center gap-3 rounded-lg p-2 text-left hover:bg-neutral-50",
+                  index === highlightedIndex && "bg-neutral-50",
+                )}
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                  insertMention(user);
+                }}
+              >
+                <UserAvatar
+                  className="size-8"
+                  userName={userName}
+                  profilePictureUrl={user.avatarReference}
+                />
+                <span className="body-sm-md truncate text-neutral-950">{userName}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/modules/Courses/CourseView/CourseChat/ReactionButton.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseChat/ReactionButton.tsx
@@ -1,0 +1,32 @@
+import { cn } from "~/lib/utils";
+
+type ReactionButtonProps = {
+  reaction: string;
+  count?: number;
+  reactedByCurrentUser?: boolean;
+  disabled: boolean;
+  onClick: () => void;
+};
+
+export function ReactionButton({
+  reaction,
+  count,
+  reactedByCurrentUser,
+  disabled,
+  onClick,
+}: ReactionButtonProps) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        "caption rounded-full border border-neutral-200 bg-background px-2 py-1 transition hover:border-primary-200 hover:bg-primary-50",
+        reactedByCurrentUser && "border-primary-300 bg-primary-50 text-primary-700",
+      )}
+      disabled={disabled}
+      onClick={onClick}
+    >
+      <span aria-hidden>{reaction}</span>
+      {count ? <span className="ml-1">{count}</span> : null}
+    </button>
+  );
+}

--- a/apps/web/app/modules/Courses/CourseView/CourseChat/courseChatUtils.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseChat/courseChatUtils.tsx
@@ -1,0 +1,41 @@
+import type { CourseChatUser } from "~/api/queries/course-chat/useCourseChat";
+
+export function getUserDisplayName(user: CourseChatUser) {
+  return `${user.firstName} ${user.lastName}`;
+}
+
+export function getActiveMentionQuery(value: string) {
+  const match = value.match(/(^|\s)@([^\s@]*)$/);
+
+  return match?.[2] ?? null;
+}
+
+export function getMentionedUserIds(content: string, users: CourseChatUser[]) {
+  return users
+    .filter((user) => content.includes(`@${getUserDisplayName(user)}`))
+    .map((user) => user.id);
+}
+
+export function renderMessageContent(content: string, users: CourseChatUser[]) {
+  const mentionLabels = users
+    .map((user) => `@${getUserDisplayName(user)}`)
+    .sort((a, b) => b.length - a.length);
+
+  if (!mentionLabels.length) return content;
+
+  const mentionRegex = new RegExp(`(${mentionLabels.map(escapeRegExp).join("|")})`, "g");
+
+  return content.split(mentionRegex).map((part, index) =>
+    mentionLabels.includes(part) ? (
+      <span key={`${part}-${index}`} className="font-medium text-primary-700">
+        {part}
+      </span>
+    ) : (
+      part
+    ),
+  );
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/apps/web/app/modules/Courses/CourseView/CourseChat/useCourseChatSocket.ts
+++ b/apps/web/app/modules/Courses/CourseView/CourseChat/useCourseChatSocket.ts
@@ -2,8 +2,10 @@ import { useEffect } from "react";
 
 import {
   type CourseChatMessage,
+  type CourseChatMessageReactionsUpdated,
   type CreateCourseChatThreadResponse,
   updateCourseChatUserPresence,
+  updateMessageReactionsInCache,
   upsertMessageInCache,
   upsertThreadInCache,
 } from "~/api/queries/course-chat/useCourseChat";
@@ -16,6 +18,7 @@ const COURSE_CHAT_SOCKET_EVENTS = {
   THREAD_CREATED: "course-chat:thread-created",
   USER_PRESENCE_CHANGED: "course-chat:user-presence-changed",
   USER_MENTIONED: "course-chat:user-mentioned",
+  MESSAGE_REACTIONS_UPDATED: "course-chat:message-reactions-updated",
 } as const;
 
 type PresenceChangedPayload = {
@@ -56,12 +59,16 @@ export function useCourseChatSocket({
     const handleMentioned = (payload: MentionedPayload) => {
       if (payload.courseId === courseId) onMentioned?.(payload);
     };
+    const handleMessageReactionsUpdated = (payload: CourseChatMessageReactionsUpdated) => {
+      if (payload.courseId === courseId) updateMessageReactionsInCache(payload);
+    };
 
     socket.on("connect", joinRoom);
     socket.on(COURSE_CHAT_SOCKET_EVENTS.MESSAGE_CREATED, handleMessageCreated);
     socket.on(COURSE_CHAT_SOCKET_EVENTS.THREAD_CREATED, handleThreadCreated);
     socket.on(COURSE_CHAT_SOCKET_EVENTS.USER_PRESENCE_CHANGED, handlePresenceChanged);
     socket.on(COURSE_CHAT_SOCKET_EVENTS.USER_MENTIONED, handleMentioned);
+    socket.on(COURSE_CHAT_SOCKET_EVENTS.MESSAGE_REACTIONS_UPDATED, handleMessageReactionsUpdated);
     socket.connect();
 
     if (socket.connected) joinRoom();
@@ -73,6 +80,10 @@ export function useCourseChatSocket({
       socket.off(COURSE_CHAT_SOCKET_EVENTS.THREAD_CREATED, handleThreadCreated);
       socket.off(COURSE_CHAT_SOCKET_EVENTS.USER_PRESENCE_CHANGED, handlePresenceChanged);
       socket.off(COURSE_CHAT_SOCKET_EVENTS.USER_MENTIONED, handleMentioned);
+      socket.off(
+        COURSE_CHAT_SOCKET_EVENTS.MESSAGE_REACTIONS_UPDATED,
+        handleMessageReactionsUpdated,
+      );
       releaseSocket();
     };
   }, [courseId, enabled, onMentioned]);

--- a/apps/web/app/modules/Courses/CourseView/CourseChat/useCourseChatSocket.ts
+++ b/apps/web/app/modules/Courses/CourseView/CourseChat/useCourseChatSocket.ts
@@ -1,0 +1,79 @@
+import { useEffect } from "react";
+
+import {
+  type CourseChatMessage,
+  type CreateCourseChatThreadResponse,
+  updateCourseChatUserPresence,
+  upsertMessageInCache,
+  upsertThreadInCache,
+} from "~/api/queries/course-chat/useCourseChat";
+import { acquireSocket, releaseSocket } from "~/api/socket";
+
+const COURSE_CHAT_SOCKET_EVENTS = {
+  JOIN: "join:course-chat",
+  LEAVE: "leave:course-chat",
+  MESSAGE_CREATED: "course-chat:message-created",
+  THREAD_CREATED: "course-chat:thread-created",
+  USER_PRESENCE_CHANGED: "course-chat:user-presence-changed",
+  USER_MENTIONED: "course-chat:user-mentioned",
+} as const;
+
+type PresenceChangedPayload = {
+  courseId: string;
+  userId: string;
+  isOnline: boolean;
+};
+
+type MentionedPayload = {
+  courseId: string;
+  message: CourseChatMessage;
+};
+
+export function useCourseChatSocket({
+  courseId,
+  enabled,
+  onMentioned,
+}: {
+  courseId: string;
+  enabled: boolean;
+  onMentioned?: (payload: MentionedPayload) => void;
+}) {
+  useEffect(() => {
+    if (!enabled || !courseId) return;
+
+    const socket = acquireSocket();
+    const joinRoom = () => socket.emit(COURSE_CHAT_SOCKET_EVENTS.JOIN, { courseId });
+    const leaveRoom = () => socket.emit(COURSE_CHAT_SOCKET_EVENTS.LEAVE, { courseId });
+    const handleMessageCreated = (message: CourseChatMessage) => {
+      if (message.courseId === courseId) upsertMessageInCache(message);
+    };
+    const handleThreadCreated = ({ thread }: CreateCourseChatThreadResponse) => {
+      if (thread.courseId === courseId) upsertThreadInCache(thread);
+    };
+    const handlePresenceChanged = (payload: PresenceChangedPayload) => {
+      if (payload.courseId === courseId) updateCourseChatUserPresence(payload);
+    };
+    const handleMentioned = (payload: MentionedPayload) => {
+      if (payload.courseId === courseId) onMentioned?.(payload);
+    };
+
+    socket.on("connect", joinRoom);
+    socket.on(COURSE_CHAT_SOCKET_EVENTS.MESSAGE_CREATED, handleMessageCreated);
+    socket.on(COURSE_CHAT_SOCKET_EVENTS.THREAD_CREATED, handleThreadCreated);
+    socket.on(COURSE_CHAT_SOCKET_EVENTS.USER_PRESENCE_CHANGED, handlePresenceChanged);
+    socket.on(COURSE_CHAT_SOCKET_EVENTS.USER_MENTIONED, handleMentioned);
+    socket.connect();
+
+    if (socket.connected) joinRoom();
+
+    return () => {
+      leaveRoom();
+      socket.off("connect", joinRoom);
+      socket.off(COURSE_CHAT_SOCKET_EVENTS.MESSAGE_CREATED, handleMessageCreated);
+      socket.off(COURSE_CHAT_SOCKET_EVENTS.THREAD_CREATED, handleThreadCreated);
+      socket.off(COURSE_CHAT_SOCKET_EVENTS.USER_PRESENCE_CHANGED, handlePresenceChanged);
+      socket.off(COURSE_CHAT_SOCKET_EVENTS.USER_MENTIONED, handleMentioned);
+      releaseSocket();
+    };
+  }, [courseId, enabled, onMentioned]);
+}

--- a/apps/web/app/modules/Courses/CourseView/CourseView.page.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseView.page.tsx
@@ -22,6 +22,7 @@ import { isSupportedLanguage } from "~/utils/browser-language";
 import { ChapterListOverview } from "./components/ChapterListOverview";
 import { CourseAdminStatistics } from "./CourseAdminStatistics/CourseAdminStatistics";
 import CourseCertificate from "./CourseCertificate";
+import { CourseChatTab } from "./CourseChat/CourseChatTab";
 
 import type { SupportedLanguages } from "@repo/shared";
 
@@ -100,13 +101,26 @@ export default function CourseViewPage() {
   const courseViewTabs = useMemo(
     () => [
       {
+        value: "chapters",
         title: t("studentCourseView.tabs.chapters"),
         itemCount: course?.chapters?.length,
         content: <ChapterListOverview />,
         isForAdminLike: false,
         isForUnregistered: true,
+        isForEnrolled: false,
       },
       {
+        value: "chat",
+        title: t("studentCourseView.tabs.chat"),
+        content: (
+          <CourseChatTab courseId={course?.id ?? ""} currentUserId={currentUser?.id ?? ""} />
+        ),
+        isForAdminLike: false,
+        isForUnregistered: false,
+        isForEnrolled: true,
+      },
+      {
+        value: "moreFromAuthor",
         title: t("studentCourseView.tabs.moreFromAuthor"),
         content: (
           <div className="flex flex-col gap-6">
@@ -116,15 +130,18 @@ export default function CourseViewPage() {
         ),
         isForAdminLike: false,
         isForUnregistered: false,
+        isForEnrolled: false,
       },
       {
+        value: "statistics",
         title: t("studentCourseView.tabs.statistics"),
         content: <CourseAdminStatistics course={course} />,
         isForAdminLike: true,
         isForUnregistered: false,
+        isForEnrolled: false,
       },
     ],
-    [t, course],
+    [t, course, currentUser?.id],
   );
 
   if (!course) return null;
@@ -137,11 +154,12 @@ export default function CourseViewPage() {
     { title: course.title, href: `/course/${id}` },
   ];
 
-  const canView = (isForAdminLike: boolean, isForUnregistered: boolean) => {
+  const canView = (isForAdminLike: boolean, isForUnregistered: boolean, isForEnrolled: boolean) => {
     const hideForAdmin = isForAdminLike && (!canViewCourseStatistics || !currentUser);
     const hideWhenUnregistered = !isForUnregistered && !currentUser;
+    const hideWhenNotEnrolled = isForEnrolled && !course.enrolled;
 
-    return !(hideForAdmin || hideWhenUnregistered);
+    return !(hideForAdmin || hideWhenUnregistered || hideWhenNotEnrolled);
   };
 
   return (
@@ -154,17 +172,17 @@ export default function CourseViewPage() {
 
               <CourseCertificate courseId={course.id} />
 
-              <Tabs defaultValue={courseViewTabs[0].title} className="w-full">
+              <Tabs defaultValue={courseViewTabs[0].value} className="w-full">
                 <TabsList className="bg-card w-full justify-start gap-4 p-0 overflow-hidden">
                   {courseViewTabs.map((tab) => {
-                    const { title, isForAdminLike, isForUnregistered } = tab;
+                    const { value, title, isForAdminLike, isForUnregistered, isForEnrolled } = tab;
 
-                    if (!canView(isForAdminLike, isForUnregistered)) return null;
+                    if (!canView(isForAdminLike, isForUnregistered, isForEnrolled)) return null;
 
                     return (
                       <TabsTrigger
-                        key={title}
-                        value={title}
+                        key={value}
+                        value={value}
                         className="flex h-full rounded-none items-center gap-1.5 data-[state=active]:shadow-none text-neutral-900 data-[state=active]:text-primary-700 data-[state=active]:border-b-2 data-[state=active]:border-b-primary-700"
                       >
                         <span className="body-sm">{title}</span>{" "}
@@ -178,14 +196,14 @@ export default function CourseViewPage() {
                   })}
                 </TabsList>
                 {courseViewTabs.map((tab) => {
-                  const { title, isForAdminLike, content, isForUnregistered } = tab;
+                  const { value, isForAdminLike, content, isForUnregistered, isForEnrolled } = tab;
 
-                  if (!canView(isForAdminLike, isForUnregistered)) return null;
+                  if (!canView(isForAdminLike, isForUnregistered, isForEnrolled)) return null;
 
                   return (
                     <TabsContent
-                      key={title}
-                      value={title}
+                      key={value}
+                      value={value}
                       className={cn({
                         "data-[state=active]:mt-6": true,
                       })}

--- a/packages/prompts/src/generated-prompts.ts
+++ b/packages/prompts/src/generated-prompts.ts
@@ -1,5 +1,5 @@
 /* AUTO-GENERATED FILE - DO NOT EDIT BY HAND */
-/* Generated At: 4/16/2026, 5:33:02 PM */
+/* Generated At: 29/04/2026, 12:10:38 */
 
 export const promptTemplates = {
   judgePrompt: {


### PR DESCRIPTION
## Issue(s)
[](https://github.com/Selleo/mentingo/issues/)

## Overview
Adds a real-time course chat feature accessible from the course view. Students enrolled in a course can create threaded discussions, reply to threads, react to messages with emojis, attach images, and @mention other participants.

Key parts:
- **Threaded model** — each post creates a thread; replies are nested under it
- **Real-time via WebSockets** — new threads, replies, reactions, and presence changes are pushed to all connected clients instantly
- **@mention system** — typing `@Name` surfaces a user picker; mentioned users receive an in-app socket notification and an email
- **Emoji reactions** — 5 reactions (👍 ❤️ 😂 🎉 😮); toggling an existing reaction removes it
- **Image attachments** — up to 5 images per message (JPEG, PNG, WebP, GIF; max 10 MB each)
- **User presence panel** — collapsible sidebar showing all enrolled users with live online/offline status

## Business Value
Live communication between students inside a course reduces friction and increases engagement — learners can ask questions, share progress, and collaborate without leaving the platform. The @mention + email notification loop ensures no one misses important messages even when offline. Threaded discussions keep conversations organized as course participation grows.




## Screenshots / Video

https://github.com/user-attachments/assets/d561eaed-aef0-4647-8673-b65ff25f7795


<img width="1764" height="1048" alt="image" src="https://github.com/user-attachments/assets/bdd77c76-b291-48b9-8cb0-6239f3986272" />
<img width="1744" height="844" alt="image" src="https://github.com/user-attachments/assets/f2e1f11f-023b-40ba-a06b-96f5ffe5c59e" />

<!-- ## Testing prerequisites




## Testing scenarios

- [ ] A
- [ ] B
- [ ] C 

# Video showing the complete working flow of the feature / enhancement / bug-fix included in this code change.
-->

### Notes 

- [ ] Fired up e2e tests and got a positive result
