### PR TITLE
chore: improve file storage reliability with better error handling and timeouts

### DIFF
--- a/apps/api/src/file/file.service.ts
+++ b/apps/api/src/file/file.service.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "crypto";
+import path from "node:path";
 import { Readable } from "stream";
 
 import {
@@ -156,12 +157,9 @@ export class FileService {
       throw new BadRequestException("Video uploads must use the TUS endpoints");
     }
 
-    const fileExtension = file.originalname.split(".").pop();
+    const fileExtension = path.extname(file.originalname);
 
-    const fileKey = prefixTenantStorageKey(
-      `${resource}/${randomUUID()}.${fileExtension}`,
-      tenantId,
-    );
+    const fileKey = prefixTenantStorageKey(`${resource}/${randomUUID()}${fileExtension}`, tenantId);
 
     try {
       await this.s3Service.uploadFile(file.buffer, fileKey, file.mimetype);

--- a/apps/api/src/file/file.service.ts
+++ b/apps/api/src/file/file.service.ts
@@ -152,33 +152,30 @@ export class FileService {
 
     const isVideo = file.mimetype.startsWith("video/");
 
-    try {
-      if (isVideo) {
-        throw new BadRequestException("Video uploads must use the TUS endpoints");
-      }
-
-      const fileExtension = file.originalname.split(".").pop();
-
-      const fileKey = prefixTenantStorageKey(
-        `${resource}/${randomUUID()}.${fileExtension}`,
-        tenantId,
-      );
-
-      try {
-        await this.s3Service.uploadFile(file.buffer, fileKey, file.mimetype);
-      } catch (s3Error) {
-        throw new ConflictException("S3 upload failed");
-      }
-
-      const fileUrl = await this.s3Service.getSignedUrl(fileKey);
-
-      return {
-        fileKey,
-        fileUrl,
-      };
-    } catch (error) {
-      throw new ConflictException("Failed to upload file");
+    if (isVideo) {
+      throw new BadRequestException("Video uploads must use the TUS endpoints");
     }
+
+    const fileExtension = file.originalname.split(".").pop();
+
+    const fileKey = prefixTenantStorageKey(
+      `${resource}/${randomUUID()}.${fileExtension}`,
+      tenantId,
+    );
+
+    try {
+      await this.s3Service.uploadFile(file.buffer, fileKey, file.mimetype);
+    } catch (s3Error) {
+      this.logFileOperationFailure("upload", fileKey, s3Error);
+      throw new ConflictException("S3 upload failed");
+    }
+
+    const fileUrl = await this.s3Service.getSignedUrl(fileKey);
+
+    return {
+      fileKey,
+      fileUrl,
+    };
   }
 
   private async resolveVideoProvider() {
@@ -390,6 +387,7 @@ export class FileService {
       }
       return await this.s3Service.deleteFile(fileKey);
     } catch (error) {
+      this.logFileOperationFailure("delete", fileKey, error);
       throw new ConflictException("Failed to delete file");
     }
   }
@@ -398,8 +396,18 @@ export class FileService {
     try {
       return await this.s3Service.getFileStream(fileKey, range);
     } catch (error) {
+      this.logFileOperationFailure("retrieve", fileKey, error);
       throw new BadRequestException("Failed to retrieve file");
     }
+  }
+
+  private logFileOperationFailure(operation: string, fileKey: string, error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+
+    this.logger.error(
+      `Failed to ${operation} file "${fileKey}": ${message}`,
+      error instanceof Error ? error.stack : undefined,
+    );
   }
 
   async listFileReferencesByPrefix(prefix: string) {

--- a/apps/api/src/file/types/file-stream.type.ts
+++ b/apps/api/src/file/types/file-stream.type.ts
@@ -9,4 +9,5 @@ export type FileStreamPayload = {
   etag?: string;
   lastModified?: Date;
   statusCode?: number;
+  streamTimeoutMs?: number;
 };

--- a/apps/api/src/file/utils/__tests__/streamFileToResponse.spec.ts
+++ b/apps/api/src/file/utils/__tests__/streamFileToResponse.spec.ts
@@ -1,0 +1,67 @@
+import { PassThrough, Writable } from "stream";
+
+import { Logger } from "@nestjs/common";
+
+import { streamFileToResponse } from "../streamFileToResponse";
+
+import type { Response } from "express";
+
+class MockResponse extends Writable {
+  headersSent = false;
+  headers = new Map<string, string>();
+  statusCode = 200;
+
+  _write(_chunk: unknown, _encoding: BufferEncoding, callback: (error?: Error | null) => void) {
+    this.headersSent = true;
+    callback();
+  }
+
+  setHeader(name: string, value: string) {
+    this.headers.set(name, value);
+    return this;
+  }
+
+  status(code: number) {
+    this.statusCode = code;
+    return this;
+  }
+}
+
+describe("streamFileToResponse", () => {
+  let loggerErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    loggerErrorSpy = jest.spyOn(Logger.prototype, "error").mockImplementation();
+  });
+
+  afterEach(() => {
+    loggerErrorSpy.mockRestore();
+  });
+
+  it("destroys the file stream when the response emits an error", () => {
+    const fileStream = new PassThrough();
+    const response = new MockResponse();
+
+    streamFileToResponse(response as unknown as Response, { stream: fileStream });
+
+    response.emit("error", new Error("socket failed"));
+
+    expect(fileStream.destroyed).toBe(true);
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      "File response failed: socket failed",
+      expect.any(String),
+    );
+  });
+
+  it("destroys the file stream when the response closes before completion", () => {
+    const fileStream = new PassThrough();
+    const response = new MockResponse();
+
+    streamFileToResponse(response as unknown as Response, { stream: fileStream });
+
+    response.emit("close");
+
+    expect(fileStream.destroyed).toBe(true);
+    expect(loggerErrorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/file/utils/streamFileToResponse.ts
+++ b/apps/api/src/file/utils/streamFileToResponse.ts
@@ -1,7 +1,63 @@
+import { Logger } from "@nestjs/common";
+
 import type { Response } from "express";
 import type { FileStreamPayload } from "src/file/types/file-stream.type";
 
+const logger = new Logger("FileDelivery");
+
 export const streamFileToResponse = (res: Response, file: FileStreamPayload) => {
+  let streamTimeout: NodeJS.Timeout | undefined;
+
+  const clearStreamTimeout = () => {
+    if (!streamTimeout) return;
+
+    clearTimeout(streamTimeout);
+    streamTimeout = undefined;
+  };
+
+  const destroyFileStream = () => {
+    if (file.stream.destroyed) return;
+    file.stream.destroy();
+  };
+
+  const handleResponseError = (error: Error) => {
+    clearStreamTimeout();
+
+    logger.error(
+      `File response failed: ${error instanceof Error ? error.message : String(error)}`,
+      error instanceof Error ? error.stack : undefined,
+    );
+
+    destroyFileStream();
+  };
+
+  const handleResponseClose = () => {
+    clearStreamTimeout();
+
+    if (!res.writableEnded) destroyFileStream();
+  };
+
+  const resetStreamTimeout = () => {
+    if (!file.streamTimeoutMs) return;
+
+    clearStreamTimeout();
+
+    streamTimeout = setTimeout(() => {
+      const message = `File stream timed out after ${file.streamTimeoutMs}ms`;
+      logger.error(message);
+      file.stream.destroy(new Error(message));
+    }, file.streamTimeoutMs);
+  };
+
+  resetStreamTimeout();
+
+  file.stream.on("data", resetStreamTimeout);
+  file.stream.on("end", clearStreamTimeout);
+  file.stream.on("close", clearStreamTimeout);
+  res.once("error", handleResponseError);
+  res.once("close", handleResponseClose);
+  res.once("finish", clearStreamTimeout);
+
   res.setHeader("Accept-Ranges", file.acceptRanges ?? "bytes");
 
   if (file.contentType) {
@@ -27,7 +83,14 @@ export const streamFileToResponse = (res: Response, file: FileStreamPayload) => 
     res.setHeader("Last-Modified", file.lastModified.toUTCString());
   }
 
-  file.stream.on("error", () => {
+  file.stream.on("error", (error) => {
+    clearStreamTimeout();
+
+    logger.error(
+      `File stream failed: ${error instanceof Error ? error.message : String(error)}`,
+      error instanceof Error ? error.stack : undefined,
+    );
+
     if (!res.headersSent) {
       res.status(500).end();
       return;

--- a/apps/api/src/s3/s3.constants.ts
+++ b/apps/api/src/s3/s3.constants.ts
@@ -1,0 +1,1 @@
+export const S3_OPERATION_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes

--- a/apps/api/src/s3/s3.service.spec.ts
+++ b/apps/api/src/s3/s3.service.spec.ts
@@ -1,0 +1,89 @@
+import { Readable } from "stream";
+
+import { Logger } from "@nestjs/common";
+
+import { S3_OPERATION_TIMEOUT_MS } from "src/s3/s3.constants";
+
+import { S3Service } from "./s3.service";
+
+import type { ConfigService } from "@nestjs/config";
+
+type S3ClientMock = {
+  send: jest.Mock;
+};
+
+const buildConfigService = () =>
+  ({
+    get: jest.fn((key: string) => {
+      const config: Record<string, string> = {
+        "s3.S3_ENDPOINT": "http://localhost:9100",
+        "s3.S3_REGION": "eu-central-1",
+        "s3.S3_ACCESS_KEY_ID": "minioadmin",
+        "s3.S3_SECRET_ACCESS_KEY": "minioadmin",
+        "s3.S3_BUCKET_NAME": "bucket",
+      };
+
+      return config[key];
+    }),
+  }) as unknown as ConfigService;
+
+const setS3Client = (service: S3Service, client: S3ClientMock) => {
+  (service as unknown as { s3Client: S3ClientMock }).s3Client = client;
+};
+
+describe("S3Service", () => {
+  let loggerErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    loggerErrorSpy = jest.spyOn(Logger.prototype, "error").mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    loggerErrorSpy.mockRestore();
+  });
+
+  it("aborts S3 operations after the S3 operation timeout", async () => {
+    jest.useFakeTimers();
+
+    const service = new S3Service(buildConfigService());
+    const send = jest.fn(
+      (_command: unknown, options?: { abortSignal?: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          options?.abortSignal?.addEventListener("abort", () => {
+            reject(new Error("aborted"));
+          });
+        }),
+    );
+
+    setS3Client(service, { send });
+
+    const request = service.getFileBuffer("tenant/file.pdf");
+    const assertion = expect(request).rejects.toThrow(
+      `S3 getFileBuffer for key "tenant/file.pdf" timed out after ${S3_OPERATION_TIMEOUT_MS}ms`,
+    );
+
+    await jest.advanceTimersByTimeAsync(S3_OPERATION_TIMEOUT_MS);
+    await assertion;
+    expect(send.mock.calls[0][1]?.abortSignal).toBeInstanceOf(AbortSignal);
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      `S3 getFileBuffer for key "tenant/file.pdf" timed out after ${S3_OPERATION_TIMEOUT_MS}ms`,
+    );
+  });
+
+  it("passes the S3 operation timeout to file streams", async () => {
+    const service = new S3Service(buildConfigService());
+    const send = jest.fn().mockResolvedValue({
+      Body: Readable.from(["file-content"]),
+      ContentType: "text/plain",
+      ContentLength: 12,
+      $metadata: { httpStatusCode: 200 },
+    });
+
+    setS3Client(service, { send });
+
+    const stream = await service.getFileStream("tenant/file.txt");
+
+    expect(stream.streamTimeoutMs).toBe(S3_OPERATION_TIMEOUT_MS);
+  });
+});

--- a/apps/api/src/s3/s3.service.ts
+++ b/apps/api/src/s3/s3.service.ts
@@ -10,14 +10,17 @@ import {
   ListObjectsV2Command,
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
-import { Injectable } from "@nestjs/common";
+import { Injectable, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
+
+import { S3_OPERATION_TIMEOUT_MS } from "src/s3/s3.constants";
 
 import type { FileStreamPayload } from "src/file/types/file-stream.type";
 import type { PassThrough, Readable } from "stream";
 
 @Injectable()
 export class S3Service {
+  private readonly logger = new Logger(S3Service.name);
   private s3Client: S3Client;
   private readonly bucketName: string;
 
@@ -77,6 +80,56 @@ export class S3Service {
     );
   }
 
+  private async sendWithTimeout<T>(
+    operation: string,
+    sendOperation: (abortSignal: AbortSignal) => Promise<T>,
+    context?: { key?: string },
+  ): Promise<T> {
+    const abortController = new AbortController();
+
+    let timedOut = false;
+
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      abortController.abort();
+    }, S3_OPERATION_TIMEOUT_MS);
+
+    try {
+      return await sendOperation(abortController.signal);
+    } catch (error) {
+      const message = this.getErrorMessage(error);
+      const statusCode = this.getErrorStatusCode(error);
+      const keyContext = context?.key ? ` for key "${context.key}"` : "";
+
+      if (timedOut) {
+        const timeoutMessage = `S3 ${operation}${keyContext} timed out after ${S3_OPERATION_TIMEOUT_MS}ms`;
+        this.logger.error(timeoutMessage);
+        throw new Error(timeoutMessage);
+      }
+
+      this.logger.error(
+        `S3 ${operation}${keyContext} failed${
+          statusCode ? ` with status ${statusCode}` : ""
+        }: ${message}`,
+        error instanceof Error ? error.stack : undefined,
+      );
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private getErrorMessage(error: unknown) {
+    return error instanceof Error ? error.message : String(error);
+  }
+
+  private getErrorStatusCode(error: unknown) {
+    if (!error || typeof error !== "object" || !("$metadata" in error)) return undefined;
+
+    const metadata = (error as { $metadata?: { httpStatusCode?: number } }).$metadata;
+    return metadata?.httpStatusCode;
+  }
+
   isConfigured(): boolean {
     const config = this.loadS3Config();
     return Boolean(
@@ -99,7 +152,12 @@ export class S3Service {
       Key: key,
     });
 
-    const response = await this.s3Client.send(command);
+    const response = await this.sendWithTimeout(
+      "getFileContent",
+      (abortSignal) => this.s3Client.send(command, { abortSignal }),
+      { key },
+    );
+
     return response.Body?.transformToString() || "";
   }
 
@@ -109,7 +167,12 @@ export class S3Service {
       Key: key,
     });
 
-    const response = await this.s3Client.send(command);
+    const response = await this.sendWithTimeout(
+      "getFileBuffer",
+      (abortSignal) => this.s3Client.send(command, { abortSignal }),
+      { key },
+    );
+
     const bytes = await response.Body?.transformToByteArray();
     return Buffer.from(bytes || []);
   }
@@ -126,7 +189,11 @@ export class S3Service {
       ContentType: contentType,
     });
 
-    await this.s3Client.send(command);
+    await this.sendWithTimeout(
+      "uploadFile",
+      (abortSignal) => this.s3Client.send(command, { abortSignal }),
+      { key },
+    );
   }
 
   async deleteFile(key: string): Promise<void> {
@@ -135,7 +202,11 @@ export class S3Service {
       Key: key,
     });
 
-    await this.s3Client.send(command);
+    await this.sendWithTimeout(
+      "deleteFile",
+      (abortSignal) => this.s3Client.send(command, { abortSignal }),
+      { key },
+    );
   }
 
   async createMultipartUpload(key: string, contentType: string): Promise<{ uploadId: string }> {
@@ -145,7 +216,11 @@ export class S3Service {
       ContentType: contentType,
     });
 
-    const response = await this.s3Client.send(command);
+    const response = await this.sendWithTimeout(
+      "createMultipartUpload",
+      (abortSignal) => this.s3Client.send(command, { abortSignal }),
+      { key },
+    );
 
     if (!response.UploadId) {
       throw new Error("Failed to initialize multipart upload");
@@ -184,7 +259,11 @@ export class S3Service {
       Body: body,
     });
 
-    const response = await this.s3Client.send(command);
+    const response = await this.sendWithTimeout(
+      "uploadMultipartPart",
+      (abortSignal) => this.s3Client.send(command, { abortSignal }),
+      { key },
+    );
 
     if (!response.ETag) {
       throw new Error("Failed to upload multipart part");
@@ -205,7 +284,11 @@ export class S3Service {
       MultipartUpload: { Parts: parts },
     });
 
-    await this.s3Client.send(command);
+    await this.sendWithTimeout(
+      "completeMultipartUpload",
+      (abortSignal) => this.s3Client.send(command, { abortSignal }),
+      { key },
+    );
   }
 
   async getFileStream(key: string, range?: string): Promise<FileStreamPayload> {
@@ -215,7 +298,12 @@ export class S3Service {
       ...(range ? { Range: range } : {}),
     });
 
-    const response = await this.s3Client.send(command);
+    const response = await this.sendWithTimeout(
+      "getFileStream",
+      (abortSignal) => this.s3Client.send(command, { abortSignal }),
+      { key },
+    );
+
     return {
       stream: response.Body as Readable,
       contentType: response.ContentType,
@@ -225,6 +313,7 @@ export class S3Service {
       etag: response.ETag,
       lastModified: response.LastModified,
       statusCode: response.$metadata.httpStatusCode,
+      streamTimeoutMs: S3_OPERATION_TIMEOUT_MS,
     };
   }
 
@@ -239,7 +328,12 @@ export class S3Service {
         ContinuationToken: continuationToken,
       });
 
-      const response = await this.s3Client.send(command);
+      const response = await this.sendWithTimeout(
+        "listFileKeysByPrefix",
+        (abortSignal) => this.s3Client.send(command, { abortSignal }),
+        { key: prefix },
+      );
+
       keys.push(...(response.Contents ?? []).flatMap((object) => (object.Key ? [object.Key] : [])));
       continuationToken = response.NextContinuationToken;
     } while (continuationToken);
@@ -251,7 +345,12 @@ export class S3Service {
     const command = new HeadObjectCommand({ Bucket: this.bucketName, Key: key });
 
     try {
-      await this.s3Client.send(command);
+      await this.sendWithTimeout(
+        "getFileExists",
+        (abortSignal) => this.s3Client.send(command, { abortSignal }),
+        { key },
+      );
+
       return true;
     } catch (err) {
       if (err?.$metadata.httpStatusCode === 404) return false;
@@ -261,7 +360,12 @@ export class S3Service {
 
   async getFileContentType(key: string): Promise<string | null> {
     const command = new HeadObjectCommand({ Bucket: this.bucketName, Key: key });
-    const response = await this.s3Client.send(command);
+    const response = await this.sendWithTimeout(
+      "getFileContentType",
+      (abortSignal) => this.s3Client.send(command, { abortSignal }),
+      { key },
+    );
+
     return response.ContentType ?? null;
   }
 }


### PR DESCRIPTION
## Issue(s)
- #1512 

## Overview

Enhances S3 and file delivery error handling so storage operations fail predictably and file streams are cleaned up when responses fail, close early, or stall.

- Adds timeout-aware S3 SDK calls using `AbortController` and a shared 5-minute operation timeout.
- Logs S3 failures with operation, key, status code when available, and original stack traces.
- Propagates the S3 timeout to file streaming responses and destroys streams on response errors, early closes, and stream timeouts.
- Improves file service logging for upload, delete, and retrieve failures while preserving API-facing exceptions.
- Adds unit coverage for S3 operation timeouts and file stream cleanup on response failure or close.

## Business Value

This reduces the risk of API requests hanging indefinitely when S3 or MinIO is slow or unavailable, prevents leaked file streams during interrupted downloads, and gives maintainers clearer logs for diagnosing storage-related incidents. End users should see more consistent failure behavior instead of stalled uploads or downloads.
