### PR TITLE
chore: rename learning paths to development paths across the platform

### DIFF
--- a/apps/web/app/locales/cs/translation.json
+++ b/apps/web/app/locales/cs/translation.json
@@ -295,7 +295,7 @@
     "progress": "Pokrok",
     "findInApplication": "Najít v aplikaci",
     "courses": "Kurzy",
-    "learningPaths": "Vzdělávací cesty",
+    "learningPaths": "Rozvojové cesty",
     "content": "Obsah",
     "categories": "Kategorie",
     "users": "Uživatelé",
@@ -387,7 +387,7 @@
       "noSearchResults": "Žádné výsledky vyhledávání pro:",
       "announcements": "Oznámení",
       "lessons": "Lekce",
-      "learningPaths": "Výukové cesty",
+      "learningPaths": "Rozvojové cesty",
       "news": "Zprávy",
       "articles": "články",
       "qa": "Otázky a odpovědi"
@@ -982,7 +982,7 @@
         "category": "kategorie",
         "group": "skupiny",
         "course": "kurzy",
-        "learning_path": "vzdělávací cesty",
+        "learning_path": "rozvojové cesty",
         "learning_mode": "režim učení",
         "learning_progress": "studijní postup",
         "certificate": "certifikáty",
@@ -2391,7 +2391,7 @@
       "ageLimitUpdatedSuccessfully": "Věkový limit byl úspěšně aktualizován",
       "newsSettingUpdatedSuccessfully": "Nastavení zpráv byla úspěšně aktualizována",
       "articlesSettingUpdatedSuccessfully": "Nastavení znalostní báze byla úspěšně aktualizována",
-      "learningPathsUpdatedSuccessfully": "Nastavení vzdělávacích cest byla úspěšně aktualizována"
+      "learningPathsUpdatedSuccessfully": "Nastavení rozvojových cest byla úspěšně aktualizována"
     }
   },
   "certificateBackgroundUpload": {
@@ -2968,9 +2968,9 @@
     "createTenant": "Vytvořit organizaci",
     "tenants": "Organizace",
     "activityLogs": "Log aktivit",
-    "learningPaths": "Vzdělávací cesty",
-    "adminLearningPaths": "Vzdělávací cesty",
-    "adminLearningPathEditor": "Editor vzdělávací cesty"
+    "learningPaths": "Rozvojové cesty",
+    "adminLearningPaths": "Rozvojové cesty",
+    "adminLearningPathEditor": "Editor rozvojové cesty"
   },
   "masterCourse": {
     "error": {
@@ -2987,19 +2987,19 @@
   "learningPathExport": {
     "error": {
       "noTargetTenants": "Vyberte alespon jednoho ciloveho tenanta",
-      "exportLinkMissing": "Vazba exportu vzdelavaci cesty nebyla nalezena",
-      "noCourses": "Vzdelavaci cesta musi pred exportem obsahovat alespon jeden kurz",
-      "courseExportFailed": "Nepodarilo se exportovat jeden z kurzu vzdelavaci cesty",
+      "exportLinkMissing": "Vazba exportu rozvojove cesty nebyla nalezena",
+      "noCourses": "Rozvojova cesta musi pred exportem obsahovat alespon jeden kurz",
+      "courseExportFailed": "Nepodarilo se exportovat jeden z kurzu rozvojove cesty",
       "targetAuthorMissing": "Autor v cilovem tenantovi nebyl nalezen",
-      "jobNotFound": "Uloha exportu vzdelavaci cesty nebyla nalezena",
-      "invalidJobData": "Neplatna data ulohy exportu vzdelavaci cesty",
-      "invalidExportId": "Neplatne ID exportu vzdelavaci cesty",
-      "invalidExportLink": "Neplatna vazba exportu vzdelavaci cesty"
+      "jobNotFound": "Uloha exportu rozvojove cesty nebyla nalezena",
+      "invalidJobData": "Neplatna data ulohy exportu rozvojove cesty",
+      "invalidExportId": "Neplatne ID exportu rozvojove cesty",
+      "invalidExportLink": "Neplatna vazba exportu rozvojove cesty"
     }
   },
   "learningPathCertificate": {
     "error": {
-      "disabled": "Certifikaty vzdelavacich cest jsou vypnute"
+      "disabled": "Certifikaty rozvojovych cest jsou vypnute"
     }
   },
   "activityLogsView": {
@@ -3075,11 +3075,11 @@
     }
   },
   "learningPathsView": {
-    "title": "Vzdělávací cesty",
-    "description": "Procházejte přiřazené vzdělávací cesty a pokračujte v uspořádaných sekvencích kurzů.",
-    "searchPlaceholder": "Hledat vzdělávací cesty",
-    "summary": "{{count}} vzdělávacích cest je dostupných.",
-    "detailsTitle": "Vzdělávací cesta",
+    "title": "Rozvojové cesty",
+    "description": "Procházejte přiřazené rozvojové cesty a pokračujte v uspořádaných sekvencích kurzů.",
+    "searchPlaceholder": "Hledat rozvojové cesty",
+    "summary": "{{count}} rozvojových cest je dostupných.",
+    "detailsTitle": "Rozvojová cesta",
     "detailsDescription": "Zkontrolujte pořadí kurzů, pokrok, uzamčení a stav certifikátu.",
     "detailsSummary": "Tato cesta obsahuje {{count}} kurzů. Aktuální pokrok: {{progress}}.",
     "emptyDescription": "Popis zatím nebyl přidán.",
@@ -3098,7 +3098,7 @@
       "certificate": "Certifikát"
     },
     "card": {
-      "openPath": "Otevřít vzdělávací cestu"
+      "openPath": "Otevřít rozvojovou cestu"
     },
     "empty": {
       "title": "Nebyly nalezeny žádné cesty",
@@ -3111,7 +3111,7 @@
     "certificate": {
       "available": "Certifikát dostupný",
       "ready": "Certifikát připraven",
-      "pathCompleted": "Vzdělávací cesta dokončena. Váš certifikát je připraven."
+      "pathCompleted": "Rozvojová cesta dokončena. Váš certifikát je připraven."
     },
     "courseState": {
       "completed": "Dokončeno",
@@ -3126,12 +3126,12 @@
       "courses": "Kurzy v této cestě",
       "courseTitle": "Kurz {{number}}",
       "completedAt": "Dokončeno {{date}}",
-      "emptyCourses": "Tato vzdělávací cesta zatím neobsahuje žádné kurzy."
+      "emptyCourses": "Tato rozvojová cesta zatím neobsahuje žádné kurzy."
     },
     "enrollment": {
       "manage": "Zapsat",
       "title": "Zapsat účastníky",
-      "description": "Spravujte zápisy studentů a skupin do této vzdělávací cesty.",
+      "description": "Spravujte zápisy studentů a skupin do této rozvojové cesty.",
       "students": "Studenti",
       "selectStudents": "Vyberte studenty",
       "groups": "Skupiny",
@@ -3151,9 +3151,9 @@
       "groupsEnrolled": "Skupiny zapsány",
       "studentsUnenrolled": "Studenti odebráni ze zápisu",
       "groupsUnenrolled": "Skupiny odebrány ze zápisu",
-      "enrolledSuccessfully": "Zapsáno do vzdělávací cesty",
-      "enrollGroupsDescription": "Vyberte skupiny, které chcete zapsat do této vzdělávací cesty.",
-      "unenrollGroupsDescription": "Vyberte skupiny, které chcete odebrat ze zápisu do této vzdělávací cesty.",
+      "enrolledSuccessfully": "Zapsáno do rozvojové cesty",
+      "enrollGroupsDescription": "Vyberte skupiny, které chcete zapsat do této rozvojové cesty.",
+      "unenrollGroupsDescription": "Vyberte skupiny, které chcete odebrat ze zápisu do této rozvojové cesty.",
       "table": {
         "selectAll": "Vybrat všechny účastníky",
         "select": "Vybrat účastníka",
@@ -3169,16 +3169,16 @@
       },
       "confirmation": {
         "title": "Potvrdit zápis",
-        "description": "Opravdu chcete zapsat vybrané studenty do této vzdělávací cesty? Tuto akci nelze vrátit zpět."
+        "description": "Opravdu chcete zapsat vybrané studenty do této rozvojové cesty? Tuto akci nelze vrátit zpět."
       },
       "unenrollConfirmation": {
         "title": "Potvrdit odebrání ze zápisu",
-        "description": "Opravdu chcete odebrat vybrané studenty ze zápisu do této vzdělávací cesty? Tuto akci nelze vrátit zpět."
+        "description": "Opravdu chcete odebrat vybrané studenty ze zápisu do této rozvojové cesty? Tuto akci nelze vrátit zpět."
       },
       "noGroups": "Nejsou dostupné žádné skupiny"
     },
     "breadcrumbs": {
-      "learningPaths": "Vzdělávací cesty",
+      "learningPaths": "Rozvojové cesty",
       "details": "Detail"
     },
     "buttons": {
@@ -3186,26 +3186,26 @@
     }
   },
   "adminLearningPathsView": {
-    "title": "Vzdělávací cesty",
+    "title": "Rozvojové cesty",
     "description": "Spravujte metadata, nastavení sekvence, kurzy, zápisy, exporty a certifikáty.",
-    "summary": "{{count}} vzdělávacích cest je dostupných v tomto prostoru.",
+    "summary": "{{count}} rozvojových cest je dostupných v tomto prostoru.",
     "breadcrumbs": {
-      "learningPaths": "Vzdělávací cesty",
+      "learningPaths": "Rozvojové cesty",
       "create": "Vytvořit",
       "edit": "Upravit"
     },
     "buttons": {
-      "create": "Vytvořit vzdělávací cestu",
+      "create": "Vytvořit rozvojovou cestu",
       "edit": "Upravit",
       "save": "Uložit změny",
       "removeImage": "Odebrat obrázek"
     },
     "editor": {
-      "createTitle": "Vytvořit vzdělávací cestu",
-      "editTitle": "Upravit vzdělávací cestu",
+      "createTitle": "Vytvořit rozvojovou cestu",
+      "editTitle": "Upravit rozvojovou cestu",
       "description": "Nastavte podrobnosti cesty, sekvenci, kurzy a stav publikování.",
-      "createSummary": "Začněte podrobnostmi vzdělávací cesty.",
-      "editSummary": "Tato vzdělávací cesta má aktuálně {{coursesCount}} kurzů.",
+      "createSummary": "Začněte podrobnostmi rozvojové cesty.",
+      "editSummary": "Tato rozvojová cesta má aktuálně {{coursesCount}} kurzů.",
       "details": "Podrobnosti",
       "courses": "Kurzy",
       "image": "Obrázek",
@@ -3218,19 +3218,19 @@
       "language": "Jazyk",
       "createdAt": "Vytvořeno",
       "actions": "Akce",
-      "untitled": "Vzdělávací cesta bez názvu",
+      "untitled": "Rozvojová cesta bez názvu",
       "emptyDescription": "Bez popisu",
       "sequential": "Sekvenční",
       "flexible": "Volné pořadí",
       "certificate": "Certifikát",
-      "empty": "Zatím nebyly vytvořeny žádné vzdělávací cesty."
+      "empty": "Zatím nebyly vytvořeny žádné rozvojové cesty."
     },
     "form": {
       "language": "Jazyk",
       "status": "Stav",
       "statusDescription": "Určuje, zda je cesta viditelná, jako koncept nebo soukromá.",
       "title": "Název",
-      "titlePlaceholder": "Pojmenujte vzdělávací cestu",
+      "titlePlaceholder": "Pojmenujte rozvojovou cestu",
       "description": "Popis",
       "descriptionPlaceholder": "Popište, co studenti v této cestě dokončí",
       "imageHint": "PNG, JPG nebo JPEG (max. 20 MB, doporučeno 1200x1200 nebo vyšší)",
@@ -3239,7 +3239,7 @@
       "includesCertificate": "Certifikát",
       "includesCertificateDescription": "Studenti mohou po dokončení cesty získat certifikát.",
       "certificateSignature": "Podpis na certifikátu",
-      "certificateSignatureDescription": "Nahrajte podpis zobrazený na certifikátech pro tuto vzdělávací cestu.",
+      "certificateSignatureDescription": "Nahrajte podpis zobrazený na certifikátech pro tuto rozvojovou cestu.",
       "certificateFontColor": "Barva písma certifikátu",
       "certificateFontColorDescription": "Pomocí výběru barvy v náhledu změňte barvu textu a linek certifikátu.",
       "certificatePreview": "Náhled certifikátu",
@@ -3270,32 +3270,32 @@
       "delete": "Smazat kurz",
       "order": "Pořadí",
       "course": "Kurz",
-      "empty": "Do této vzdělávací cesty zatím nebyly přidány žádné kurzy.",
-      "saveFirst": "Před přidáním kurzů vzdělávací cestu uložte.",
+      "empty": "Do této rozvojové cesty zatím nebyly přidány žádné kurzy.",
+      "saveFirst": "Před přidáním kurzů rozvojovou cestu uložte.",
       "unknownCourse": "Podrobnosti kurzu nejsou dostupné"
     },
     "sharedLearningPath": {
       "badgeExported": "Sdíleno",
       "exportButton": "Sdílet",
-      "exportSuccess": "Vzdělávací cesta byla sdílena",
-      "exportsDescription": "Sdílejte tuto vzdělávací cestu s vybranými organizacemi.",
+      "exportSuccess": "Rozvojová cesta byla sdílena",
+      "exportsDescription": "Sdílejte tuto rozvojovou cestu s vybranými organizacemi.",
       "exportsTitle": "Sdílení",
       "exportingButton": "Sdílení...",
       "selectTenants": "Vyberte organizace",
       "selectedCount": "Vybráno:"
     },
     "deleteModal": {
-      "title": "Smazat vzdělávací cestu",
-      "description": "Tím se smaže vzdělávací cesta a odebere přístup ke kurzům udělený touto cestou."
+      "title": "Smazat rozvojovou cestu",
+      "description": "Tím se smaže rozvojová cesta a odebere přístup ke kurzům udělený touto cestou."
     },
     "toast": {
-      "created": "Vzdělávací cesta byla vytvořena",
-      "updated": "Vzdělávací cesta byla aktualizována",
-      "deleted": "Vzdělávací cesta byla smazána",
-      "languageCreated": "Jazyk vzdělávací cesty byl vytvořen",
-      "coursesAdded": "Kurzy byly přidány do vzdělávací cesty",
-      "courseRemoved": "Kurz byl odebrán ze vzdělávací cesty",
-      "coursesReordered": "Pořadí kurzů ve vzdělávací cestě bylo aktualizováno"
+      "created": "Rozvojová cesta byla vytvořena",
+      "updated": "Rozvojová cesta byla aktualizována",
+      "deleted": "Rozvojová cesta byla smazána",
+      "languageCreated": "Jazyk rozvojové cesty byl vytvořen",
+      "coursesAdded": "Kurzy byly přidány do rozvojové cesty",
+      "courseRemoved": "Kurz byl odebrán z rozvojové cesty",
+      "coursesReordered": "Pořadí kurzů v rozvojové cestě bylo aktualizováno"
     }
   },
   "lessonPreview": {
@@ -3403,12 +3403,12 @@
     }
   },
   "learningPathsPreferences": {
-    "subHeader": "Konfigurace nastavení vzdělávacích cest",
-    "header": "Nastavení vzdělávacích cest",
+    "subHeader": "Konfigurace nastavení rozvojových cest",
+    "header": "Nastavení rozvojových cest",
     "settings": {
       "learningPathsEnabled": {
-        "label": "Povolit vzdělávací cesty",
-        "description": "Povolte vzdělávací cesty. Po vypnutí jsou skryté a zablokované pro všechny uživatele."
+        "label": "Povolit rozvojové cesty",
+        "description": "Povolte rozvojové cesty. Po vypnutí jsou skryté a zablokované pro všechny uživatele."
       }
     }
   },

--- a/apps/web/app/locales/de/translation.json
+++ b/apps/web/app/locales/de/translation.json
@@ -295,7 +295,7 @@
     "progress": "Fortschritt",
     "findInApplication": "Finden Sie in der Anwendung",
     "courses": "Kurse",
-    "learningPaths": "Lernpfade",
+    "learningPaths": "Entwicklungspfade",
     "content": "Inhalt",
     "categories": "Kategorien",
     "users": "Benutzer",
@@ -387,7 +387,7 @@
       "noSearchResults": "Keine Suchergebnisse für:",
       "announcements": "Ankündigungen",
       "lessons": "Unterricht",
-      "learningPaths": "Lernpfade",
+      "learningPaths": "Entwicklungspfade",
       "news": "Nachricht",
       "articles": "Artikel",
       "qa": "Fragen und Antworten"
@@ -982,7 +982,7 @@
         "category": "Kategorien",
         "group": "Gruppen",
         "course": "Kurse",
-        "learning_path": "Lernpfade",
+        "learning_path": "Entwicklungspfade",
         "learning_mode": "Lernmodus",
         "learning_progress": "Lernfortschritt",
         "certificate": "Zertifikate",
@@ -2389,7 +2389,7 @@
       "ageLimitUpdatedSuccessfully": "Altersgrenze erfolgreich aktualisiert",
       "newsSettingUpdatedSuccessfully": "Nachrichteneinstellungen erfolgreich aktualisiert",
       "articlesSettingUpdatedSuccessfully": "Die Einstellungen der Wissensdatenbank wurden erfolgreich aktualisiert",
-      "learningPathsUpdatedSuccessfully": "Die Lernpfad-Einstellungen wurden erfolgreich aktualisiert"
+      "learningPathsUpdatedSuccessfully": "Die Entwicklungspfad-Einstellungen wurden erfolgreich aktualisiert"
     }
   },
   "certificateBackgroundUpload": {
@@ -2966,9 +2966,9 @@
     "createTenant": "Organisation erstellen",
     "tenants": "Organisationen",
     "activityLogs": "Aktivitätsprotokoll",
-    "learningPaths": "Lernpfade",
-    "adminLearningPaths": "Lernpfade",
-    "adminLearningPathEditor": "Lernpfad Editor"
+    "learningPaths": "Entwicklungspfade",
+    "adminLearningPaths": "Entwicklungspfade",
+    "adminLearningPathEditor": "Entwicklungspfad Editor"
   },
   "masterCourse": {
     "error": {
@@ -2985,19 +2985,19 @@
   "learningPathExport": {
     "error": {
       "noTargetTenants": "Waehlen Sie mindestens einen Ziel-Tenant aus",
-      "exportLinkMissing": "Lernpfad-Exportverknuepfung nicht gefunden",
-      "noCourses": "Der Lernpfad muss vor dem Export mindestens einen Kurs enthalten",
-      "courseExportFailed": "Einer der Lernpfadkurse konnte nicht exportiert werden",
+      "exportLinkMissing": "Entwicklungspfad-Exportverknuepfung nicht gefunden",
+      "noCourses": "Der Entwicklungspfad muss vor dem Export mindestens einen Kurs enthalten",
+      "courseExportFailed": "Einer der Entwicklungspfadkurse konnte nicht exportiert werden",
       "targetAuthorMissing": "Autor im Ziel-Tenant nicht gefunden",
-      "jobNotFound": "Lernpfad-Exportauftrag nicht gefunden",
-      "invalidJobData": "Ungueltige Daten fuer den Lernpfad-Exportauftrag",
-      "invalidExportId": "Ungueltige Lernpfad-Export-ID",
-      "invalidExportLink": "Ungueltige Lernpfad-Exportverknuepfung"
+      "jobNotFound": "Entwicklungspfad-Exportauftrag nicht gefunden",
+      "invalidJobData": "Ungueltige Daten fuer den Entwicklungspfad-Exportauftrag",
+      "invalidExportId": "Ungueltige Entwicklungspfad-Export-ID",
+      "invalidExportLink": "Ungueltige Entwicklungspfad-Exportverknuepfung"
     }
   },
   "learningPathCertificate": {
     "error": {
-      "disabled": "Lernpfad-Zertifikate sind deaktiviert"
+      "disabled": "Entwicklungspfad-Zertifikate sind deaktiviert"
     }
   },
   "activityLogsView": {
@@ -3073,11 +3073,11 @@
     }
   },
   "learningPathsView": {
-    "title": "Lernpfade",
-    "description": "Durchsuchen Sie zugewiesene Lernpfade und setzen Sie geordnete Kurssequenzen fort.",
-    "searchPlaceholder": "Lernpfade suchen",
-    "summary": "{{count}} Lernpfade sind verfügbar.",
-    "detailsTitle": "Lernpfad",
+    "title": "Entwicklungspfade",
+    "description": "Durchsuchen Sie zugewiesene Entwicklungspfade und setzen Sie geordnete Kurssequenzen fort.",
+    "searchPlaceholder": "Entwicklungspfade suchen",
+    "summary": "{{count}} Entwicklungspfade sind verfügbar.",
+    "detailsTitle": "Entwicklungspfad",
     "detailsDescription": "Prüfen Sie Kursreihenfolge, Fortschritt, Sperren und Zertifikatsstatus.",
     "detailsSummary": "Dieser Pfad enthält {{count}} Kurse. Aktueller Fortschritt: {{progress}}.",
     "emptyDescription": "Es wurde noch keine Beschreibung hinzugefügt.",
@@ -3096,10 +3096,10 @@
       "certificate": "Zertifikat"
     },
     "card": {
-      "openPath": "Lernpfad öffnen"
+      "openPath": "Entwicklungspfad öffnen"
     },
     "empty": {
-      "title": "Keine Lernpfade gefunden",
+      "title": "Keine Entwicklungspfade gefunden",
       "description": "Passen Sie die Suche an oder prüfen Sie später erneut."
     },
     "progress": {
@@ -3109,7 +3109,7 @@
     "certificate": {
       "available": "Zertifikat verfügbar",
       "ready": "Zertifikat bereit",
-      "pathCompleted": "Lernpfad abgeschlossen. Ihr Zertifikat ist bereit."
+      "pathCompleted": "Entwicklungspfad abgeschlossen. Ihr Zertifikat ist bereit."
     },
     "courseState": {
       "completed": "Abgeschlossen",
@@ -3124,12 +3124,12 @@
       "courses": "Kurse in diesem Pfad",
       "courseTitle": "Kurs {{number}}",
       "completedAt": "Abgeschlossen am {{date}}",
-      "emptyCourses": "Dieser Lernpfad enthält noch keine Kurse."
+      "emptyCourses": "Dieser Entwicklungspfad enthält noch keine Kurse."
     },
     "enrollment": {
       "manage": "Einschreiben",
       "title": "Lernende einschreiben",
-      "description": "Verwalten Sie Einschreibungen von Studierenden und Gruppen für diesen Lernpfad.",
+      "description": "Verwalten Sie Einschreibungen von Studierenden und Gruppen für diesen Entwicklungspfad.",
       "students": "Studierende",
       "selectStudents": "Studierende auswählen",
       "groups": "Gruppen",
@@ -3149,9 +3149,9 @@
       "groupsEnrolled": "Gruppen eingeschrieben",
       "studentsUnenrolled": "Studierende abgemeldet",
       "groupsUnenrolled": "Gruppen abgemeldet",
-      "enrolledSuccessfully": "Lernpfad eingeschrieben",
-      "enrollGroupsDescription": "Wählen Sie Gruppen aus, die in diesen Lernpfad eingeschrieben werden sollen.",
-      "unenrollGroupsDescription": "Wählen Sie Gruppen aus, die aus diesem Lernpfad abgemeldet werden sollen.",
+      "enrolledSuccessfully": "Entwicklungspfad eingeschrieben",
+      "enrollGroupsDescription": "Wählen Sie Gruppen aus, die in diesen Entwicklungspfad eingeschrieben werden sollen.",
+      "unenrollGroupsDescription": "Wählen Sie Gruppen aus, die aus diesem Entwicklungspfad abgemeldet werden sollen.",
       "table": {
         "selectAll": "Alle Lernenden auswählen",
         "select": "Lernenden auswählen",
@@ -3167,16 +3167,16 @@
       },
       "confirmation": {
         "title": "Einschreibung bestätigen",
-        "description": "Sind Sie sicher, dass Sie die ausgewählten Studierenden in diesen Lernpfad einschreiben möchten? Diese Aktion kann nicht rückgängig gemacht werden."
+        "description": "Sind Sie sicher, dass Sie die ausgewählten Studierenden in diesen Entwicklungspfad einschreiben möchten? Diese Aktion kann nicht rückgängig gemacht werden."
       },
       "unenrollConfirmation": {
         "title": "Abmeldung bestätigen",
-        "description": "Sind Sie sicher, dass Sie die ausgewählten Studierenden aus diesem Lernpfad abmelden möchten? Diese Aktion kann nicht rückgängig gemacht werden."
+        "description": "Sind Sie sicher, dass Sie die ausgewählten Studierenden aus diesem Entwicklungspfad abmelden möchten? Diese Aktion kann nicht rückgängig gemacht werden."
       },
       "noGroups": "Keine Gruppen verfügbar"
     },
     "breadcrumbs": {
-      "learningPaths": "Lernpfade",
+      "learningPaths": "Entwicklungspfade",
       "details": "Details"
     },
     "buttons": {
@@ -3184,26 +3184,26 @@
     }
   },
   "adminLearningPathsView": {
-    "title": "Lernpfade",
+    "title": "Entwicklungspfade",
     "description": "Verwalten Sie Metadaten, Sequenzeinstellungen, Kurse, Einschreibungen, Exporte und Zertifikate.",
-    "summary": "{{count}} Lernpfade sind in diesem Arbeitsbereich verfügbar.",
+    "summary": "{{count}} Entwicklungspfade sind in diesem Arbeitsbereich verfügbar.",
     "breadcrumbs": {
-      "learningPaths": "Lernpfade",
+      "learningPaths": "Entwicklungspfade",
       "create": "Erstellen",
       "edit": "Bearbeiten"
     },
     "buttons": {
-      "create": "Lernpfad erstellen",
+      "create": "Entwicklungspfad erstellen",
       "edit": "Bearbeiten",
       "save": "Änderungen speichern",
       "removeImage": "Bild entfernen"
     },
     "editor": {
-      "createTitle": "Lernpfad erstellen",
-      "editTitle": "Lernpfad bearbeiten",
-      "description": "Richten Sie Details, Sequenzeinstellungen, Kurse und Veröffentlichungsstatus des Lernpfads ein.",
-      "createSummary": "Beginnen Sie mit den Lernpfaddetails.",
-      "editSummary": "Dieser Lernpfad hat derzeit {{coursesCount}} Kurse.",
+      "createTitle": "Entwicklungspfad erstellen",
+      "editTitle": "Entwicklungspfad bearbeiten",
+      "description": "Richten Sie Details, Sequenzeinstellungen, Kurse und Veröffentlichungsstatus des Entwicklungspfads ein.",
+      "createSummary": "Beginnen Sie mit den Entwicklungspfaddetails.",
+      "editSummary": "Dieser Entwicklungspfad hat derzeit {{coursesCount}} Kurse.",
       "details": "Details",
       "courses": "Kurse",
       "image": "Bild",
@@ -3216,40 +3216,40 @@
       "language": "Sprache",
       "createdAt": "Erstellt",
       "actions": "Aktionen",
-      "untitled": "Lernpfad ohne Titel",
+      "untitled": "Entwicklungspfad ohne Titel",
       "emptyDescription": "Keine Beschreibung",
       "sequential": "Sequenziell",
       "flexible": "Flexible Reihenfolge",
       "certificate": "Zertifikat",
-      "empty": "Es wurden noch keine Lernpfade erstellt."
+      "empty": "Es wurden noch keine Entwicklungspfade erstellt."
     },
     "form": {
       "language": "Sprache",
       "status": "Status",
-      "statusDescription": "Legt fest, ob dieser Lernpfad sichtbar, ein Entwurf oder privat ist.",
+      "statusDescription": "Legt fest, ob dieser Entwicklungspfad sichtbar, ein Entwurf oder privat ist.",
       "title": "Titel",
-      "titlePlaceholder": "Lernpfad benennen",
+      "titlePlaceholder": "Entwicklungspfad benennen",
       "description": "Beschreibung",
-      "descriptionPlaceholder": "Beschreiben Sie, was Teilnehmer in diesem Lernpfad abschließen",
+      "descriptionPlaceholder": "Beschreiben Sie, was Teilnehmer in diesem Entwicklungspfad abschließen",
       "imageHint": "PNG, JPG oder JPEG (max. 20 MB, empfohlen 1200x1200 oder höher)",
       "sequenceEnabled": "Sequenzielles Lernen",
       "sequenceEnabledDescription": "Teilnehmer müssen Kurse in der angezeigten Reihenfolge abschließen.",
       "includesCertificate": "Zertifikat",
-      "includesCertificateDescription": "Teilnehmer können nach Abschluss des Lernpfads ein Zertifikat erhalten.",
+      "includesCertificateDescription": "Teilnehmer können nach Abschluss des Entwicklungspfads ein Zertifikat erhalten.",
       "certificateSignature": "Zertifikatssignatur",
-      "certificateSignatureDescription": "Laden Sie die Signatur hoch, die auf Zertifikaten für diesen Lernpfad angezeigt wird.",
+      "certificateSignatureDescription": "Laden Sie die Signatur hoch, die auf Zertifikaten für diesen Entwicklungspfad angezeigt wird.",
       "certificateFontColor": "Schriftfarbe des Zertifikats",
       "certificateFontColorDescription": "Verwenden Sie den Farbwähler in der Vorschau, um die Text- und Linienfarbe des Zertifikats zu ändern.",
       "certificatePreview": "Zertifikatsvorschau",
       "certificatePreviewDescription": "Zeigen Sie das Zertifikat in der Vorschau an und passen Sie die Schriftfarbe an."
     },
     "detailsContent": {
-      "title": "Lernpfaddetails",
+      "title": "Entwicklungspfaddetails",
       "description": "Definieren Sie den lokalisierten Namen und die Beschreibung für Teilnehmer."
     },
     "detailsImage": {
       "title": "Titelbild",
-      "description": "Verwenden Sie ein Bild, das diesen Lernpfad leichter erkennbar macht."
+      "description": "Verwenden Sie ein Bild, das diesen Entwicklungspfad leichter erkennbar macht."
     },
     "detailsSettings": {
       "title": "Veröffentlichung und Verhalten",
@@ -3259,7 +3259,7 @@
       "baseLanguage": "Basissprache"
     },
     "languageSelector": {
-      "tooltip": "Basissprache dieses Lernpfads ist {{baseLanguage}}."
+      "tooltip": "Basissprache dieses Entwicklungspfads ist {{baseLanguage}}."
     },
     "courses": {
       "select": "Kurs auswählen",
@@ -3268,32 +3268,32 @@
       "delete": "Kurs löschen",
       "order": "Reihenfolge",
       "course": "Kurs",
-      "empty": "Diesem Lernpfad wurden noch keine Kurse hinzugefügt.",
-      "saveFirst": "Speichern Sie den Lernpfad, bevor Sie Kurse hinzufügen.",
+      "empty": "Diesem Entwicklungspfad wurden noch keine Kurse hinzugefügt.",
+      "saveFirst": "Speichern Sie den Entwicklungspfad, bevor Sie Kurse hinzufügen.",
       "unknownCourse": "Kursdetails nicht verfügbar"
     },
     "sharedLearningPath": {
       "badgeExported": "Geteilt",
       "exportButton": "Teilen",
-      "exportSuccess": "Lernpfad wurde geteilt",
-      "exportsDescription": "Teilen Sie diesen Lernpfad mit ausgewählten Organisationen.",
+      "exportSuccess": "Entwicklungspfad wurde geteilt",
+      "exportsDescription": "Teilen Sie diesen Entwicklungspfad mit ausgewählten Organisationen.",
       "exportsTitle": "Teilen",
       "exportingButton": "Teilen...",
       "selectTenants": "Organisationen auswählen",
       "selectedCount": "Ausgewählt:"
     },
     "deleteModal": {
-      "title": "Lernpfad löschen",
-      "description": "Dadurch wird der Lernpfad gelöscht und der pfadbasierte Kurszugriff entfernt."
+      "title": "Entwicklungspfad löschen",
+      "description": "Dadurch wird der Entwicklungspfad gelöscht und der pfadbasierte Kurszugriff entfernt."
     },
     "toast": {
-      "created": "Lernpfad erfolgreich erstellt",
-      "updated": "Lernpfad erfolgreich aktualisiert",
-      "deleted": "Lernpfad erfolgreich gelöscht",
-      "languageCreated": "Lernpfadsprache erfolgreich erstellt",
-      "coursesAdded": "Kurse erfolgreich zum Lernpfad hinzugefügt",
-      "courseRemoved": "Kurs erfolgreich aus dem Lernpfad entfernt",
-      "coursesReordered": "Lernpfadkurse erfolgreich neu sortiert"
+      "created": "Entwicklungspfad erfolgreich erstellt",
+      "updated": "Entwicklungspfad erfolgreich aktualisiert",
+      "deleted": "Entwicklungspfad erfolgreich gelöscht",
+      "languageCreated": "Entwicklungspfadsprache erfolgreich erstellt",
+      "coursesAdded": "Kurse erfolgreich zum Entwicklungspfad hinzugefügt",
+      "courseRemoved": "Kurs erfolgreich aus dem Entwicklungspfad entfernt",
+      "coursesReordered": "Entwicklungspfadkurse erfolgreich neu sortiert"
     }
   },
   "lessonPreview": {
@@ -3401,12 +3401,12 @@
     }
   },
   "learningPathsPreferences": {
-    "subHeader": "Konfigurieren Sie die Lernpfad-Einstellungen",
-    "header": "Lernpfad-Einstellungen",
+    "subHeader": "Konfigurieren Sie die Entwicklungspfad-Einstellungen",
+    "header": "Entwicklungspfad-Einstellungen",
     "settings": {
       "learningPathsEnabled": {
-        "label": "Lernpfade aktivieren",
-        "description": "Aktivieren Sie Lernpfade. Wenn deaktiviert, werden Lernpfade fuer alle Benutzer ausgeblendet und blockiert."
+        "label": "Entwicklungspfade aktivieren",
+        "description": "Aktivieren Sie Entwicklungspfade. Wenn deaktiviert, werden Entwicklungspfade fuer alle Benutzer ausgeblendet und blockiert."
       }
     }
   },

--- a/apps/web/app/locales/en/translation.json
+++ b/apps/web/app/locales/en/translation.json
@@ -295,7 +295,7 @@
     "progress": "Progress",
     "findInApplication": "Find in application",
     "courses": "Courses",
-    "learningPaths": "Learning Paths",
+    "learningPaths": "Development Paths",
     "content": "Content",
     "categories": "Categories",
     "users": "Users",
@@ -388,7 +388,7 @@
       "noSearchResults": "No search results for:",
       "announcements": "Announcements",
       "lessons": "Lessons",
-      "learningPaths": "Learning Paths",
+      "learningPaths": "Development Paths",
       "news": "News",
       "articles": "Articles",
       "qa": "Q&A"
@@ -983,7 +983,7 @@
         "category": "categories",
         "group": "groups",
         "course": "courses",
-        "learning_path": "learning paths",
+        "learning_path": "development paths",
         "learning_mode": "learning mode",
         "learning_progress": "learning progress",
         "certificate": "certificates",
@@ -1015,15 +1015,15 @@
         "category_manage": "Create, edit, and delete course categories.",
         "group_read": "View user groups.",
         "group_manage": "Create, edit, and delete user groups.",
-        "learning_path_read": "View learning paths.",
-        "learning_path_create": "Create learning paths.",
-        "learning_path_update": "Edit any learning path.",
-        "learning_path_update_own": "Edit learning paths created by this user.",
-        "learning_path_delete": "Delete learning paths.",
-        "learning_path_course_update": "Add, remove, and reorder courses in any learning path.",
-        "learning_path_course_update_own": "Add, remove, and reorder courses in own learning paths.",
-        "learning_path_enrollment": "Manage learning path enrollments.",
-        "learning_path_export": "Export learning paths to tenants.",
+        "learning_path_read": "View development paths.",
+        "learning_path_create": "Create development paths.",
+        "learning_path_update": "Edit any development path.",
+        "learning_path_update_own": "Edit development paths created by this user.",
+        "learning_path_delete": "Delete development paths.",
+        "learning_path_course_update": "Add, remove, and reorder courses in any development path.",
+        "learning_path_course_update_own": "Add, remove, and reorder courses in own development paths.",
+        "learning_path_enrollment": "Manage development path enrollments.",
+        "learning_path_export": "Export development paths to tenants.",
         "course_read_assigned": "View courses assigned to this user.",
         "course_read_manageable": "View courses this user can manage.",
         "course_read": "View course content.",
@@ -2452,7 +2452,7 @@
       "ageLimitUpdatedSuccessfully": "Age limit updated successfully",
       "newsSettingUpdatedSuccessfully": "News settings updated successfully",
       "articlesSettingUpdatedSuccessfully": "Knowledge base settings updated successfully",
-      "learningPathsUpdatedSuccessfully": "Learning Paths settings updated successfully"
+      "learningPathsUpdatedSuccessfully": "Development Paths settings updated successfully"
     }
   },
   "certificateBackgroundUpload": {
@@ -3029,16 +3029,16 @@
     "tenant": "Organization Details",
     "createTenant": "Create Organization",
     "tenants": "Organizations",
-    "learningPaths": "Learning Paths",
-    "adminLearningPaths": "Learning Paths",
-    "adminLearningPathEditor": "Learning Path Editor"
+    "learningPaths": "Development Paths",
+    "adminLearningPaths": "Development Paths",
+    "adminLearningPathEditor": "Development Path Editor"
   },
   "learningPathsView": {
-    "title": "Learning Paths",
-    "description": "Browse assigned learning paths and continue through their ordered course sequences.",
-    "searchPlaceholder": "Search learning paths",
-    "summary": "{{count}} learning paths are available.",
-    "detailsTitle": "Learning Path",
+    "title": "Development Paths",
+    "description": "Browse assigned development paths and continue through their ordered course sequences.",
+    "searchPlaceholder": "Search development paths",
+    "summary": "{{count}} development paths are available.",
+    "detailsTitle": "Development Path",
     "detailsDescription": "Review the ordered course sequence, progress, locks, and certificate state.",
     "detailsSummary": "This path contains {{count}} courses. Current progress: {{progress}}.",
     "emptyDescription": "No description has been added yet.",
@@ -3057,10 +3057,10 @@
       "certificate": "Certificate"
     },
     "card": {
-      "openPath": "Open learning path"
+      "openPath": "Open development path"
     },
     "empty": {
-      "title": "No learning paths found",
+      "title": "No development paths found",
       "description": "Adjust your search or check back after paths are assigned."
     },
     "progress": {
@@ -3070,7 +3070,7 @@
     "certificate": {
       "available": "Certificate available",
       "ready": "Certificate ready",
-      "pathCompleted": "Learning path completed. Your certificate is ready."
+      "pathCompleted": "Development path completed. Your certificate is ready."
     },
     "courseState": {
       "completed": "Finished",
@@ -3085,12 +3085,12 @@
       "courses": "Courses in this path",
       "courseTitle": "Course {{number}}",
       "completedAt": "Completed {{date}}",
-      "emptyCourses": "This learning path does not include any courses yet."
+      "emptyCourses": "This development path does not include any courses yet."
     },
     "enrollment": {
       "manage": "Enroll",
       "title": "Enroll learners",
-      "description": "Manage student and group enrollment for this learning path.",
+      "description": "Manage student and group enrollment for this development path.",
       "students": "Students",
       "selectStudents": "Select students",
       "groups": "Groups",
@@ -3110,9 +3110,9 @@
       "groupsEnrolled": "Groups enrolled",
       "studentsUnenrolled": "Students unenrolled",
       "groupsUnenrolled": "Groups unenrolled",
-      "enrolledSuccessfully": "Learning path enrolled",
-      "enrollGroupsDescription": "Select groups to enroll in this learning path.",
-      "unenrollGroupsDescription": "Select groups to unenroll from this learning path.",
+      "enrolledSuccessfully": "Development path enrolled",
+      "enrollGroupsDescription": "Select groups to enroll in this development path.",
+      "unenrollGroupsDescription": "Select groups to unenroll from this development path.",
       "table": {
         "selectAll": "Select all learners",
         "select": "Select learner",
@@ -3128,16 +3128,16 @@
       },
       "confirmation": {
         "title": "Confirm enrollment",
-        "description": "Are you sure you want to enroll the selected students in this learning path? This action cannot be undone."
+        "description": "Are you sure you want to enroll the selected students in this development path? This action cannot be undone."
       },
       "unenrollConfirmation": {
         "title": "Unenroll confirmation",
-        "description": "Are you sure you want to unenroll the selected students from this learning path? This action cannot be undone."
+        "description": "Are you sure you want to unenroll the selected students from this development path? This action cannot be undone."
       },
       "noGroups": "No groups available"
     },
     "breadcrumbs": {
-      "learningPaths": "Learning Paths",
+      "learningPaths": "Development Paths",
       "details": "Details"
     },
     "buttons": {
@@ -3145,26 +3145,26 @@
     }
   },
   "adminLearningPathsView": {
-    "title": "Learning Paths",
+    "title": "Development Paths",
     "description": "Manage path metadata, sequence settings, ordered courses, enrollment, exports, and certificates.",
-    "summary": "{{count}} learning paths are available in this workspace.",
+    "summary": "{{count}} development paths are available in this workspace.",
     "breadcrumbs": {
-      "learningPaths": "Learning Paths",
+      "learningPaths": "Development Paths",
       "create": "Create",
       "edit": "Edit"
     },
     "buttons": {
-      "create": "Create learning path",
+      "create": "Create development path",
       "edit": "Edit",
       "save": "Save changes",
       "removeImage": "Remove image"
     },
     "editor": {
-      "createTitle": "Create Learning Path",
-      "editTitle": "Edit Learning Path",
-      "description": "Set up the learning path details, sequence settings, courses, and publishing state.",
-      "createSummary": "Start with the learning path details.",
-      "editSummary": "This learning path currently has {{coursesCount}} courses.",
+      "createTitle": "Create Development Path",
+      "editTitle": "Edit Development Path",
+      "description": "Set up the development path details, sequence settings, courses, and publishing state.",
+      "createSummary": "Start with the development path details.",
+      "editSummary": "This development path currently has {{coursesCount}} courses.",
       "details": "Details",
       "courses": "Courses",
       "image": "Image",
@@ -3177,19 +3177,19 @@
       "language": "Language",
       "createdAt": "Created",
       "actions": "Actions",
-      "untitled": "Untitled learning path",
+      "untitled": "Untitled development path",
       "emptyDescription": "No description",
       "sequential": "Sequential",
       "flexible": "Flexible",
       "certificate": "Certificate",
-      "empty": "No learning paths have been created yet."
+      "empty": "No development paths have been created yet."
     },
     "form": {
       "language": "Language",
       "status": "Status",
       "statusDescription": "Controls whether this path is visible, draft-only, or private.",
       "title": "Title",
-      "titlePlaceholder": "Name the learning path",
+      "titlePlaceholder": "Name the development path",
       "description": "Description",
       "descriptionPlaceholder": "Describe what students will complete in this path",
       "imageHint": "PNG, JPG or JPEG (max. 20 MB, recommended 1200x1200 or higher)",
@@ -3198,14 +3198,14 @@
       "includesCertificate": "Certificate",
       "includesCertificateDescription": "Students can receive a certificate after completing the path.",
       "certificateSignature": "Certificate signature",
-      "certificateSignatureDescription": "Upload the signature shown on certificates for this learning path.",
+      "certificateSignatureDescription": "Upload the signature shown on certificates for this development path.",
       "certificateFontColor": "Certificate font color",
       "certificateFontColorDescription": "Use the preview color picker to update the certificate text and line color.",
       "certificatePreview": "Certificate preview",
       "certificatePreviewDescription": "Preview the certificate and adjust its font color."
     },
     "detailsContent": {
-      "title": "Learning path details",
+      "title": "Development path details",
       "description": "Define the localized name and student-facing description."
     },
     "detailsImage": {
@@ -3220,7 +3220,7 @@
       "baseLanguage": "Base language"
     },
     "languageSelector": {
-      "tooltip": "This learning path base language is {{baseLanguage}}."
+      "tooltip": "This development path base language is {{baseLanguage}}."
     },
     "courses": {
       "select": "Select a course",
@@ -3231,32 +3231,32 @@
       "course": "Course",
       "chapter_one": "{{count}} chapter",
       "chapter_other": "{{count}} chapters",
-      "empty": "No courses have been added to this learning path yet.",
-      "saveFirst": "Save the learning path before adding courses.",
+      "empty": "No courses have been added to this development path yet.",
+      "saveFirst": "Save the development path before adding courses.",
       "unknownCourse": "Course details unavailable"
     },
     "sharedLearningPath": {
       "badgeExported": "Shared",
       "exportButton": "Share",
-      "exportSuccess": "Learning path was exported",
-      "exportsDescription": "Share this learning path with selected organizations.",
+      "exportSuccess": "Development path was exported",
+      "exportsDescription": "Share this development path with selected organizations.",
       "exportsTitle": "Sharing",
       "exportingButton": "Sharing...",
       "selectTenants": "Select organizations",
       "selectedCount": "Selected:"
     },
     "deleteModal": {
-      "title": "Delete learning path",
-      "description": "This will delete the learning path and remove its path-based course access."
+      "title": "Delete development path",
+      "description": "This will delete the development path and remove its path-based course access."
     },
     "toast": {
-      "created": "Learning path created successfully",
-      "updated": "Learning path updated successfully",
-      "deleted": "Learning path deleted successfully",
-      "languageCreated": "Learning path language created successfully",
-      "coursesAdded": "Courses added to learning path successfully",
-      "courseRemoved": "Course removed from learning path successfully",
-      "coursesReordered": "Learning path courses reordered successfully"
+      "created": "Development path created successfully",
+      "updated": "Development path updated successfully",
+      "deleted": "Development path deleted successfully",
+      "languageCreated": "Development path language created successfully",
+      "coursesAdded": "Courses added to development path successfully",
+      "courseRemoved": "Course removed from development path successfully",
+      "coursesReordered": "Development path courses reordered successfully"
     }
   },
   "lessonPreview": {
@@ -3364,12 +3364,12 @@
     }
   },
   "learningPathsPreferences": {
-    "subHeader": "Configure Learning Paths settings",
-    "header": "Learning Paths Settings",
+    "subHeader": "Configure Development Paths settings",
+    "header": "Development Paths Settings",
     "settings": {
       "learningPathsEnabled": {
-        "label": "Enable Learning Paths",
-        "description": "Enable Learning Paths. When disabled, Learning Paths are hidden and blocked for all users."
+        "label": "Enable Development Paths",
+        "description": "Enable Development Paths. When disabled, Development Paths are hidden and blocked for all users."
       }
     }
   },
@@ -3650,19 +3650,19 @@
   "learningPathExport": {
     "error": {
       "noTargetTenants": "Select at least one target tenant",
-      "exportLinkMissing": "Learning path export link not found",
-      "noCourses": "Learning path must include at least one course before export",
-      "courseExportFailed": "Failed to export one of the learning path courses",
+      "exportLinkMissing": "Development path export link not found",
+      "noCourses": "Development path must include at least one course before export",
+      "courseExportFailed": "Failed to export one of the development path courses",
       "targetAuthorMissing": "Target tenant author not found",
-      "jobNotFound": "Learning path export job not found",
-      "invalidJobData": "Invalid learning path export job data",
-      "invalidExportId": "Invalid learning path export id",
-      "invalidExportLink": "Invalid learning path export link"
+      "jobNotFound": "Development path export job not found",
+      "invalidJobData": "Invalid development path export job data",
+      "invalidExportId": "Invalid development path export id",
+      "invalidExportLink": "Invalid development path export link"
     }
   },
   "learningPathCertificate": {
     "error": {
-      "disabled": "Learning path certificates are disabled"
+      "disabled": "Development path certificates are disabled"
     }
   },
   "activityLogsView": {

--- a/apps/web/app/locales/lt/translation.json
+++ b/apps/web/app/locales/lt/translation.json
@@ -295,7 +295,7 @@
     "progress": "Pažanga",
     "findInApplication": "Rasti programoje",
     "courses": "Kursai",
-    "learningPaths": "Mokymosi keliai",
+    "learningPaths": "Tobulėjimo keliai",
     "content": "Turinys",
     "categories": "Kategorijos",
     "users": "Vartotojai",
@@ -387,7 +387,7 @@
       "noSearchResults": "Nėra paieškos rezultatų:",
       "announcements": "Skelbimai",
       "lessons": "Pamokos",
-      "learningPaths": "Mokymosi keliai",
+      "learningPaths": "Tobulėjimo keliai",
       "news": "Naujienos",
       "articles": "Straipsniai",
       "qa": "Klausimai ir atsakymai"
@@ -982,7 +982,7 @@
         "category": "kategorijas",
         "group": "grupes",
         "course": "kursus",
-        "learning_path": "mokymosi kelius",
+        "learning_path": "tobulėjimo kelius",
         "learning_mode": "mokymosi režimą",
         "learning_progress": "mokymosi pažangą",
         "certificate": "sertifikatus",
@@ -2391,7 +2391,7 @@
       "ageLimitUpdatedSuccessfully": "Amžiaus riba sėkmingai atnaujinta",
       "newsSettingUpdatedSuccessfully": "Naujienų nustatymai sėkmingai atnaujinti",
       "articlesSettingUpdatedSuccessfully": "Žinių bazės nustatymai sėkmingai atnaujinti",
-      "learningPathsUpdatedSuccessfully": "Mokymosi kelių nustatymai sėkmingai atnaujinti"
+      "learningPathsUpdatedSuccessfully": "Tobulėjimo kelių nustatymai sėkmingai atnaujinti"
     }
   },
   "certificateBackgroundUpload": {
@@ -2969,9 +2969,9 @@
     "createTenant": "Sukurti organizaciją",
     "tenants": "Organizacijos",
     "activityLogs": "Veiklos žurnalas",
-    "learningPaths": "Mokymosi keliai",
-    "adminLearningPaths": "Mokymosi keliai",
-    "adminLearningPathEditor": "Mokymosi kelio redaktorius"
+    "learningPaths": "Tobulėjimo keliai",
+    "adminLearningPaths": "Tobulėjimo keliai",
+    "adminLearningPathEditor": "Tobulėjimo kelio redaktorius"
   },
   "masterCourse": {
     "error": {
@@ -2988,19 +2988,19 @@
   "learningPathExport": {
     "error": {
       "noTargetTenants": "Pasirinkite bent viena tiksline organizacija",
-      "exportLinkMissing": "Mokymosi kelio eksporto rysys nerastas",
-      "noCourses": "Pries eksportuojant mokymosi kelyje turi buti bent vienas kursas",
-      "courseExportFailed": "Nepavyko eksportuoti vieno is mokymosi kelio kursu",
+      "exportLinkMissing": "Tobulėjimo kelio eksporto rysys nerastas",
+      "noCourses": "Pries eksportuojant tobulėjimo kelyje turi buti bent vienas kursas",
+      "courseExportFailed": "Nepavyko eksportuoti vieno is tobulėjimo kelio kursu",
       "targetAuthorMissing": "Tikslines organizacijos autorius nerastas",
-      "jobNotFound": "Mokymosi kelio eksporto uzduotis nerasta",
-      "invalidJobData": "Neteisingi mokymosi kelio eksporto uzduoties duomenys",
-      "invalidExportId": "Neteisingas mokymosi kelio eksporto ID",
-      "invalidExportLink": "Neteisingas mokymosi kelio eksporto rysys"
+      "jobNotFound": "Tobulėjimo kelio eksporto uzduotis nerasta",
+      "invalidJobData": "Neteisingi tobulėjimo kelio eksporto uzduoties duomenys",
+      "invalidExportId": "Neteisingas tobulėjimo kelio eksporto ID",
+      "invalidExportLink": "Neteisingas tobulėjimo kelio eksporto rysys"
     }
   },
   "learningPathCertificate": {
     "error": {
-      "disabled": "Mokymosi kelio sertifikatai isjungti"
+      "disabled": "Tobulėjimo kelio sertifikatai isjungti"
     }
   },
   "activityLogsView": {
@@ -3076,11 +3076,11 @@
     }
   },
   "learningPathsView": {
-    "title": "Mokymosi keliai",
-    "description": "Naršykite priskirtus mokymosi kelius ir tęskite sutvarkytas kursų sekas.",
-    "searchPlaceholder": "Ieškoti mokymosi kelių",
-    "summary": "{{count}} mokymosi keliai yra pasiekiami.",
-    "detailsTitle": "Mokymosi kelias",
+    "title": "Tobulėjimo keliai",
+    "description": "Naršykite priskirtus tobulėjimo kelius ir tęskite sutvarkytas kursų sekas.",
+    "searchPlaceholder": "Ieškoti tobulėjimo kelių",
+    "summary": "{{count}} tobulėjimo keliai yra pasiekiami.",
+    "detailsTitle": "Tobulėjimo kelias",
     "detailsDescription": "Peržiūrėkite kursų seką, pažangą, užraktus ir sertifikato būseną.",
     "detailsSummary": "Šiame kelyje yra {{count}} kursų. Dabartinė pažanga: {{progress}}.",
     "emptyDescription": "Aprašymas dar nepridėtas.",
@@ -3099,10 +3099,10 @@
       "certificate": "Sertifikatas"
     },
     "card": {
-      "openPath": "Atidaryti mokymosi kelią"
+      "openPath": "Atidaryti tobulėjimo kelią"
     },
     "empty": {
-      "title": "Mokymosi kelių nerasta",
+      "title": "Tobulėjimo kelių nerasta",
       "description": "Pakeiskite paiešką arba grįžkite, kai keliai bus priskirti."
     },
     "progress": {
@@ -3112,7 +3112,7 @@
     "certificate": {
       "available": "Sertifikatas pasiekiamas",
       "ready": "Sertifikatas paruoštas",
-      "pathCompleted": "Mokymosi kelias baigtas. Jūsų sertifikatas paruoštas."
+      "pathCompleted": "Tobulėjimo kelias baigtas. Jūsų sertifikatas paruoštas."
     },
     "courseState": {
       "completed": "Baigta",
@@ -3127,12 +3127,12 @@
       "courses": "Šio kelio kursai",
       "courseTitle": "Kursas {{number}}",
       "completedAt": "Baigta {{date}}",
-      "emptyCourses": "Šiame mokymosi kelyje dar nėra kursų."
+      "emptyCourses": "Šiame tobulėjimo kelyje dar nėra kursų."
     },
     "enrollment": {
       "manage": "Registruoti",
       "title": "Registruoti besimokančiuosius",
-      "description": "Tvarkykite studentų ir grupių registraciją į šį mokymosi kelią.",
+      "description": "Tvarkykite studentų ir grupių registraciją į šį tobulėjimo kelią.",
       "students": "Studentai",
       "selectStudents": "Pasirinkti studentus",
       "groups": "Grupės",
@@ -3152,9 +3152,9 @@
       "groupsEnrolled": "Grupės užregistruotos",
       "studentsUnenrolled": "Studentai išregistruoti",
       "groupsUnenrolled": "Grupės išregistruotos",
-      "enrolledSuccessfully": "Užregistruota į mokymosi kelią",
-      "enrollGroupsDescription": "Pasirinkite grupes, kurias norite registruoti į šį mokymosi kelią.",
-      "unenrollGroupsDescription": "Pasirinkite grupes, kurias norite išregistruoti iš šio mokymosi kelio.",
+      "enrolledSuccessfully": "Užregistruota į tobulėjimo kelią",
+      "enrollGroupsDescription": "Pasirinkite grupes, kurias norite registruoti į šį tobulėjimo kelią.",
+      "unenrollGroupsDescription": "Pasirinkite grupes, kurias norite išregistruoti iš šio tobulėjimo kelio.",
       "table": {
         "selectAll": "Pasirinkti visus besimokančiuosius",
         "select": "Pasirinkti besimokantįjį",
@@ -3170,16 +3170,16 @@
       },
       "confirmation": {
         "title": "Patvirtinti registraciją",
-        "description": "Ar tikrai norite užregistruoti pasirinktus studentus į šį mokymosi kelią? Šio veiksmo negalima atšaukti."
+        "description": "Ar tikrai norite užregistruoti pasirinktus studentus į šį tobulėjimo kelią? Šio veiksmo negalima atšaukti."
       },
       "unenrollConfirmation": {
         "title": "Patvirtinti išregistravimą",
-        "description": "Ar tikrai norite išregistruoti pasirinktus studentus iš šio mokymosi kelio? Šio veiksmo negalima atšaukti."
+        "description": "Ar tikrai norite išregistruoti pasirinktus studentus iš šio tobulėjimo kelio? Šio veiksmo negalima atšaukti."
       },
       "noGroups": "Nėra pasiekiamų grupių"
     },
     "breadcrumbs": {
-      "learningPaths": "Mokymosi keliai",
+      "learningPaths": "Tobulėjimo keliai",
       "details": "Informacija"
     },
     "buttons": {
@@ -3187,26 +3187,26 @@
     }
   },
   "adminLearningPathsView": {
-    "title": "Mokymosi keliai",
+    "title": "Tobulėjimo keliai",
     "description": "Tvarkykite metaduomenis, sekos nustatymus, kursus, registracijas, eksportą ir sertifikatus.",
-    "summary": "{{count}} mokymosi keliai yra pasiekiami šioje darbo srityje.",
+    "summary": "{{count}} tobulėjimo keliai yra pasiekiami šioje darbo srityje.",
     "breadcrumbs": {
-      "learningPaths": "Mokymosi keliai",
+      "learningPaths": "Tobulėjimo keliai",
       "create": "Sukurti",
       "edit": "Redaguoti"
     },
     "buttons": {
-      "create": "Sukurti mokymosi kelią",
+      "create": "Sukurti tobulėjimo kelią",
       "edit": "Redaguoti",
       "save": "Išsaugoti pakeitimus",
       "removeImage": "Pašalinti paveikslėlį"
     },
     "editor": {
-      "createTitle": "Sukurti mokymosi kelią",
-      "editTitle": "Redaguoti mokymosi kelią",
-      "description": "Nustatykite mokymosi kelio informaciją, seką, kursus ir publikavimo būseną.",
-      "createSummary": "Pradėkite nuo mokymosi kelio informacijos.",
-      "editSummary": "Šiame mokymosi kelyje šiuo metu yra {{coursesCount}} kursų.",
+      "createTitle": "Sukurti tobulėjimo kelią",
+      "editTitle": "Redaguoti tobulėjimo kelią",
+      "description": "Nustatykite tobulėjimo kelio informaciją, seką, kursus ir publikavimo būseną.",
+      "createSummary": "Pradėkite nuo tobulėjimo kelio informacijos.",
+      "editSummary": "Šiame tobulėjimo kelyje šiuo metu yra {{coursesCount}} kursų.",
       "details": "Informacija",
       "courses": "Kursai",
       "image": "Paveikslėlis",
@@ -3219,35 +3219,35 @@
       "language": "Kalba",
       "createdAt": "Sukurta",
       "actions": "Veiksmai",
-      "untitled": "Mokymosi kelias be pavadinimo",
+      "untitled": "Tobulėjimo kelias be pavadinimo",
       "emptyDescription": "Nėra aprašymo",
       "sequential": "Nuoseklus",
       "flexible": "Laisva tvarka",
       "certificate": "Sertifikatas",
-      "empty": "Dar nėra sukurtų mokymosi kelių."
+      "empty": "Dar nėra sukurtų tobulėjimo kelių."
     },
     "form": {
       "language": "Kalba",
       "status": "Būsena",
       "statusDescription": "Nustato, ar kelias matomas, juodraštis, ar privatus.",
       "title": "Pavadinimas",
-      "titlePlaceholder": "Pavadinkite mokymosi kelią",
+      "titlePlaceholder": "Pavadinkite tobulėjimo kelią",
       "description": "Aprašymas",
-      "descriptionPlaceholder": "Aprašykite, ką dalyviai atliks šiame mokymosi kelyje",
+      "descriptionPlaceholder": "Aprašykite, ką dalyviai atliks šiame tobulėjimo kelyje",
       "imageHint": "PNG, JPG arba JPEG (maks. 20 MB, rekomenduojama 1200x1200 ar didesnė)",
       "sequenceEnabled": "Nuoseklus mokymasis",
       "sequenceEnabledDescription": "Dalyviai turi baigti kursus rodoma tvarka.",
       "includesCertificate": "Sertifikatas",
-      "includesCertificateDescription": "Dalyviai gali gauti sertifikatą baigę mokymosi kelią.",
+      "includesCertificateDescription": "Dalyviai gali gauti sertifikatą baigę tobulėjimo kelią.",
       "certificateSignature": "Sertifikato parašas",
-      "certificateSignatureDescription": "Įkelkite parašą, rodomą šio mokymosi kelio sertifikatuose.",
+      "certificateSignatureDescription": "Įkelkite parašą, rodomą šio tobulėjimo kelio sertifikatuose.",
       "certificateFontColor": "Sertifikato šrifto spalva",
       "certificateFontColorDescription": "Naudokite peržiūros spalvų parinkiklį, kad pakeistumėte sertifikato teksto ir linijų spalvą.",
       "certificatePreview": "Sertifikato peržiūra",
       "certificatePreviewDescription": "Peržiūrėkite sertifikatą ir pakoreguokite šrifto spalvą."
     },
     "detailsContent": {
-      "title": "Mokymosi kelio informacija",
+      "title": "Tobulėjimo kelio informacija",
       "description": "Nustatykite lokalizuotą pavadinimą ir dalyviams matomą aprašymą."
     },
     "detailsImage": {
@@ -3262,7 +3262,7 @@
       "baseLanguage": "Pagrindinė kalba"
     },
     "languageSelector": {
-      "tooltip": "Šio mokymosi kelio pagrindinė kalba yra {{baseLanguage}}."
+      "tooltip": "Šio tobulėjimo kelio pagrindinė kalba yra {{baseLanguage}}."
     },
     "courses": {
       "select": "Pasirinkite kursą",
@@ -3271,32 +3271,32 @@
       "delete": "Ištrinti kursą",
       "order": "Eilė",
       "course": "Kursas",
-      "empty": "Į šį mokymosi kelią dar nepridėta kursų.",
-      "saveFirst": "Išsaugokite mokymosi kelią prieš pridėdami kursus.",
+      "empty": "Į šį tobulėjimo kelią dar nepridėta kursų.",
+      "saveFirst": "Išsaugokite tobulėjimo kelią prieš pridėdami kursus.",
       "unknownCourse": "Kurso informacija nepasiekiama"
     },
     "sharedLearningPath": {
       "badgeExported": "Dalinamas",
       "exportButton": "Dalintis",
-      "exportSuccess": "Mokymosi kelias buvo bendrinamas",
-      "exportsDescription": "Dalinkitės šiuo mokymosi keliu su pasirinktomis organizacijomis.",
+      "exportSuccess": "Tobulėjimo kelias buvo bendrinamas",
+      "exportsDescription": "Dalinkitės šiuo tobulėjimo keliu su pasirinktomis organizacijomis.",
       "exportsTitle": "Dalijimasis",
       "exportingButton": "Bendrinama...",
       "selectTenants": "Pasirinkite organizacijas",
       "selectedCount": "Pasirinkta:"
     },
     "deleteModal": {
-      "title": "Ištrinti mokymosi kelią",
-      "description": "Tai ištrins mokymosi kelią ir pašalins per jį suteiktą prieigą prie kursų."
+      "title": "Ištrinti tobulėjimo kelią",
+      "description": "Tai ištrins tobulėjimo kelią ir pašalins per jį suteiktą prieigą prie kursų."
     },
     "toast": {
-      "created": "Mokymosi kelias sukurtas",
-      "updated": "Mokymosi kelias atnaujintas",
-      "deleted": "Mokymosi kelias ištrintas",
-      "languageCreated": "Mokymosi kelio kalba sukurta",
-      "coursesAdded": "Kursai pridėti prie mokymosi kelio",
-      "courseRemoved": "Kursas pašalintas iš mokymosi kelio",
-      "coursesReordered": "Mokymosi kelio kursų tvarka atnaujinta"
+      "created": "Tobulėjimo kelias sukurtas",
+      "updated": "Tobulėjimo kelias atnaujintas",
+      "deleted": "Tobulėjimo kelias ištrintas",
+      "languageCreated": "Tobulėjimo kelio kalba sukurta",
+      "coursesAdded": "Kursai pridėti prie tobulėjimo kelio",
+      "courseRemoved": "Kursas pašalintas iš tobulėjimo kelio",
+      "coursesReordered": "Tobulėjimo kelio kursų tvarka atnaujinta"
     }
   },
   "lessonPreview": {
@@ -3404,12 +3404,12 @@
     }
   },
   "learningPathsPreferences": {
-    "subHeader": "Konfigūruokite mokymosi kelių nustatymus",
-    "header": "Mokymosi kelių nustatymai",
+    "subHeader": "Konfigūruokite tobulėjimo kelių nustatymus",
+    "header": "Tobulėjimo kelių nustatymai",
     "settings": {
       "learningPathsEnabled": {
-        "label": "Įjungti mokymosi kelius",
-        "description": "Įjunkite mokymosi kelius. Išjungus jie paslepiami ir užblokuojami visiems naudotojams."
+        "label": "Įjungti tobulėjimo kelius",
+        "description": "Įjunkite tobulėjimo kelius. Išjungus jie paslepiami ir užblokuojami visiems naudotojams."
       }
     }
   },

--- a/apps/web/app/locales/pl/translation.json
+++ b/apps/web/app/locales/pl/translation.json
@@ -312,16 +312,16 @@
     "articles": "Baza wiedzy",
     "tenants": "Organizacje",
     "activityLogs": "Dziennik zdarzeń",
-    "learningPaths": "Ścieżki edukacyjne",
-    "adminLearningPaths": "Ścieżki edukacyjne",
-    "adminLearningPathEditor": "Edytor ścieżki edukacyjnej"
+    "learningPaths": "Ścieżki Rozwoju",
+    "adminLearningPaths": "Ścieżki Rozwoju",
+    "adminLearningPathEditor": "Edytor ścieżki rozwoju"
   },
   "learningPathsView": {
-    "title": "Ścieżki edukacyjne",
-    "description": "Przeglądaj przypisane ścieżki edukacyjne i kontynuuj uporządkowane sekwencje kursów.",
-    "searchPlaceholder": "Szukaj ścieżek edukacyjnych",
-    "summary": "{{count}} ścieżek edukacyjnych jest dostępnych.",
-    "detailsTitle": "Ścieżka edukacyjna",
+    "title": "Ścieżki Rozwoju",
+    "description": "Przeglądaj przypisane ścieżki rozwoju i kontynuuj uporządkowane sekwencje kursów.",
+    "searchPlaceholder": "Szukaj ścieżek rozwoju",
+    "summary": "{{count}} ścieżek rozwoju jest dostępnych.",
+    "detailsTitle": "Ścieżka Rozwoju",
     "detailsDescription": "Sprawdź kolejność kursów, postęp, blokady i status certyfikatu.",
     "detailsSummary": "Ta ścieżka zawiera {{count}} kursów. Aktualny postęp: {{progress}}.",
     "emptyDescription": "Nie dodano jeszcze opisu.",
@@ -353,7 +353,7 @@
     "certificate": {
       "available": "Certyfikat dostępny",
       "ready": "Certyfikat gotowy",
-      "pathCompleted": "Ścieżka edukacyjna ukończona. Twój certyfikat jest gotowy."
+      "pathCompleted": "Ścieżka Rozwoju ukończona. Twój certyfikat jest gotowy."
     },
     "courseState": {
       "completed": "Ukończony",
@@ -368,7 +368,7 @@
       "courses": "Kursy w tej ścieżce",
       "courseTitle": "Kurs {{number}}",
       "completedAt": "Ukończono {{date}}",
-      "emptyCourses": "Ta ścieżka edukacyjna nie zawiera jeszcze kursów."
+      "emptyCourses": "Ta ścieżka rozwoju nie zawiera jeszcze kursów."
     },
     "enrollment": {
       "manage": "Zapisz",
@@ -394,8 +394,8 @@
       "studentsUnenrolled": "Usunięto uczniów z zapisów",
       "groupsUnenrolled": "Usunięto grupy z zapisów",
       "enrolledSuccessfully": "Zapisano do ścieżki",
-      "enrollGroupsDescription": "Wybierz grupy do zapisania do tej ścieżki edukacyjnej.",
-      "unenrollGroupsDescription": "Wybierz grupy do usunięcia z tej ścieżki edukacyjnej.",
+      "enrollGroupsDescription": "Wybierz grupy do zapisania do tej ścieżki rozwoju.",
+      "unenrollGroupsDescription": "Wybierz grupy do usunięcia z tej ścieżki rozwoju.",
       "table": {
         "selectAll": "Zaznacz wszystkich uczestników",
         "select": "Zaznacz uczestnika",
@@ -411,16 +411,16 @@
       },
       "confirmation": {
         "title": "Potwierdź zapis",
-        "description": "Czy na pewno chcesz zapisać wybranych studentów do tej ścieżki edukacyjnej? Tej operacji nie można cofnąć."
+        "description": "Czy na pewno chcesz zapisać wybranych studentów do tej ścieżki rozwoju? Tej operacji nie można cofnąć."
       },
       "unenrollConfirmation": {
         "title": "Potwierdź wypisanie",
-        "description": "Czy na pewno chcesz wypisać wybranych studentów z tej ścieżki edukacyjnej? Tej operacji nie można cofnąć."
+        "description": "Czy na pewno chcesz wypisać wybranych studentów z tej ścieżki rozwoju? Tej operacji nie można cofnąć."
       },
       "noGroups": "Brak dostępnych grup"
     },
     "breadcrumbs": {
-      "learningPaths": "Ścieżki edukacyjne",
+      "learningPaths": "Ścieżki Rozwoju",
       "details": "Szczegóły"
     },
     "buttons": {
@@ -428,11 +428,11 @@
     }
   },
   "adminLearningPathsView": {
-    "title": "Ścieżki edukacyjne",
+    "title": "Ścieżki Rozwoju",
     "description": "Zarządzaj metadanymi, ustawieniami sekwencji, kursami, zapisami, eksportem i certyfikatami.",
-    "summary": "{{count}} ścieżek edukacyjnych jest dostępnych w tej organizacji.",
+    "summary": "{{count}} ścieżek rozwoju jest dostępnych w tej organizacji.",
     "breadcrumbs": {
-      "learningPaths": "Ścieżki edukacyjne",
+      "learningPaths": "Ścieżki Rozwoju",
       "create": "Utwórz",
       "edit": "Edytuj"
     },
@@ -443,11 +443,11 @@
       "removeImage": "Usuń obraz"
     },
     "editor": {
-      "createTitle": "Utwórz ścieżkę edukacyjną",
-      "editTitle": "Edytuj ścieżkę edukacyjną",
+      "createTitle": "Utwórz ścieżkę rozwoju",
+      "editTitle": "Edytuj ścieżkę rozwoju",
       "description": "Skonfiguruj szczegóły ścieżki, ustawienia sekwencji, kursy i status publikacji.",
-      "createSummary": "Zacznij od szczegółów ścieżki edukacyjnej.",
-      "editSummary": "Ta ścieżka edukacyjna ma obecnie {{coursesCount}} kursów.",
+      "createSummary": "Zacznij od szczegółów ścieżki rozwoju.",
+      "editSummary": "Ta ścieżka rozwoju ma obecnie {{coursesCount}} kursów.",
       "details": "Szczegóły",
       "courses": "Kursy",
       "image": "Obraz",
@@ -465,14 +465,14 @@
       "sequential": "Sekwencyjna",
       "flexible": "Dowolna kolejność",
       "certificate": "Certyfikat",
-      "empty": "Nie utworzono jeszcze żadnych ścieżek edukacyjnych."
+      "empty": "Nie utworzono jeszcze żadnych ścieżek rozwoju."
     },
     "form": {
       "language": "Język",
       "status": "Status",
       "statusDescription": "Określa, czy ścieżka jest widoczna, robocza czy prywatna.",
       "title": "Tytuł",
-      "titlePlaceholder": "Nazwij ścieżkę edukacyjną",
+      "titlePlaceholder": "Nazwij ścieżkę rozwoju",
       "description": "Opis",
       "descriptionPlaceholder": "Opisz, co uczestnicy ukończą w tej ścieżce",
       "imageHint": "PNG, JPG lub JPEG (maks. 20 MB, zalecane 1200x1200 lub większe)",
@@ -481,7 +481,7 @@
       "includesCertificate": "Certyfikat",
       "includesCertificateDescription": "Uczestnicy mogą otrzymać certyfikat po ukończeniu ścieżki.",
       "certificateSignature": "Podpis na certyfikacie",
-      "certificateSignatureDescription": "Prześlij podpis widoczny na certyfikatach tej ścieżki edukacyjnej.",
+      "certificateSignatureDescription": "Prześlij podpis widoczny na certyfikatach tej ścieżki rozwoju.",
       "certificateFontColor": "Kolor tekstu certyfikatu",
       "certificateFontColorDescription": "Użyj próbnika kolorów w podglądzie, aby zmienić kolor tekstu i linii certyfikatu.",
       "certificatePreview": "Podgląd certyfikatu",
@@ -529,17 +529,17 @@
       "selectedCount": "Wybrano:"
     },
     "deleteModal": {
-      "title": "Usuń ścieżkę edukacyjną",
+      "title": "Usuń ścieżkę rozwoju",
       "description": "Spowoduje to usunięcie ścieżki i dostępu do kursów przyznanego przez tę ścieżkę."
     },
     "toast": {
-      "created": "Ścieżka edukacyjna została utworzona",
-      "updated": "Ścieżka edukacyjna została zaktualizowana",
-      "deleted": "Ścieżka edukacyjna została usunięta",
-      "languageCreated": "Język ścieżki edukacyjnej został utworzony",
-      "coursesAdded": "Kursy zostały dodane do ścieżki edukacyjnej",
-      "courseRemoved": "Kurs został usunięty ze ścieżki edukacyjnej",
-      "coursesReordered": "Kolejność kursów w ścieżce edukacyjnej została zaktualizowana"
+      "created": "Ścieżka Rozwoju została utworzona",
+      "updated": "Ścieżka Rozwoju została zaktualizowana",
+      "deleted": "Ścieżka Rozwoju została usunięta",
+      "languageCreated": "Język ścieżki rozwoju został utworzony",
+      "coursesAdded": "Kursy zostały dodane do ścieżki rozwoju",
+      "courseRemoved": "Kurs został usunięty ze ścieżki rozwoju",
+      "coursesReordered": "Kolejność kursów w ścieżce rozwoju została zaktualizowana"
     }
   },
   "newsView": {
@@ -619,7 +619,7 @@
       "noSearchResults": "Brak wyników wyszukiwania dla:",
       "announcements": "Powiadomienia",
       "lessons": "Lekcje",
-      "learningPaths": "Ścieżki edukacyjne",
+      "learningPaths": "Ścieżki Rozwoju",
       "news": "Aktualności",
       "articles": "Artykuły",
       "qa": "Pytania i odpowiedzi"
@@ -1194,7 +1194,7 @@
         "category": "kategorie",
         "group": "grupy",
         "course": "kursy",
-        "learning_path": "ścieżki nauki",
+        "learning_path": "ścieżki rozwoju",
         "learning_mode": "tryb nauki",
         "learning_progress": "postęp nauki",
         "certificate": "certyfikaty",
@@ -1226,15 +1226,15 @@
         "category_manage": "Może tworzyć, edytować i usuwać kategorie kursów.",
         "group_read": "Może przeglądać grupy użytkowników.",
         "group_manage": "Może tworzyć, edytować i usuwać grupy użytkowników.",
-        "learning_path_read": "Może przeglądać ścieżki nauki.",
-        "learning_path_create": "Może tworzyć ścieżki nauki.",
-        "learning_path_update": "Może edytować dowolną ścieżkę nauki.",
-        "learning_path_update_own": "Może edytować utworzone przez siebie ścieżki nauki.",
-        "learning_path_delete": "Może usuwać ścieżki nauki.",
-        "learning_path_course_update": "Może dodawać, usuwać i zmieniać kolejność kursów w dowolnej ścieżce nauki.",
-        "learning_path_course_update_own": "Może dodawać, usuwać i zmieniać kolejność kursów we własnych ścieżkach nauki.",
-        "learning_path_enrollment": "Może zarządzać zapisami na ścieżki nauki.",
-        "learning_path_export": "Może eksportować ścieżki nauki do tenantów.",
+        "learning_path_read": "Może przeglądać ścieżki rozwoju.",
+        "learning_path_create": "Może tworzyć ścieżki rozwoju.",
+        "learning_path_update": "Może edytować dowolną ścieżkę rozwoju.",
+        "learning_path_update_own": "Może edytować utworzone przez siebie ścieżki rozwoju.",
+        "learning_path_delete": "Może usuwać ścieżki rozwoju.",
+        "learning_path_course_update": "Może dodawać, usuwać i zmieniać kolejność kursów w dowolnej ścieżce rozwoju.",
+        "learning_path_course_update_own": "Może dodawać, usuwać i zmieniać kolejność kursów we własnych ścieżkach rozwoju.",
+        "learning_path_enrollment": "Może zarządzać zapisami na ścieżki rozwoju.",
+        "learning_path_export": "Może eksportować ścieżki rozwoju do tenantów.",
         "course_read_assigned": "Może przeglądać kursy przypisane do tego użytkownika.",
         "course_read_manageable": "Może przeglądać kursy, którymi ten użytkownik może zarządzać.",
         "course_read": "Może przeglądać treści kursów.",
@@ -2681,7 +2681,7 @@
       "ageLimitUpdatedSuccessfully": "Limit wieku został pomyślnie zaktualizowany",
       "newsSettingUpdatedSuccessfully": "Ustawienia aktualności zostały pomyślnie zaktualizowane",
       "articlesSettingUpdatedSuccessfully": "Ustawienia bazy wiedzy zostały pomyślnie zaktualizowane",
-      "learningPathsUpdatedSuccessfully": "Ustawienia ścieżek edukacyjnych zostały pomyślnie zaktualizowane"
+      "learningPathsUpdatedSuccessfully": "Ustawienia ścieżek rozwoju zostały pomyślnie zaktualizowane"
     }
   },
   "platformSimpleLogo": {
@@ -3390,12 +3390,12 @@
     }
   },
   "learningPathsPreferences": {
-    "subHeader": "Skonfiguruj ustawienia ścieżek edukacyjnych",
-    "header": "Ustawienia ścieżek edukacyjnych",
+    "subHeader": "Skonfiguruj ustawienia ścieżek rozwoju",
+    "header": "Ustawienia ścieżek rozwoju",
     "settings": {
       "learningPathsEnabled": {
-        "label": "Włącz ścieżki edukacyjne",
-        "description": "Włącz ścieżki edukacyjne. Po wyłączeniu są ukryte i zablokowane dla wszystkich użytkowników."
+        "label": "Włącz ścieżki rozwoju",
+        "description": "Włącz ścieżki rozwoju. Po wyłączeniu są ukryte i zablokowane dla wszystkich użytkowników."
       }
     }
   },
@@ -3676,19 +3676,19 @@
   "learningPathExport": {
     "error": {
       "noTargetTenants": "Wybierz co najmniej jednego docelowego tenanta",
-      "exportLinkMissing": "Nie znaleziono powiązania eksportu ścieżki edukacyjnej",
-      "noCourses": "Ścieżka edukacyjna musi zawierać co najmniej jeden kurs przed eksportem",
-      "courseExportFailed": "Nie udało się wyeksportować jednego z kursów ścieżki edukacyjnej",
+      "exportLinkMissing": "Nie znaleziono powiązania eksportu ścieżki rozwoju",
+      "noCourses": "Ścieżka Rozwoju musi zawierać co najmniej jeden kurs przed eksportem",
+      "courseExportFailed": "Nie udało się wyeksportować jednego z kursów ścieżki rozwoju",
       "targetAuthorMissing": "Nie znaleziono autora w docelowym tenancie",
-      "jobNotFound": "Nie znaleziono zadania eksportu ścieżki edukacyjnej",
-      "invalidJobData": "Nieprawidłowe dane zadania eksportu ścieżki edukacyjnej",
-      "invalidExportId": "Nieprawidłowy identyfikator eksportu ścieżki edukacyjnej",
-      "invalidExportLink": "Nieprawidłowe powiązanie eksportu ścieżki edukacyjnej"
+      "jobNotFound": "Nie znaleziono zadania eksportu ścieżki rozwoju",
+      "invalidJobData": "Nieprawidłowe dane zadania eksportu ścieżki rozwoju",
+      "invalidExportId": "Nieprawidłowy identyfikator eksportu ścieżki rozwoju",
+      "invalidExportLink": "Nieprawidłowe powiązanie eksportu ścieżki rozwoju"
     }
   },
   "learningPathCertificate": {
     "error": {
-      "disabled": "Certyfikaty ścieżek edukacyjnych są wyłączone"
+      "disabled": "Certyfikaty ścieżek rozwoju są wyłączone"
     }
   },
   "activityLogsView": {

--- a/apps/web/app/modules/Profile/Certificates/CertificateContent.tsx
+++ b/apps/web/app/modules/Profile/Certificates/CertificateContent.tsx
@@ -29,7 +29,7 @@ const translations = {
     certifyThat: "NINIEJSZYM ZAŚWIADCZA SIĘ, ŻE",
     successfulCompletion: {
       [CERTIFICATE_KIND.COURSE]: "ukończył/a kurs",
-      [CERTIFICATE_KIND.LEARNING_PATH]: "ukończył/a ścieżkę edukacyjną",
+      [CERTIFICATE_KIND.LEARNING_PATH]: "ukończył/a ścieżkę rozwoju",
     },
     confirmation: "potwierdzając tym samym realizację programu szkoleniowego.",
     date: "Data",
@@ -40,7 +40,7 @@ const translations = {
     certifyThat: "THIS IS TO CERTIFY THAT",
     successfulCompletion: {
       [CERTIFICATE_KIND.COURSE]: "has successfully completed the course",
-      [CERTIFICATE_KIND.LEARNING_PATH]: "has successfully completed the learning path",
+      [CERTIFICATE_KIND.LEARNING_PATH]: "has successfully completed the development path",
     },
     confirmation: "thereby confirming participation in the full training program.",
     date: "Date",

--- a/packages/email-templates/src/translations/userFinishedCourse.ts
+++ b/packages/email-templates/src/translations/userFinishedCourse.ts
@@ -19,7 +19,7 @@ export const getUserFinishedCourseEmailTranslations = (
       heading: "Kurs ukończony",
       paragraphs: [
         "Gratulacje! 🏁",
-        `Ukończyłeś(-aś) ${courseName}. ${hasCertificate ? "Certyfikat jest gotowy do pobrania; sprawdź też proponowane ścieżki dalszej nauki." : ""}`,
+        `Ukończyłeś(-aś) ${courseName}. ${hasCertificate ? "Certyfikat jest gotowy do pobrania; sprawdź też proponowane ścieżki rozwoju." : ""}`,
       ],
       buttonText: hasCertificate ? "POBIERZ CERTYFIKAT" : "KONTYNUUJ SWOJĄ NAUKĘ",
     },

--- a/packages/shared/src/utils/certificate.ts
+++ b/packages/shared/src/utils/certificate.ts
@@ -51,7 +51,7 @@ const certificateTranslations = {
     certifyThat: "NINIEJSZYM ZAŚWIADCZA SIĘ, ŻE",
     successfulCompletion: {
       [CERTIFICATE_KIND.COURSE]: "ukończył/a kurs",
-      [CERTIFICATE_KIND.LEARNING_PATH]: "ukończył/a ścieżkę edukacyjną",
+      [CERTIFICATE_KIND.LEARNING_PATH]: "ukończył/a ścieżkę rozwoju",
     },
     confirmation: "potwierdzając tym samym realizację programu szkoleniowego.",
     date: "Data",
@@ -63,7 +63,7 @@ const certificateTranslations = {
     certifyThat: "THIS IS TO CERTIFY THAT",
     successfulCompletion: {
       [CERTIFICATE_KIND.COURSE]: "has successfully completed the course",
-      [CERTIFICATE_KIND.LEARNING_PATH]: "has successfully completed the learning path",
+      [CERTIFICATE_KIND.LEARNING_PATH]: "has successfully completed the development path",
     },
     confirmation: "thereby confirming participation in the full training program.",
     date: "Date",
@@ -75,7 +75,7 @@ const certificateTranslations = {
     certifyThat: "HIERMIT WIRD BESTÄTIGT, DASS",
     successfulCompletion: {
       [CERTIFICATE_KIND.COURSE]: "hat den Kurs erfolgreich abgeschlossen",
-      [CERTIFICATE_KIND.LEARNING_PATH]: "hat den Lernpfad erfolgreich abgeschlossen",
+      [CERTIFICATE_KIND.LEARNING_PATH]: "hat den Entwicklungspfad erfolgreich abgeschlossen",
     },
     confirmation: "und bestätigt damit die Teilnahme am gesamten Schulungsprogramm.",
     date: "Datum",
@@ -87,7 +87,7 @@ const certificateTranslations = {
     certifyThat: "ŠIUO PATVIRTINAMA, KAD",
     successfulCompletion: {
       [CERTIFICATE_KIND.COURSE]: "sėkmingai baigė kursą",
-      [CERTIFICATE_KIND.LEARNING_PATH]: "sėkmingai baigė mokymosi kelią",
+      [CERTIFICATE_KIND.LEARNING_PATH]: "sėkmingai baigė tobulėjimo kelią",
     },
     confirmation: "taip patvirtindamas dalyvavimą visoje mokymo programoje.",
     date: "Data",
@@ -99,7 +99,7 @@ const certificateTranslations = {
     certifyThat: "TÍMTO SE POTVRZUJE, ŽE",
     successfulCompletion: {
       [CERTIFICATE_KIND.COURSE]: "úspěšně absolvoval/a kurz",
-      [CERTIFICATE_KIND.LEARNING_PATH]: "úspěšně dokončil/a vzdělávací cestu",
+      [CERTIFICATE_KIND.LEARNING_PATH]: "úspěšně dokončil/a rozvojovou cestu",
     },
     confirmation: "čímž potvrzuje účast na celém školicím programu.",
     date: "Datum",


### PR DESCRIPTION
## Issue(s)
- #1544 

## Overview
Renames user-facing Learning Paths copy to Development Paths while keeping internal `learningPath` identifiers, routes, permissions, and API contracts unchanged.

The update covers all supported web locales, certificate text, and the related course-completion email copy.

## Business Value

Aligns the product terminology with the requested naming so users see consistent Development Paths wording across navigation, settings, permissions, path management, certificates, and notifications.

