### PR TITLE
fix: improve multiple file uploads for smoother course creation

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -106,6 +106,11 @@ Frontend-specific instructions for `apps/web`. Preserve generated API usage, rou
 - E2E setup uses `e2e/fixtures`, `e2e/factories`, and `e2e/flows`.
 - E2E API setup uses `e2e/utils/api-client.ts`, which wraps the generated API.
 - Prefer readonly fixtures for assertions and worker/isolated fixtures for mutations.
+- Keep to the conventions in `e2e/strategy.md`:
+  - use `withReadonlyPage` for non-mutating specs;
+  - use `withWorkerPage` for mutating specs;
+  - register cleanup for created entities unless test purpose is persistence validation;
+  - keep UI assertions in specs and backend consistency checks through `expect.poll(...)`.
 
 ## Safety Boundaries
 

--- a/apps/web/app/components/RichText/Editor.tsx
+++ b/apps/web/app/components/RichText/Editor.tsx
@@ -52,11 +52,11 @@ const Editor = ({
   const handleDrop = useCallback(
     async (event: DragEvent) => {
       const activeEditor = editorRef.current;
-      const file = event.dataTransfer?.files[0];
-      if (!file) return false;
+      const files = Array.from(event.dataTransfer?.files ?? []);
+      if (!files.length) return false;
 
       event.preventDefault();
-      await onUpload?.(file, activeEditor);
+      await Promise.allSettled(files.map((file) => onUpload?.(file, activeEditor)));
       return true;
     },
     [onUpload],

--- a/apps/web/app/components/RichText/Editor.tsx
+++ b/apps/web/app/components/RichText/Editor.tsx
@@ -50,13 +50,13 @@ const Editor = ({
   );
 
   const handleDrop = useCallback(
-    async (event: DragEvent) => {
+    (event: DragEvent) => {
       const activeEditor = editorRef.current;
       const files = Array.from(event.dataTransfer?.files ?? []);
       if (!files.length) return false;
 
       event.preventDefault();
-      await Promise.allSettled(files.map((file) => onUpload?.(file, activeEditor)));
+      void Promise.allSettled(files.map((file) => onUpload?.(file, activeEditor)));
       return true;
     },
     [onUpload],

--- a/apps/web/app/components/RichText/extensions/utils/videoUploadNode.ts
+++ b/apps/web/app/components/RichText/extensions/utils/videoUploadNode.ts
@@ -1,5 +1,5 @@
 import { VIDEO_AUTOPLAY } from "@repo/shared";
-import { NodeSelection, TextSelection } from "@tiptap/pm/state";
+import { TextSelection } from "@tiptap/pm/state";
 
 import type { Editor as TiptapEditor } from "@tiptap/react";
 
@@ -136,10 +136,8 @@ export const insertVideoUploadPlaceholder = ({
     .run();
 
   const { state, view } = editor;
-  const { selection } = state;
-  const targetPos = selection instanceof NodeSelection ? selection.to + 1 : selection.to;
-  const clampedPos = Math.max(1, Math.min(targetPos, state.doc.content.size));
-  const nextSelection = TextSelection.create(state.doc, clampedPos);
+  const clampedPos = Math.max(0, Math.min(state.selection.to, state.doc.content.size));
+  const nextSelection = TextSelection.near(state.doc.resolve(clampedPos), 1);
 
   view.dispatch(state.tr.setSelection(nextSelection).scrollIntoView());
 };

--- a/apps/web/app/components/RichText/toolbar/EditorToolbar.tsx
+++ b/apps/web/app/components/RichText/toolbar/EditorToolbar.tsx
@@ -69,13 +69,13 @@ const EditorToolbar = ({
 
   const acceptedImages = acceptedFileTypes.join(",");
 
-  const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files ?? []);
     if (!files.length || !onUpload) return;
 
     if (fileUploadRef.current) fileUploadRef.current.value = "";
 
-    await Promise.allSettled(files.map((file) => onUpload(file, editor)));
+    void Promise.allSettled(files.map((file) => onUpload(file, editor)));
   };
 
   return (

--- a/apps/web/app/hooks/buildRichTextFileUploadHandler.ts
+++ b/apps/web/app/hooks/buildRichTextFileUploadHandler.ts
@@ -46,7 +46,7 @@ const createSerialQueue = () => {
 };
 
 const displayModePromptQueue = createSerialQueue();
-const videoInsertQueue = createSerialQueue();
+const editorMutationQueue = createSerialQueue();
 
 const askForDisplayModeSequentially = (
   askForDisplayMode: (filename: string) => Promise<DisplayMode | null>,
@@ -55,19 +55,21 @@ const askForDisplayModeSequentially = (
   return displayModePromptQueue(() => askForDisplayMode(filename));
 };
 
-const insertPendingVideoNodeSequentially = async (args: {
+const insertPendingVideoNode = (args: {
   editor?: TiptapEditor | null;
   file: File;
   uploadId: string;
-}) => {
-  await videoInsertQueue(() =>
+}) =>
+  editorMutationQueue(() =>
     insertVideoUploadPlaceholder({
       editor: args.editor,
       uploadId: args.uploadId,
       uploadLabel: args.file.name,
     }),
   );
-};
+
+const insertResourceNode = (args: Parameters<typeof insertResourceIntoEditor>[0]) =>
+  editorMutationQueue(() => insertResourceIntoEditor(args));
 
 const handleVideoUpload = async ({
   editor,
@@ -95,66 +97,70 @@ const handleVideoUpload = async ({
     uploadQueue?.setStatus(queueId, UPLOAD_STATUS.QUEUED);
   }
 
-  await insertPendingVideoNodeSequentially({
+  await insertPendingVideoNode({
     editor,
     file,
     uploadId,
   });
 
-  try {
-    const session = await getVideoSessionForFile(file);
-    if (queueId) {
-      uploadQueue?.attachUploadId(queueId, session.uploadId);
-    }
+  const processVideoUpload = async () => {
+    try {
+      const session = await getVideoSessionForFile(file);
+      if (queueId) {
+        uploadQueue?.attachUploadId(queueId, session.uploadId);
+      }
 
-    if (session.resourceId) {
-      updateVideoUploadNodeById(editor, uploadId, {
-        src: buildEntityResourceUrl(session.resourceId, entityType),
-        sourceType: session.provider === "s3" ? "external" : "internal",
-        provider: session.provider,
-        hasError: false,
-        uploadStatus: null,
-        uploadErrorMessage: null,
-      });
-    }
-
-    await uploadVideo({
-      file,
-      session,
-      onUploadingStart: () => {
-        if (queueId) uploadQueue?.setStatus(queueId, UPLOAD_STATUS.UPLOADING);
-      },
-      onProgress: (progress) => {
-        if (queueId) uploadQueue?.setProgress(queueId, progress);
-      },
-      onUploaded: () => {
-        if (queueId) uploadQueue?.setStatus(queueId, UPLOAD_STATUS.SUCCESS);
-      },
-      onError: (error) => {
-        if (queueId) {
-          uploadQueue?.setStatus(queueId, UPLOAD_STATUS.FAILED, {
-            errorMessage: error.message,
-          });
-        }
+      if (session.resourceId) {
         updateVideoUploadNodeById(editor, uploadId, {
-          hasError: true,
-          uploadStatus: VIDEO_UPLOAD_NODE_STATUS.FAILED,
-          uploadErrorMessage: error.message,
+          src: buildEntityResourceUrl(session.resourceId, entityType),
+          sourceType: session.provider === "s3" ? "external" : "internal",
+          provider: session.provider,
+          hasError: false,
+          uploadStatus: null,
+          uploadErrorMessage: null,
         });
-      },
-    });
-  } catch (error) {
-    if (queueId) {
-      uploadQueue?.setStatus(queueId, UPLOAD_STATUS.FAILED, {
-        errorMessage: error instanceof Error ? error.message : fallbackUploadErrorMessage,
+      }
+
+      await uploadVideo({
+        file,
+        session,
+        onUploadingStart: () => {
+          if (queueId) uploadQueue?.setStatus(queueId, UPLOAD_STATUS.UPLOADING);
+        },
+        onProgress: (progress) => {
+          if (queueId) uploadQueue?.setProgress(queueId, progress);
+        },
+        onUploaded: () => {
+          if (queueId) uploadQueue?.setStatus(queueId, UPLOAD_STATUS.SUCCESS);
+        },
+        onError: (error) => {
+          if (queueId) {
+            uploadQueue?.setStatus(queueId, UPLOAD_STATUS.FAILED, {
+              errorMessage: error.message,
+            });
+          }
+          updateVideoUploadNodeById(editor, uploadId, {
+            hasError: true,
+            uploadStatus: VIDEO_UPLOAD_NODE_STATUS.FAILED,
+            uploadErrorMessage: error.message,
+          });
+        },
       });
+    } catch (error) {
+      if (queueId) {
+        uploadQueue?.setStatus(queueId, UPLOAD_STATUS.FAILED, {
+          errorMessage: error instanceof Error ? error.message : fallbackUploadErrorMessage,
+        });
+      }
+      updateVideoUploadNodeById(editor, uploadId, {
+        uploadStatus: VIDEO_UPLOAD_NODE_STATUS.FAILED,
+        uploadErrorMessage: error instanceof Error ? error.message : fallbackUploadErrorMessage,
+      });
+      onVideoUploadError(error);
     }
-    updateVideoUploadNodeById(editor, uploadId, {
-      uploadStatus: VIDEO_UPLOAD_NODE_STATUS.FAILED,
-      uploadErrorMessage: error instanceof Error ? error.message : fallbackUploadErrorMessage,
-    });
-    onVideoUploadError(error);
-  }
+  };
+
+  void processVideoUpload();
 };
 
 const handleResourceUpload = async ({
@@ -212,7 +218,7 @@ const handleResourceUpload = async ({
     throw error;
   }
 
-  insertResourceIntoEditor({
+  await insertResourceNode({
     editor,
     resourceId,
     entityType,
@@ -256,7 +262,6 @@ type RichTextResourceType = (typeof RICH_TEXT_RESOURCE_TYPE)[keyof typeof RICH_T
 
 type FileCharacteristics = {
   isVideo: boolean;
-  isImage: boolean;
   isPresentation: boolean;
   isPdf: boolean;
   isDocument: boolean;
@@ -264,7 +269,6 @@ type FileCharacteristics = {
 };
 
 const getFileCharacteristics = (file: File): FileCharacteristics => {
-  const isImage = ALLOWED_LESSON_IMAGE_FILE_TYPES.includes(file.type);
   const isVideo = ALLOWED_VIDEO_FILE_TYPES.includes(file.type);
   const isPresentation = ALLOWED_PRESENTATION_FILE_TYPES.includes(file.type);
   const isPdf = ALLOWED_PDF_FILE_TYPES.includes(file.type);
@@ -274,18 +278,15 @@ const getFileCharacteristics = (file: File): FileCharacteristics => {
     ALLOWED_WORD_FILE_TYPES.includes(file.type);
 
   return {
-    isImage,
     isVideo,
     isPresentation,
     isPdf,
     isDocument,
     resourceType: match({
-      isImage,
       isPresentation,
       isPdf,
       isDocument,
     })
-      .with({ isImage: true }, () => RICH_TEXT_RESOURCE_TYPE.IMAGE)
       .with({ isPresentation: true }, () => RICH_TEXT_RESOURCE_TYPE.PRESENTATION)
       .with({ isPdf: true }, () => RICH_TEXT_RESOURCE_TYPE.PDF)
       .with({ isDocument: true }, () => RICH_TEXT_RESOURCE_TYPE.DOCUMENT)

--- a/apps/web/app/hooks/useEntityResourceUpload.ts
+++ b/apps/web/app/hooks/useEntityResourceUpload.ts
@@ -1,4 +1,5 @@
 import { ENTITY_TYPES, type EntityType, type SupportedLanguages } from "@repo/shared";
+import { TextSelection } from "@tiptap/pm/state";
 import { match } from "ts-pattern";
 
 import { useLessonFileUpload } from "~/api/mutations/admin/useLessonFileUpload";
@@ -22,7 +23,6 @@ export const RICH_TEXT_RESOURCE_TYPE = {
   PRESENTATION: "presentation",
   PDF: "pdf",
   DOCUMENT: "document",
-  IMAGE: "image",
   OTHER: "other",
 } as const;
 
@@ -52,6 +52,21 @@ export const buildEntityResourceUrl = (resourceId: string, entityType: EntityTyp
   }
 };
 
+const insertContentIntoEditor = (
+  editor: TiptapEditor | null | undefined,
+  content: Parameters<TiptapEditor["commands"]["insertContentAt"]>[1],
+) => {
+  if (!editor) return;
+
+  editor.chain().focus().insertContent(content).run();
+
+  const { state, view } = editor;
+  const clampedPos = Math.max(0, Math.min(state.selection.to, state.doc.content.size));
+  const nextSelection = TextSelection.near(state.doc.resolve(clampedPos), 1);
+
+  view.dispatch(state.tr.setSelection(nextSelection).scrollIntoView());
+};
+
 export const insertResourceIntoEditor = ({
   editor,
   resourceId,
@@ -61,58 +76,63 @@ export const insertResourceIntoEditor = ({
   displayMode = "preview",
 }: InsertResourceArgs) => {
   const resourceUrl = buildEntityResourceUrl(resourceId, entityType);
-  const chain = editor?.chain().focus();
 
   if (resourceType === "presentation") {
     if (displayMode === "download") {
-      chain
-        ?.setDownloadableFile({
+      insertContentIntoEditor(editor, {
+        type: "downloadableFile",
+        attrs: {
           src: resourceUrl,
           name: file.name,
-        })
-        .run();
+        },
+      });
       return;
     }
 
-    chain?.setPresentationEmbed({ src: resourceUrl, sourceType: "internal" }).run();
+    insertContentIntoEditor(editor, {
+      type: "presentation",
+      attrs: { src: resourceUrl, sourceType: "internal" },
+    });
     return;
   }
 
   if (resourceType === "pdf") {
     if (displayMode === "preview") {
-      chain
-        ?.setPdfPreviewEmbed({
+      insertContentIntoEditor(editor, {
+        type: "pdfPreview",
+        attrs: {
           src: resourceUrl,
           name: file.name,
-        })
-        .run();
+        },
+      });
       return;
     }
 
-    chain
-      ?.setDownloadableFile({
+    insertContentIntoEditor(editor, {
+      type: "downloadableFile",
+      attrs: {
         src: resourceUrl,
         name: file.name,
-      })
-      .run();
+      },
+    });
     return;
   }
 
   if (resourceType === "document") {
-    chain
-      ?.setDownloadableFile({
+    insertContentIntoEditor(editor, {
+      type: "downloadableFile",
+      attrs: {
         src: resourceUrl,
         name: file.name,
-      })
-      .run();
+      },
+    });
     return;
   }
 
-  chain
-    ?.insertContent(
-      `<br /><a href="${resourceUrl}" data-resource-id="${resourceId}">${resourceUrl}</a>`,
-    )
-    .run();
+  insertContentIntoEditor(
+    editor,
+    `<br /><a href="${resourceUrl}" data-resource-id="${resourceId}">${resourceUrl}</a>`,
+  );
 };
 
 export const useEntityResourceUpload = () => {

--- a/apps/web/e2e/data/curriculum/curriculum.data.ts
+++ b/apps/web/e2e/data/curriculum/curriculum.data.ts
@@ -19,4 +19,16 @@ export const CURRICULUM_TEST_DATA = {
     aiMentorResource: fixturePath("ai-mentor-resource.pdf"),
     aiMentorAvatar: fixturePath("ai-mentor-avatar.png"),
   },
+  resourceUploads: {
+    multi: [
+      {
+        path: fixturePath("content-image.png"),
+        fileName: "content-image.png",
+      },
+      {
+        path: fixturePath("content-video.mp4"),
+        fileName: "content-video.mp4",
+      },
+    ],
+  },
 } as const;

--- a/apps/web/e2e/flows/curriculum/upload-content-resource.flow.ts
+++ b/apps/web/e2e/flows/curriculum/upload-content-resource.flow.ts
@@ -3,7 +3,7 @@ import { RICH_TEXT_HANDLES } from "../../data/common/handles";
 import type { Page } from "@playwright/test";
 
 type UploadContentResourceInput = {
-  path: string;
+  path: string | string[];
   displayMode?: "preview" | "download";
 };
 
@@ -11,7 +11,9 @@ export const uploadContentResourceFlow = async (
   page: Page,
   { path, displayMode }: UploadContentResourceInput,
 ) => {
-  await page.getByTestId(RICH_TEXT_HANDLES.UPLOAD_FILE_INPUT).setInputFiles(path);
+  const paths = Array.isArray(path) ? path : [path];
+
+  await page.getByTestId(RICH_TEXT_HANDLES.UPLOAD_FILE_INPUT).setInputFiles(paths);
 
   if (displayMode) {
     await page.getByTestId(RICH_TEXT_HANDLES.UPLOAD_DISPLAY_MODE_DIALOG).waitFor();

--- a/apps/web/e2e/specs/curriculum/content-lesson-resources.spec.ts
+++ b/apps/web/e2e/specs/curriculum/content-lesson-resources.spec.ts
@@ -44,6 +44,8 @@ const resourceCases: ResourceCase[] = [
   },
 ];
 
+const multiResourceFiles = CURRICULUM_TEST_DATA.resourceUploads.multi;
+
 for (const resourceCase of resourceCases) {
   const resourceTest = existsSync(resourceCase.path) ? test : test.skip;
 
@@ -94,6 +96,54 @@ for (const resourceCase of resourceCases) {
     },
   );
 }
+
+test("admin can save content lesson with multiple files in one upload", async ({
+  cleanup,
+  factories,
+  withWorkerPage,
+}) => {
+  await withWorkerPage(USER_ROLE.admin, async ({ page }) => {
+    const { category, course, categoryFactory, courseFactory } = await createCurriculumCourse(
+      factories,
+      `curriculum-resource-${Date.now()}`,
+    );
+    const curriculumFactory = factories.createCurriculumFactory();
+    const chapter = await curriculumFactory.createChapter({
+      courseId: course.id,
+      title: `resource-chapter-${Date.now()}`,
+    });
+    const lessonTitle = `resource-lesson-${Date.now()}`;
+
+    cleanup.add(async () => {
+      await courseFactory.delete(course.id);
+      await categoryFactory.delete(category.id);
+    });
+
+    await openCurriculumPageFlow(page, course.id);
+    await openNewLessonFormFlow(page, chapter.id, "content");
+    await fillContentLessonFormFlow(page, {
+      title: lessonTitle,
+      description: `Resource lesson ${Date.now()}`,
+    });
+    await uploadContentResourceFlow(page, {
+      path: multiResourceFiles.map((file) => file.path),
+    });
+    await expect(page.getByTestId(RICH_TEXT_HANDLES.UPLOAD_QUEUE)).toBeVisible({
+      timeout: 30_000,
+    });
+    for (const { fileName } of multiResourceFiles) {
+      await expect(page.getByTestId(RICH_TEXT_HANDLES.uploadQueueItem(fileName))).toBeVisible();
+    }
+    await saveContentLessonFormFlow(page);
+
+    await expect
+      .poll(async () => {
+        const updatedCourse = await courseFactory.getById(course.id);
+        return updatedCourse.chapters[0]?.lessons?.some((lesson) => lesson.title === lessonTitle);
+      })
+      .toBe(true);
+  });
+});
 
 test("admin can save content lesson with a YouTube video embed", async ({
   cleanup,


### PR DESCRIPTION
## Issue(s)
- #1492 

## Overview
This PR improves rich text resource uploads so admins can upload multiple files in a single action when creating or editing content lessons.

The editor toolbar and drag-and-drop upload path now process all selected files instead of only the first one. Rich text resource insertion is queued through a shared editor mutation queue so concurrent uploads insert their placeholders/resources consistently without selection drift. Video uploads insert their pending node immediately and continue processing asynchronously, while uploaded resources use a safer selection update after insertion.

The E2E curriculum resource flow now accepts multiple file paths, includes multi-resource fixture data, and covers saving a content lesson after uploading an image and video together. The web agent instructions were also updated to point E2E changes at the existing `e2e/strategy.md` conventions.

## Business Value
Admins can add lesson resources faster and with less friction by selecting multiple files at once instead of repeating the upload flow for each asset.

This also makes content authoring more reliable when several uploads finish around the same time, reducing the chance of missing resources or incorrectly positioned rich text embeds in saved lessons.

## Screenshots / Video

https://github.com/user-attachments/assets/205260d2-d8b9-4969-be2c-a438299dde50

