### PR TITLE
chore: make background event processing more reliable with Postgres listener

### DIFF
--- a/.github/workflows/pr-backend-ci.yml
+++ b/.github/workflows/pr-backend-ci.yml
@@ -103,6 +103,8 @@ jobs:
         run: pnpm run build
 
       - name: Verify build output
+        env:
+          DISABLE_OUTBOX_PROCESSING: "true"
         run: |
           pnpm start:prod &
           APP_PID=$!

--- a/apps/api/src/outbox/outbox-dispatcher.cron.ts
+++ b/apps/api/src/outbox/outbox-dispatcher.cron.ts
@@ -7,7 +7,7 @@ import { OutboxDispatcherService } from "./outbox-dispatcher.service";
 export class OutboxDispatcherCron {
   constructor(private readonly outboxDispatcherService: OutboxDispatcherService) {}
 
-  @Cron(CronExpression.EVERY_10_SECONDS)
+  @Cron(CronExpression.EVERY_5_MINUTES)
   async dispatchOutboxEvents() {
     await this.outboxDispatcherService.dispatchPendingEvents();
   }

--- a/apps/api/src/outbox/outbox-listener.service.ts
+++ b/apps/api/src/outbox/outbox-listener.service.ts
@@ -1,0 +1,64 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import postgres from "postgres";
+
+import { OutboxDispatcherService } from "./outbox-dispatcher.service";
+import { OUTBOX_NOTIFY_CHANNEL } from "./outbox.constants";
+
+import type { OnModuleDestroy, OnModuleInit } from "@nestjs/common";
+
+@Injectable()
+export class OutboxListenerService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(OutboxListenerService.name);
+  private readonly client: postgres.Sql;
+  private listenMeta: postgres.ListenMeta | null = null;
+  private dispatchScheduled: NodeJS.Immediate | null = null;
+  private isShuttingDown = false;
+
+  constructor(
+    configService: ConfigService,
+    private readonly outboxDispatcherService: OutboxDispatcherService,
+  ) {
+    this.client = postgres(configService.get<string>("database.urlApp")!, {
+      max: 1,
+      idle_timeout: 0,
+      max_lifetime: 0,
+    });
+  }
+
+  async onModuleInit(): Promise<void> {
+    this.listenMeta = await this.client.listen(
+      OUTBOX_NOTIFY_CHANNEL,
+      () => this.scheduleDispatch(),
+      () => this.logger.log(`Listening for ${OUTBOX_NOTIFY_CHANNEL} notifications`),
+    );
+
+    this.scheduleDispatch();
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    this.isShuttingDown = true;
+
+    if (this.dispatchScheduled) {
+      clearImmediate(this.dispatchScheduled);
+      this.dispatchScheduled = null;
+    }
+
+    await this.listenMeta?.unlisten();
+    await this.client.end({ timeout: 5 });
+  }
+
+  private scheduleDispatch(): void {
+    if (this.isShuttingDown || this.dispatchScheduled) return;
+
+    this.dispatchScheduled = setImmediate(async () => {
+      this.dispatchScheduled = null;
+
+      try {
+        await this.outboxDispatcherService.dispatchPendingEvents();
+      } catch (error) {
+        this.logger.error(`Failed dispatching outbox events after notification: ${error}`);
+      }
+    });
+  }
+}

--- a/apps/api/src/outbox/outbox.constants.ts
+++ b/apps/api/src/outbox/outbox.constants.ts
@@ -1,1 +1,4 @@
 export const OUTBOX_NOTIFY_CHANNEL = "outbox_events";
+
+export const isOutboxProcessingEnabled = () =>
+  !process.env.JEST_WORKER_ID && process.env.DISABLE_OUTBOX_PROCESSING !== "true";

--- a/apps/api/src/outbox/outbox.constants.ts
+++ b/apps/api/src/outbox/outbox.constants.ts
@@ -1,0 +1,1 @@
+export const OUTBOX_NOTIFY_CHANNEL = "outbox_events";

--- a/apps/api/src/outbox/outbox.module.ts
+++ b/apps/api/src/outbox/outbox.module.ts
@@ -3,6 +3,7 @@ import { CqrsModule } from "@nestjs/cqrs";
 
 import { OutboxDispatcherCron } from "./outbox-dispatcher.cron";
 import { OutboxDispatcherService } from "./outbox-dispatcher.service";
+import { OutboxListenerService } from "./outbox-listener.service";
 import { OutboxPublisher } from "./outbox.publisher";
 import { OutboxRepository } from "./outbox.repository";
 
@@ -13,7 +14,7 @@ import { OutboxRepository } from "./outbox.repository";
     OutboxRepository,
     OutboxPublisher,
     OutboxDispatcherService,
-    ...(process.env.JEST_WORKER_ID ? [] : [OutboxDispatcherCron]),
+    ...(process.env.JEST_WORKER_ID ? [] : [OutboxDispatcherCron, OutboxListenerService]),
   ],
   exports: [OutboxPublisher],
 })

--- a/apps/api/src/outbox/outbox.module.ts
+++ b/apps/api/src/outbox/outbox.module.ts
@@ -4,6 +4,7 @@ import { CqrsModule } from "@nestjs/cqrs";
 import { OutboxDispatcherCron } from "./outbox-dispatcher.cron";
 import { OutboxDispatcherService } from "./outbox-dispatcher.service";
 import { OutboxListenerService } from "./outbox-listener.service";
+import { isOutboxProcessingEnabled } from "./outbox.constants";
 import { OutboxPublisher } from "./outbox.publisher";
 import { OutboxRepository } from "./outbox.repository";
 
@@ -14,7 +15,7 @@ import { OutboxRepository } from "./outbox.repository";
     OutboxRepository,
     OutboxPublisher,
     OutboxDispatcherService,
-    ...(process.env.JEST_WORKER_ID ? [] : [OutboxDispatcherCron, OutboxListenerService]),
+    ...(isOutboxProcessingEnabled() ? [OutboxDispatcherCron, OutboxListenerService] : []),
   ],
   exports: [OutboxPublisher],
 })

--- a/apps/api/src/outbox/outbox.publisher.ts
+++ b/apps/api/src/outbox/outbox.publisher.ts
@@ -6,7 +6,7 @@ import { DatabasePg } from "src/common";
 import { DB } from "src/storage/db/db.providers";
 import { outboxEvents } from "src/storage/schema";
 
-import { OUTBOX_NOTIFY_CHANNEL } from "./outbox.constants";
+import { isOutboxProcessingEnabled, OUTBOX_NOTIFY_CHANNEL } from "./outbox.constants";
 
 @Injectable()
 export class OutboxPublisher {
@@ -16,7 +16,7 @@ export class OutboxPublisher {
   ) {}
 
   async publish(event: object, dbInstance?: DatabasePg): Promise<void> {
-    if (process.env.JEST_WORKER_ID) {
+    if (!isOutboxProcessingEnabled()) {
       await this.eventBus.publish(event);
       return;
     }

--- a/apps/api/src/outbox/outbox.publisher.ts
+++ b/apps/api/src/outbox/outbox.publisher.ts
@@ -1,9 +1,12 @@
 import { Inject, Injectable } from "@nestjs/common";
 import { EventBus } from "@nestjs/cqrs";
+import { sql } from "drizzle-orm";
 
 import { DatabasePg } from "src/common";
 import { DB } from "src/storage/db/db.providers";
 import { outboxEvents } from "src/storage/schema";
+
+import { OUTBOX_NOTIFY_CHANNEL } from "./outbox.constants";
 
 @Injectable()
 export class OutboxPublisher {
@@ -29,6 +32,8 @@ export class OutboxPublisher {
       status: "pending",
       attemptCount: 0,
     });
+
+    await db.execute(sql`SELECT pg_notify(${OUTBOX_NOTIFY_CHANNEL}, '')`);
   }
 
   private getEventType(event: object): string {


### PR DESCRIPTION
<!--
 1. Make sure you have correct branch name i.e. `ab_prefix_123_task_name`, where `123` is a issue ID, and `ab` is an author
 2. Make sure you have meaningful title related to task with correct prefix: feat/fix/chore/style/docs/refactor
 3. Reference multiple issues in one PR by listing them in the issues section
 4. Make sure all necessary sections are filled, remove obsolete sections
 5. Do a self review first
 6. Check if your PR includes only code related to your task
 7. `Notes` is used for additional info but also to notify if any action is required
-->

## Issue(s)
[1481](https://github.com/Selleo/mentingo/issues/1481)

 ## Overview

  Adds PostgreSQL LISTEN/NOTIFY dispatching for the outbox while
  keeping a low-frequency cron fallback.

  Changes include:

  - adds a shared OUTBOX_NOTIFY_CHANNEL constant for the outbox
    channel name
  - sends pg_notify after persisting a pending outbox event
  - adds OutboxListenerService with a dedicated Postgres listen
    connection
  - dispatches pending outbox events on notification and once on
    module startup
  - reduces the cron dispatcher frequency from every 10 seconds to
    every 5 minutes as a fallback drain

  ## Business Value

  Outbox events are dispatched immediately after they are created
  instead of waiting for the next scheduled cron tick. The fallback
  cron preserves operational resilience by periodically draining
  pending events if PostgreSQL notifications are missed or the
  listener is unavailable.