### PR TITLE
feat: add integration endpoint for retrieving student progress

### DIFF
--- a/apps/api/src/integration/__tests__/integration.controller.e2e-spec.ts
+++ b/apps/api/src/integration/__tests__/integration.controller.e2e-spec.ts
@@ -636,6 +636,20 @@ describe("IntegrationController (e2e)", () => {
         perPage: 1,
       });
 
+      const tenantStudentFilterResponse = await request(app.getHttpServer())
+        .get("/api/integration/training-results")
+        .set("X-API-Key", apiKey)
+        .set("X-Tenant-Id", admin.tenantId)
+        .query({ scope: "tenant", studentId: studentOne.id })
+        .expect(200);
+
+      expect(tenantStudentFilterResponse.body.data).toHaveLength(1);
+      expect(tenantStudentFilterResponse.body.pagination).toEqual({
+        totalItems: 1,
+        page: 1,
+        perPage: 20,
+      });
+
       const studentResponse = await request(app.getHttpServer())
         .get("/api/integration/training-results")
         .set("X-API-Key", apiKey)
@@ -698,6 +712,40 @@ describe("IntegrationController (e2e)", () => {
               certificate: expect.objectContaining({ status: "not_issued" }),
             }),
           ],
+        }),
+      );
+
+      const courseStudentFilterResponse = await request(app.getHttpServer())
+        .get("/api/integration/training-results")
+        .set("X-API-Key", apiKey)
+        .set("X-Tenant-Id", admin.tenantId)
+        .query({ scope: "course", courseId, studentId: studentOne.id })
+        .expect(200);
+
+      expect(courseStudentFilterResponse.body.data).toHaveLength(1);
+      expect(courseStudentFilterResponse.body.data[0]).toEqual(
+        expect.objectContaining({
+          scope: "course",
+          tenantId: admin.tenantId,
+          student: expect.objectContaining({ id: studentOne.id }),
+          courses: [expect.objectContaining({ id: courseId })],
+        }),
+      );
+
+      const courseStudentTwoFilterResponse = await request(app.getHttpServer())
+        .get("/api/integration/training-results")
+        .set("X-API-Key", apiKey)
+        .set("X-Tenant-Id", admin.tenantId)
+        .query({ scope: "student", studentId: studentTwo.id, courseId })
+        .expect(200);
+
+      expect(courseStudentTwoFilterResponse.body.data).toHaveLength(1);
+      expect(courseStudentTwoFilterResponse.body.data[0]).toEqual(
+        expect.objectContaining({
+          scope: "student",
+          tenantId: admin.tenantId,
+          student: expect.objectContaining({ id: studentTwo.id }),
+          courses: [expect.objectContaining({ id: courseId })],
         }),
       );
     });

--- a/apps/api/src/integration/__tests__/integration.controller.e2e-spec.ts
+++ b/apps/api/src/integration/__tests__/integration.controller.e2e-spec.ts
@@ -1,12 +1,24 @@
 import { randomUUID } from "node:crypto";
 
-import { SYSTEM_ROLE_SLUGS } from "@repo/shared";
+import { COURSE_ENROLLMENT, SYSTEM_ROLE_SLUGS } from "@repo/shared";
 import { and, eq, isNull } from "drizzle-orm";
 import request from "supertest";
 
+import { buildJsonbField } from "src/common/helpers/sqlHelpers";
+import { LESSON_SEQUENCE_ENABLED, QUIZ_FEEDBACK_ENABLED } from "src/courses/constants";
 import { RATE_LIMITS } from "src/rate-limit/rate-limit.constants";
 import { DB, DB_ADMIN } from "src/storage/db/db.providers";
-import { integrationApiKeys, tenants } from "src/storage/schema";
+import {
+  categories,
+  certificates,
+  chapters,
+  courses,
+  integrationApiKeys,
+  lessons,
+  studentCourses,
+  studentLessonProgress,
+  tenants,
+} from "src/storage/schema";
 
 import { createE2ETest } from "../../../test/create-e2e-test";
 import { createGroupFactory } from "../../../test/factory/group.factory";
@@ -159,10 +171,15 @@ describe("IntegrationController (e2e)", () => {
         .set("X-Tenant-Id", admin.tenantId)
         .expect(200);
 
-      expect(response.body.data).toHaveLength(1);
-      expect(response.body.data[0].id).toBe(group.id);
-      expect(response.body.data[0].name).toBe(group.name);
-      expect(response.body.pagination.totalItems).toBe(1);
+      expect(response.body.data).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: group.id,
+            name: group.name,
+          }),
+        ]),
+      );
+      expect(response.body.pagination.totalItems).toBeGreaterThanOrEqual(1);
     });
 
     it("returns 401 when X-Tenant-Id header is missing for non-tenant-list endpoint", async () => {
@@ -343,6 +360,484 @@ describe("IntegrationController (e2e)", () => {
         .set("X-API-Key", apiKey)
         .set("X-Tenant-Id", otherTenantId)
         .expect(200);
+    });
+  });
+
+  describe("integration training results endpoint", () => {
+    it("returns per-student-per-course rows with scope-based filtering", async () => {
+      const admin = await userFactory
+        .withCredentials({ password })
+        .withAdminSettings(db)
+        .create({ role: SYSTEM_ROLE_SLUGS.ADMIN });
+      const cookies = await cookieFor(admin, app);
+
+      const [studentOne, studentTwo] = await Promise.all([
+        userFactory.create({ role: SYSTEM_ROLE_SLUGS.STUDENT, tenantId: admin.tenantId }),
+        userFactory.create({ role: SYSTEM_ROLE_SLUGS.STUDENT, tenantId: admin.tenantId }),
+      ]);
+
+      const chapterId = randomUUID();
+      const categoryId = randomUUID();
+      const courseId = randomUUID();
+      const lessonOneId = randomUUID();
+      const lessonTwoId = randomUUID();
+      const now = new Date().toISOString();
+      const categoryTitle = `Integration category ${randomUUID()}`;
+
+      await db.insert(categories).values({
+        id: categoryId,
+        title: categoryTitle,
+        tenantId: admin.tenantId,
+      });
+
+      await db.insert(courses).values({
+        id: courseId,
+        title: { en: "Integration course" },
+        description: {},
+        status: "published",
+        hasCertificate: true,
+        authorId: admin.id,
+        categoryId,
+        settings: {
+          lessonSequenceEnabled: LESSON_SEQUENCE_ENABLED,
+          quizFeedbackEnabled: QUIZ_FEEDBACK_ENABLED,
+          certificateSignature: null,
+          certificateFontColor: null,
+        },
+        tenantId: admin.tenantId,
+      });
+
+      await db.insert(chapters).values({
+        id: chapterId,
+        title: {},
+        courseId,
+        authorId: admin.id,
+        isFreemium: false,
+        displayOrder: 1,
+        lessonCount: 2,
+        tenantId: admin.tenantId,
+      });
+
+      await db.insert(lessons).values([
+        {
+          id: lessonOneId,
+          chapterId,
+          type: "quiz",
+          title: { en: "Quiz lesson" },
+          thresholdScore: 50,
+          displayOrder: 1,
+          tenantId: admin.tenantId,
+        },
+        {
+          id: lessonTwoId,
+          chapterId,
+          type: "text",
+          title: { en: "Text lesson" },
+          displayOrder: 2,
+          tenantId: admin.tenantId,
+        },
+      ]);
+
+      await db.insert(studentCourses).values([
+        {
+          studentId: studentOne.id,
+          courseId,
+          status: COURSE_ENROLLMENT.ENROLLED,
+          tenantId: admin.tenantId,
+        },
+        {
+          studentId: studentTwo.id,
+          courseId,
+          status: COURSE_ENROLLMENT.ENROLLED,
+          tenantId: admin.tenantId,
+        },
+      ]);
+
+      await db.insert(studentLessonProgress).values([
+        {
+          studentId: studentOne.id,
+          chapterId,
+          lessonId: lessonOneId,
+          quizScore: 80,
+          attempts: 1,
+          isQuizPassed: true,
+          completedQuestionCount: 1,
+          completedAt: now,
+          tenantId: admin.tenantId,
+        },
+        {
+          studentId: studentTwo.id,
+          chapterId,
+          lessonId: lessonOneId,
+          quizScore: 40,
+          attempts: 2,
+          isQuizPassed: false,
+          completedQuestionCount: 1,
+          completedAt: now,
+          tenantId: admin.tenantId,
+        },
+        {
+          studentId: studentTwo.id,
+          chapterId,
+          lessonId: lessonTwoId,
+          completedQuestionCount: 1,
+          completedAt: now,
+          tenantId: admin.tenantId,
+        },
+      ]);
+
+      await db.insert(certificates).values({
+        userId: studentOne.id,
+        courseId,
+        tenantId: admin.tenantId,
+      });
+
+      const rotateResponse = await request(app.getHttpServer())
+        .post("/api/integration/key")
+        .set("Cookie", cookies)
+        .expect(201);
+
+      const apiKey = rotateResponse.body.data.key as string;
+
+      const tenantResponse = await request(app.getHttpServer())
+        .get("/api/integration/training-results")
+        .set("X-API-Key", apiKey)
+        .set("X-Tenant-Id", admin.tenantId)
+        .query({ scope: "tenant" })
+        .expect(200);
+
+      expect(tenantResponse.body.data).toHaveLength(2);
+      expect(tenantResponse.body.pagination).toEqual({
+        totalItems: 2,
+        page: 1,
+        perPage: 20,
+      });
+      const tenantStudentOneRow = tenantResponse.body.data.find(
+        (row: { student: { id: string }; courses: { id: string }[] }) =>
+          row.student.id === studentOne.id && row.courses.some((course) => course.id === courseId),
+      );
+      const tenantStudentTwoRow = tenantResponse.body.data.find(
+        (row: { student: { id: string }; courses: { id: string }[] }) =>
+          row.student.id === studentTwo.id && row.courses.some((course) => course.id === courseId),
+      );
+
+      expect(tenantStudentOneRow).toEqual(
+        expect.objectContaining({
+          scope: "tenant",
+          tenantId: admin.tenantId,
+          student: expect.objectContaining({
+            id: studentOne.id,
+            email: studentOne.email,
+          }),
+          courses: [
+            expect.objectContaining({
+              id: courseId,
+              title: expect.any(String),
+              certificate: {
+                enabled: true,
+                status: "issued",
+                issuedAt: expect.any(String),
+              },
+            }),
+          ],
+        }),
+      );
+      expect(tenantStudentOneRow.courses[0].lessons).toEqual([
+        {
+          lessonId: lessonOneId,
+          chapterId,
+          title: expect.any(String),
+          type: "quiz",
+          completed: true,
+          completedAt: expect.any(String),
+        },
+        {
+          lessonId: lessonTwoId,
+          chapterId,
+          title: expect.any(String),
+          type: "text",
+          completed: false,
+          completedAt: null,
+        },
+      ]);
+      expect(tenantStudentOneRow.courses[0].quizzes).toEqual([
+        {
+          lessonId: lessonOneId,
+          chapterId,
+          title: expect.any(String),
+          score: 80,
+          passed: true,
+          attempts: 1,
+          completedAt: expect.any(String),
+        },
+      ]);
+
+      expect(tenantStudentTwoRow).toEqual(
+        expect.objectContaining({
+          scope: "tenant",
+          tenantId: admin.tenantId,
+          student: expect.objectContaining({
+            id: studentTwo.id,
+            email: studentTwo.email,
+          }),
+          courses: [
+            expect.objectContaining({
+              id: courseId,
+              title: expect.any(String),
+              certificate: {
+                enabled: true,
+                status: "not_issued",
+                issuedAt: null,
+              },
+            }),
+          ],
+        }),
+      );
+      expect(tenantStudentTwoRow.courses[0].lessons).toEqual([
+        {
+          lessonId: lessonOneId,
+          chapterId,
+          title: expect.any(String),
+          type: "quiz",
+          completed: true,
+          completedAt: expect.any(String),
+        },
+        {
+          lessonId: lessonTwoId,
+          chapterId,
+          title: expect.any(String),
+          type: "text",
+          completed: true,
+          completedAt: expect.any(String),
+        },
+      ]);
+      expect(tenantStudentTwoRow.courses[0].quizzes).toEqual([
+        {
+          lessonId: lessonOneId,
+          chapterId,
+          title: expect.any(String),
+          score: 40,
+          passed: false,
+          attempts: 2,
+          completedAt: expect.any(String),
+        },
+      ]);
+      const paginatedTenantResponse = await request(app.getHttpServer())
+        .get("/api/integration/training-results")
+        .set("X-API-Key", apiKey)
+        .set("X-Tenant-Id", admin.tenantId)
+        .query({ scope: "tenant", page: 2, perPage: 1 })
+        .expect(200);
+
+      expect(paginatedTenantResponse.body.data).toHaveLength(1);
+      expect(paginatedTenantResponse.body.pagination).toEqual({
+        totalItems: 2,
+        page: 2,
+        perPage: 1,
+      });
+
+      const studentResponse = await request(app.getHttpServer())
+        .get("/api/integration/training-results")
+        .set("X-API-Key", apiKey)
+        .set("X-Tenant-Id", admin.tenantId)
+        .query({ scope: "student", studentId: studentOne.id })
+        .expect(200);
+
+      expect(studentResponse.body.data).toHaveLength(1);
+      expect(studentResponse.body.data[0]).toEqual(
+        expect.objectContaining({
+          scope: "student",
+          tenantId: admin.tenantId,
+          student: expect.objectContaining({ id: studentOne.id }),
+          courses: [
+            expect.objectContaining({
+              id: courseId,
+              certificate: expect.objectContaining({ status: "issued" }),
+            }),
+          ],
+        }),
+      );
+
+      const courseResponse = await request(app.getHttpServer())
+        .get("/api/integration/training-results")
+        .set("X-API-Key", apiKey)
+        .set("X-Tenant-Id", admin.tenantId)
+        .query({ scope: "course", courseId })
+        .expect(200);
+
+      expect(courseResponse.body.data).toHaveLength(2);
+      const courseStudentOneRow = courseResponse.body.data.find(
+        (row: { student: { id: string } }) => row.student.id === studentOne.id,
+      );
+      const courseStudentTwoRow = courseResponse.body.data.find(
+        (row: { student: { id: string } }) => row.student.id === studentTwo.id,
+      );
+
+      expect(courseStudentOneRow).toEqual(
+        expect.objectContaining({
+          scope: "course",
+          tenantId: admin.tenantId,
+          student: expect.objectContaining({ id: studentOne.id }),
+          courses: [
+            expect.objectContaining({
+              id: courseId,
+              certificate: expect.objectContaining({ status: "issued" }),
+            }),
+          ],
+        }),
+      );
+
+      expect(courseStudentTwoRow).toEqual(
+        expect.objectContaining({
+          scope: "course",
+          tenantId: admin.tenantId,
+          student: expect.objectContaining({ id: studentTwo.id }),
+          courses: [
+            expect.objectContaining({
+              id: courseId,
+              certificate: expect.objectContaining({ status: "not_issued" }),
+            }),
+          ],
+        }),
+      );
+    });
+
+    it("returns 400 when scope-specific required filter is missing", async () => {
+      const admin = await userFactory
+        .withCredentials({ password })
+        .withAdminSettings(db)
+        .create({ role: SYSTEM_ROLE_SLUGS.ADMIN });
+      const cookies = await cookieFor(admin, app);
+
+      const rotateResponse = await request(app.getHttpServer())
+        .post("/api/integration/key")
+        .set("Cookie", cookies)
+        .expect(201);
+
+      const apiKey = rotateResponse.body.data.key as string;
+
+      await request(app.getHttpServer())
+        .get("/api/integration/training-results")
+        .set("X-API-Key", apiKey)
+        .set("X-Tenant-Id", admin.tenantId)
+        .query({ scope: "student" })
+        .expect(400);
+
+      await request(app.getHttpServer())
+        .get("/api/integration/training-results")
+        .set("X-API-Key", apiKey)
+        .set("X-Tenant-Id", admin.tenantId)
+        .query({ scope: "course" })
+        .expect(400);
+    });
+
+    it("returns not_applicable certificate status when course certificates are disabled", async () => {
+      const admin = await userFactory
+        .withCredentials({ password })
+        .withAdminSettings(db)
+        .create({ role: SYSTEM_ROLE_SLUGS.ADMIN });
+      const cookies = await cookieFor(admin, app);
+      const student = await userFactory.create({
+        role: SYSTEM_ROLE_SLUGS.STUDENT,
+        tenantId: admin.tenantId,
+      });
+
+      const chapterId = randomUUID();
+      const categoryId = randomUUID();
+      const courseId = randomUUID();
+      const lessonId = randomUUID();
+
+      const categoryTitle = `Integration category ${randomUUID()}`;
+
+      await db.insert(categories).values({
+        id: categoryId,
+        title: categoryTitle,
+        tenantId: admin.tenantId,
+      });
+
+      await db.insert(courses).values({
+        id: courseId,
+        title: { en: "No certificate course" },
+        description: {},
+        status: "published",
+        hasCertificate: false,
+        authorId: admin.id,
+        categoryId,
+        settings: {
+          lessonSequenceEnabled: LESSON_SEQUENCE_ENABLED,
+          quizFeedbackEnabled: QUIZ_FEEDBACK_ENABLED,
+          certificateSignature: null,
+          certificateFontColor: null,
+        },
+        tenantId: admin.tenantId,
+      });
+
+      await db.insert(chapters).values({
+        id: chapterId,
+        title: {},
+        courseId,
+        authorId: admin.id,
+        isFreemium: false,
+        displayOrder: 1,
+        lessonCount: 1,
+        tenantId: admin.tenantId,
+      });
+
+      await db.insert(lessons).values({
+        id: lessonId,
+        chapterId,
+        type: "text",
+        title: buildJsonbField("en", "Text lesson"),
+        displayOrder: 1,
+        tenantId: admin.tenantId,
+      });
+
+      await db.insert(studentCourses).values({
+        studentId: student.id,
+        courseId,
+        status: COURSE_ENROLLMENT.ENROLLED,
+        tenantId: admin.tenantId,
+      });
+
+      const rotateResponse = await request(app.getHttpServer())
+        .post("/api/integration/key")
+        .set("Cookie", cookies)
+        .expect(201);
+
+      const apiKey = rotateResponse.body.data.key as string;
+
+      const response = await request(app.getHttpServer())
+        .get("/api/integration/training-results")
+        .set("X-API-Key", apiKey)
+        .set("X-Tenant-Id", admin.tenantId)
+        .query({ scope: "course", courseId })
+        .expect(200);
+
+      expect(response.body.data).toHaveLength(1);
+      expect(response.body.data[0]).toEqual(
+        expect.objectContaining({
+          courses: [
+            expect.objectContaining({
+              certificate: {
+                enabled: false,
+                status: "not_applicable",
+                issuedAt: null,
+              },
+              quizzes: [],
+            }),
+          ],
+        }),
+      );
+      expect(response.body.data[0].courses[0].lessons).toEqual([
+        {
+          lessonId,
+          chapterId,
+          title: "Text lesson",
+          type: "text",
+          completed: false,
+          completedAt: null,
+        },
+      ]);
     });
   });
 });

--- a/apps/api/src/integration/integration.controller.ts
+++ b/apps/api/src/integration/integration.controller.ts
@@ -46,8 +46,12 @@ import {
   integrationDeleteUserResponseSchema,
   integrationMessageResponseSchema,
   integrationTenantsSchema,
+  integrationTrainingResultsSchema,
+  integrationTrainingResultsScopeSchema,
   setUserGroupsSchema,
   unenrollGroupsPayloadSchema,
+  type IntegrationTrainingResult,
+  type IntegrationTrainingResultsScope,
   type IntegrationTenant,
   type SetUserGroupsBody,
   type UnenrollGroupsPayload,
@@ -158,6 +162,48 @@ export class IntegrationController {
     const users = await this.userService.getUsers(query);
 
     return new PaginatedResponse(users);
+  }
+
+  @Get("training-results")
+  @RequirePermission(PERMISSIONS.INTEGRATION_API_USE)
+  @ApiEndpointDocs({
+    summary: "Get training results for integration reporting",
+    description:
+      "Returns training results in JSON for the tenant selected by X-Tenant-Id.\n\nEach response row represents one student-course pair.\n\nUse scope=tenant to list all rows for the tenant, scope=student to list rows for a specific student (studentId required), and scope=course to list rows for a specific course (courseId required). Optional extra filter can further narrow results.",
+    headers: [API_HEADERS.X_TENANT_ID],
+  })
+  @Validate({
+    request: [
+      {
+        type: "query",
+        name: "scope",
+        schema: integrationTrainingResultsScopeSchema,
+        required: true,
+      },
+      { type: "query", name: "studentId", schema: UUIDSchema },
+      { type: "query", name: "courseId", schema: UUIDSchema },
+      { type: "query", name: "page", schema: Type.Number({ minimum: 1 }) },
+      { type: "query", name: "perPage", schema: Type.Number() },
+    ],
+    response: paginatedResponse(integrationTrainingResultsSchema),
+  })
+  async getTrainingResults(
+    @Query("scope") scope: IntegrationTrainingResultsScope,
+    @Query("studentId") studentId: UUIDType | undefined,
+    @Query("courseId") courseId: UUIDType | undefined,
+    @Query("page") page: number | undefined,
+    @Query("perPage") perPage: number | undefined,
+    @CurrentUser() currentUser: CurrentUserType,
+  ): Promise<PaginatedResponse<IntegrationTrainingResult[]>> {
+    return new PaginatedResponse(
+      await this.integrationService.getTrainingResults(currentUser, {
+        scope,
+        studentId,
+        courseId,
+        page,
+        perPage,
+      }),
+    );
   }
 
   @Get("users/:userId")

--- a/apps/api/src/integration/integration.module.ts
+++ b/apps/api/src/integration/integration.module.ts
@@ -2,6 +2,7 @@ import { Module } from "@nestjs/common";
 
 import { CourseModule } from "src/courses/course.module";
 import { GroupModule } from "src/group/group.module";
+import { LocalizationModule } from "src/localization/localization.module";
 import { PermissionsModule } from "src/permissions/permissions.module";
 import { UserModule } from "src/user/user.module";
 
@@ -12,7 +13,7 @@ import { IntegrationRepository } from "./integration.repository";
 import { IntegrationService } from "./integration.service";
 
 @Module({
-  imports: [UserModule, GroupModule, CourseModule, PermissionsModule],
+  imports: [UserModule, GroupModule, CourseModule, PermissionsModule, LocalizationModule],
   controllers: [IntegrationController, IntegrationAdminController],
   providers: [IntegrationService, IntegrationRepository, IntegrationApiKeyGuard],
 })

--- a/apps/api/src/integration/integration.repository.ts
+++ b/apps/api/src/integration/integration.repository.ts
@@ -1,22 +1,51 @@
-import { Inject, Injectable } from "@nestjs/common";
-import { and, eq, isNull, sql } from "drizzle-orm";
+import { BadRequestException, Inject, Injectable } from "@nestjs/common";
+import { COURSE_ENROLLMENT } from "@repo/shared";
+import { and, countDistinct, eq, inArray, isNull, sql, type SQL } from "drizzle-orm";
+import { P, match } from "ts-pattern";
+import { validate as uuidValidate } from "uuid";
 
 import { DatabasePg } from "src/common";
+import { DEFAULT_PAGE_SIZE } from "src/common/pagination";
+import { LocalizationService } from "src/localization/localization.service";
 import { DB, DB_ADMIN } from "src/storage/db/db.providers";
-import { integrationApiKeys, tenants, users } from "src/storage/schema";
+import {
+  certificates,
+  chapters,
+  courses,
+  integrationApiKeys,
+  lessons,
+  studentCourses,
+  studentLessonProgress,
+  tenants,
+  users,
+} from "src/storage/schema";
 
 import type {
   FindIntegrationKeyCandidateParams,
   IntegrationApiKeyCandidate,
   IntegrationKeyMetadataRecord,
+  IntegrationTrainingResultCourse,
+  IntegrationTrainingResultsData,
+  IntegrationTrainingResultRow,
+  IntegrationTrainingResultsQuery,
+  IntegrationTrainingResultsScope,
   RotateIntegrationKeyParams,
 } from "./integration.types";
+
+type NormalizedTrainingResultsQuery = {
+  scope: IntegrationTrainingResultsQuery["scope"];
+  studentId?: string;
+  courseId?: string;
+  page: number;
+  perPage: number;
+};
 
 @Injectable()
 export class IntegrationRepository {
   constructor(
     @Inject(DB) private readonly db: DatabasePg,
     @Inject(DB_ADMIN) private readonly dbAdmin: DatabasePg,
+    private readonly localizationService: LocalizationService,
   ) {}
 
   async getCurrentActiveKeyByCreator(userId: string): Promise<IntegrationKeyMetadataRecord | null> {
@@ -129,5 +158,332 @@ export class IntegrationRepository {
       .update(integrationApiKeys)
       .set({ lastUsedAt: sql`NOW()` })
       .where(eq(integrationApiKeys.id, keyId));
+  }
+
+  async getTrainingResults(
+    tenantId: string,
+    query: IntegrationTrainingResultsQuery,
+  ): Promise<IntegrationTrainingResultsData> {
+    const standardizedQuery = this.normalizeTrainingResultsQuery(query);
+    const { filters } = this.buildTrainingResultsFilters(tenantId, standardizedQuery);
+
+    return this.db.transaction(async (trx) => {
+      const totalItems = await this.getTrainingResultTotalItems(trx, filters);
+
+      const { page, perPage } = standardizedQuery;
+
+      if (totalItems === 0) {
+        return {
+          data: [],
+          pagination: {
+            totalItems,
+            page,
+            perPage,
+          },
+        };
+      }
+
+      const data = await this.getTrainingResultRows(trx, tenantId, standardizedQuery, filters);
+
+      return {
+        data,
+        pagination: {
+          totalItems,
+          page,
+          perPage,
+        },
+      };
+    });
+  }
+
+  private normalizeTrainingResultsQuery(
+    query: IntegrationTrainingResultsQuery,
+  ): NormalizedTrainingResultsQuery {
+    return {
+      scope: query.scope,
+      studentId: this.normalizeOptionalUuid(
+        query.studentId,
+        "integration.trainingResults.errors.invalidStudentId",
+      ),
+      courseId: this.normalizeOptionalUuid(
+        query.courseId,
+        "integration.trainingResults.errors.invalidCourseId",
+      ),
+      page: this.normalizePositiveNumber(query.page, 1),
+      perPage: this.normalizePositiveNumber(query.perPage, DEFAULT_PAGE_SIZE),
+    };
+  }
+
+  private buildTrainingResultsFilters(tenantId: string, query: NormalizedTrainingResultsQuery) {
+    const scopeFilters = match(query)
+      .with({ scope: "tenant" }, () => [])
+      .with({ scope: "student", studentId: P.string }, ({ studentId }) => [
+        eq(studentCourses.studentId, studentId),
+      ])
+      .with({ scope: "course", courseId: P.string }, ({ courseId }) => [
+        eq(studentCourses.courseId, courseId),
+      ])
+      .with({ scope: "student" }, () => {
+        throw new BadRequestException("integration.trainingResults.errors.studentIdRequired");
+      })
+      .with({ scope: "course" }, () => {
+        throw new BadRequestException("integration.trainingResults.errors.courseIdRequired");
+      })
+      .exhaustive();
+
+    const filters = [
+      eq(studentCourses.tenantId, tenantId),
+      isNull(users.deletedAt),
+      inArray(studentCourses.status, [
+        COURSE_ENROLLMENT.ENROLLED,
+        COURSE_ENROLLMENT.GROUP_ENROLLED,
+      ]),
+      ...scopeFilters,
+    ];
+
+    match(query)
+      .with({ scope: P.union("tenant", "course"), studentId: P.string }, ({ studentId }) => {
+        filters.push(eq(studentCourses.studentId, studentId));
+      })
+      .otherwise(() => undefined);
+
+    match(query)
+      .with({ scope: P.union("tenant", "student"), courseId: P.string }, ({ courseId }) => {
+        filters.push(eq(studentCourses.courseId, courseId));
+      })
+      .otherwise(() => undefined);
+
+    return { filters };
+  }
+
+  private async getTrainingResultTotalItems(db: DatabasePg, filters: SQL[]) {
+    const enrollmentsCte = db.$with("training_result_enrollments").as(
+      db
+        .select({
+          tenantId: studentCourses.tenantId,
+          studentId: studentCourses.studentId,
+          studentEmail: users.email,
+          studentFirstName: users.firstName,
+          studentLastName: users.lastName,
+          courseId: studentCourses.courseId,
+          courseTitle: this.localizationService
+            .getLocalizedSqlField(courses.title)
+            .as("courseTitle"),
+          certificateEnabled: courses.hasCertificate,
+        })
+        .from(studentCourses)
+        .innerJoin(users, eq(users.id, studentCourses.studentId))
+        .innerJoin(courses, eq(courses.id, studentCourses.courseId))
+        .where(and(...filters)),
+    );
+
+    const [{ totalItems }] = await db
+      .with(enrollmentsCte)
+      .select({ totalItems: countDistinct(enrollmentsCte.studentId) })
+      .from(enrollmentsCte);
+
+    return totalItems ?? 0;
+  }
+
+  private async getTrainingResultRows(
+    db: DatabasePg,
+    tenantId: string,
+    query: NormalizedTrainingResultsQuery,
+    filters: SQL[],
+  ): Promise<IntegrationTrainingResultRow[]> {
+    const enrollmentsCte = db.$with("training_result_enrollments").as(
+      db
+        .select({
+          tenantId: studentCourses.tenantId,
+          studentId: studentCourses.studentId,
+          studentEmail: users.email,
+          studentFirstName: users.firstName,
+          studentLastName: users.lastName,
+          courseId: studentCourses.courseId,
+          courseTitle: this.localizationService
+            .getLocalizedSqlField(courses.title)
+            .as("courseTitle"),
+          certificateEnabled: courses.hasCertificate,
+          certificateIssuedAt: certificates.createdAt,
+        })
+        .from(studentCourses)
+        .innerJoin(users, eq(users.id, studentCourses.studentId))
+        .innerJoin(courses, eq(courses.id, studentCourses.courseId))
+        .leftJoin(
+          certificates,
+          and(
+            eq(certificates.userId, studentCourses.studentId),
+            eq(certificates.courseId, studentCourses.courseId),
+            eq(certificates.tenantId, studentCourses.tenantId),
+          ),
+        )
+        .where(and(...filters)),
+    );
+
+    const pagedStudentsCte = db.$with("training_result_paged_students").as(
+      db
+        .with(enrollmentsCte)
+        .selectDistinct({
+          tenantId: enrollmentsCte.tenantId,
+          studentId: enrollmentsCte.studentId,
+          studentEmail: enrollmentsCte.studentEmail,
+          studentFirstName: enrollmentsCte.studentFirstName,
+          studentLastName: enrollmentsCte.studentLastName,
+        })
+        .from(enrollmentsCte)
+        .orderBy(enrollmentsCte.studentEmail, enrollmentsCte.studentId)
+        .limit(query.perPage)
+        .offset((query.page - 1) * query.perPage),
+    );
+
+    const pagedEnrollmentsCte = db.$with("training_result_paged_enrollments").as(
+      db
+        .with(enrollmentsCte, pagedStudentsCte)
+        .select({
+          tenantId: enrollmentsCte.tenantId,
+          studentId: enrollmentsCte.studentId,
+          studentEmail: enrollmentsCte.studentEmail,
+          studentFirstName: enrollmentsCte.studentFirstName,
+          studentLastName: enrollmentsCte.studentLastName,
+          courseId: enrollmentsCte.courseId,
+          courseTitle: enrollmentsCte.courseTitle,
+          certificateEnabled: enrollmentsCte.certificateEnabled,
+          certificateIssuedAt: enrollmentsCte.certificateIssuedAt,
+        })
+        .from(enrollmentsCte)
+        .innerJoin(pagedStudentsCte, eq(enrollmentsCte.studentId, pagedStudentsCte.studentId))
+        .orderBy(enrollmentsCte.studentEmail, enrollmentsCte.courseTitle),
+    );
+
+    const lessonsSql = sql<IntegrationTrainingResultCourse["lessons"]>`
+      COALESCE(
+        (
+          SELECT jsonb_agg(
+            jsonb_build_object(
+              'lessonId', ${lessons.id},
+              'chapterId', ${chapters.id},
+              'title', ${this.localizationService.getLocalizedSqlField(lessons.title)},
+              'type', ${lessons.type},
+              'completed', CASE WHEN ${
+                studentLessonProgress.completedAt
+              } IS NOT NULL THEN TRUE ELSE FALSE END,
+              'completedAt', ${studentLessonProgress.completedAt}
+            )
+            ORDER BY ${chapters.displayOrder}, ${lessons.displayOrder}
+          )
+          FROM ${lessons}
+          INNER JOIN ${chapters} ON ${chapters.id} = ${lessons.chapterId}
+          INNER JOIN ${courses} ON ${courses.id} = ${chapters.courseId}
+          LEFT JOIN ${studentLessonProgress}
+            ON ${studentLessonProgress.lessonId} = ${lessons.id}
+           AND ${studentLessonProgress.chapterId} = ${chapters.id}
+           AND ${studentLessonProgress.studentId} = ${pagedEnrollmentsCte.studentId}
+           AND ${studentLessonProgress.tenantId} = ${pagedEnrollmentsCte.tenantId}
+          WHERE ${lessons.tenantId} = ${tenantId}
+            AND ${chapters.courseId} = ${pagedEnrollmentsCte.courseId}
+        ),
+        '[]'::jsonb
+      )
+    `;
+
+    const quizzesSql = sql<IntegrationTrainingResultCourse["quizzes"]>`
+      COALESCE(
+        (
+          SELECT jsonb_agg(
+            jsonb_build_object(
+              'lessonId', ${lessons.id},
+              'chapterId', ${chapters.id},
+              'title', ${this.localizationService.getLocalizedSqlField(lessons.title)},
+              'score', ${studentLessonProgress.quizScore},
+              'passed', ${studentLessonProgress.isQuizPassed},
+              'attempts', ${studentLessonProgress.attempts},
+              'completedAt', ${studentLessonProgress.completedAt}
+            )
+            ORDER BY ${chapters.displayOrder}, ${lessons.displayOrder}
+          )
+          FROM ${lessons}
+          INNER JOIN ${chapters} ON ${chapters.id} = ${lessons.chapterId}
+          INNER JOIN ${courses} ON ${courses.id} = ${chapters.courseId}
+          LEFT JOIN ${studentLessonProgress}
+            ON ${studentLessonProgress.lessonId} = ${lessons.id}
+           AND ${studentLessonProgress.chapterId} = ${chapters.id}
+           AND ${studentLessonProgress.studentId} = ${pagedEnrollmentsCte.studentId}
+           AND ${studentLessonProgress.tenantId} = ${pagedEnrollmentsCte.tenantId}
+          WHERE ${lessons.tenantId} = ${tenantId}
+            AND ${chapters.courseId} = ${pagedEnrollmentsCte.courseId}
+            AND ${lessons.type} = 'quiz'
+        ),
+        '[]'::jsonb
+      )
+    `;
+
+    const entries = await db
+      .with(enrollmentsCte, pagedStudentsCte, pagedEnrollmentsCte)
+      .select({
+        scope: sql<IntegrationTrainingResultsScope>`${query.scope}`,
+        tenantId: pagedEnrollmentsCte.tenantId,
+        student: sql<IntegrationTrainingResultRow["student"]>`
+          jsonb_build_object(
+            'id', ${pagedEnrollmentsCte.studentId},
+            'email', ${pagedEnrollmentsCte.studentEmail},
+            'firstName', ${pagedEnrollmentsCte.studentFirstName},
+            'lastName', ${pagedEnrollmentsCte.studentLastName},
+            'fullName', ${pagedEnrollmentsCte.studentFirstName} || ' ' || ${pagedEnrollmentsCte.studentLastName}
+          )
+        `,
+        courses: sql<IntegrationTrainingResultCourse[]>`
+          COALESCE(
+            jsonb_agg(
+              jsonb_build_object(
+                'id', ${pagedEnrollmentsCte.courseId},
+                'title', ${pagedEnrollmentsCte.courseTitle},
+                'lessons', ${lessonsSql},
+                'quizzes', ${quizzesSql},
+                'certificate', jsonb_build_object(
+                  'enabled', ${pagedEnrollmentsCte.certificateEnabled},
+                  'status', CASE
+                    WHEN NOT ${pagedEnrollmentsCte.certificateEnabled} THEN 'not_applicable'
+                    WHEN ${pagedEnrollmentsCte.certificateIssuedAt} IS NOT NULL THEN 'issued'
+                    ELSE 'not_issued'
+                  END,
+                  'issuedAt', ${pagedEnrollmentsCte.certificateIssuedAt}
+                )
+              )
+              ORDER BY ${pagedEnrollmentsCte.courseTitle}
+            ),
+            '[]'::jsonb
+          )
+        `,
+      })
+      .from(pagedEnrollmentsCte)
+      .groupBy(
+        pagedEnrollmentsCte.tenantId,
+        pagedEnrollmentsCte.studentId,
+        pagedEnrollmentsCte.studentEmail,
+        pagedEnrollmentsCte.studentFirstName,
+        pagedEnrollmentsCte.studentLastName,
+      )
+      .orderBy(pagedEnrollmentsCte.studentEmail, pagedEnrollmentsCte.studentId);
+
+    return entries;
+  }
+
+  private normalizeOptionalUuid(value: string | undefined, errorMessage: string) {
+    if (!value) return undefined;
+    if (!uuidValidate(value)) throw new BadRequestException(errorMessage);
+
+    return value;
+  }
+
+  private normalizePositiveNumber(value: unknown, defaultValue: number) {
+    if (value === undefined || value === null || value === "") return defaultValue;
+
+    const normalizedValue = Number(value);
+
+    if (!Number.isFinite(normalizedValue) || normalizedValue < 1) {
+      throw new BadRequestException("integration.trainingResults.errors.invalidPagination");
+    }
+
+    return normalizedValue;
   }
 }

--- a/apps/api/src/integration/integration.service.ts
+++ b/apps/api/src/integration/integration.service.ts
@@ -2,17 +2,25 @@ import { randomBytes, createHmac, timingSafeEqual } from "node:crypto";
 
 import {
   ForbiddenException,
+  Inject,
   Injectable,
   InternalServerErrorException,
   UnauthorizedException,
 } from "@nestjs/common";
 import { PERMISSIONS } from "@repo/shared";
 
+import { DatabasePg } from "src/common";
 import { PermissionsService } from "src/permissions/permissions.service";
+import { DB_ADMIN } from "src/storage/db/db.providers";
 
 import { IntegrationRepository } from "./integration.repository";
 
-import type { CurrentAdminKeyData, RotateAdminKeyData } from "./integration.types";
+import type {
+  CurrentAdminKeyData,
+  IntegrationTrainingResultsData,
+  IntegrationTrainingResultsQuery,
+  RotateAdminKeyData,
+} from "./integration.types";
 import type { CurrentUserType } from "src/common/types/current-user.type";
 
 @Injectable()
@@ -22,6 +30,7 @@ export class IntegrationService {
   constructor(
     private readonly integrationRepository: IntegrationRepository,
     private readonly permissionsService: PermissionsService,
+    @Inject(DB_ADMIN) private readonly dbAdmin: DatabasePg,
   ) {
     if (!process.env.MASTER_KEY) throw new Error("MASTER_KEY is required for integration API keys");
 
@@ -76,7 +85,10 @@ export class IntegrationService {
 
     if (key.userDeletedAt) throw new ForbiddenException("integrationApiKey.errors.ownerInactive");
 
-    const { roleSlugs, permissions } = await this.permissionsService.getUserAccess(key.userId);
+    const { roleSlugs, permissions } = await this.permissionsService.getUserAccess(
+      key.userId,
+      this.dbAdmin,
+    );
 
     if (!permissions.includes(PERMISSIONS.INTEGRATION_API_USE)) {
       throw new ForbiddenException("integrationApiKey.errors.ownerNotAdmin");
@@ -122,6 +134,13 @@ export class IntegrationService {
     }
 
     return this.integrationRepository.getAllTenants();
+  }
+
+  async getTrainingResults(
+    actor: CurrentUserType,
+    query: IntegrationTrainingResultsQuery,
+  ): Promise<IntegrationTrainingResultsData> {
+    return this.integrationRepository.getTrainingResults(actor.tenantId, query);
   }
 
   private buildRawApiKey() {

--- a/apps/api/src/integration/integration.types.ts
+++ b/apps/api/src/integration/integration.types.ts
@@ -45,3 +45,75 @@ export type RotateAdminKeyData = {
   key: string;
   metadata: IntegrationKeyMetadata;
 };
+
+export const INTEGRATION_TRAINING_RESULTS_SCOPES = {
+  TENANT: "tenant",
+  STUDENT: "student",
+  COURSE: "course",
+} as const;
+
+export type IntegrationTrainingResultsScope =
+  (typeof INTEGRATION_TRAINING_RESULTS_SCOPES)[keyof typeof INTEGRATION_TRAINING_RESULTS_SCOPES];
+
+export type IntegrationTrainingResultsQuery = {
+  scope: IntegrationTrainingResultsScope;
+  studentId?: string;
+  courseId?: string;
+  page?: number;
+  perPage?: number;
+};
+
+export type IntegrationTrainingResultRow = {
+  scope: IntegrationTrainingResultsScope;
+  tenantId: string;
+  student: {
+    id: string;
+    email: string;
+    firstName: string;
+    lastName: string;
+    fullName: string;
+  };
+  courses: IntegrationTrainingResultCourse[];
+};
+
+export type IntegrationTrainingResultCourse = {
+  id: string;
+  title: string;
+  lessons: IntegrationTrainingResultLesson[];
+  quizzes: IntegrationTrainingResultQuiz[];
+  certificate: IntegrationTrainingResultCertificate;
+};
+
+export type IntegrationTrainingResultLesson = {
+  lessonId: string;
+  chapterId: string;
+  title: string;
+  type: string;
+  completed: boolean;
+  completedAt: string | null;
+};
+
+export type IntegrationTrainingResultQuiz = {
+  lessonId: string;
+  chapterId: string;
+  title: string;
+  score: number | null;
+  passed: boolean | null;
+  attempts: number | null;
+  completedAt: string | null;
+};
+
+export type IntegrationTrainingResultCertificate = {
+  enabled: boolean;
+  status: "issued" | "not_issued" | "not_applicable";
+  issuedAt: string | null;
+};
+
+export type IntegrationTrainingResultsData = {
+  data: IntegrationTrainingResultRow[];
+  pagination: {
+    totalItems: number;
+    page: number;
+    perPage: number;
+  };
+};

--- a/apps/api/src/integration/schemas/integration.schema.ts
+++ b/apps/api/src/integration/schemas/integration.schema.ts
@@ -3,6 +3,7 @@ import { type Static, Type } from "@sinclair/typebox";
 import { UUIDSchema } from "src/common";
 import { enrolledCourseGroupsPayload } from "src/courses/schemas/course.schema";
 import { createCoursesEnrollmentSchema } from "src/courses/schemas/createCoursesEnrollment";
+import { INTEGRATION_TRAINING_RESULTS_SCOPES } from "src/integration/integration.types";
 
 import type { createUserSchema } from "src/user/schemas/createUser.schema";
 import type { updateUserSchema } from "src/user/schemas/updateUser.schema";
@@ -27,6 +28,62 @@ export const integrationTenantSchema = Type.Object({
 
 export const integrationTenantsSchema = Type.Array(integrationTenantSchema);
 
+export const integrationTrainingResultsScopeSchema = Type.Union([
+  Type.Literal(INTEGRATION_TRAINING_RESULTS_SCOPES.TENANT),
+  Type.Literal(INTEGRATION_TRAINING_RESULTS_SCOPES.STUDENT),
+  Type.Literal(INTEGRATION_TRAINING_RESULTS_SCOPES.COURSE),
+]);
+
+export const integrationTrainingResultSchema = Type.Object({
+  scope: integrationTrainingResultsScopeSchema,
+  tenantId: UUIDSchema,
+  student: Type.Object({
+    id: UUIDSchema,
+    email: Type.String(),
+    firstName: Type.String(),
+    lastName: Type.String(),
+    fullName: Type.String(),
+  }),
+  courses: Type.Array(
+    Type.Object({
+      id: UUIDSchema,
+      title: Type.String(),
+      lessons: Type.Array(
+        Type.Object({
+          lessonId: UUIDSchema,
+          chapterId: UUIDSchema,
+          title: Type.String(),
+          type: Type.String(),
+          completed: Type.Boolean(),
+          completedAt: Type.Union([Type.String(), Type.Null()]),
+        }),
+      ),
+      quizzes: Type.Array(
+        Type.Object({
+          lessonId: UUIDSchema,
+          chapterId: UUIDSchema,
+          title: Type.String(),
+          score: Type.Union([Type.Number(), Type.Null()]),
+          passed: Type.Union([Type.Boolean(), Type.Null()]),
+          attempts: Type.Union([Type.Number(), Type.Null()]),
+          completedAt: Type.Union([Type.String(), Type.Null()]),
+        }),
+      ),
+      certificate: Type.Object({
+        enabled: Type.Boolean(),
+        status: Type.Union([
+          Type.Literal("issued"),
+          Type.Literal("not_issued"),
+          Type.Literal("not_applicable"),
+        ]),
+        issuedAt: Type.Union([Type.String(), Type.Null()]),
+      }),
+    }),
+  ),
+});
+
+export const integrationTrainingResultsSchema = Type.Array(integrationTrainingResultSchema);
+
 export const unenrollUsersPayloadSchema = createCoursesEnrollmentSchema;
 export const enrollUsersPayloadSchema = createCoursesEnrollmentSchema;
 
@@ -43,3 +100,5 @@ export type EnrollUsersPayload = Static<typeof enrollUsersPayloadSchema>;
 export type UnenrollUsersPayload = Static<typeof unenrollUsersPayloadSchema>;
 export type EnrollGroupsPayload = Static<typeof enrollGroupsPayloadSchema>;
 export type UnenrollGroupsPayload = Static<typeof unenrollGroupsPayloadSchema>;
+export type IntegrationTrainingResultsScope = Static<typeof integrationTrainingResultsScopeSchema>;
+export type IntegrationTrainingResult = Static<typeof integrationTrainingResultSchema>;

--- a/apps/api/src/swagger/api-schema.json
+++ b/apps/api/src/swagger/api-schema.json
@@ -7711,6 +7711,109 @@
         ]
       }
     },
+    "/api/integration/training-results": {
+      "get": {
+        "operationId": "IntegrationController_getTrainingResults",
+        "summary": "Get training results for integration reporting",
+        "description": "Returns training results in JSON for the tenant selected by X-Tenant-Id.\n\nEach response row represents one student-course pair.\n\nUse scope=tenant to list all rows for the tenant, scope=student to list rows for a specific student (studentId required), and scope=course to list rows for a specific course (courseId required). Optional extra filter can further narrow results.",
+        "parameters": [
+          {
+            "name": "X-API-Key",
+            "in": "header",
+            "description": "Integration API key used to authenticate every integration request.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "scope",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "anyOf": [
+                {
+                  "const": "tenant",
+                  "type": "string"
+                },
+                {
+                  "const": "student",
+                  "type": "string"
+                },
+                {
+                  "const": "course",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          {
+            "name": "studentId",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "courseId",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "minimum": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "perPage",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "X-Tenant-Id",
+            "in": "header",
+            "description": "Target tenant context for this request. Must be one of the tenant IDs returned by GET /integration/tenants.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetTrainingResultsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid integration API key."
+          },
+          "403": {
+            "description": "Authenticated integration key owner is not authorized."
+          }
+        },
+        "tags": [
+          "Integration"
+        ]
+      }
+    },
     "/api/integration/users/{userId}": {
       "get": {
         "operationId": "IntegrationController_getUserById",
@@ -27022,6 +27125,274 @@
         },
         "required": [
           "data"
+        ]
+      },
+      "GetTrainingResultsResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "scope": {
+                  "anyOf": [
+                    {
+                      "const": "tenant",
+                      "type": "string"
+                    },
+                    {
+                      "const": "student",
+                      "type": "string"
+                    },
+                    {
+                      "const": "course",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "tenantId": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "student": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "email": {
+                      "type": "string"
+                    },
+                    "firstName": {
+                      "type": "string"
+                    },
+                    "lastName": {
+                      "type": "string"
+                    },
+                    "fullName": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "email",
+                    "firstName",
+                    "lastName",
+                    "fullName"
+                  ]
+                },
+                "courses": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "format": "uuid",
+                        "type": "string"
+                      },
+                      "title": {
+                        "type": "string"
+                      },
+                      "lessons": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "lessonId": {
+                              "format": "uuid",
+                              "type": "string"
+                            },
+                            "chapterId": {
+                              "format": "uuid",
+                              "type": "string"
+                            },
+                            "title": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "completed": {
+                              "type": "boolean"
+                            },
+                            "completedAt": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "lessonId",
+                            "chapterId",
+                            "title",
+                            "type",
+                            "completed",
+                            "completedAt"
+                          ]
+                        }
+                      },
+                      "quizzes": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "lessonId": {
+                              "format": "uuid",
+                              "type": "string"
+                            },
+                            "chapterId": {
+                              "format": "uuid",
+                              "type": "string"
+                            },
+                            "title": {
+                              "type": "string"
+                            },
+                            "score": {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "passed": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "attempts": {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "completedAt": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "lessonId",
+                            "chapterId",
+                            "title",
+                            "score",
+                            "passed",
+                            "attempts",
+                            "completedAt"
+                          ]
+                        }
+                      },
+                      "certificate": {
+                        "type": "object",
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "status": {
+                            "anyOf": [
+                              {
+                                "const": "issued",
+                                "type": "string"
+                              },
+                              {
+                                "const": "not_issued",
+                                "type": "string"
+                              },
+                              {
+                                "const": "not_applicable",
+                                "type": "string"
+                              }
+                            ]
+                          },
+                          "issuedAt": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          }
+                        },
+                        "required": [
+                          "enabled",
+                          "status",
+                          "issuedAt"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "title",
+                      "lessons",
+                      "quizzes",
+                      "certificate"
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "scope",
+                "tenantId",
+                "student",
+                "courses"
+              ]
+            }
+          },
+          "pagination": {
+            "type": "object",
+            "properties": {
+              "totalItems": {
+                "type": "number"
+              },
+              "page": {
+                "type": "number"
+              },
+              "perPage": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "totalItems",
+              "page",
+              "perPage"
+            ]
+          },
+          "appliedFilters": {
+            "type": "object",
+            "patternProperties": {
+              "^(.*)$": {}
+            }
+          }
+        },
+        "required": [
+          "data",
+          "pagination"
         ]
       },
       "DeleteUserResponse": {

--- a/apps/api/src/swagger/integration-api-schema.json
+++ b/apps/api/src/swagger/integration-api-schema.json
@@ -251,6 +251,109 @@
         ]
       }
     },
+    "/api/integration/training-results": {
+      "get": {
+        "operationId": "IntegrationController_getTrainingResults",
+        "summary": "Get training results for integration reporting",
+        "description": "Returns training results in JSON for the tenant selected by X-Tenant-Id.\n\nEach response row represents one student-course pair.\n\nUse scope=tenant to list all rows for the tenant, scope=student to list rows for a specific student (studentId required), and scope=course to list rows for a specific course (courseId required). Optional extra filter can further narrow results.",
+        "parameters": [
+          {
+            "name": "X-API-Key",
+            "in": "header",
+            "description": "Integration API key used to authenticate every integration request.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "scope",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "anyOf": [
+                {
+                  "const": "tenant",
+                  "type": "string"
+                },
+                {
+                  "const": "student",
+                  "type": "string"
+                },
+                {
+                  "const": "course",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          {
+            "name": "studentId",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "courseId",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "minimum": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "perPage",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "X-Tenant-Id",
+            "in": "header",
+            "description": "Target tenant context for this request. Must be one of the tenant IDs returned by GET /integration/tenants.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetTrainingResultsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid integration API key."
+          },
+          "403": {
+            "description": "Authenticated integration key owner is not authorized."
+          }
+        },
+        "tags": [
+          "Integration"
+        ]
+      }
+    },
     "/api/integration/users/{userId}": {
       "get": {
         "operationId": "IntegrationController_getUserById",
@@ -1033,6 +1136,274 @@
                     "groups"
                   ]
                 }
+              ]
+            }
+          },
+          "pagination": {
+            "type": "object",
+            "properties": {
+              "totalItems": {
+                "type": "number"
+              },
+              "page": {
+                "type": "number"
+              },
+              "perPage": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "totalItems",
+              "page",
+              "perPage"
+            ]
+          },
+          "appliedFilters": {
+            "type": "object",
+            "patternProperties": {
+              "^(.*)$": {}
+            }
+          }
+        },
+        "required": [
+          "data",
+          "pagination"
+        ]
+      },
+      "GetTrainingResultsResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "scope": {
+                  "anyOf": [
+                    {
+                      "const": "tenant",
+                      "type": "string"
+                    },
+                    {
+                      "const": "student",
+                      "type": "string"
+                    },
+                    {
+                      "const": "course",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "tenantId": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "student": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "email": {
+                      "type": "string"
+                    },
+                    "firstName": {
+                      "type": "string"
+                    },
+                    "lastName": {
+                      "type": "string"
+                    },
+                    "fullName": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "email",
+                    "firstName",
+                    "lastName",
+                    "fullName"
+                  ]
+                },
+                "courses": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "format": "uuid",
+                        "type": "string"
+                      },
+                      "title": {
+                        "type": "string"
+                      },
+                      "lessons": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "lessonId": {
+                              "format": "uuid",
+                              "type": "string"
+                            },
+                            "chapterId": {
+                              "format": "uuid",
+                              "type": "string"
+                            },
+                            "title": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "completed": {
+                              "type": "boolean"
+                            },
+                            "completedAt": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "lessonId",
+                            "chapterId",
+                            "title",
+                            "type",
+                            "completed",
+                            "completedAt"
+                          ]
+                        }
+                      },
+                      "quizzes": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "lessonId": {
+                              "format": "uuid",
+                              "type": "string"
+                            },
+                            "chapterId": {
+                              "format": "uuid",
+                              "type": "string"
+                            },
+                            "title": {
+                              "type": "string"
+                            },
+                            "score": {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "passed": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "attempts": {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "completedAt": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "lessonId",
+                            "chapterId",
+                            "title",
+                            "score",
+                            "passed",
+                            "attempts",
+                            "completedAt"
+                          ]
+                        }
+                      },
+                      "certificate": {
+                        "type": "object",
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "status": {
+                            "anyOf": [
+                              {
+                                "const": "issued",
+                                "type": "string"
+                              },
+                              {
+                                "const": "not_issued",
+                                "type": "string"
+                              },
+                              {
+                                "const": "not_applicable",
+                                "type": "string"
+                              }
+                            ]
+                          },
+                          "issuedAt": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          }
+                        },
+                        "required": [
+                          "enabled",
+                          "status",
+                          "issuedAt"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "title",
+                      "lessons",
+                      "quizzes",
+                      "certificate"
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "scope",
+                "tenantId",
+                "student",
+                "courses"
               ]
             }
           },

--- a/apps/web/app/api/generated-api.ts
+++ b/apps/web/app/api/generated-api.ts
@@ -3521,6 +3521,59 @@ export interface GetTenantsResponse {
   }[];
 }
 
+export interface GetTrainingResultsResponse {
+  data: {
+    scope: "tenant" | "student" | "course";
+    /** @format uuid */
+    tenantId: string;
+    student: {
+      /** @format uuid */
+      id: string;
+      email: string;
+      firstName: string;
+      lastName: string;
+      fullName: string;
+    };
+    courses: {
+      /** @format uuid */
+      id: string;
+      title: string;
+      lessons: {
+        /** @format uuid */
+        lessonId: string;
+        /** @format uuid */
+        chapterId: string;
+        title: string;
+        type: string;
+        completed: boolean;
+        completedAt: string | null;
+      }[];
+      quizzes: {
+        /** @format uuid */
+        lessonId: string;
+        /** @format uuid */
+        chapterId: string;
+        title: string;
+        score: number | null;
+        passed: boolean | null;
+        attempts: number | null;
+        completedAt: string | null;
+      }[];
+      certificate: {
+        enabled: boolean;
+        status: "issued" | "not_issued" | "not_applicable";
+        issuedAt: string | null;
+      };
+    }[];
+  }[];
+  pagination: {
+    totalItems: number;
+    page: number;
+    perPage: number;
+  };
+  appliedFilters?: object;
+}
+
 export interface DeleteUserResponse {
   data: {
     message: string;
@@ -8630,6 +8683,35 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         method: "POST",
         body: data,
         type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Returns training results in JSON for the tenant selected by X-Tenant-Id. Each response row represents one student-course pair. Use scope=tenant to list all rows for the tenant, scope=student to list rows for a specific student (studentId required), and scope=course to list rows for a specific course (courseId required). Optional extra filter can further narrow results.
+     *
+     * @tags Integration
+     * @name IntegrationControllerGetTrainingResults
+     * @summary Get training results for integration reporting
+     * @request GET:/api/integration/training-results
+     */
+    integrationControllerGetTrainingResults: (
+      query: {
+        scope: "tenant" | "student" | "course";
+        /** @format uuid */
+        studentId?: string;
+        /** @format uuid */
+        courseId?: string;
+        /** @min 1 */
+        page?: number;
+        perPage?: number;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<GetTrainingResultsResponse, void>({
+        path: `/api/integration/training-results`,
+        method: "GET",
+        query: query,
         format: "json",
         ...params,
       }),


### PR DESCRIPTION
## Issue(s)
- #1473 

## Overview
Adds the integration training-results endpoint for retrieving student progress data. The endpoint returns per-student, per-course progress with lesson completion, quiz results, and certificate status, and supports tenant, student, and course scoped queries with pagination.

## Business Value
External systems can read authoritative progress data directly from Mentingo, making it easier to sync learner status, report completion, and drive downstream automations without relying on internal data access.

### Notes

- [x] Fired up e2e tests and got a positive result
