### PR TITLE
chore: improve the learning paths experience with usability enhancements

### DIFF
--- a/apps/api/src/common/helpers/__tests__/sqlHelpers.spec.ts
+++ b/apps/api/src/common/helpers/__tests__/sqlHelpers.spec.ts
@@ -40,6 +40,13 @@ describe("sqlHelpers", () => {
 
       expect(result).toBeDefined();
     });
+
+    it("returns SQL template for boolean false values", () => {
+      const result = setJsonbField({}, "key", false);
+
+      expect(result).toBeDefined();
+      expect(result).toHaveProperty("queryChunks");
+    });
   });
 
   describe("buildJsonbField", () => {

--- a/apps/api/src/common/helpers/sqlHelpers.ts
+++ b/apps/api/src/common/helpers/sqlHelpers.ts
@@ -5,12 +5,13 @@ import type { AnyPgColumn } from "drizzle-orm/pg-core";
 export function setJsonbField(
   field: any,
   key?: string | null,
-  value?: string | null,
+  value?: string | boolean | null,
   createMissing: boolean = true,
   allowEmpty: boolean = false,
 ) {
   if (key == null || value === undefined) return undefined;
-  if (!allowEmpty && !(key && value)) return undefined;
+  if (!allowEmpty && !key) return undefined;
+  if (!allowEmpty && (value === null || (typeof value === "string" && !value))) return undefined;
   if (allowEmpty && value === null) return sql`null`;
 
   const objectField = sql`
@@ -24,7 +25,11 @@ export function setJsonbField(
     jsonb_set(
       ${objectField},
       ARRAY[${key}]::text[],
-      to_jsonb(${value}::text),
+      ${
+        typeof value === "boolean"
+          ? sql`to_jsonb(${value}::boolean)`
+          : sql`to_jsonb(${value}::text)`
+      },
       ${createMissing}
     )
   `;

--- a/apps/api/src/common/types.ts
+++ b/apps/api/src/common/types.ts
@@ -10,6 +10,7 @@ export type ActivityHistory = {
 
 export type GlobalSettings = {
   unregisteredUserCoursesAccessibility: boolean;
+  learningPathsEnabled: boolean;
   enforceSSO: boolean;
   companyInformation?: CompanyInformationSchema;
   userEmailTriggers?: UserEmailTriggersSchema;

--- a/apps/api/src/courses/__tests__/course.controller.e2e-spec.ts
+++ b/apps/api/src/courses/__tests__/course.controller.e2e-spec.ts
@@ -1310,6 +1310,41 @@ describe("CourseController (e2e)", () => {
         expect(response.body.data[0].id).toBe(availableCourse.id);
       });
 
+      it("returns published courses with inactive learning path enrollment rows", async () => {
+        const student = await userFactory
+          .withCredentials({ password })
+          .withUserSettings(db)
+          .create({ role: SYSTEM_ROLE_SLUGS.STUDENT });
+        const cookies = await cookieFor(student, app);
+        const category = await categoryFactory.create();
+        const contentCreator = await userFactory.create({
+          role: SYSTEM_ROLE_SLUGS.CONTENT_CREATOR,
+        });
+
+        const lockedLearningPathCourse = await courseFactory.create({
+          authorId: contentCreator.id,
+          categoryId: category.id,
+          status: "published",
+          thumbnailS3Key: null,
+        });
+
+        await db.insert(studentCourses).values({
+          studentId: student.id,
+          courseId: lockedLearningPathCourse.id,
+          finishedChapterCount: 0,
+          status: COURSE_ENROLLMENT.NOT_ENROLLED,
+        });
+
+        const response = await request(app.getHttpServer())
+          .get("/api/course/available-courses")
+          .set("Cookie", cookies)
+          .expect(200);
+
+        expect(response.body.data).toEqual(
+          expect.arrayContaining([expect.objectContaining({ id: lockedLearningPathCourse.id })]),
+        );
+      });
+
       it("filters by title", async () => {
         const student = await userFactory
           .withCredentials({ password })

--- a/apps/api/src/courses/course.service.ts
+++ b/apps/api/src/courses/course.service.ts
@@ -3210,15 +3210,18 @@ export class CourseService {
       conditions.push(ne(courses.id, excludeCourseId));
     }
 
-    const availableCourses: Record<string, string>[] = await trx.execute(sql`
-      SELECT ${courses.id} AS "courseId"
-      FROM ${courses}
-      WHERE ${conditions.length ? and(...conditions) : true} AND ${courses.id} NOT IN (
-        SELECT DISTINCT ${studentCourses.courseId}
-        FROM ${studentCourses}
-        WHERE ${studentCourses.studentId} = ${currentUserId}
+    const availableCourses = await trx
+      .select({ courseId: courses.id })
+      .from(courses)
+      .leftJoin(
+        studentCourses,
+        and(
+          eq(studentCourses.courseId, courses.id),
+          eq(studentCourses.studentId, currentUserId),
+          eq(studentCourses.status, COURSE_ENROLLMENT.ENROLLED),
+        ),
       )
-    `);
+      .where(and(...conditions, isNull(studentCourses.id)));
 
     return availableCourses.map(({ courseId }) => courseId);
   }

--- a/apps/api/src/learning-path/__tests__/learning-path.controller.e2e-spec.ts
+++ b/apps/api/src/learning-path/__tests__/learning-path.controller.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { LEARNING_PATH_ENROLLMENT_TYPES, SYSTEM_ROLE_SLUGS } from "@repo/shared";
-import { eq } from "drizzle-orm";
+import { eq, isNull, sql } from "drizzle-orm";
 import request from "supertest";
 
 import { LearningPathCourseSyncEvent } from "src/events";
@@ -10,6 +10,7 @@ import {
   groupLearningPaths,
   learningPathCourses,
   learningPaths,
+  settings,
   studentLearningPathCourses,
   studentLearningPaths,
 } from "src/storage/schema";
@@ -87,6 +88,24 @@ describe("LearningPathController (e2e)", () => {
     });
 
     describe("POST /api/learning-path", () => {
+      it("should block learning path endpoints when the feature is disabled", async () => {
+        await db
+          .update(settings)
+          .set({
+            settings: sql`
+              jsonb_set(settings.settings, '{learningPathsEnabled}', to_jsonb(false), true)
+            `,
+          })
+          .where(isNull(settings.userId));
+
+        const response = await request(app.getHttpServer())
+          .get("/api/learning-path?page=1&perPage=10&language=en")
+          .set("Cookie", adminCookies)
+          .expect(403);
+
+        expect(response.body.message).toBe(LEARNING_PATH_ERRORS.FEATURE_DISABLED);
+      });
+
       it("should create a learning path using the provided language as base language", async () => {
         const response = await request(app.getHttpServer())
           .post("/api/learning-path")

--- a/apps/api/src/learning-path/constants/learning-path.errors.ts
+++ b/apps/api/src/learning-path/constants/learning-path.errors.ts
@@ -24,4 +24,5 @@ export const LEARNING_PATH_ERRORS = {
   EXPORT_ID_INVALID: "learningPathExport.error.invalidExportId",
   EXPORT_LINK_INVALID: "learningPathExport.error.invalidExportLink",
   CERTIFICATE_DISABLED: "learningPathCertificate.error.disabled",
+  FEATURE_DISABLED: "learningPathView.toast.featureDisabled",
 } as const;

--- a/apps/api/src/learning-path/controllers/learning-path-certificate.controller.ts
+++ b/apps/api/src/learning-path/controllers/learning-path-certificate.controller.ts
@@ -12,6 +12,7 @@ import { getRequestBaseUrl } from "src/common/helpers/getRequestBaseUrl";
 import { CurrentUserType } from "src/common/types/current-user.type";
 import { supportedLanguagesSchema } from "src/courses/schemas/course.schema";
 
+import { LearningPathsEnabledGuard } from "../guards/learning-paths-enabled.guard";
 import {
   learningPathCertificateCreateShareLinkSchema,
   learningPathCertificateDownloadSchema,
@@ -25,7 +26,7 @@ import {
 import { LearningPathCertificateService } from "../services/learning-path-certificate.service";
 
 @Controller("learning-path/certificates")
-@UseGuards(PermissionsGuard)
+@UseGuards(PermissionsGuard, LearningPathsEnabledGuard)
 export class LearningPathCertificateController {
   constructor(private readonly learningPathCertificateService: LearningPathCertificateService) {}
 

--- a/apps/api/src/learning-path/controllers/learning-path-course.controller.ts
+++ b/apps/api/src/learning-path/controllers/learning-path-course.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Param, Patch, Post } from "@nestjs/common";
+import { Body, Controller, Delete, Param, Patch, Post, UseGuards } from "@nestjs/common";
 import { PERMISSIONS } from "@repo/shared";
 import { Validate } from "nestjs-typebox";
 
@@ -8,6 +8,7 @@ import { CurrentUser } from "src/common/decorators/user.decorator";
 import { CurrentUserType } from "src/common/types/current-user.type";
 
 import { LEARNING_PATH_SUCCESS_MESSAGES } from "../constants/learning-path.success-messages";
+import { LearningPathsEnabledGuard } from "../guards/learning-paths-enabled.guard";
 import {
   learningPathCourseIdsSchema,
   learningPathMessageResponseSchema,
@@ -17,6 +18,7 @@ import {
 import { LearningPathService } from "../services/learning-path.service";
 
 @Controller("learning-path")
+@UseGuards(LearningPathsEnabledGuard)
 export class LearningPathCourseController {
   constructor(private readonly learningPathService: LearningPathService) {}
 

--- a/apps/api/src/learning-path/controllers/learning-path-enrollment.controller.ts
+++ b/apps/api/src/learning-path/controllers/learning-path-enrollment.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Param, Post, Query } from "@nestjs/common";
+import { Body, Controller, Delete, Get, Param, Post, Query, UseGuards } from "@nestjs/common";
 import { PERMISSIONS } from "@repo/shared";
 import { Type } from "@sinclair/typebox";
 import { Validate } from "nestjs-typebox";
@@ -23,6 +23,7 @@ import { groupsFilterSchema } from "src/group/group.schema";
 import { GroupsFilterSchema } from "src/group/group.types";
 
 import { LEARNING_PATH_SUCCESS_MESSAGES } from "../constants/learning-path.success-messages";
+import { LearningPathsEnabledGuard } from "../guards/learning-paths-enabled.guard";
 import {
   learningPathGroupIdsSchema,
   learningPathMessageResponseSchema,
@@ -36,6 +37,7 @@ import { LearningPathService } from "../services/learning-path.service";
 import type { EnrolledStudent } from "src/courses/schemas/enrolledStudent.schema";
 
 @Controller("learning-path")
+@UseGuards(LearningPathsEnabledGuard)
 export class LearningPathEnrollmentController {
   constructor(private readonly learningPathService: LearningPathService) {}
 

--- a/apps/api/src/learning-path/controllers/learning-path-export.controller.ts
+++ b/apps/api/src/learning-path/controllers/learning-path-export.controller.ts
@@ -10,6 +10,7 @@ import { ManagingTenantAdminGuard } from "src/common/guards/managing-tenant-admi
 import { CurrentUserType } from "src/common/types/current-user.type";
 
 import { LEARNING_PATH_ERRORS } from "../constants/learning-path.errors";
+import { LearningPathsEnabledGuard } from "../guards/learning-paths-enabled.guard";
 import {
   learningPathExportBodySchema,
   learningPathExportCandidatesResponseSchema,
@@ -21,7 +22,7 @@ import {
 import { LearningPathExportService } from "../services/learning-path-export.service";
 
 @Controller("learning-path/master")
-@UseGuards(ManagingTenantAdminGuard)
+@UseGuards(ManagingTenantAdminGuard, LearningPathsEnabledGuard)
 export class LearningPathExportController {
   constructor(private readonly learningPathExportService: LearningPathExportService) {}
 

--- a/apps/api/src/learning-path/controllers/learning-path.controller.ts
+++ b/apps/api/src/learning-path/controllers/learning-path.controller.ts
@@ -8,6 +8,7 @@ import {
   Post,
   Query,
   UploadedFiles,
+  UseGuards,
   UseInterceptors,
 } from "@nestjs/common";
 import { FileFieldsInterceptor } from "@nestjs/platform-express";
@@ -30,6 +31,7 @@ import { CurrentUserType } from "src/common/types/current-user.type";
 import { ValidateMultipartPipe } from "src/utils/pipes/validateMultipartPipe";
 
 import { LEARNING_PATH_SUCCESS_MESSAGES } from "../constants/learning-path.success-messages";
+import { LearningPathsEnabledGuard } from "../guards/learning-paths-enabled.guard";
 import {
   createLearningPathSchema,
   learningPathDetailSchema,
@@ -57,6 +59,7 @@ const learningPathFileFields = FileFieldsInterceptor([
   { name: "certificateSignature", maxCount: 1 },
 ]);
 @Controller("learning-path")
+@UseGuards(LearningPathsEnabledGuard)
 export class LearningPathController {
   constructor(private readonly learningPathService: LearningPathService) {}
 

--- a/apps/api/src/learning-path/guards/learning-paths-enabled.guard.ts
+++ b/apps/api/src/learning-path/guards/learning-paths-enabled.guard.ts
@@ -1,0 +1,39 @@
+import {
+  ForbiddenException,
+  Injectable,
+  UnauthorizedException,
+  type CanActivate,
+  type ExecutionContext,
+} from "@nestjs/common";
+
+import { SettingsService } from "src/settings/settings.service";
+import { TenantDbRunnerService } from "src/storage/db/tenant-db-runner.service";
+import { TenantResolverService } from "src/storage/db/tenant-resolver.service";
+
+import { LEARNING_PATH_ERRORS } from "../constants/learning-path.errors";
+
+@Injectable()
+export class LearningPathsEnabledGuard implements CanActivate {
+  constructor(
+    private readonly settingsService: SettingsService,
+    private readonly tenantResolver: TenantResolverService,
+    private readonly tenantRunner: TenantDbRunnerService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const tenantId = await this.tenantResolver.resolveTenantId(request);
+
+    if (!tenantId) throw new UnauthorizedException("Missing tenantId");
+
+    await this.tenantRunner.runWithTenant(tenantId, async () => {
+      const globalSettings = await this.settingsService.getGlobalSettings();
+
+      if (!globalSettings.learningPathsEnabled) {
+        throw new ForbiddenException(LEARNING_PATH_ERRORS.FEATURE_DISABLED);
+      }
+    });
+
+    return true;
+  }
+}

--- a/apps/api/src/learning-path/learning-path.module.ts
+++ b/apps/api/src/learning-path/learning-path.module.ts
@@ -11,6 +11,7 @@ import { LearningPathCourseController } from "./controllers/learning-path-course
 import { LearningPathEnrollmentController } from "./controllers/learning-path-enrollment.controller";
 import { LearningPathExportController } from "./controllers/learning-path-export.controller";
 import { LearningPathController } from "./controllers/learning-path.controller";
+import { LearningPathsEnabledGuard } from "./guards/learning-paths-enabled.guard";
 import { LearningPathCourseSyncHandler } from "./handlers/learning-path-course-sync.handler";
 import { LearningPathQueueService } from "./learning-path.queue.service";
 import { LearningPathRepository } from "./learning-path.repository";
@@ -44,6 +45,7 @@ import { LearningPathService } from "./services/learning-path.service";
     LearningPathQueueService,
     LearningPathCertificateService,
     LearningPathWorker,
+    LearningPathsEnabledGuard,
   ],
   exports: [LearningPathService, LearningPathRepository],
 })

--- a/apps/api/src/learning-path/learning-path.repository.ts
+++ b/apps/api/src/learning-path/learning-path.repository.ts
@@ -195,6 +195,11 @@ export class LearningPathRepository {
   async getLearningPaths(query: LearningPathListQuery = {}, dbInstance: DatabasePg = this.db) {
     const { page = 1, perPage = DEFAULT_PAGE_SIZE, language, searchQuery, visibility } = query;
 
+    const studentLearningPathJoinCondition =
+      visibility && !visibility.canReadAll
+        ? eq(studentLearningPaths.studentId, visibility.studentId)
+        : sql`false`;
+
     const visibilityCondition = visibility?.canReadAll
       ? undefined
       : or(
@@ -225,7 +230,7 @@ export class LearningPathRepository {
         studentLearningPaths,
         and(
           eq(studentLearningPaths.learningPathId, learningPaths.id),
-          visibility ? eq(studentLearningPaths.studentId, visibility.studentId) : undefined,
+          studentLearningPathJoinCondition,
         ),
       )
       .where(whereCondition)
@@ -240,7 +245,7 @@ export class LearningPathRepository {
         studentLearningPaths,
         and(
           eq(studentLearningPaths.learningPathId, learningPaths.id),
-          visibility ? eq(studentLearningPaths.studentId, visibility.studentId) : undefined,
+          studentLearningPathJoinCondition,
         ),
       )
       .where(whereCondition);
@@ -376,7 +381,7 @@ export class LearningPathRepository {
 
   async getLearningPathCoursePreviews(
     learningPathIds: UUIDType[],
-    studentId: UUIDType,
+    studentId?: UUIDType,
     language?: SupportedLanguages,
     dbInstance: DatabasePg = this.db,
   ): Promise<LearningPathCoursePreviewGroup[]> {
@@ -397,7 +402,7 @@ export class LearningPathRepository {
         priorStudentCourses,
         and(
           eq(priorStudentCourses.courseId, learningPathCourses.courseId),
-          eq(priorStudentCourses.studentId, studentId),
+          studentId ? eq(priorStudentCourses.studentId, studentId) : sql`false`,
         ),
       )
       .where(
@@ -422,7 +427,7 @@ export class LearningPathRepository {
       END
     `;
 
-    return dbInstance
+    const previews = await dbInstance
       .select({
         learningPathId: currentPathCourse.learningPathId,
         courses: sql<LearningPathCoursePreviewGroup["courses"]>`
@@ -454,18 +459,20 @@ export class LearningPathRepository {
         studentCourses,
         and(
           eq(studentCourses.courseId, currentPathCourse.courseId),
-          eq(studentCourses.studentId, studentId),
+          studentId ? eq(studentCourses.studentId, studentId) : sql`false`,
         ),
       )
       .leftJoin(
         studentLearningPaths,
         and(
           eq(studentLearningPaths.learningPathId, currentPathCourse.learningPathId),
-          eq(studentLearningPaths.studentId, studentId),
+          studentId ? eq(studentLearningPaths.studentId, studentId) : sql`false`,
         ),
       )
       .where(inArray(currentPathCourse.learningPathId, learningPathIds))
       .groupBy(currentPathCourse.learningPathId);
+
+    return previews;
   }
 
   async getLearningPathStudentIds(pathId: UUIDType, dbInstance: DatabasePg = this.db) {
@@ -492,10 +499,12 @@ export class LearningPathRepository {
 
   async getEnrolledLearningPathIds(
     pathIds: UUIDType[],
-    studentId: UUIDType,
+    studentId?: UUIDType,
     dbInstance: DatabasePg = this.db,
   ) {
-    if (pathIds.length === 0) return [];
+    if (pathIds.length === 0 || !studentId) {
+      return [];
+    }
 
     const enrolledLearningPaths = await dbInstance
       .select({ learningPathId: studentLearningPaths.learningPathId })
@@ -507,7 +516,9 @@ export class LearningPathRepository {
         ),
       );
 
-    return enrolledLearningPaths.map(({ learningPathId }) => learningPathId);
+    const enrolledIds = enrolledLearningPaths.map(({ learningPathId }) => learningPathId);
+
+    return enrolledIds;
   }
 
   async getLearningPathIdsForStudentCourse(

--- a/apps/api/src/learning-path/services/learning-path.service.ts
+++ b/apps/api/src/learning-path/services/learning-path.service.ts
@@ -353,6 +353,7 @@ export class LearningPathService {
 
     const canReadAll = this.canReadAllLearningPaths(currentUser);
     const canReadOwn = this.canReadOwnLearningPaths(currentUser);
+    const studentScopedUserId = canReadAll ? undefined : currentUser.userId;
 
     const learningPaths = await this.learningPathRepository.getLearningPaths({
       page,
@@ -365,11 +366,13 @@ export class LearningPathService {
         studentId: currentUser.userId,
       },
     });
+
     const learningPathIds = learningPaths.data.map((learningPath) => learningPath.id);
+
     const enrolledLearningPathIds = new Set(
       await this.learningPathRepository.getEnrolledLearningPathIds(
         learningPathIds,
-        currentUser.userId,
+        studentScopedUserId,
       ),
     );
     const editableCourseLearningPathIds = learningPaths.data
@@ -385,7 +388,7 @@ export class LearningPathService {
 
     const coursePreviews = await this.learningPathRepository.getLearningPathCoursePreviews(
       learningPathIds,
-      currentUser.userId,
+      studentScopedUserId,
       language,
     );
 

--- a/apps/api/src/settings/__tests__/settings.controller.e2e-spec.ts
+++ b/apps/api/src/settings/__tests__/settings.controller.e2e-spec.ts
@@ -206,6 +206,7 @@ describe("SettingsController (e2e)", () => {
         expect(response.body).toBeDefined();
         expect(response.body.data).toBeDefined();
         expect(response.body.data.unregisteredUserCoursesAccessibility).toBeDefined();
+        expect(response.body.data.learningPathsEnabled).toBe(true);
       });
 
       it("should return updated global settings after admin changes via PATCH endpoint", async () => {
@@ -349,6 +350,63 @@ describe("SettingsController (e2e)", () => {
       it("should return 401 if not authenticated", async () => {
         await request(app.getHttpServer())
           .patch("/api/settings/admin/unregistered-user-courses-accessibility")
+          .expect(401);
+      });
+    });
+
+    describe("PATCH /api/settings/admin/learning-paths-enabled", () => {
+      let adminUser: UserWithCredentials;
+      let adminCookies: string;
+
+      beforeEach(async () => {
+        await truncateTables(db, ["settings"]);
+        await globalSettingsFactory.create({ userId: null });
+
+        adminUser = await userFactory
+          .withCredentials({ password: testPassword })
+          .withAdminSettings(db)
+          .create();
+
+        adminCookies = await cookieFor(adminUser, app);
+      });
+
+      afterEach(async () => {
+        await truncateTables(db, ["settings"]);
+      });
+
+      it("should toggle the global learning paths enabled setting (as Admin)", async () => {
+        const response = await request(app.getHttpServer())
+          .patch("/api/settings/admin/learning-paths-enabled")
+          .set("Cookie", adminCookies)
+          .expect(200);
+
+        expect(response.body.data.learningPathsEnabled).toBe(false);
+
+        const toggleResponse = await request(app.getHttpServer())
+          .patch("/api/settings/admin/learning-paths-enabled")
+          .set("Cookie", adminCookies)
+          .expect(200);
+
+        expect(toggleResponse.body.data.learningPathsEnabled).toBe(true);
+      });
+
+      it("should return 403 if user is not an admin", async () => {
+        const nonAdminUser = await userFactory
+          .withCredentials({ password: testPassword })
+          .withUserSettings(db)
+          .create();
+
+        const nonAdminCookies = await cookieFor(nonAdminUser, app);
+
+        await request(app.getHttpServer())
+          .patch("/api/settings/admin/learning-paths-enabled")
+          .set("Cookie", nonAdminCookies)
+          .expect(403);
+      });
+
+      it("should return 401 if not authenticated", async () => {
+        await request(app.getHttpServer())
+          .patch("/api/settings/admin/learning-paths-enabled")
           .expect(401);
       });
     });

--- a/apps/api/src/settings/__tests__/settings.controller.e2e-spec.ts
+++ b/apps/api/src/settings/__tests__/settings.controller.e2e-spec.ts
@@ -206,7 +206,7 @@ describe("SettingsController (e2e)", () => {
         expect(response.body).toBeDefined();
         expect(response.body.data).toBeDefined();
         expect(response.body.data.unregisteredUserCoursesAccessibility).toBeDefined();
-        expect(response.body.data.learningPathsEnabled).toBe(false);
+        expect(response.body.data.learningPathsEnabled).toBe(true);
       });
 
       it("should return updated global settings after admin changes via PATCH endpoint", async () => {
@@ -380,14 +380,14 @@ describe("SettingsController (e2e)", () => {
           .set("Cookie", adminCookies)
           .expect(200);
 
-        expect(response.body.data.learningPathsEnabled).toBe(true);
+        expect(response.body.data.learningPathsEnabled).toBe(false);
 
         const toggleResponse = await request(app.getHttpServer())
           .patch("/api/settings/admin/learning-paths-enabled")
           .set("Cookie", adminCookies)
           .expect(200);
 
-        expect(toggleResponse.body.data.learningPathsEnabled).toBe(false);
+        expect(toggleResponse.body.data.learningPathsEnabled).toBe(true);
       });
 
       it("should return 403 if user is not an admin", async () => {

--- a/apps/api/src/settings/__tests__/settings.controller.e2e-spec.ts
+++ b/apps/api/src/settings/__tests__/settings.controller.e2e-spec.ts
@@ -206,7 +206,7 @@ describe("SettingsController (e2e)", () => {
         expect(response.body).toBeDefined();
         expect(response.body.data).toBeDefined();
         expect(response.body.data.unregisteredUserCoursesAccessibility).toBeDefined();
-        expect(response.body.data.learningPathsEnabled).toBe(true);
+        expect(response.body.data.learningPathsEnabled).toBe(false);
       });
 
       it("should return updated global settings after admin changes via PATCH endpoint", async () => {
@@ -380,14 +380,14 @@ describe("SettingsController (e2e)", () => {
           .set("Cookie", adminCookies)
           .expect(200);
 
-        expect(response.body.data.learningPathsEnabled).toBe(false);
+        expect(response.body.data.learningPathsEnabled).toBe(true);
 
         const toggleResponse = await request(app.getHttpServer())
           .patch("/api/settings/admin/learning-paths-enabled")
           .set("Cookie", adminCookies)
           .expect(200);
 
-        expect(toggleResponse.body.data.learningPathsEnabled).toBe(true);
+        expect(toggleResponse.body.data.learningPathsEnabled).toBe(false);
       });
 
       it("should return 403 if user is not an admin", async () => {

--- a/apps/api/src/settings/constants/settings.constants.ts
+++ b/apps/api/src/settings/constants/settings.constants.ts
@@ -25,6 +25,7 @@ export const DEFAULT_GLOBAL_SETTINGS = {
   newsEnabled: false,
   unregisteredUserArticlesAccessibility: false,
   articlesEnabled: false,
+  learningPathsEnabled: false,
   unregisteredUserCoursesAccessibility: false,
   modernCourseListEnabled: true,
   companyInformation: DEFAULT_COMPANY_INFORMATION,

--- a/apps/api/src/settings/schemas/settings.schema.ts
+++ b/apps/api/src/settings/schemas/settings.schema.ts
@@ -46,6 +46,7 @@ export const globalSettingsJSONSchema = Type.Object({
   newsEnabled: Type.Boolean(),
   unregisteredUserArticlesAccessibility: Type.Boolean(),
   articlesEnabled: Type.Boolean(),
+  learningPathsEnabled: Type.Boolean(),
   ageLimit: Type.Union(ALLOWED_AGE_LIMITS.map((age) => (!age ? Type.Null() : Type.Literal(age)))),
   loginPageFiles: Type.Array(Type.String()),
 });

--- a/apps/api/src/settings/settings.controller.ts
+++ b/apps/api/src/settings/settings.controller.ts
@@ -182,6 +182,18 @@ export class SettingsController {
     return new BaseResponse(result);
   }
 
+  @Patch("admin/learning-paths-enabled")
+  @RequirePermission(PERMISSIONS.SETTINGS_MANAGE)
+  @Validate({
+    response: baseResponse(globalSettingsJSONSchema),
+  })
+  async updateLearningPathsEnabled(
+    @CurrentUser() currentUser: CurrentUserType,
+  ): Promise<BaseResponse<GlobalSettingsJSONContentSchema>> {
+    const result = await this.settingsService.updateGlobalLearningPathsEnabled(currentUser);
+    return new BaseResponse(result);
+  }
+
   @Patch("admin/finished-course-notification")
   @UseGuards(DisallowInSupportModeGuard)
   @RequirePermission(PERMISSIONS.SETTINGS_MANAGE)

--- a/apps/api/src/settings/settings.service.ts
+++ b/apps/api/src/settings/settings.service.ts
@@ -21,7 +21,7 @@ import sharp from "sharp";
 
 import { CORS_ORIGIN } from "src/auth/consts";
 import { DatabasePg } from "src/common";
-import { buildJsonbFieldWithMultipleEntries } from "src/common/helpers/sqlHelpers";
+import { buildJsonbFieldWithMultipleEntries, setJsonbField } from "src/common/helpers/sqlHelpers";
 import { getSupportModeContext } from "src/common/helpers/support-mode-context";
 import { UpdateSettingsEvent } from "src/events";
 import { RESOURCE_CATEGORIES, RESOURCE_RELATIONSHIP_TYPES } from "src/file/file.constants";
@@ -704,6 +704,33 @@ export class SettingsService {
             true
           )
         `,
+      })
+      .where(isNull(settings.userId))
+      .returning({ settings: sql<GlobalSettingsJSONContentSchema>`${settings.settings}` });
+
+    const updatedRecord = await this.getGlobalSettingsRecord();
+
+    await this.recordSettingsUpdate({
+      actor,
+      previousSnapshot: this.buildSettingsSnapshot(previousRecord),
+      updatedSnapshot: updatedRecord ? this.buildSettingsSnapshot(updatedRecord) : null,
+    });
+
+    return this.parseGlobalSettings(updatedGlobalSettings);
+  }
+
+  public async updateGlobalLearningPathsEnabled(
+    actor?: CurrentUserType,
+  ): Promise<GlobalSettingsJSONContentSchema> {
+    const previousRecord = await this.getGlobalSettingsRecord();
+
+    const current =
+      previousRecord.settings.learningPathsEnabled ?? DEFAULT_GLOBAL_SETTINGS.learningPathsEnabled;
+
+    const [{ settings: updatedGlobalSettings }] = await this.db
+      .update(settings)
+      .set({
+        settings: setJsonbField(settings.settings, "learningPathsEnabled", !current),
       })
       .where(isNull(settings.userId))
       .returning({ settings: sql<GlobalSettingsJSONContentSchema>`${settings.settings}` });
@@ -1620,6 +1647,8 @@ export class SettingsService {
       ...settings,
       modernCourseListEnabled:
         settings.modernCourseListEnabled ?? DEFAULT_GLOBAL_SETTINGS.modernCourseListEnabled,
+      learningPathsEnabled:
+        settings.learningPathsEnabled ?? DEFAULT_GLOBAL_SETTINGS.learningPathsEnabled,
       MFAEnforcedRoles: Array.isArray(settings.MFAEnforcedRoles)
         ? settings.MFAEnforcedRoles
         : JSON.parse(settings.MFAEnforcedRoles ?? "[]"),

--- a/apps/api/src/swagger/api-schema.json
+++ b/apps/api/src/swagger/api-schema.json
@@ -551,6 +551,23 @@
         }
       }
     },
+    "/api/settings/admin/learning-paths-enabled": {
+      "patch": {
+        "operationId": "SettingsController_updateLearningPathsEnabled",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateLearningPathsEnabledResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/settings/admin/finished-course-notification": {
       "patch": {
         "operationId": "SettingsController_updateAdminFinishedCourseNotification",
@@ -13534,6 +13551,9 @@
               "articlesEnabled": {
                 "type": "boolean"
               },
+              "learningPathsEnabled": {
+                "type": "boolean"
+              },
               "ageLimit": {
                 "anyOf": [
                   {
@@ -13576,6 +13596,7 @@
               "newsEnabled",
               "unregisteredUserArticlesAccessibility",
               "articlesEnabled",
+              "learningPathsEnabled",
               "ageLimit",
               "loginPageFiles"
             ]
@@ -14290,6 +14311,9 @@
               "articlesEnabled": {
                 "type": "boolean"
               },
+              "learningPathsEnabled": {
+                "type": "boolean"
+              },
               "ageLimit": {
                 "anyOf": [
                   {
@@ -14332,6 +14356,7 @@
               "newsEnabled",
               "unregisteredUserArticlesAccessibility",
               "articlesEnabled",
+              "learningPathsEnabled",
               "ageLimit",
               "loginPageFiles"
             ]
@@ -14518,6 +14543,9 @@
               "articlesEnabled": {
                 "type": "boolean"
               },
+              "learningPathsEnabled": {
+                "type": "boolean"
+              },
               "ageLimit": {
                 "anyOf": [
                   {
@@ -14560,6 +14588,7 @@
               "newsEnabled",
               "unregisteredUserArticlesAccessibility",
               "articlesEnabled",
+              "learningPathsEnabled",
               "ageLimit",
               "loginPageFiles"
             ]
@@ -14746,6 +14775,9 @@
               "articlesEnabled": {
                 "type": "boolean"
               },
+              "learningPathsEnabled": {
+                "type": "boolean"
+              },
               "ageLimit": {
                 "anyOf": [
                   {
@@ -14788,6 +14820,239 @@
               "newsEnabled",
               "unregisteredUserArticlesAccessibility",
               "articlesEnabled",
+              "learningPathsEnabled",
+              "ageLimit",
+              "loginPageFiles"
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "UpdateLearningPathsEnabledResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "unregisteredUserCoursesAccessibility": {
+                "type": "boolean"
+              },
+              "modernCourseListEnabled": {
+                "type": "boolean"
+              },
+              "enforceSSO": {
+                "type": "boolean"
+              },
+              "certificateBackgroundImage": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "companyInformation": {
+                "type": "object",
+                "properties": {
+                  "companyName": {
+                    "type": "string"
+                  },
+                  "companyShortName": {
+                    "maxLength": 10,
+                    "type": "string"
+                  },
+                  "registeredAddress": {
+                    "type": "string"
+                  },
+                  "taxNumber": {
+                    "type": "string"
+                  },
+                  "emailAddress": {
+                    "type": "string"
+                  },
+                  "courtRegisterNumber": {
+                    "type": "string"
+                  }
+                }
+              },
+              "platformLogoS3Key": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "loginBackgroundImageS3Key": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "platformSimpleLogoS3Key": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "MFAEnforcedRoles": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "defaultCourseCurrency": {
+                "anyOf": [
+                  {
+                    "const": "pln",
+                    "type": "string"
+                  },
+                  {
+                    "const": "eur",
+                    "type": "string"
+                  },
+                  {
+                    "const": "gbp",
+                    "type": "string"
+                  },
+                  {
+                    "const": "usd",
+                    "type": "string"
+                  }
+                ]
+              },
+              "inviteOnlyRegistration": {
+                "type": "boolean"
+              },
+              "userEmailTriggers": {
+                "type": "object",
+                "properties": {
+                  "userFirstLogin": {
+                    "type": "boolean"
+                  },
+                  "userCourseAssignment": {
+                    "type": "boolean"
+                  },
+                  "userShortInactivity": {
+                    "type": "boolean"
+                  },
+                  "userLongInactivity": {
+                    "type": "boolean"
+                  },
+                  "userChapterFinished": {
+                    "type": "boolean"
+                  },
+                  "userCourseFinished": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "userFirstLogin",
+                  "userCourseAssignment",
+                  "userShortInactivity",
+                  "userLongInactivity",
+                  "userChapterFinished",
+                  "userCourseFinished"
+                ]
+              },
+              "primaryColor": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "contrastColor": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "unregisteredUserQAAccessibility": {
+                "type": "boolean"
+              },
+              "QAEnabled": {
+                "type": "boolean"
+              },
+              "unregisteredUserNewsAccessibility": {
+                "type": "boolean"
+              },
+              "newsEnabled": {
+                "type": "boolean"
+              },
+              "unregisteredUserArticlesAccessibility": {
+                "type": "boolean"
+              },
+              "articlesEnabled": {
+                "type": "boolean"
+              },
+              "learningPathsEnabled": {
+                "type": "boolean"
+              },
+              "ageLimit": {
+                "anyOf": [
+                  {
+                    "const": 13,
+                    "type": "number"
+                  },
+                  {
+                    "const": 16,
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "loginPageFiles": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": [
+              "unregisteredUserCoursesAccessibility",
+              "modernCourseListEnabled",
+              "enforceSSO",
+              "certificateBackgroundImage",
+              "platformLogoS3Key",
+              "loginBackgroundImageS3Key",
+              "platformSimpleLogoS3Key",
+              "MFAEnforcedRoles",
+              "defaultCourseCurrency",
+              "inviteOnlyRegistration",
+              "userEmailTriggers",
+              "primaryColor",
+              "contrastColor",
+              "unregisteredUserQAAccessibility",
+              "QAEnabled",
+              "unregisteredUserNewsAccessibility",
+              "newsEnabled",
+              "unregisteredUserArticlesAccessibility",
+              "articlesEnabled",
+              "learningPathsEnabled",
               "ageLimit",
               "loginPageFiles"
             ]
@@ -15129,6 +15394,9 @@
               "articlesEnabled": {
                 "type": "boolean"
               },
+              "learningPathsEnabled": {
+                "type": "boolean"
+              },
               "ageLimit": {
                 "anyOf": [
                   {
@@ -15171,6 +15439,7 @@
               "newsEnabled",
               "unregisteredUserArticlesAccessibility",
               "articlesEnabled",
+              "learningPathsEnabled",
               "ageLimit",
               "loginPageFiles"
             ]

--- a/apps/api/test/factory/settings.factory.ts
+++ b/apps/api/test/factory/settings.factory.ts
@@ -5,11 +5,11 @@ import { match } from "ts-pattern";
 import {
   DEFAULT_ADMIN_SETTINGS,
   DEFAULT_STUDENT_SETTINGS,
-  DEFAULT_GLOBAL_SETTINGS,
 } from "src/settings/constants/settings.constants";
 import { settingsToJSONBuildObject } from "src/utils/settings-to-json-build-object";
 
 import { settings } from "../../src/storage/schema";
+import { DEFAULT_E2E_GLOBAL_SETTINGS } from "../helpers/e2e-settings";
 
 import type { InferSelectModel } from "drizzle-orm";
 import type { DatabasePg, UUIDType } from "src/common";
@@ -22,7 +22,7 @@ export const createSettingsFactory = (
   isAdmin: boolean = false,
 ) => {
   const defaultSettings = match({ isAdmin, userId })
-    .with({ isAdmin: false, userId: null }, () => DEFAULT_GLOBAL_SETTINGS)
+    .with({ isAdmin: false, userId: null }, () => DEFAULT_E2E_GLOBAL_SETTINGS)
     .with({ isAdmin: true }, () => DEFAULT_ADMIN_SETTINGS)
     .with({ isAdmin: false }, () => DEFAULT_STUDENT_SETTINGS)
     .exhaustive();

--- a/apps/api/test/helpers/e2e-settings.ts
+++ b/apps/api/test/helpers/e2e-settings.ts
@@ -1,0 +1,6 @@
+import { DEFAULT_GLOBAL_SETTINGS } from "src/settings/constants/settings.constants";
+
+export const DEFAULT_E2E_GLOBAL_SETTINGS = {
+  ...DEFAULT_GLOBAL_SETTINGS,
+  learningPathsEnabled: true,
+};

--- a/apps/api/test/helpers/test-helpers.ts
+++ b/apps/api/test/helpers/test-helpers.ts
@@ -1,10 +1,11 @@
 import { sql } from "drizzle-orm";
 import request from "supertest";
 
-import { DEFAULT_GLOBAL_SETTINGS } from "src/settings/constants/settings.constants";
 import { settingsToJSONBuildObject } from "src/utils/settings-to-json-build-object";
 
 import { settings } from "../../src/storage/schema";
+
+import { DEFAULT_E2E_GLOBAL_SETTINGS } from "./e2e-settings";
 
 import type { DatabasePg } from "../../src/common";
 import type { INestApplication } from "@nestjs/common";
@@ -61,7 +62,7 @@ export async function truncateAllTables(
   await scopedConnection.insert(settings).values({
     userId: null,
     createdAt: new Date().toISOString(),
-    settings: settingsToJSONBuildObject(DEFAULT_GLOBAL_SETTINGS),
+    settings: settingsToJSONBuildObject(DEFAULT_E2E_GLOBAL_SETTINGS),
   });
 }
 

--- a/apps/web/app/api/generated-api.ts
+++ b/apps/web/app/api/generated-api.ts
@@ -354,6 +354,7 @@ export interface GetPublicGlobalSettingsResponse {
     newsEnabled: boolean;
     unregisteredUserArticlesAccessibility: boolean;
     articlesEnabled: boolean;
+    learningPathsEnabled: boolean;
     ageLimit: 13 | 16 | null;
     loginPageFiles: string[];
   };
@@ -482,6 +483,7 @@ export interface UpdateUnregisteredUserCoursesAccessibilityResponse {
     newsEnabled: boolean;
     unregisteredUserArticlesAccessibility: boolean;
     articlesEnabled: boolean;
+    learningPathsEnabled: boolean;
     ageLimit: 13 | 16 | null;
     loginPageFiles: string[];
   };
@@ -524,6 +526,7 @@ export interface UpdateEnforceSSOResponse {
     newsEnabled: boolean;
     unregisteredUserArticlesAccessibility: boolean;
     articlesEnabled: boolean;
+    learningPathsEnabled: boolean;
     ageLimit: 13 | 16 | null;
     loginPageFiles: string[];
   };
@@ -566,6 +569,50 @@ export interface UpdateModernCourseListEnabledResponse {
     newsEnabled: boolean;
     unregisteredUserArticlesAccessibility: boolean;
     articlesEnabled: boolean;
+    learningPathsEnabled: boolean;
+    ageLimit: 13 | 16 | null;
+    loginPageFiles: string[];
+  };
+}
+
+export interface UpdateLearningPathsEnabledResponse {
+  data: {
+    unregisteredUserCoursesAccessibility: boolean;
+    modernCourseListEnabled: boolean;
+    enforceSSO: boolean;
+    certificateBackgroundImage: string | null;
+    companyInformation?: {
+      companyName?: string;
+      /** @maxLength 10 */
+      companyShortName?: string;
+      registeredAddress?: string;
+      taxNumber?: string;
+      emailAddress?: string;
+      courtRegisterNumber?: string;
+    };
+    platformLogoS3Key: string | null;
+    loginBackgroundImageS3Key: string | null;
+    platformSimpleLogoS3Key: string | null;
+    MFAEnforcedRoles: string[];
+    defaultCourseCurrency: "pln" | "eur" | "gbp" | "usd";
+    inviteOnlyRegistration: boolean;
+    userEmailTriggers: {
+      userFirstLogin: boolean;
+      userCourseAssignment: boolean;
+      userShortInactivity: boolean;
+      userLongInactivity: boolean;
+      userChapterFinished: boolean;
+      userCourseFinished: boolean;
+    };
+    primaryColor: string | null;
+    contrastColor: string | null;
+    unregisteredUserQAAccessibility: boolean;
+    QAEnabled: boolean;
+    unregisteredUserNewsAccessibility: boolean;
+    newsEnabled: boolean;
+    unregisteredUserArticlesAccessibility: boolean;
+    articlesEnabled: boolean;
+    learningPathsEnabled: boolean;
     ageLimit: 13 | 16 | null;
     loginPageFiles: string[];
   };
@@ -639,6 +686,7 @@ export interface UpdateColorSchemaResponse {
     newsEnabled: boolean;
     unregisteredUserArticlesAccessibility: boolean;
     articlesEnabled: boolean;
+    learningPathsEnabled: boolean;
     ageLimit: 13 | 16 | null;
     loginPageFiles: string[];
   };
@@ -5865,6 +5913,20 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     settingsControllerUpdateModernCourseListEnabled: (params: RequestParams = {}) =>
       this.request<UpdateModernCourseListEnabledResponse, any>({
         path: `/api/settings/admin/modern-course-list`,
+        method: "PATCH",
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @name SettingsControllerUpdateLearningPathsEnabled
+     * @request PATCH:/api/settings/admin/learning-paths-enabled
+     */
+    settingsControllerUpdateLearningPathsEnabled: (params: RequestParams = {}) =>
+      this.request<UpdateLearningPathsEnabledResponse, any>({
+        path: `/api/settings/admin/learning-paths-enabled`,
         method: "PATCH",
         format: "json",
         ...params,

--- a/apps/web/app/api/mutations/admin/useToggleLearningPathsEnabled.ts
+++ b/apps/web/app/api/mutations/admin/useToggleLearningPathsEnabled.ts
@@ -1,0 +1,31 @@
+import { useMutation } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+
+import { ApiClient } from "~/api/api-client";
+import { globalSettingsQueryOptions } from "~/api/queries/useGlobalSettings";
+import { queryClient } from "~/api/queryClient";
+import { useToast } from "~/components/ui/use-toast";
+
+export function useToggleLearningPathsEnabled() {
+  const { toast } = useToast();
+  const { t } = useTranslation();
+
+  return useMutation({
+    mutationFn: async () => {
+      const response = await ApiClient.api.settingsControllerUpdateLearningPathsEnabled();
+
+      return response.data;
+    },
+    onSuccess: () => {
+      toast({ description: t("settings.toast.learningPathsUpdatedSuccessfully") });
+
+      queryClient.invalidateQueries({ queryKey: globalSettingsQueryOptions.queryKey });
+    },
+    onError: () => {
+      toast({
+        description: t("settings.toast.error.globalNotFound"),
+        variant: "destructive",
+      });
+    },
+  });
+}

--- a/apps/web/app/components/Navigation/GlobalSearch/GlobalSearchContent.tsx
+++ b/apps/web/app/components/Navigation/GlobalSearch/GlobalSearchContent.tsx
@@ -14,6 +14,7 @@ import type {
   GetArticlesResponse,
   GetAvailableCoursesResponse,
   GetLessonsResponse,
+  GetLearningPathsResponse,
   GetNewsListResponse,
   GetStudentCoursesResponse,
   GetUsersResponse,
@@ -41,6 +42,14 @@ export type GlobalSearchItem =
       resultData: GetAvailableCoursesResponse["data"];
       Component: (props: {
         item: GetAvailableCoursesResponse["data"][number];
+        onSelect: () => void;
+      }) => JSX.Element;
+    }
+  | {
+      resultType: "learningPaths";
+      resultData: GetLearningPathsResponse["data"];
+      Component: (props: {
+        item: GetLearningPathsResponse["data"][number];
         onSelect: () => void;
       }) => JSX.Element;
     }

--- a/apps/web/app/components/Navigation/GlobalSearch/GlobalSearchResults.tsx
+++ b/apps/web/app/components/Navigation/GlobalSearch/GlobalSearchResults.tsx
@@ -16,6 +16,8 @@ import { articlesSearchQueryOptions } from "~/api/queries/useArticlesSearch";
 import { availableCoursesQueryOptions } from "~/api/queries/useAvailableCourses";
 import { contentCreatorCoursesOptions } from "~/api/queries/useContentCreatorCourses";
 import { useCurrentUser } from "~/api/queries/useCurrentUser";
+import { useGlobalSettings } from "~/api/queries/useGlobalSettings";
+import { learningPathsQueryOptions } from "~/api/queries/useLearningPaths";
 import { newsSearchQueryOptions } from "~/api/queries/useNewsList";
 import { hasAnyPermission, hasPermission } from "~/common/permissions/permission.utils";
 import { usePermissions } from "~/hooks/usePermissions";
@@ -27,6 +29,7 @@ import { CategoryEntry } from "./CategoryEntry";
 import { CourseEntry } from "./CourseEntry";
 import { GlobalSearchContent } from "./GlobalSearchContent";
 import { GroupEntry } from "./GroupEntry";
+import { LearningPathEntry } from "./LearningPathEntry";
 import { LessonEntry } from "./LessonEntry";
 import { MyCourseEntry } from "./MyCourseEntry";
 import { NewsEntry } from "./NewsEntry";
@@ -47,8 +50,10 @@ export const GlobalSearchResults = ({
   setTotalItems: (count: number) => void;
 }) => {
   const { data: currentUser } = useCurrentUser();
+  const { data: globalSettings } = useGlobalSettings();
   const { permissions } = usePermissions();
   const { language } = useLanguageStore();
+  const isLearningPathsEnabled = globalSettings?.learningPathsEnabled !== false;
 
   const {
     canSearchAllCourses,
@@ -63,6 +68,7 @@ export const GlobalSearchResults = ({
     canSearchNews,
     canSearchArticles,
     canSearchQA,
+    canSearchLearningPaths,
   } = useMemo(() => {
     return {
       canSearchAllCourses: hasAnyPermission(permissions, [PERMISSIONS.COURSE_UPDATE]),
@@ -95,6 +101,7 @@ export const GlobalSearchResults = ({
         PERMISSIONS.QA_MANAGE,
         PERMISSIONS.QA_MANAGE_OWN,
       ]),
+      canSearchLearningPaths: hasPermission(permissions, PERMISSIONS.LEARNING_PATH_READ),
     };
   }, [permissions]);
 
@@ -137,6 +144,10 @@ export const GlobalSearchResults = ({
         { searchQuery: debouncedSearch, language },
         { enabled: isSearchReady && canSearchLessons },
       ),
+      learningPathsQueryOptions(
+        { searchQuery: debouncedSearch, language },
+        { enabled: isSearchReady && canSearchLearningPaths && isLearningPathsEnabled },
+      ),
       newsSearchQueryOptions(
         { searchQuery: debouncedSearch, language },
         { enabled: isSearchReady && canSearchNews },
@@ -161,6 +172,7 @@ export const GlobalSearchResults = ({
         availableCourses,
         announcements,
         lessons,
+        learningPaths,
         newsResults,
         articlesResults,
         qaResults,
@@ -187,6 +199,11 @@ export const GlobalSearchResults = ({
           resultType: "availableCourses",
           resultData: availableCourses?.data ?? [],
           Component: CourseEntry,
+        },
+        {
+          resultType: "learningPaths",
+          resultData: learningPaths?.data?.data ?? [],
+          Component: LearningPathEntry,
         },
         {
           resultType: "lessons",

--- a/apps/web/app/components/Navigation/GlobalSearch/LearningPathEntry.tsx
+++ b/apps/web/app/components/Navigation/GlobalSearch/LearningPathEntry.tsx
@@ -1,0 +1,40 @@
+import { Link } from "@remix-run/react";
+import { BookOpen } from "lucide-react";
+
+import DefaultPhotoCourse from "~/assets/svgs/default-photo-course.svg";
+
+import type { GetLearningPathsResponse } from "~/api/generated-api";
+
+export const LearningPathEntry = ({
+  item,
+  onSelect,
+}: {
+  item: GetLearningPathsResponse["data"][number];
+  onSelect: () => void;
+}) => {
+  const searchParams = new URLSearchParams({ searchQuery: item.title });
+
+  return (
+    <Link
+      to={`/learning-paths?${searchParams.toString()}`}
+      onClick={onSelect}
+      className="group focus:outline-none focus-visible:outline-none"
+    >
+      <li className="flex items-center gap-3 rounded-md px-2 py-1.5 text-sm text-neutral-900 hover:bg-primary-50 group-focus:bg-primary-100">
+        <img
+          src={item.thumbnailReference || DefaultPhotoCourse}
+          alt={item.title}
+          className="size-4 rounded-sm bg-[#D9D9D9] object-cover"
+          onError={(event) => {
+            event.currentTarget.src = DefaultPhotoCourse;
+          }}
+        />
+        <span className="line-clamp-1 flex-1 body-sm-md">{item.title}</span>
+        <span className="flex items-center gap-1 ps-3 details-md text-neutral-600">
+          <BookOpen className="size-3.5" />
+          {item.courses.length}
+        </span>
+      </li>
+    </Link>
+  );
+};

--- a/apps/web/app/components/Navigation/Navigation.tsx
+++ b/apps/web/app/components/Navigation/Navigation.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import { useCurrentUser } from "~/api/queries";
 import { useConfigurationState } from "~/api/queries/admin/useConfigurationState";
 import { useGlobalSettings } from "~/api/queries/useGlobalSettings";
+import { useLearningPaths } from "~/api/queries/useLearningPaths";
 import { useStripeConfigured } from "~/api/queries/useStripeConfigured";
 import { matchesRequirement } from "~/common/permissions/permission.utils";
 import { Icon } from "~/components/Icon";
@@ -15,6 +16,7 @@ import { getNavigationConfig, mapNavigationItems } from "~/config/navigationConf
 import { usePermissions } from "~/hooks/usePermissions";
 import { cn } from "~/lib/utils";
 import { shouldHideTopbarAndSidebar } from "~/modules/Admin/Admin.layout";
+import { useLanguageStore } from "~/modules/Dashboard/Settings/Language/LanguageStore";
 
 import { Button } from "../ui/button";
 
@@ -31,15 +33,34 @@ type DashboardNavigationProps = { menuItems?: NavigationGroups[] };
 
 export function Navigation({ menuItems }: DashboardNavigationProps) {
   const { isMobileNavOpen, setIsMobileNavOpen } = useMobileNavigation();
+
   const { hasAccess: canManageEnvs, permissions } = usePermissions({
     required: [PERMISSIONS.ENV_MANAGE],
   });
+  const { hasAccess: canAccessLearningPathAdmin } = usePermissions({
+    required: [
+      PERMISSIONS.LEARNING_PATH_CREATE,
+      PERMISSIONS.LEARNING_PATH_UPDATE,
+      PERMISSIONS.LEARNING_PATH_UPDATE_OWN,
+      PERMISSIONS.LEARNING_PATH_COURSE_UPDATE,
+      PERMISSIONS.LEARNING_PATH_COURSE_UPDATE_OWN,
+      PERMISSIONS.LEARNING_PATH_DELETE,
+      PERMISSIONS.LEARNING_PATH_ENROLLMENT,
+      PERMISSIONS.LEARNING_PATH_EXPORT,
+    ],
+  });
+  const { hasAccess: canReadLearningPaths } = usePermissions({
+    required: [PERMISSIONS.LEARNING_PATH_READ],
+  });
+
   const { t } = useTranslation();
   const { pathname } = useLocation();
   const [is2xlBreakpoint, setIs2xlBreakpoint] = useState(false);
   const { data: isStripeConfigured } = useStripeConfigured();
 
   const { data: globalSettings } = useGlobalSettings();
+
+  const language = useLanguageStore((state) => state.language);
 
   const { data: user } = useCurrentUser();
 
@@ -51,6 +72,19 @@ export function Navigation({ menuItems }: DashboardNavigationProps) {
     canManageEnvs && configurationState?.hasIssues && !configurationState?.isWarningDismissed;
 
   const { isSidebarCollapsed, toggleSidebarCollapsed } = useNavigationStore();
+
+  const isLearningPathsEnabled = globalSettings?.learningPathsEnabled !== false;
+
+  const { data: studentLearningPaths } = useLearningPaths(
+    { page: 1, perPage: 1, language },
+    {
+      enabled:
+        isLearningPathsEnabled && canReadLearningPaths && !canAccessLearningPathAdmin && !!user?.id,
+    },
+  );
+
+  const shouldShowLearningPaths =
+    canAccessLearningPathAdmin || Boolean(studentLearningPaths?.pagination.totalItems);
 
   useEffect(() => {
     const updateBreakpoint = () => {
@@ -72,6 +106,8 @@ export function Navigation({ menuItems }: DashboardNavigationProps) {
         globalSettings?.newsEnabled,
         globalSettings?.articlesEnabled,
         isStripeConfigured?.enabled,
+        isLearningPathsEnabled,
+        shouldShowLearningPaths,
       ),
     );
   }

--- a/apps/web/app/components/ui/command.tsx
+++ b/apps/web/app/components/ui/command.tsx
@@ -69,15 +69,18 @@ function CommandInput({
   );
 }
 
-function CommandList({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.List>) {
-  return (
-    <CommandPrimitive.List
-      data-slot="command-list"
-      className={cn("max-h-80 flex-1 overflow-x-hidden overflow-y-auto", className)}
-      {...props}
-    />
-  );
-}
+const CommandList = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.List
+    ref={ref}
+    data-slot="command-list"
+    className={cn("max-h-80 flex-1 overflow-x-hidden overflow-y-auto", className)}
+    {...props}
+  />
+));
+CommandList.displayName = CommandPrimitive.List.displayName;
 
 function CommandEmpty({ ...props }: React.ComponentProps<typeof CommandPrimitive.Empty>) {
   return (

--- a/apps/web/app/components/ui/multiselect.tsx
+++ b/apps/web/app/components/ui/multiselect.tsx
@@ -203,6 +203,7 @@ const MultipleSelector = React.forwardRef<MultipleSelectorRef, MultipleSelectorP
     const [onScrollbar, setOnScrollbar] = React.useState(false);
     const [isLoading, setIsLoading] = React.useState(false);
     const dropdownRef = React.useRef<HTMLDivElement>(null);
+    const commandListRef = React.useRef<HTMLDivElement>(null);
 
     const [selected, setSelected] = React.useState<Option[]>(value || []);
     const [options, setOptions] = React.useState<GroupOption>(
@@ -380,6 +381,12 @@ const MultipleSelector = React.forwardRef<MultipleSelectorRef, MultipleSelectorP
       void exec();
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [debouncedSearchTerm, groupBy, open, triggerSearchOnFocus]);
+
+    useEffect(() => {
+      if (!open) return;
+
+      commandListRef.current?.scrollTo({ top: 0 });
+    }, [inputValue, open, options]);
 
     const CreatableItem = () => {
       if (!creatable) return undefined;
@@ -673,6 +680,7 @@ const MultipleSelector = React.forwardRef<MultipleSelectorRef, MultipleSelectorP
           >
             {open && (
               <CommandList
+                ref={commandListRef}
                 className="bg-popover text-popover-foreground shadow-lg outline-hidden"
                 onMouseLeave={() => {
                   setOnScrollbar(false);

--- a/apps/web/app/config/__tests__/navigationConfig.test.ts
+++ b/apps/web/app/config/__tests__/navigationConfig.test.ts
@@ -1,8 +1,9 @@
 import { PERMISSIONS } from "@repo/shared";
 
-import { findMatchingRoute, mapNavigationItems } from "../navigationConfig";
+import { findMatchingRoute, getNavigationConfig, mapNavigationItems } from "../navigationConfig";
 
 import type { NavigationItem, NavigationGroups } from "../navigationConfig";
+import type { TFunction } from "i18next";
 
 describe("findMatchingRoute", () => {
   it("should find exact matches", () => {
@@ -140,5 +141,38 @@ describe("mapNavigationItems", () => {
     const mapped = mappedGroups[0].items;
 
     expect(mapped[0].accessRequirement).toBeUndefined();
+  });
+});
+
+describe("getNavigationConfig", () => {
+  const t = ((key: string) => key) as TFunction;
+
+  const getCourseItems = (isLearningPathsEnabled: boolean, shouldShowLearningPaths: boolean) =>
+    getNavigationConfig(
+      t,
+      false,
+      false,
+      false,
+      false,
+      isLearningPathsEnabled,
+      shouldShowLearningPaths,
+    )[0].items;
+
+  it("should hide learning paths when the feature is disabled", () => {
+    const items = getCourseItems(false, true);
+
+    expect(items.some((item) => item.path === "learning-paths")).toBe(false);
+  });
+
+  it("should hide learning paths when students have no available paths", () => {
+    const items = getCourseItems(true, false);
+
+    expect(items.some((item) => item.path === "learning-paths")).toBe(false);
+  });
+
+  it("should show learning paths when enabled and available", () => {
+    const items = getCourseItems(true, true);
+
+    expect(items.some((item) => item.path === "learning-paths")).toBe(true);
   });
 });

--- a/apps/web/app/config/navigationConfig.ts
+++ b/apps/web/app/config/navigationConfig.ts
@@ -44,6 +44,8 @@ export const getNavigationConfig = (
   isNewsEnabled = false,
   isArticlesEnabled = false,
   isStripeConfigured = false,
+  isLearningPathsEnabled = false,
+  shouldShowLearningPaths = false,
 ): NavigationGroups[] => {
   const isAnyContentFeatureEnabled = isQAEnabled || isNewsEnabled || isArticlesEnabled;
 
@@ -59,12 +61,16 @@ export const getNavigationConfig = (
           iconName: "Course",
           testId: NAVIGATION_HANDLES.COURSES_LINK,
         },
-        {
-          label: t("navigationSideBar.learningPaths"),
-          path: "learning-paths",
-          iconName: "Route",
-          testId: NAVIGATION_HANDLES.LEARNING_PATHS_LINK,
-        },
+        ...(isLearningPathsEnabled && shouldShowLearningPaths
+          ? ([
+              {
+                label: t("navigationSideBar.learningPaths"),
+                path: "learning-paths",
+                iconName: "Route",
+                testId: NAVIGATION_HANDLES.LEARNING_PATHS_LINK,
+              },
+            ] as NavigationItem[])
+          : []),
         {
           label: t("navigationSideBar.analytics"),
           path: "admin/analytics",

--- a/apps/web/app/locales/cs/translation.json
+++ b/apps/web/app/locales/cs/translation.json
@@ -388,6 +388,7 @@
       "noSearchResults": "Žádné výsledky vyhledávání pro:",
       "announcements": "Oznámení",
       "lessons": "Lekce",
+      "learningPaths": "Výukové cesty",
       "news": "Zprávy",
       "articles": "články",
       "qa": "Otázky a odpovědi"
@@ -2342,7 +2343,8 @@
       "qaSettingUpdatedSuccessfully": "Nastavení QA bylo úspěšně aktualizováno",
       "ageLimitUpdatedSuccessfully": "Věkový limit byl úspěšně aktualizován",
       "newsSettingUpdatedSuccessfully": "Nastavení zpráv byla úspěšně aktualizována",
-      "articlesSettingUpdatedSuccessfully": "Nastavení znalostní báze byla úspěšně aktualizována"
+      "articlesSettingUpdatedSuccessfully": "Nastavení znalostní báze byla úspěšně aktualizována",
+      "learningPathsUpdatedSuccessfully": "Nastavení vzdělávacích cest byla úspěšně aktualizována"
     }
   },
   "certificateBackgroundUpload": {
@@ -3349,6 +3351,16 @@
     },
     "tooltip": {
       "disabled": "Chcete-li toto pole přepnout, nejprve povolte sekci znalostní báze."
+    }
+  },
+  "learningPathsPreferences": {
+    "subHeader": "Konfigurace nastavení vzdělávacích cest",
+    "header": "Nastavení vzdělávacích cest",
+    "settings": {
+      "learningPathsEnabled": {
+        "label": "Povolit vzdělávací cesty",
+        "description": "Povolte vzdělávací cesty. Po vypnutí jsou skryté a zablokované pro všechny uživatele."
+      }
     }
   },
   "qaView": {

--- a/apps/web/app/locales/de/translation.json
+++ b/apps/web/app/locales/de/translation.json
@@ -388,6 +388,7 @@
       "noSearchResults": "Keine Suchergebnisse für:",
       "announcements": "Ankündigungen",
       "lessons": "Unterricht",
+      "learningPaths": "Lernpfade",
       "news": "Nachricht",
       "articles": "Artikel",
       "qa": "Fragen und Antworten"
@@ -2340,7 +2341,8 @@
       "qaSettingUpdatedSuccessfully": "Die QA-Einstellungen wurden erfolgreich aktualisiert",
       "ageLimitUpdatedSuccessfully": "Altersgrenze erfolgreich aktualisiert",
       "newsSettingUpdatedSuccessfully": "Nachrichteneinstellungen erfolgreich aktualisiert",
-      "articlesSettingUpdatedSuccessfully": "Die Einstellungen der Wissensdatenbank wurden erfolgreich aktualisiert"
+      "articlesSettingUpdatedSuccessfully": "Die Einstellungen der Wissensdatenbank wurden erfolgreich aktualisiert",
+      "learningPathsUpdatedSuccessfully": "Die Lernpfad-Einstellungen wurden erfolgreich aktualisiert"
     }
   },
   "certificateBackgroundUpload": {
@@ -3347,6 +3349,16 @@
     },
     "tooltip": {
       "disabled": "Um dieses Feld umzuschalten, aktivieren Sie bitte zuerst den Abschnitt „Wissensdatenbank“."
+    }
+  },
+  "learningPathsPreferences": {
+    "subHeader": "Konfigurieren Sie die Lernpfad-Einstellungen",
+    "header": "Lernpfad-Einstellungen",
+    "settings": {
+      "learningPathsEnabled": {
+        "label": "Lernpfade aktivieren",
+        "description": "Aktivieren Sie Lernpfade. Wenn deaktiviert, werden Lernpfade fuer alle Benutzer ausgeblendet und blockiert."
+      }
     }
   },
   "qaView": {

--- a/apps/web/app/locales/en/translation.json
+++ b/apps/web/app/locales/en/translation.json
@@ -389,6 +389,7 @@
       "noSearchResults": "No search results for:",
       "announcements": "Announcements",
       "lessons": "Lessons",
+      "learningPaths": "Learning Paths",
       "news": "News",
       "articles": "Articles",
       "qa": "Q&A"
@@ -2403,7 +2404,8 @@
       "qaSettingUpdatedSuccessfully": "QA settings updated successfully",
       "ageLimitUpdatedSuccessfully": "Age limit updated successfully",
       "newsSettingUpdatedSuccessfully": "News settings updated successfully",
-      "articlesSettingUpdatedSuccessfully": "Knowledge base settings updated successfully"
+      "articlesSettingUpdatedSuccessfully": "Knowledge base settings updated successfully",
+      "learningPathsUpdatedSuccessfully": "Learning Paths settings updated successfully"
     }
   },
   "certificateBackgroundUpload": {
@@ -3312,6 +3314,16 @@
     },
     "tooltip": {
       "disabled": "To toggle this field, please enable the knowledge base section first."
+    }
+  },
+  "learningPathsPreferences": {
+    "subHeader": "Configure Learning Paths settings",
+    "header": "Learning Paths Settings",
+    "settings": {
+      "learningPathsEnabled": {
+        "label": "Enable Learning Paths",
+        "description": "Enable Learning Paths. When disabled, Learning Paths are hidden and blocked for all users."
+      }
     }
   },
   "qaView": {

--- a/apps/web/app/locales/lt/translation.json
+++ b/apps/web/app/locales/lt/translation.json
@@ -388,6 +388,7 @@
       "noSearchResults": "Nėra paieškos rezultatų:",
       "announcements": "Skelbimai",
       "lessons": "Pamokos",
+      "learningPaths": "Mokymosi keliai",
       "news": "Naujienos",
       "articles": "Straipsniai",
       "qa": "Klausimai ir atsakymai"
@@ -2342,7 +2343,8 @@
       "qaSettingUpdatedSuccessfully": "QA nustatymai sėkmingai atnaujinti",
       "ageLimitUpdatedSuccessfully": "Amžiaus riba sėkmingai atnaujinta",
       "newsSettingUpdatedSuccessfully": "Naujienų nustatymai sėkmingai atnaujinti",
-      "articlesSettingUpdatedSuccessfully": "Žinių bazės nustatymai sėkmingai atnaujinti"
+      "articlesSettingUpdatedSuccessfully": "Žinių bazės nustatymai sėkmingai atnaujinti",
+      "learningPathsUpdatedSuccessfully": "Mokymosi kelių nustatymai sėkmingai atnaujinti"
     }
   },
   "certificateBackgroundUpload": {
@@ -3350,6 +3352,16 @@
     },
     "tooltip": {
       "disabled": "Norėdami perjungti šį lauką, pirmiausia įgalinkite žinių bazės skyrių."
+    }
+  },
+  "learningPathsPreferences": {
+    "subHeader": "Konfigūruokite mokymosi kelių nustatymus",
+    "header": "Mokymosi kelių nustatymai",
+    "settings": {
+      "learningPathsEnabled": {
+        "label": "Įjungti mokymosi kelius",
+        "description": "Įjunkite mokymosi kelius. Išjungus jie paslepiami ir užblokuojami visiems naudotojams."
+      }
     }
   },
   "qaView": {

--- a/apps/web/app/locales/pl/translation.json
+++ b/apps/web/app/locales/pl/translation.json
@@ -620,6 +620,7 @@
       "noSearchResults": "Brak wyników wyszukiwania dla:",
       "announcements": "Powiadomienia",
       "lessons": "Lekcje",
+      "learningPaths": "Ścieżki edukacyjne",
       "news": "Aktualności",
       "articles": "Artykuły",
       "qa": "Pytania i odpowiedzi"
@@ -2632,7 +2633,8 @@
       "qaSettingUpdatedSuccessfully": "Ustawienia QA zostały pomyślnie zaktualizowane",
       "ageLimitUpdatedSuccessfully": "Limit wieku został pomyślnie zaktualizowany",
       "newsSettingUpdatedSuccessfully": "Ustawienia aktualności zostały pomyślnie zaktualizowane",
-      "articlesSettingUpdatedSuccessfully": "Ustawienia bazy wiedzy zostały pomyślnie zaktualizowane"
+      "articlesSettingUpdatedSuccessfully": "Ustawienia bazy wiedzy zostały pomyślnie zaktualizowane",
+      "learningPathsUpdatedSuccessfully": "Ustawienia ścieżek edukacyjnych zostały pomyślnie zaktualizowane"
     }
   },
   "platformSimpleLogo": {
@@ -3338,6 +3340,16 @@
     },
     "tooltip": {
       "disabled": "Aby przełączyć to pole, najpierw włącz sekcję bazy wiedzy."
+    }
+  },
+  "learningPathsPreferences": {
+    "subHeader": "Skonfiguruj ustawienia ścieżek edukacyjnych",
+    "header": "Ustawienia ścieżek edukacyjnych",
+    "settings": {
+      "learningPathsEnabled": {
+        "label": "Włącz ścieżki edukacyjne",
+        "description": "Włącz ścieżki edukacyjne. Po wyłączeniu są ukryte i zablokowane dla wszystkich użytkowników."
+      }
     }
   },
   "qaView": {

--- a/apps/web/app/modules/Admin/LearningPaths/LearningPaths.page.tsx
+++ b/apps/web/app/modules/Admin/LearningPaths/LearningPaths.page.tsx
@@ -12,10 +12,13 @@ import type { ClientLoaderFunctionArgs, MetaFunction } from "@remix-run/react";
 export const meta: MetaFunction = ({ matches }) =>
   setPageTitle(matches, "pages.adminLearningPaths");
 
-export const clientLoader = async (_: ClientLoaderFunctionArgs) => {
+export const clientLoader = async ({ request }: ClientLoaderFunctionArgs) => {
+  const url = new URL(request.url);
+  const searchQuery = url.searchParams.get("searchQuery") ?? "";
+
   const { language } = useLanguageStore.getState();
 
-  return queryClient.fetchQuery(learningPathsQueryOptions({ language }));
+  return queryClient.fetchQuery(learningPathsQueryOptions({ language, searchQuery }));
 };
 
 export default function AdminLearningPathsPage() {

--- a/apps/web/app/modules/Admin/LearningPaths/components/AdminLearningPathsHeader.tsx
+++ b/apps/web/app/modules/Admin/LearningPaths/components/AdminLearningPathsHeader.tsx
@@ -1,16 +1,15 @@
-import { Plus, Search } from "lucide-react";
+import { Plus } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import { Button } from "~/components/ui/button";
-import { Input } from "~/components/ui/input";
 
 import { LEARNING_PATHS_PAGE_HANDLES } from "../../../../../e2e/data/learning-paths/handles";
+import { LearningPathsSearchInput } from "../../../LearningPaths/components/LearningPathsSearchInput";
 import { useAdminLearningPathsPageContext } from "../context/AdminLearningPathsPageContext";
 
 export function AdminLearningPathsHeader() {
   const { t } = useTranslation();
-  const { searchValue, setSearchValue, totalPaths, canCreateLearningPaths, openCreateCard } =
-    useAdminLearningPathsPageContext();
+  const { totalPaths, canCreateLearningPaths, openCreateCard } = useAdminLearningPathsPageContext();
 
   return (
     <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
@@ -24,16 +23,8 @@ export function AdminLearningPathsHeader() {
         </p>
       </div>
 
-      <div className="flex shrink-0 gap-3">
-        <div className="relative w-full lg:w-80">
-          <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-neutral-500" />
-          <Input
-            value={searchValue}
-            onChange={(event) => setSearchValue(event.target.value)}
-            placeholder={t("learningPathsView.searchPlaceholder")}
-            className="h-10 pl-9 text-sm"
-          />
-        </div>
+      <div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row">
+        <LearningPathsSearchInput />
         {canCreateLearningPaths && (
           <Button type="button" variant="primary" className="gap-2" onClick={openCreateCard}>
             <Plus className="size-4" />

--- a/apps/web/app/modules/Admin/LearningPaths/hooks/useAdminLearningPathsPage.ts
+++ b/apps/web/app/modules/Admin/LearningPaths/hooks/useAdminLearningPathsPage.ts
@@ -26,6 +26,7 @@ import type { CreateLearningPathBody, GetLearningPathsResponse } from "~/api/gen
 
 export function useAdminLearningPathsPage() {
   const [searchParams, setSearchParams] = useSearchParams();
+  const searchQuery = searchParams.get("searchQuery") ?? "";
 
   const loaderLearningPaths = useLoaderData<GetLearningPathsResponse>();
 
@@ -33,8 +34,6 @@ export function useAdminLearningPathsPage() {
 
   const { data: currentUser } = useCurrentUserSuspense();
   const { permissions } = usePermissions();
-
-  const [searchValue, setSearchValue] = useState("");
 
   const [pathLanguages, setPathLanguages] = useState<Record<string, SupportedLanguages>>({});
   const [createLanguage, setCreateLanguage] = useState<SupportedLanguages>(appLanguage);
@@ -44,7 +43,7 @@ export function useAdminLearningPathsPage() {
 
   const { data: learningPaths = loaderLearningPaths } = useLearningPaths({
     language: appLanguage,
-    searchQuery: searchValue.trim() || undefined,
+    searchQuery,
   });
 
   const { data: groups = [] } = useGroupsQuery();
@@ -145,8 +144,6 @@ export function useAdminLearningPathsPage() {
     appLanguage,
     learningPaths,
     totalPaths: learningPaths.pagination.totalItems,
-    searchValue,
-    setSearchValue,
     createLanguage,
     setCreateLanguage,
     createCardRef,

--- a/apps/web/app/modules/Courses/CourseView/CourseCertificate.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseCertificate.tsx
@@ -1,4 +1,3 @@
-import { format } from "date-fns";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -11,6 +10,7 @@ import { Card } from "~/components/ui/card";
 import { useCourseAccessProvider } from "~/modules/Courses/context/CourseAccessProvider";
 import { useLanguageStore } from "~/modules/Dashboard/Settings/Language/LanguageStore";
 import CertificatePreview from "~/modules/Profile/Certificates/CertificatePreview";
+import { formatCertificateDate } from "~/utils/formatCertificateDate";
 
 const CourseCertificate = ({ courseId }: { courseId: string }) => {
   const { t } = useTranslation();
@@ -41,7 +41,7 @@ const CourseCertificate = ({ courseId }: { courseId: string }) => {
     const studentName = certificate?.fullName || `${currentUser.firstName} ${currentUser.lastName}`;
     const courseName = certificate?.courseTitle || course.title;
     const completionDate = certificate ? certificate.completionDate : null;
-    const formattedDate = completionDate ? format(new Date(completionDate), "dd.MM.yyyy") : "";
+    const formattedDate = formatCertificateDate(completionDate);
 
     return { studentName, courseName, formattedDate };
   }, [certificate, currentUser, course, isEffectiveStudentExperience]);

--- a/apps/web/app/modules/Dashboard/Settings/components/admin/CustomizePlatformTabContent.tsx
+++ b/apps/web/app/modules/Dashboard/Settings/components/admin/CustomizePlatformTabContent.tsx
@@ -1,5 +1,6 @@
 import ArticlesPreferences from "~/modules/Dashboard/Settings/components/admin/ArticlesPreferences";
 import { CertificateBackgroundUpload } from "~/modules/Dashboard/Settings/components/admin/CertificateBackgroundUpload";
+import LearningPathsPreferences from "~/modules/Dashboard/Settings/components/admin/LearningPathsPreferences";
 import NewsPreferences from "~/modules/Dashboard/Settings/components/admin/NewsPreferences";
 import { OrganizationLoginBackgroundUpload } from "~/modules/Dashboard/Settings/components/admin/OrganizationLoginBackgroundUpload";
 import { OrganizationTheme } from "~/modules/Dashboard/Settings/components/admin/OrganizationTheme";
@@ -27,6 +28,7 @@ export default function CustomizePlatformTabContent({
       <QAPreferences globalSettings={globalSettings} />
       <NewsPreferences globalSettings={globalSettings} />
       <ArticlesPreferences globalSettings={globalSettings} />
+      <LearningPathsPreferences globalSettings={globalSettings} />
       <div className="grid w-full grid-cols-1 gap-4 md:grid-cols-2">
         <CertificateBackgroundUpload
           certificateBackgroundImage={globalSettings.certificateBackgroundImage}

--- a/apps/web/app/modules/Dashboard/Settings/components/admin/LearningPathsPreferences.tsx
+++ b/apps/web/app/modules/Dashboard/Settings/components/admin/LearningPathsPreferences.tsx
@@ -1,0 +1,38 @@
+import { useTranslation } from "react-i18next";
+
+import { useToggleLearningPathsEnabled } from "~/api/mutations/admin/useToggleLearningPathsEnabled";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "~/components/ui/card";
+import { SettingItem } from "~/modules/Dashboard/Settings/components/SettingItem";
+
+import type { GlobalSettings } from "../../types";
+
+interface LearningPathsPreferencesProps {
+  globalSettings: GlobalSettings;
+}
+
+export default function LearningPathsPreferences({
+  globalSettings,
+}: LearningPathsPreferencesProps) {
+  const { t } = useTranslation();
+  const { mutate: toggleLearningPathsEnabled } = useToggleLearningPathsEnabled();
+
+  return (
+    <Card id="learning-paths-preferences">
+      <CardHeader>
+        <CardTitle className="h5">{t("learningPathsPreferences.header")}</CardTitle>
+        <CardDescription className="body-lg-md">
+          {t("learningPathsPreferences.subHeader")}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <SettingItem
+          id="learning-paths-enabled"
+          label={t("learningPathsPreferences.settings.learningPathsEnabled.label")}
+          description={t("learningPathsPreferences.settings.learningPathsEnabled.description")}
+          checked={globalSettings.learningPathsEnabled}
+          onCheckedChange={() => toggleLearningPathsEnabled()}
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/app/modules/LearningPaths/LearningPaths.page.tsx
+++ b/apps/web/app/modules/LearningPaths/LearningPaths.page.tsx
@@ -1,8 +1,10 @@
-import { redirect } from "@remix-run/react";
+import { redirect, useNavigate } from "@remix-run/react";
 import { PERMISSIONS } from "@repo/shared";
+import { useLayoutEffect } from "react";
 import { useTranslation } from "react-i18next";
 
 import { currentUserQueryOptions } from "~/api/queries";
+import { globalSettingsQueryOptions, useGlobalSettings } from "~/api/queries/useGlobalSettings";
 import { learningPathsQueryOptions } from "~/api/queries/useLearningPaths";
 import { queryClient } from "~/api/queryClient";
 import { hasAnyPermission } from "~/common/permissions/permission.utils";
@@ -14,6 +16,7 @@ import { saveEntryToNavigationHistory } from "~/utils/saveEntryToNavigationHisto
 import { setPageTitle } from "~/utils/setPageTitle";
 
 import { LEARNING_PATHS_PAGE_HANDLES } from "../../../e2e/data/learning-paths/handles";
+import { LOGIN_REDIRECT_URL } from "../Auth/constants";
 
 import { LearningPathsEmptyState } from "./components/LearningPathsEmptyState";
 import { LearningPathsPageHeader } from "./components/LearningPathsPageHeader";
@@ -25,6 +28,9 @@ import type { ClientLoaderFunctionArgs, MetaFunction } from "@remix-run/react";
 export const meta: MetaFunction = ({ matches }) => setPageTitle(matches, "pages.learningPaths");
 
 export const clientLoader = async ({ request }: ClientLoaderFunctionArgs) => {
+  const url = new URL(request.url);
+  const searchQuery = url.searchParams.get("searchQuery") ?? "";
+
   try {
     const user = await queryClient.ensureQueryData(currentUserQueryOptions);
 
@@ -37,21 +43,21 @@ export const clientLoader = async ({ request }: ClientLoaderFunctionArgs) => {
     throw redirect("/auth/login");
   }
 
+  const globalSettings = await queryClient.ensureQueryData(globalSettingsQueryOptions);
+
+  if (globalSettings?.data.learningPathsEnabled === false) {
+    throw redirect(LOGIN_REDIRECT_URL);
+  }
+
   const { language } = useLanguageStore.getState();
 
-  return queryClient.fetchQuery(learningPathsQueryOptions({ language }));
+  return queryClient.fetchQuery(learningPathsQueryOptions({ language, searchQuery }));
 };
 
 function StudentLearningPathsPage() {
   const { t } = useTranslation();
-  const {
-    language,
-    learningPaths,
-    searchValue,
-    setSearchValue,
-    enrollLearningPath,
-    isEnrollPending,
-  } = useStudentLearningPathsPage();
+  const { language, learningPaths, enrollLearningPath, isEnrollPending } =
+    useStudentLearningPathsPage();
 
   return (
     <PageWrapper
@@ -66,7 +72,7 @@ function StudentLearningPathsPage() {
         className="flex flex-col gap-6 md:gap-8"
         data-testid={LEARNING_PATHS_PAGE_HANDLES.PAGE}
       >
-        <LearningPathsPageHeader searchValue={searchValue} onSearchChange={setSearchValue} />
+        <LearningPathsPageHeader />
 
         <div className="flex flex-col gap-4">
           {learningPaths.data.map((learningPath) => (
@@ -87,7 +93,10 @@ function StudentLearningPathsPage() {
 }
 
 export default function LearningPathsPage() {
+  const navigate = useNavigate();
+
   const { permissions } = usePermissions();
+  const { data: globalSettings } = useGlobalSettings();
 
   const canAccessLearningPathAdmin = hasAnyPermission(permissions, [
     PERMISSIONS.LEARNING_PATH_CREATE,
@@ -99,6 +108,14 @@ export default function LearningPathsPage() {
     PERMISSIONS.LEARNING_PATH_ENROLLMENT,
     PERMISSIONS.LEARNING_PATH_EXPORT,
   ]);
+
+  useLayoutEffect(() => {
+    if (globalSettings?.learningPathsEnabled === false) {
+      navigate("/courses");
+    }
+  }, [globalSettings?.learningPathsEnabled, navigate]);
+
+  if (globalSettings?.learningPathsEnabled === false) return null;
 
   return canAccessLearningPathAdmin ? <AdminLearningPathsPage /> : <StudentLearningPathsPage />;
 }

--- a/apps/web/app/modules/LearningPaths/components/LearningPathCertificate.tsx
+++ b/apps/web/app/modules/LearningPaths/components/LearningPathCertificate.tsx
@@ -1,4 +1,3 @@
-import { format } from "date-fns";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -11,6 +10,7 @@ import { cn } from "~/lib/utils";
 import { useLanguageStore } from "~/modules/Dashboard/Settings/Language/LanguageStore";
 import { CERTIFICATE_KIND } from "~/modules/Profile/Certificates/certificateKind";
 import CertificatePreview from "~/modules/Profile/Certificates/CertificatePreview";
+import { formatCertificateDate } from "~/utils/formatCertificateDate";
 
 type LearningPathCertificateProps = {
   learningPathId: string;
@@ -48,7 +48,7 @@ export function LearningPathCertificate({
     const studentName = certificate?.fullName || `${currentUser.firstName} ${currentUser.lastName}`;
     const pathName = certificate?.courseTitle || title;
     const completionDate = certificate ? certificate.completionDate : null;
-    const formattedDate = completionDate ? format(new Date(completionDate), "dd.MM.yyyy") : "";
+    const formattedDate = formatCertificateDate(completionDate);
 
     return { studentName, pathName, formattedDate };
   }, [certificate, currentUser, title]);

--- a/apps/web/app/modules/LearningPaths/components/LearningPathEnrollmentDrawer.tsx
+++ b/apps/web/app/modules/LearningPaths/components/LearningPathEnrollmentDrawer.tsx
@@ -178,7 +178,7 @@ export function LearningPathEnrollmentDrawer({
   );
 
   return (
-    <Drawer direction="right">
+    <Drawer direction="right" handleOnly>
       <DrawerTrigger asChild>
         <Button
           type="button"

--- a/apps/web/app/modules/LearningPaths/components/LearningPathSettingsDrawer.tsx
+++ b/apps/web/app/modules/LearningPaths/components/LearningPathSettingsDrawer.tsx
@@ -125,7 +125,7 @@ export function LearningPathSettingsDrawer({
   };
 
   return (
-    <Drawer direction="right">
+    <Drawer direction="right" handleOnly>
       <DrawerTrigger asChild>
         <Button
           type="button"

--- a/apps/web/app/modules/LearningPaths/components/LearningPathsPageHeader.tsx
+++ b/apps/web/app/modules/LearningPaths/components/LearningPathsPageHeader.tsx
@@ -1,39 +1,21 @@
-import { Search } from "lucide-react";
 import { useTranslation } from "react-i18next";
-
-import { Input } from "~/components/ui/input";
 
 import { LEARNING_PATHS_PAGE_HANDLES } from "../../../../e2e/data/learning-paths/handles";
 
-type LearningPathsPageHeaderProps = {
-  searchValue: string;
-  onSearchChange: (value: string) => void;
-};
+import { LearningPathsSearchInput } from "./LearningPathsSearchInput";
 
-export function LearningPathsPageHeader({
-  searchValue,
-  onSearchChange,
-}: LearningPathsPageHeaderProps) {
+export function LearningPathsPageHeader() {
   const { t } = useTranslation();
 
   return (
-    <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+    <div className="flex flex-col gap-4 lg:p-0">
       <div className="flex flex-col lg:p-0">
         <h4 className="h4 pb-1 text-neutral-950" data-testid={LEARNING_PATHS_PAGE_HANDLES.HEADING}>
           {t("learningPathsView.title")}
         </h4>
         <p className="body-lg-md text-neutral-800">{t("learningPathsView.description")}</p>
       </div>
-
-      <div className="relative w-full lg:max-w-sm">
-        <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-neutral-500" />
-        <Input
-          value={searchValue}
-          onChange={(event) => onSearchChange(event.target.value)}
-          placeholder={t("learningPathsView.searchPlaceholder")}
-          className="h-10 pl-9 text-sm"
-        />
-      </div>
+      <LearningPathsSearchInput />
     </div>
   );
 }

--- a/apps/web/app/modules/LearningPaths/components/LearningPathsSearchInput.tsx
+++ b/apps/web/app/modules/LearningPaths/components/LearningPathsSearchInput.tsx
@@ -1,0 +1,63 @@
+import { useSearchParams } from "@remix-run/react";
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { SearchInput } from "~/components/SearchInput/SearchInput";
+import { useDebounce } from "~/hooks/useDebounce";
+
+import { LEARNING_PATHS_PAGE_HANDLES } from "../../../../e2e/data/learning-paths/handles";
+
+export function LearningPathsSearchInput() {
+  const { t } = useTranslation();
+
+  const [searchParams, setSearchParams] = useSearchParams();
+  const searchQuery = searchParams.get("searchQuery") ?? "";
+
+  const [value, setValue] = useState(searchQuery);
+  const debouncedValue = useDebounce(value, 300);
+
+  const isHydratingFromUrlRef = useRef(false);
+
+  useEffect(() => {
+    isHydratingFromUrlRef.current = true;
+
+    setValue(searchQuery);
+  }, [searchQuery]);
+
+  useEffect(() => {
+    if (debouncedValue !== value) return;
+
+    if (isHydratingFromUrlRef.current) {
+      isHydratingFromUrlRef.current = false;
+      return;
+    }
+
+    const nextSearchQuery = debouncedValue.trim();
+
+    if (nextSearchQuery === searchQuery) return;
+
+    const nextParams = new URLSearchParams(searchParams);
+
+    if (nextSearchQuery) {
+      nextParams.set("searchQuery", nextSearchQuery);
+    } else {
+      nextParams.delete("searchQuery");
+    }
+
+    setSearchParams(nextParams, { replace: true });
+  }, [debouncedValue, searchParams, searchQuery, setSearchParams, value]);
+
+  return (
+    <SearchInput
+      data-testid={LEARNING_PATHS_PAGE_HANDLES.SEARCH_INPUT}
+      value={value}
+      clearable
+      wrapperClassName="w-full max-w-lg"
+      placeholder={t("learningPathsView.searchPlaceholder")}
+      onChange={(event) => {
+        isHydratingFromUrlRef.current = false;
+        setValue(event.target.value);
+      }}
+    />
+  );
+}

--- a/apps/web/app/modules/LearningPaths/hooks/useStudentLearningPathsPage.ts
+++ b/apps/web/app/modules/LearningPaths/hooks/useStudentLearningPathsPage.ts
@@ -1,5 +1,4 @@
-import { useLoaderData } from "@remix-run/react";
-import { useState } from "react";
+import { useLoaderData, useSearchParams } from "@remix-run/react";
 
 import { useEnrollCurrentUserToLearningPath } from "~/api/mutations/useLearningPathMutations";
 import { useLearningPaths } from "~/api/queries/useLearningPaths";
@@ -10,13 +9,14 @@ import type { GetLearningPathsResponse } from "~/api/generated-api";
 export function useStudentLearningPathsPage() {
   const loaderLearningPaths = useLoaderData<GetLearningPathsResponse>();
 
-  const language = useLanguageStore((state) => state.language);
+  const [searchParams] = useSearchParams();
+  const searchQuery = searchParams.get("searchQuery") ?? "";
 
-  const [searchValue, setSearchValue] = useState("");
+  const language = useLanguageStore((state) => state.language);
 
   const { data: learningPaths = loaderLearningPaths } = useLearningPaths({
     language,
-    searchQuery: searchValue.trim() || undefined,
+    searchQuery,
   });
 
   const { mutateAsync: enrollCurrentUserToLearningPath, isPending: isEnrollPending } =
@@ -29,8 +29,6 @@ export function useStudentLearningPathsPage() {
   return {
     language,
     learningPaths,
-    searchValue,
-    setSearchValue,
     enrollLearningPath,
     isEnrollPending,
   };

--- a/apps/web/app/utils/__tests__/formatCertificateDate.test.ts
+++ b/apps/web/app/utils/__tests__/formatCertificateDate.test.ts
@@ -1,0 +1,17 @@
+import { formatCertificateDate } from "../formatCertificateDate";
+
+describe("formatCertificateDate", () => {
+  it("formats ISO dates", () => {
+    expect(formatCertificateDate("2026-05-18T10:30:00.000Z")).toBe("18.05.2026");
+  });
+
+  it("keeps already formatted certificate dates", () => {
+    expect(formatCertificateDate("18.05.2026")).toBe("18.05.2026");
+  });
+
+  it("returns an empty string for missing and invalid dates", () => {
+    expect(formatCertificateDate(null)).toBe("");
+    expect(formatCertificateDate("")).toBe("");
+    expect(formatCertificateDate("not-a-date")).toBe("");
+  });
+});

--- a/apps/web/app/utils/formatCertificateDate.ts
+++ b/apps/web/app/utils/formatCertificateDate.ts
@@ -1,0 +1,17 @@
+import { format } from "date-fns";
+
+const FORMATTED_CERTIFICATE_DATE_PATTERN = /^\d{2}\.\d{2}\.\d{4}$/;
+
+export const formatCertificateDate = (completionDate?: string | null) => {
+  if (!completionDate) return "";
+
+  if (FORMATTED_CERTIFICATE_DATE_PATTERN.test(completionDate)) {
+    return completionDate;
+  }
+
+  const parsedDate = new Date(completionDate);
+
+  if (Number.isNaN(parsedDate.getTime())) return "";
+
+  return format(parsedDate, "dd.MM.yyyy");
+};

--- a/apps/web/e2e/data/learning-paths/handles.ts
+++ b/apps/web/e2e/data/learning-paths/handles.ts
@@ -3,4 +3,5 @@ export const LEARNING_PATHS_PAGE_HANDLES = {
   ADMIN_PAGE: "admin-learning-paths-page",
   ADMIN_EDITOR_PAGE: "admin-learning-path-editor-page",
   HEADING: "learning-paths-heading",
+  SEARCH_INPUT: "learning-paths-search-input",
 };


### PR DESCRIPTION
## Issue(s)
- #1513 
- #1501

## Overview

Improves the learning paths experience across API and web:

- Adds a global admin setting for enabling/disabling learning paths.
- Blocks learning path API endpoints when the feature is disabled.
- Hides learning paths from navigation when disabled or when a student has no available paths.
- Adds learning paths to global search results.
- Moves student learning path search into the URL query so search state is shareable and reload-safe.
- Fixes course availability checks for learning paths to account for enrollment status.
- Handles already-formatted certificate dates without producing invalid certificate output.

## Business Value

Admins can now control whether learning paths are available on a tenant, which makes the feature safer to roll out gradually and easier to hide when not configured. Students get a cleaner experience because navigation and search only expose relevant learning path entries, while certificate and course selection fixes reduce confusing edge cases in completed or managed paths.

## Screenshots / Video

https://github.com/user-attachments/assets/6986b249-d181-4158-a1b8-3675cc480e52