### PR TITLE
fix: make course discussions visible to enrolled learners

### DIFF
--- a/apps/web/app/api/mutations/useToggleCourseStudentMode.ts
+++ b/apps/web/app/api/mutations/useToggleCourseStudentMode.ts
@@ -2,13 +2,12 @@ import { useMutation } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 
 import { ApiClient } from "~/api/api-client";
-import { currentUserQueryOptions, courseQueryOptions } from "~/api/queries";
+import { currentUserQueryOptions } from "~/api/queries";
 import { queryClient } from "~/api/queryClient";
 import { toast } from "~/components/ui/use-toast";
 
 import type { ApiErrorResponse } from "../types";
 import type { AxiosError } from "axios";
-import type { CurrentUserResponse } from "~/api/generated-api";
 
 export const useToggleCourseStudentMode = (courseId: string) => {
   const { t } = useTranslation();
@@ -21,21 +20,9 @@ export const useToggleCourseStudentMode = (courseId: string) => {
 
       return response.data.data;
     },
-    onSuccess: async (data) => {
-      queryClient.setQueryData<CurrentUserResponse | null>(
-        currentUserQueryOptions.queryKey,
-        (prev) =>
-          prev && {
-            ...prev,
-            data: {
-              ...prev.data,
-              studentModeCourseIds: data.studentModeCourseIds,
-            },
-          },
-      );
-
+    onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: currentUserQueryOptions.queryKey });
-      await queryClient.invalidateQueries({ queryKey: courseQueryOptions(courseId).queryKey });
+      await queryClient.invalidateQueries({ queryKey: ["course"] });
     },
     onError: (error: AxiosError) => {
       const { message } = error.response?.data as ApiErrorResponse;

--- a/apps/web/app/modules/Courses/CourseView/CourseView.page.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseView.page.tsx
@@ -133,7 +133,7 @@ export default function CourseViewPage() {
             )}
           />
         ),
-        isForAdminLike: true,
+        isForAdminLike: false,
         isForUnregistered: false,
         isForEnrolled: true,
       },

--- a/apps/web/app/modules/Courses/Lesson/Lesson.page.tsx
+++ b/apps/web/app/modules/Courses/Lesson/Lesson.page.tsx
@@ -4,7 +4,7 @@ import { first, get, last, orderBy } from "lodash-es";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import { useCourse, useCurrentUser, useLesson } from "~/api/queries";
+import { courseQueryOptions, useCourse, useCurrentUser, useLesson } from "~/api/queries";
 import { queryClient } from "~/api/queryClient";
 import ErrorPage from "~/components/ErrorPage/ErrorPage";
 import { LoaderWithTextSequence } from "~/components/LoaderWithTextSequence";
@@ -58,6 +58,12 @@ export default function LessonPage() {
     isError: lessonError,
   } = useLesson(lessonId, language, user?.id || "");
   const { data: course } = useCourse(courseId, language);
+
+  useEffect(() => {
+    if (!lesson?.id || !courseId) return;
+
+    queryClient.invalidateQueries(courseQueryOptions(courseId, language));
+  }, [courseId, language, lesson?.id]);
 
   useLearningTimeTracker({
     lessonId,


### PR DESCRIPTION
<!--
 1. Make sure you have correct branch name i.e. `ab_prefix_123_task_name`, where `123` is a issue ID, and `ab` is an author
 2. Make sure you have meaningful title related to task with correct prefix: feat/fix/chore/style/docs/refactor
 3. Reference multiple issues in one PR by listing them in the issues section
 4. Make sure all necessary sections are filled, remove obsolete sections
 5. Do a self review first
 6. Check if your PR includes only code related to your task
 7. `Notes` is used for additional info but also to notify if any action is required
-->

## Issue(s)
[1528](https://github.com/Selleo/mentingo/issues/1528)

## Overview

  Fixes course discussion tab visibility for enrolled users and
  learning mode users.

  - Makes the discussion tab available as an enrolled-user tab
    instead of treating it as admin-like content.
  - Invalidates the course query after lesson load so course
    enrollment state is refreshed when lesson entry creates or
    updates learner state.
  - Updates learning mode toggling to invalidate current-user data
    and all course queries instead of manually patching cached user
    state, covering course queries keyed by slug and language.

  ## Business Value

  Users entering a lesson or switching into learning mode can see the
  course discussion tab without needing a manual page refresh. This
  makes discussion access feel consistent with the actual enrollment/
  learning-mode state and removes a confusing navigation issue from
  the learning flow.
