### PR TITLE
chore: improve the SCORM experience with usability and reliability enhancements

### DIFF
--- a/apps/api/src/queue/queue.types.ts
+++ b/apps/api/src/queue/queue.types.ts
@@ -8,6 +8,7 @@ export const QUEUE_NAMES = {
   LEARNING_PATH_EXPORT: "learning-path-export",
   LEARNING_PATH_SYNC: "learning-path-sync",
   AUDIO: "audio",
+  SCORM_IMPORT: "scorm-import",
 } as const;
 
 export type QueueName = (typeof QUEUE_NAMES)[keyof typeof QUEUE_NAMES];

--- a/apps/api/src/scorm/__tests__/scorm.controller.e2e-spec.ts
+++ b/apps/api/src/scorm/__tests__/scorm.controller.e2e-spec.ts
@@ -4,6 +4,7 @@ import {
   COURSE_ENROLLMENT,
   SCORM_COMPLETION_STATUS,
   SCORM_PACKAGE_ENTITY_TYPE,
+  SCORM_PACKAGE_STATUS,
   SCORM_SUCCESS_STATUS,
   SYSTEM_ROLE_SLUGS,
 } from "@repo/shared";
@@ -71,6 +72,19 @@ class InMemoryS3Service {
 
   async deleteFile(key: string) {
     this.files.delete(key);
+  }
+
+  async getFileBuffer(key: string) {
+    const file = this.files.get(key);
+
+    if (!file) {
+      const error = new Error("No such key") as Error & { name: string; Code: string };
+      error.name = "NoSuchKey";
+      error.Code = "NoSuchKey";
+      throw error;
+    }
+
+    return file.buffer;
   }
 
   async getFileStream(key: string): Promise<FileStreamPayload> {
@@ -228,6 +242,23 @@ describe("ScormController (e2e)", () => {
       contentType: "application/zip",
     });
 
+  const waitForScormPackageReady = async (packageId: string) => {
+    for (let attempt = 0; attempt < 30; attempt += 1) {
+      const [scormPackage] = await db
+        .select()
+        .from(scormPackages)
+        .where(eq(scormPackages.id, packageId));
+
+      if (scormPackage?.status === SCORM_PACKAGE_STATUS.READY) {
+        return scormPackage;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+
+    throw new Error(`SCORM package did not become ready: ${packageId}`);
+  };
+
   const importScormCourse = async (admin: UserWithCredentials) => {
     const category = await categoryFactory.create();
     const response = await attachScormPackage(
@@ -255,6 +286,7 @@ describe("ScormController (e2e)", () => {
           eq(scormPackages.language, "en"),
         ),
       );
+    await waitForScormPackageReady(scormPackage.id);
     const [sco] = await db.select().from(scormScos).where(eq(scormScos.packageId, scormPackage.id));
 
     return {
@@ -389,11 +421,12 @@ describe("ScormController (e2e)", () => {
         .select()
         .from(scormScos)
         .where(eq(scormScos.packageId, scormPackage.id));
+      const readyScormPackage = await waitForScormPackageReady(scormPackage.id);
 
       expect(lesson.chapterId).toBe(chapter.id);
       expect(lesson.type).toBe("scorm");
       expect(scormPackage.language).toBe("en");
-      expect(scormPackage.status).toBe("ready");
+      expect(readyScormPackage.status).toBe("ready");
       expect(sco.lessonId).toBe(lessonId);
       expect(sco.resourceIdentifier).toBe("RES-1");
       expect(sco.resourceMetadataJson).toEqual(
@@ -446,9 +479,13 @@ describe("ScormController (e2e)", () => {
           ),
         );
 
+      const readyPackages = await Promise.all(
+        packages.map((scormPackage) => waitForScormPackageReady(scormPackage.id)),
+      );
+
       expect(packages).toHaveLength(2);
       expect(packages.map((scormPackage) => scormPackage.language).sort()).toEqual(["en", "pl"]);
-      expect(packages.every((scormPackage) => scormPackage.status === "ready")).toBe(true);
+      expect(readyPackages.every((scormPackage) => scormPackage.status === "ready")).toBe(true);
 
       const courseResponse = await request(app.getHttpServer())
         .get(`/api/course/beta-course-by-id?id=${course.id}&language=en`)
@@ -604,6 +641,7 @@ describe("ScormController (e2e)", () => {
             eq(scormPackages.entityId, lessonId),
           ),
         );
+      await waitForScormPackageReady(scormPackage.id);
       const scos = (
         await db.select().from(scormScos).where(eq(scormScos.packageId, scormPackage.id))
       ).sort((firstSco, secondSco) => firstSco.displayOrder - secondSco.displayOrder);

--- a/apps/api/src/scorm/__tests__/scorm.controller.e2e-spec.ts
+++ b/apps/api/src/scorm/__tests__/scorm.controller.e2e-spec.ts
@@ -1,6 +1,12 @@
 import { Readable } from "node:stream";
 
-import { COURSE_ENROLLMENT, SCORM_PACKAGE_ENTITY_TYPE, SYSTEM_ROLE_SLUGS } from "@repo/shared";
+import {
+  COURSE_ENROLLMENT,
+  SCORM_COMPLETION_STATUS,
+  SCORM_PACKAGE_ENTITY_TYPE,
+  SCORM_SUCCESS_STATUS,
+  SYSTEM_ROLE_SLUGS,
+} from "@repo/shared";
 import AdmZip from "adm-zip";
 import { and, eq } from "drizzle-orm";
 import request from "supertest";
@@ -129,6 +135,58 @@ const buildMinimalScormPackage = () => {
     ),
   );
   zip.addFile("scripts/runtime.js", Buffer.from("window.__SCORM_FIXTURE__ = true;"));
+
+  return zip.toBuffer();
+};
+
+const buildMultiScoScormPackage = () => {
+  const zip = new AdmZip();
+
+  zip.addFile(
+    "imsmanifest.xml",
+    Buffer.from(
+      `<?xml version="1.0" encoding="UTF-8"?>
+<manifest identifier="mentingo-multi-scorm" version="1.2"
+  xmlns="http://www.imsproject.org/xsd/imscp_rootv1p1p2"
+  xmlns:adlcp="http://www.adlnet.org/xsd/adlcp_rootv1p2">
+  <metadata>
+    <schema>ADL SCORM</schema>
+    <schemaversion>1.2</schemaversion>
+  </metadata>
+  <organizations default="ORG-1">
+    <organization identifier="ORG-1">
+      <title>Multi SCO SCORM Lesson</title>
+      <item identifier="ITEM-1" identifierref="RES-1">
+        <title>Quiz SCO</title>
+      </item>
+      <item identifier="ITEM-2" identifierref="RES-2">
+        <title>Summary SCO</title>
+      </item>
+    </organization>
+  </organizations>
+  <resources>
+    <resource identifier="RES-1" type="webcontent" adlcp:scormtype="sco" href="quiz.html">
+      <file href="quiz.html" />
+    </resource>
+    <resource identifier="RES-2" type="webcontent" adlcp:scormtype="sco" href="summary.html">
+      <file href="summary.html" />
+    </resource>
+  </resources>
+</manifest>`,
+    ),
+  );
+  zip.addFile(
+    "quiz.html",
+    Buffer.from(
+      "<!doctype html><html><head><title>Quiz SCO</title></head><body>Quiz</body></html>",
+    ),
+  );
+  zip.addFile(
+    "summary.html",
+    Buffer.from(
+      "<!doctype html><html><head><title>Summary SCO</title></head><body>Summary</body></html>",
+    ),
+  );
 
   return zip.toBuffer();
 };
@@ -513,6 +571,155 @@ describe("ScormController (e2e)", () => {
       expect(attempt.completedAt).toBeTruthy();
       expect(finishedState.completionStatus).toBe("completed");
       expect(finishedState.totalTime).toBe("0000:01:05.00");
+      expect(progress.completedAt).toBeTruthy();
+    });
+
+    it("completes a multi-SCO lesson after every SCO reaches terminal SCORM status", async () => {
+      const admin = await createAdmin();
+      const student = await createStudent();
+      const course = await courseFactory.create({ authorId: admin.id });
+      const chapter = await chapterFactory.create({
+        authorId: admin.id,
+        courseId: course.id,
+        lessonCount: 0,
+      });
+
+      const importResponse = await attachScormPackage(
+        request(app.getHttpServer())
+          .post("/api/scorm/lesson")
+          .set("Cookie", await cookieFor(admin, app))
+          .field("chapterId", chapter.id)
+          .field("title", "Imported multi-SCO SCORM Lesson")
+          .field("language", "en"),
+        buildMultiScoScormPackage(),
+      ).expect(201);
+
+      const lessonId = importResponse.body.data.id as string;
+      const [scormPackage] = await db
+        .select()
+        .from(scormPackages)
+        .where(
+          and(
+            eq(scormPackages.entityType, SCORM_PACKAGE_ENTITY_TYPE.LESSON),
+            eq(scormPackages.entityId, lessonId),
+          ),
+        );
+      const scos = (
+        await db.select().from(scormScos).where(eq(scormScos.packageId, scormPackage.id))
+      ).sort((firstSco, secondSco) => firstSco.displayOrder - secondSco.displayOrder);
+      const [firstSco, secondSco] = scos;
+
+      expect(scos).toHaveLength(2);
+
+      await enrollStudent(student.id, course.id);
+
+      const studentCookies = await cookieFor(student, app);
+      const firstLaunchResponse = await request(app.getHttpServer())
+        .get(`/api/scorm/runtime/launch?lessonId=${lessonId}&language=en`)
+        .set("Cookie", studentCookies)
+        .expect(200);
+      const firstLaunch = firstLaunchResponse.body.data;
+
+      expect(firstLaunch.scoId).toBe(firstSco.id);
+      expect(firstLaunch.navigation).toEqual({
+        previousScoId: null,
+        nextScoId: secondSco.id,
+      });
+
+      const firstFinishResponse = await request(app.getHttpServer())
+        .post("/api/scorm/runtime/finish")
+        .set("Cookie", studentCookies)
+        .send({
+          attemptId: firstLaunch.attemptId,
+          packageId: firstLaunch.packageId,
+          scoId: firstLaunch.scoId,
+          lessonId: firstLaunch.lessonId,
+          courseId: firstLaunch.courseId,
+          values: {
+            "cmi.core.lesson_status": "failed",
+            "cmi.core.lesson_location": "quiz-finished",
+            "cmi.suspend_data": "selected-answer-token",
+          },
+          language: "en",
+        })
+        .expect(201);
+
+      expect(firstFinishResponse.body.data).toEqual(
+        expect.objectContaining({
+          finished: true,
+          lessonCompleted: false,
+          scormStatus: "failed",
+        }),
+      );
+
+      const [firstRuntimeState] = await db
+        .select()
+        .from(scormRuntimeState)
+        .where(eq(scormRuntimeState.attemptId, firstLaunch.attemptId));
+
+      expect(firstRuntimeState.completionStatus).toBe(SCORM_COMPLETION_STATUS.COMPLETED);
+      expect(firstRuntimeState.successStatus).toBe(SCORM_SUCCESS_STATUS.FAILED);
+      expect(firstRuntimeState.suspendData).toBe("selected-answer-token");
+
+      const secondLaunchResponse = await request(app.getHttpServer())
+        .get(`/api/scorm/runtime/launch?lessonId=${lessonId}&scoId=${secondSco.id}&language=en`)
+        .set("Cookie", studentCookies)
+        .expect(200);
+      const secondLaunch = secondLaunchResponse.body.data;
+
+      expect(secondLaunch.scoId).toBe(secondSco.id);
+      expect(secondLaunch.navigation).toEqual({
+        previousScoId: firstSco.id,
+        nextScoId: null,
+      });
+
+      const secondFinishResponse = await request(app.getHttpServer())
+        .post("/api/scorm/runtime/finish")
+        .set("Cookie", studentCookies)
+        .send({
+          attemptId: secondLaunch.attemptId,
+          packageId: secondLaunch.packageId,
+          scoId: secondLaunch.scoId,
+          lessonId: secondLaunch.lessonId,
+          courseId: secondLaunch.courseId,
+          values: {
+            "cmi.core.lesson_status": "completed",
+          },
+          language: "en",
+        })
+        .expect(201);
+
+      expect(secondFinishResponse.body.data).toEqual(
+        expect.objectContaining({
+          finished: true,
+          lessonCompleted: true,
+          scormStatus: "completed",
+        }),
+      );
+
+      const resumedFirstScoResponse = await request(app.getHttpServer())
+        .get(`/api/scorm/runtime/launch?lessonId=${lessonId}&scoId=${firstSco.id}&language=en`)
+        .set("Cookie", studentCookies)
+        .expect(200);
+
+      expect(resumedFirstScoResponse.body.data.runtime["cmi.core.entry"]).toBe("resume");
+      expect(resumedFirstScoResponse.body.data.runtime["cmi.core.lesson_location"]).toBe(
+        "quiz-finished",
+      );
+      expect(resumedFirstScoResponse.body.data.runtime["cmi.suspend_data"]).toBe(
+        "selected-answer-token",
+      );
+
+      const [progress] = await db
+        .select()
+        .from(studentLessonProgress)
+        .where(
+          and(
+            eq(studentLessonProgress.lessonId, lessonId),
+            eq(studentLessonProgress.studentId, student.id),
+          ),
+        );
+
       expect(progress.completedAt).toBeTruthy();
     });
   });

--- a/apps/api/src/scorm/repositories/scorm.repository.ts
+++ b/apps/api/src/scorm/repositories/scorm.repository.ts
@@ -464,27 +464,13 @@ export class ScormRepository {
     });
   }
 
-  async deleteImportedLesson(lessonId: string) {
+  async deleteLessonPackages(lessonId: string) {
     await this.db
       .delete(scormPackages)
       .where(
         and(
           eq(scormPackages.entityType, SCORM_PACKAGE_ENTITY_TYPE.LESSON),
           eq(scormPackages.entityId, lessonId),
-        ),
-      );
-
-    await this.db.delete(lessons).where(eq(lessons.id, lessonId));
-  }
-
-  async deleteImportedLessonPackage(params: { lessonId: string; language: SupportedLanguages }) {
-    await this.db
-      .delete(scormPackages)
-      .where(
-        and(
-          eq(scormPackages.entityType, SCORM_PACKAGE_ENTITY_TYPE.LESSON),
-          eq(scormPackages.entityId, params.lessonId),
-          eq(scormPackages.language, params.language),
         ),
       );
   }

--- a/apps/api/src/scorm/scorm-import.worker.ts
+++ b/apps/api/src/scorm/scorm-import.worker.ts
@@ -1,0 +1,76 @@
+import {
+  HttpException,
+  Injectable,
+  InternalServerErrorException,
+  type OnModuleDestroy,
+} from "@nestjs/common";
+import { Worker } from "bullmq";
+
+import { QUEUE_NAMES, QueueService } from "src/queue";
+import { TenantDbRunnerService } from "src/storage/db/tenant-db-runner.service";
+
+import { SCORM_IMPORT_JOB_NAME } from "./scorm-queue.service";
+import { ScormService } from "./scorm.service";
+
+import type {
+  ScormImportJobData,
+  ScormImportJobFailure,
+  ScormImportJobResult,
+} from "./scorm.types";
+import type { Job } from "bullmq";
+
+@Injectable()
+export class ScormImportWorker implements OnModuleDestroy {
+  private readonly worker: Worker<ScormImportJobData, ScormImportJobResult>;
+
+  constructor(
+    private readonly queueService: QueueService,
+    private readonly scormService: ScormService,
+    private readonly tenantDbRunnerService: TenantDbRunnerService,
+  ) {
+    this.worker = new Worker<ScormImportJobData, ScormImportJobResult>(
+      QUEUE_NAMES.SCORM_IMPORT,
+      (job) => this.handleScormImport(job),
+      {
+        connection: this.queueService.getConnection(),
+        concurrency: Number(process.env.SCORM_WORKER_CONCURRENCY || 1),
+      },
+    );
+  }
+
+  private async handleScormImport(job: Job<ScormImportJobData>): Promise<ScormImportJobResult> {
+    if (job.name !== SCORM_IMPORT_JOB_NAME) {
+      throw new InternalServerErrorException("adminScorm.errors.unknownImportJob");
+    }
+
+    try {
+      const data = await this.tenantDbRunnerService.runWithTenant(
+        job.data.currentUser.tenantId,
+        () => this.scormService.processQueuedImportJob(job.data),
+      );
+
+      return { success: true, data };
+    } catch (error) {
+      await this.tenantDbRunnerService.runWithTenant(job.data.currentUser.tenantId, () =>
+        this.scormService.handleQueuedImportFailure(job.data),
+      );
+
+      if (error instanceof HttpException) return this.toFailureResult(error);
+
+      throw error;
+    }
+  }
+
+  private toFailureResult(error: HttpException): ScormImportJobFailure {
+    return {
+      success: false,
+      statusCode: error.getStatus(),
+      message: error.message,
+      response: error.getResponse(),
+    };
+  }
+
+  async onModuleDestroy() {
+    await this.worker.close();
+  }
+}

--- a/apps/api/src/scorm/scorm-import.worker.ts
+++ b/apps/api/src/scorm/scorm-import.worker.ts
@@ -40,7 +40,7 @@ export class ScormImportWorker implements OnModuleDestroy {
 
   private async handleScormImport(job: Job<ScormImportJobData>): Promise<ScormImportJobResult> {
     if (job.name !== SCORM_IMPORT_JOB_NAME) {
-      throw new InternalServerErrorException("adminScorm.errors.unknownImportJob");
+      throw new InternalServerErrorException(`Unexpected SCORM import job name: ${job.name}`);
     }
 
     try {

--- a/apps/api/src/scorm/scorm-queue.service.ts
+++ b/apps/api/src/scorm/scorm-queue.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from "@nestjs/common";
+
+import { QUEUE_NAMES, QueueService } from "src/queue";
+
+import type { ScormImportJobData } from "./scorm.types";
+
+export const SCORM_IMPORT_JOB_NAME = "scorm-import";
+
+@Injectable()
+export class ScormQueueService {
+  constructor(private readonly queueService: QueueService) {}
+
+  async enqueueImportJob(data: ScormImportJobData): Promise<void> {
+    await this.queueService.enqueue<ScormImportJobData>(
+      QUEUE_NAMES.SCORM_IMPORT,
+      SCORM_IMPORT_JOB_NAME,
+      data,
+      {
+        attempts: 1,
+        removeOnComplete: true,
+      },
+    );
+  }
+}

--- a/apps/api/src/scorm/scorm-storage-paths.ts
+++ b/apps/api/src/scorm/scorm-storage-paths.ts
@@ -53,6 +53,13 @@ export const getScormOriginalFileReference = (
     originalFilename,
   )}`;
 
+export const getScormStagedUploadReference = (
+  tenantId: UUIDType,
+  packageId: UUIDType,
+  originalFilename: string,
+) =>
+  `${getScormPackagePrefix(tenantId, packageId)}/staged/${sanitizeScormFilename(originalFilename)}`;
+
 export const getScormExtractedFilesReference = (tenantId: UUIDType, packageId: UUIDType) =>
   `${getScormPackagePrefix(tenantId, packageId)}/extracted`;
 

--- a/apps/api/src/scorm/scorm.module.ts
+++ b/apps/api/src/scorm/scorm.module.ts
@@ -5,15 +5,25 @@ import { FileModule } from "src/file/files.module";
 import { LessonModule } from "src/lesson/lesson.module";
 import { S3Module } from "src/s3/s3.module";
 import { StudentLessonProgressModule } from "src/studentLessonProgress/studentLessonProgress.module";
+import { WebSocketModule } from "src/websocket";
 
 import { ScormRepository } from "./repositories/scorm.repository";
+import { ScormImportWorker } from "./scorm-import.worker";
+import { ScormQueueService } from "./scorm-queue.service";
 import { ScormController } from "./scorm.controller";
 import { ScormService } from "./scorm.service";
 
 @Module({
-  imports: [CourseModule, FileModule, LessonModule, S3Module, StudentLessonProgressModule],
+  imports: [
+    CourseModule,
+    FileModule,
+    LessonModule,
+    S3Module,
+    StudentLessonProgressModule,
+    WebSocketModule,
+  ],
   controllers: [ScormController],
-  providers: [ScormService, ScormRepository],
+  providers: [ScormService, ScormQueueService, ScormImportWorker, ScormRepository],
   exports: [ScormService, ScormRepository],
 })
 export class ScormModule {}

--- a/apps/api/src/scorm/scorm.service.ts
+++ b/apps/api/src/scorm/scorm.service.ts
@@ -980,6 +980,7 @@ export class ScormService {
     switch (lessonStatus) {
       case SCORM_1_2_LESSON_STATUS.COMPLETED:
       case SCORM_1_2_LESSON_STATUS.PASSED:
+      case SCORM_1_2_LESSON_STATUS.FAILED:
         return SCORM_COMPLETION_STATUS.COMPLETED;
       case SCORM_1_2_LESSON_STATUS.INCOMPLETE:
         return SCORM_COMPLETION_STATUS.INCOMPLETE;

--- a/apps/api/src/scorm/scorm.service.ts
+++ b/apps/api/src/scorm/scorm.service.ts
@@ -12,6 +12,8 @@ import {
 import {
   PERMISSIONS,
   SCORM_COMPLETION_STATUS,
+  SCORM_IMPORT_ACTION,
+  SCORM_IMPORT_SOCKET,
   SCORM_PACKAGE_STATUS,
   SCORM_STANDARD,
   SCORM_SUCCESS_STATUS,
@@ -26,6 +28,7 @@ import { LESSON_TYPES } from "src/lesson/lesson.type";
 import { AdminLessonService } from "src/lesson/services/adminLesson.service";
 import { S3Service } from "src/s3/s3.service";
 import { StudentLessonProgressService } from "src/studentLessonProgress/studentLessonProgress.service";
+import { WsGateway } from "src/websocket";
 
 import { PROMISE_SETTLED_STATUS } from "./promise-settled-status";
 import { ScormRepository } from "./repositories/scorm.repository";
@@ -34,6 +37,7 @@ import {
   MAX_SCORM_EXTRACTED_FILE_COUNT,
   MAX_SCORM_TOTAL_UNCOMPRESSED_SIZE_BYTES,
 } from "./scorm-package-limits";
+import { ScormQueueService } from "./scorm-queue.service";
 import {
   SCORM_1_2_CMI_KEYS,
   SCORM_1_2_ALLOWED_RUNTIME_KEY_PATTERNS,
@@ -46,11 +50,13 @@ import {
   getScormExtractedFilesReference,
   getScormManifestReference,
   getScormOriginalFileReference,
+  getScormStagedUploadReference,
   joinScormRelativePath,
   normalizeScormRelativePath,
 } from "./scorm-storage-paths";
 import { addScorm12Times, SCORM_ZERO_TIME } from "./scorm-time";
 
+import type { ScormPackageStatus } from "@repo/shared";
 import type { UUIDType } from "src/common";
 import type { CurrentUserType } from "src/common/types/current-user.type";
 import type {
@@ -59,6 +65,9 @@ import type {
   CreateScormLessonImportParams,
   ParsedScormManifest,
   PreparedPackageArtifacts,
+  QueuedScormPackageFile,
+  ScormImportJobData,
+  ScormImportResult,
   ScormItemManifest,
   ScormRuntimeCommitParams,
   ScormRuntimeFinishParams,
@@ -76,6 +85,8 @@ export class ScormService {
     private readonly courseService: CourseService,
     private readonly adminLessonService: AdminLessonService,
     private readonly studentLessonProgressService: StudentLessonProgressService,
+    private readonly wsGateway: WsGateway,
+    private readonly scormQueueService: ScormQueueService,
   ) {}
 
   async createCourseImport({
@@ -83,127 +94,172 @@ export class ScormService {
     metadata,
     currentUser,
     isPlaywrightTest,
-  }: CreateScormCourseImportParams) {
-    if (!scormPackage?.buffer?.length) {
-      throw new BadRequestException("adminScorm.errors.packageRequired");
-    }
-
-    const artifacts = this.preparePackageArtifacts(scormPackage, currentUser);
-    let packageIds: UUIDType[] = [];
-    const course = await this.db.transaction(async (trx) => {
-      const createdCourse = await this.courseService.createCourseInTransaction(
-        {
-          ...metadata,
-          status: metadata.status ?? "draft",
-          isScorm: true,
-        },
-        currentUser,
-        isPlaywrightTest,
-        trx,
-      );
-
-      packageIds = await this.scormRepository.persistCoursePackage(
-        {
-          courseId: createdCourse.id,
-          packageId: artifacts.packageId,
-          metadata,
-          manifest: artifacts.manifest,
-          originalFileReference: artifacts.originalFileReference,
-          extractedFilesReference: artifacts.extractedFilesReference,
-          manifestEntryPoint: artifacts.manifest.scos[0].launchPath,
-          manifestReference: artifacts.manifestReference,
-          currentUser,
-        },
-        trx,
-      );
-
-      return createdCourse;
-    });
-
-    let uploadedReferences: string[] = [];
-
-    try {
-      uploadedReferences = await this.uploadPackageFiles(artifacts, currentUser.tenantId);
-      await this.scormRepository.markPackagesReady(packageIds);
-    } catch (error) {
-      await this.deleteUploadedPackageFiles(uploadedReferences);
-      await this.scormRepository.deleteImportedCourse(course.id);
-      throw error;
-    }
-
-    await this.courseService.publishCreateCourseEvent(course.id, metadata.language, currentUser);
-
-    return {
-      id: course.id,
-      packageId: packageIds[0] ?? artifacts.packageId,
-      fileName: scormPackage.originalname,
-      fileSize: scormPackage.size,
-      mimeType: scormPackage.mimetype,
-      scoCount: artifacts.manifest.scos.length,
-    };
-  }
-
-  async createLessonImport({ scormPackage, metadata, currentUser }: CreateScormLessonImportParams) {
-    if (!scormPackage?.buffer?.length) {
-      throw new BadRequestException("adminScorm.errors.packageRequired");
-    }
-
-    const artifacts = this.preparePackageArtifacts(scormPackage, currentUser);
-    const createdLesson = await this.db.transaction(async (trx) => {
-      const lesson = await this.adminLessonService.createLessonForChapterInTransaction(
-        {
-          chapterId: metadata.chapterId,
-          title: metadata.title,
-          description: "",
-          type: LESSON_TYPES.SCORM,
-        },
-        currentUser,
-        trx,
-      );
-
-      await this.scormRepository.persistLessonPackage(
-        {
-          lessonId: lesson.lessonId,
-          packageId: artifacts.packageId,
-          manifest: artifacts.manifest,
-          originalFileReference: artifacts.originalFileReference,
-          extractedFilesReference: artifacts.extractedFilesReference,
-          manifestEntryPoint: artifacts.manifest.scos[0].launchPath,
-          manifestReference: artifacts.manifestReference,
-          language: metadata.language,
-          currentUser,
-        },
-        trx,
-      );
-
-      return lesson;
-    });
-
-    let uploadedReferences: string[] = [];
-
-    try {
-      uploadedReferences = await this.uploadPackageFiles(artifacts, currentUser.tenantId);
-      await this.scormRepository.markPackageReady(artifacts.packageId);
-    } catch (error) {
-      await this.deleteUploadedPackageFiles(uploadedReferences);
-      await this.scormRepository.deleteImportedLesson(createdLesson.lessonId);
-      throw error;
-    }
-
-    await this.adminLessonService.publishCreateLessonEvent(
-      createdLesson.lessonId,
-      createdLesson.language,
-      currentUser,
+  }: CreateScormCourseImportParams): Promise<ScormImportResult> {
+    const { packageId, queuedPackage } = await this.stagePackageForImport(
+      scormPackage,
+      currentUser.tenantId,
     );
 
-    return {
-      id: createdLesson.lessonId,
-      packageId: artifacts.packageId,
-      fileName: scormPackage.originalname,
-      fileSize: scormPackage.size,
-      mimeType: scormPackage.mimetype,
-      scoCount: artifacts.manifest.scos.length,
-    };
+    let courseId: UUIDType | undefined;
+    let processingJobData: ScormImportJobData | undefined;
+
+    try {
+      const artifacts = this.preparePackageArtifacts(scormPackage, currentUser, packageId);
+
+      let packageIds: UUIDType[] = [];
+
+      const course = await this.db.transaction(async (trx) => {
+        const createdCourse = await this.courseService.createCourseInTransaction(
+          {
+            ...metadata,
+            status: metadata.status ?? "draft",
+            isScorm: true,
+          },
+          currentUser,
+          isPlaywrightTest,
+          trx,
+        );
+
+        packageIds = await this.scormRepository.persistCoursePackage(
+          {
+            courseId: createdCourse.id,
+            packageId: artifacts.packageId,
+            metadata,
+            manifest: artifacts.manifest,
+            originalFileReference: artifacts.originalFileReference,
+            extractedFilesReference: artifacts.extractedFilesReference,
+            manifestEntryPoint: artifacts.manifest.scos[0].launchPath,
+            manifestReference: artifacts.manifestReference,
+            currentUser,
+          },
+          trx,
+        );
+
+        return createdCourse;
+      });
+
+      courseId = course.id;
+
+      const result = this.buildImportResult({
+        id: course.id,
+        packageId: packageIds[0] ?? artifacts.packageId,
+        scormPackage,
+        scoCount: artifacts.manifest.scos.length,
+      });
+
+      const jobData = {
+        action: SCORM_IMPORT_ACTION.CREATE_COURSE,
+        packageId,
+        scormPackage: queuedPackage,
+        result,
+        metadata,
+        currentUser,
+        isPlaywrightTest,
+      };
+
+      await this.courseService.publishCreateCourseEvent(course.id, metadata.language, currentUser);
+
+      processingJobData = jobData;
+
+      await this.enqueueScormImportJob(jobData);
+
+      return result;
+    } catch (error) {
+      await this.cleanupSynchronousCourseImportFailure({
+        stagedFileReference: queuedPackage.stagedFileReference,
+        courseId,
+        jobData: processingJobData,
+      });
+
+      throw error;
+    }
+  }
+
+  async createLessonImport({
+    scormPackage,
+    metadata,
+    currentUser,
+  }: CreateScormLessonImportParams): Promise<ScormImportResult> {
+    const { packageId, queuedPackage } = await this.stagePackageForImport(
+      scormPackage,
+      currentUser.tenantId,
+    );
+
+    let lessonId: UUIDType | undefined;
+    let processingJobData: ScormImportJobData | undefined;
+
+    try {
+      const artifacts = this.preparePackageArtifacts(scormPackage, currentUser, packageId);
+
+      const createdLesson = await this.db.transaction(async (trx) => {
+        const lesson = await this.adminLessonService.createLessonForChapterInTransaction(
+          {
+            chapterId: metadata.chapterId,
+            title: metadata.title,
+            description: "",
+            type: LESSON_TYPES.SCORM,
+          },
+          currentUser,
+          trx,
+        );
+
+        await this.scormRepository.persistLessonPackage(
+          {
+            lessonId: lesson.lessonId,
+            packageId: artifacts.packageId,
+            manifest: artifacts.manifest,
+            originalFileReference: artifacts.originalFileReference,
+            extractedFilesReference: artifacts.extractedFilesReference,
+            manifestEntryPoint: artifacts.manifest.scos[0].launchPath,
+            manifestReference: artifacts.manifestReference,
+            language: metadata.language,
+            currentUser,
+          },
+          trx,
+        );
+
+        return lesson;
+      });
+
+      lessonId = createdLesson.lessonId;
+
+      const result = this.buildImportResult({
+        id: createdLesson.lessonId,
+        packageId: artifacts.packageId,
+        scormPackage,
+        scoCount: artifacts.manifest.scos.length,
+      });
+
+      const jobData = {
+        action: SCORM_IMPORT_ACTION.CREATE_LESSON,
+        packageId,
+        scormPackage: queuedPackage,
+        result,
+        metadata,
+        currentUser,
+      };
+
+      await this.adminLessonService.publishCreateLessonEvent(
+        createdLesson.lessonId,
+        createdLesson.language,
+        currentUser,
+      );
+
+      processingJobData = jobData;
+
+      await this.enqueueScormImportJob(jobData);
+
+      return result;
+    } catch (error) {
+      await this.cleanupSynchronousLessonImportFailure({
+        stagedFileReference: queuedPackage.stagedFileReference,
+        lessonId,
+        jobData: processingJobData,
+        currentUser,
+      });
+
+      throw error;
+    }
   }
 
   async attachLessonPackage({
@@ -211,72 +267,232 @@ export class ScormService {
     scormPackage,
     metadata,
     currentUser,
-  }: AttachScormLessonPackageParams) {
-    if (!scormPackage?.buffer?.length) {
-      throw new BadRequestException("adminScorm.errors.packageRequired");
-    }
-
-    const existingPackage = await this.scormRepository.findLessonPackage({
-      lessonId,
-      language: metadata.language,
-    });
-
-    if (existingPackage) {
-      throw new BadRequestException("adminScorm.errors.packageAlreadyAttached");
-    }
-
-    const artifacts = this.preparePackageArtifacts(scormPackage, currentUser);
-
-    await this.adminLessonService.updateLesson(
-      lessonId,
-      {
-        title: metadata.title,
-        description: "",
-        type: LESSON_TYPES.SCORM,
-        language: metadata.language,
-      },
-      currentUser,
+  }: AttachScormLessonPackageParams): Promise<ScormImportResult> {
+    const { packageId, queuedPackage } = await this.stagePackageForImport(
+      scormPackage,
+      currentUser.tenantId,
     );
 
-    await this.db.transaction((trx) =>
-      this.scormRepository.persistLessonPackage(
-        {
-          lessonId,
-          packageId: artifacts.packageId,
-          manifest: artifacts.manifest,
-          originalFileReference: artifacts.originalFileReference,
-          extractedFilesReference: artifacts.extractedFilesReference,
-          manifestEntryPoint: artifacts.manifest.scos[0].launchPath,
-          manifestReference: artifacts.manifestReference,
-          language: metadata.language,
-          currentUser,
-        },
-        trx,
-      ),
-    );
-
-    let uploadedReferences: string[] = [];
+    let packagePersisted = false;
+    let processingJobData: ScormImportJobData | undefined;
 
     try {
-      uploadedReferences = await this.uploadPackageFiles(artifacts, currentUser.tenantId);
-      await this.scormRepository.markPackageReady(artifacts.packageId);
-    } catch (error) {
-      await this.deleteUploadedPackageFiles(uploadedReferences);
-      await this.scormRepository.deleteImportedLessonPackage({
+      const existingPackage = await this.scormRepository.findLessonPackage({
         lessonId,
         language: metadata.language,
       });
+
+      if (existingPackage) {
+        throw new BadRequestException("adminScorm.errors.packageAlreadyAttached");
+      }
+
+      const artifacts = this.preparePackageArtifacts(scormPackage, currentUser, packageId);
+
+      await this.adminLessonService.updateLesson(
+        lessonId,
+        {
+          title: metadata.title,
+          description: "",
+          type: LESSON_TYPES.SCORM,
+          language: metadata.language,
+        },
+        currentUser,
+      );
+
+      await this.db.transaction((trx) =>
+        this.scormRepository.persistLessonPackage(
+          {
+            lessonId,
+            packageId: artifacts.packageId,
+            manifest: artifacts.manifest,
+            originalFileReference: artifacts.originalFileReference,
+            extractedFilesReference: artifacts.extractedFilesReference,
+            manifestEntryPoint: artifacts.manifest.scos[0].launchPath,
+            manifestReference: artifacts.manifestReference,
+            language: metadata.language,
+            currentUser,
+          },
+          trx,
+        ),
+      );
+
+      packagePersisted = true;
+
+      const result = this.buildImportResult({
+        id: lessonId,
+        packageId: artifacts.packageId,
+        scormPackage,
+        scoCount: artifacts.manifest.scos.length,
+      });
+
+      const jobData = {
+        action: SCORM_IMPORT_ACTION.ATTACH_LESSON_PACKAGE,
+        packageId,
+        scormPackage: queuedPackage,
+        result,
+        lessonId,
+        metadata,
+        currentUser,
+      };
+
+      processingJobData = jobData;
+      await this.enqueueScormImportJob(jobData);
+
+      return result;
+    } catch (error) {
+      await this.cleanupSynchronousLessonImportFailure({
+        stagedFileReference: queuedPackage.stagedFileReference,
+        lessonId: packagePersisted ? lessonId : undefined,
+        jobData: processingJobData,
+        currentUser,
+      });
+
       throw error;
     }
+  }
 
+  async processQueuedImportJob(jobData: ScormImportJobData): Promise<ScormImportResult> {
+    let uploadedReferences: string[] = [];
+
+    try {
+      const buffer = await this.s3Service.getFileBuffer(jobData.scormPackage.stagedFileReference);
+
+      const scormPackage = this.buildQueuedScormPackage(jobData.scormPackage, buffer);
+
+      const artifacts = this.preparePackageArtifacts(
+        scormPackage,
+        jobData.currentUser,
+        jobData.packageId,
+      );
+
+      uploadedReferences = await this.uploadPackageFiles(artifacts, jobData.currentUser.tenantId);
+
+      await this.scormRepository.markPackageReady(jobData.packageId);
+
+      this.publishScormImportStatus(jobData, SCORM_PACKAGE_STATUS.READY);
+
+      return jobData.result;
+    } catch (error) {
+      await this.deleteUploadedPackageFiles(uploadedReferences);
+
+      throw error;
+    } finally {
+      await this.deleteUploadedPackageFiles([jobData.scormPackage.stagedFileReference]);
+    }
+  }
+
+  async handleQueuedImportFailure(jobData: ScormImportJobData) {
+    try {
+      await this.deleteFailedQueuedImport(jobData);
+    } finally {
+      this.publishScormImportStatus(jobData, SCORM_PACKAGE_STATUS.FAILED);
+    }
+  }
+
+  private buildImportResult(params: {
+    id: UUIDType;
+    packageId: UUIDType;
+    scormPackage: Express.Multer.File;
+    scoCount: number;
+  }): ScormImportResult {
     return {
-      id: lessonId,
-      packageId: artifacts.packageId,
-      fileName: scormPackage.originalname,
-      fileSize: scormPackage.size,
-      mimeType: scormPackage.mimetype,
-      scoCount: artifacts.manifest.scos.length,
+      id: params.id,
+      packageId: params.packageId,
+      fileName: params.scormPackage.originalname,
+      fileSize: params.scormPackage.size,
+      mimeType: params.scormPackage.mimetype,
+      scoCount: params.scoCount,
     };
+  }
+
+  private async enqueueScormImportJob(jobData: ScormImportJobData) {
+    this.publishScormImportStatus(jobData, SCORM_PACKAGE_STATUS.PROCESSING);
+    await this.scormQueueService.enqueueImportJob(jobData);
+  }
+
+  private async cleanupSynchronousCourseImportFailure(params: {
+    stagedFileReference: string;
+    courseId?: UUIDType;
+    jobData?: ScormImportJobData;
+  }) {
+    await this.deleteUploadedPackageFiles([params.stagedFileReference]);
+
+    if (params.courseId) await this.scormRepository.deleteImportedCourse(params.courseId);
+
+    if (params.jobData) this.publishScormImportStatus(params.jobData, SCORM_PACKAGE_STATUS.FAILED);
+  }
+
+  private async cleanupSynchronousLessonImportFailure(params: {
+    stagedFileReference: string;
+    lessonId?: UUIDType;
+    jobData?: ScormImportJobData;
+    currentUser: CurrentUserType;
+  }) {
+    await this.deleteUploadedPackageFiles([params.stagedFileReference]);
+
+    if (params.lessonId) await this.removeImportedLesson(params.lessonId, params.currentUser);
+
+    if (params.jobData) this.publishScormImportStatus(params.jobData, SCORM_PACKAGE_STATUS.FAILED);
+  }
+
+  private publishScormImportStatus(jobData: ScormImportJobData, status: ScormPackageStatus) {
+    this.wsGateway.emitToUser(
+      jobData.currentUser.userId,
+      SCORM_IMPORT_SOCKET.EVENTS.STATUS_CHANGED,
+      {
+        action: jobData.action,
+        status,
+        courseId:
+          jobData.action === SCORM_IMPORT_ACTION.CREATE_COURSE ? jobData.result.id : undefined,
+        lessonId:
+          jobData.action === SCORM_IMPORT_ACTION.CREATE_COURSE ? undefined : jobData.result.id,
+        packageId: jobData.packageId,
+        language: jobData.metadata.language,
+        messageKey: this.getScormImportMessageKey(jobData, status),
+      },
+    );
+  }
+
+  private getScormImportMessageKey(jobData: ScormImportJobData, status: ScormPackageStatus) {
+    if (status === SCORM_PACKAGE_STATUS.PROCESSING) {
+      return SCORM_IMPORT_SOCKET.MESSAGE_KEYS.PROCESSING;
+    }
+
+    if (status === SCORM_PACKAGE_STATUS.READY) {
+      return SCORM_IMPORT_SOCKET.MESSAGE_KEYS.READY;
+    }
+
+    if (jobData.action === SCORM_IMPORT_ACTION.CREATE_COURSE) {
+      return SCORM_IMPORT_SOCKET.MESSAGE_KEYS.FAILED_COURSE;
+    }
+
+    return SCORM_IMPORT_SOCKET.MESSAGE_KEYS.FAILED_LESSON;
+  }
+
+  private async deleteFailedQueuedImport(jobData: ScormImportJobData) {
+    switch (jobData.action) {
+      case SCORM_IMPORT_ACTION.CREATE_COURSE:
+        await this.scormRepository.deleteImportedCourse(jobData.result.id);
+        return;
+      case SCORM_IMPORT_ACTION.CREATE_LESSON:
+        await this.removeImportedLesson(jobData.result.id, jobData.currentUser);
+        return;
+      case SCORM_IMPORT_ACTION.ATTACH_LESSON_PACKAGE:
+        await this.removeImportedLesson(jobData.lessonId, jobData.currentUser);
+        return;
+      default:
+        throw new InternalServerErrorException("adminScorm.errors.unsupportedImportAction");
+    }
+  }
+
+  private async removeImportedLesson(lessonId: UUIDType, currentUser: CurrentUserType) {
+    try {
+      await this.adminLessonService.removeLesson(lessonId, currentUser);
+    } catch (error) {
+      if (!(error instanceof NotFoundException)) throw error;
+    }
+
+    await this.scormRepository.deleteLessonPackages(lessonId);
   }
 
   async launchRuntime({ lessonId, scoId, language, currentUser }: ScormRuntimeLaunchParams) {
@@ -443,11 +659,60 @@ export class ScormService {
     }
   }
 
+  private async stagePackageForImport(
+    scormPackage: Express.Multer.File,
+    tenantId: UUIDType,
+  ): Promise<{ packageId: UUIDType; queuedPackage: QueuedScormPackageFile }> {
+    this.assertScormPackage(scormPackage);
+
+    const packageId = randomUUID();
+
+    const stagedFileReference = getScormStagedUploadReference(
+      tenantId,
+      packageId,
+      scormPackage.originalname,
+    );
+
+    await this.s3Service.uploadFile(
+      scormPackage.buffer,
+      stagedFileReference,
+      scormPackage.mimetype || "application/zip",
+    );
+
+    return {
+      packageId,
+      queuedPackage: {
+        stagedFileReference,
+        originalname: scormPackage.originalname,
+        mimetype: scormPackage.mimetype,
+        size: scormPackage.size,
+      },
+    };
+  }
+
+  private buildQueuedScormPackage(
+    file: QueuedScormPackageFile,
+    buffer: Buffer,
+  ): Express.Multer.File {
+    return {
+      buffer,
+      originalname: file.originalname,
+      mimetype: file.mimetype,
+      size: file.size,
+    } as Express.Multer.File;
+  }
+
+  private assertScormPackage(scormPackage: Express.Multer.File) {
+    if (!scormPackage?.buffer?.length) {
+      throw new BadRequestException("adminScorm.errors.packageRequired");
+    }
+  }
+
   private preparePackageArtifacts(
     scormPackage: Express.Multer.File,
     currentUser: CurrentUserType,
+    packageId: UUIDType = randomUUID(),
   ): PreparedPackageArtifacts {
-    const packageId = randomUUID();
     const zip = new AdmZip(scormPackage.buffer);
     const entries = this.getValidatedZipEntries(zip);
     const manifestEntry = this.getManifestEntry(entries);
@@ -831,6 +1096,8 @@ export class ScormService {
   }
 
   private async deleteUploadedPackageFiles(references: string[]) {
+    if (!references.length) return;
+
     await Promise.allSettled(references.map((reference) => this.s3Service.deleteFile(reference)));
   }
 

--- a/apps/api/src/scorm/scorm.types.ts
+++ b/apps/api/src/scorm/scorm.types.ts
@@ -1,4 +1,9 @@
-import type { ScormCompletionStatus, ScormSuccessStatus, SupportedLanguages } from "@repo/shared";
+import type {
+  ScormCompletionStatus,
+  SCORM_IMPORT_ACTION,
+  ScormSuccessStatus,
+  SupportedLanguages,
+} from "@repo/shared";
 import type AdmZip from "adm-zip";
 import type { UUIDType } from "src/common";
 import type { CurrentUserType } from "src/common/types/current-user.type";
@@ -28,6 +33,65 @@ export type AttachScormLessonPackageParams = {
   metadata: Omit<CreateScormLessonBody, "chapterId">;
   currentUser: CurrentUserType;
 };
+
+export type ScormImportResult = {
+  id: UUIDType;
+  packageId: UUIDType;
+  fileName: string;
+  fileSize: number;
+  mimeType: string;
+  scoCount: number;
+};
+
+export type QueuedScormPackageFile = {
+  stagedFileReference: string;
+  originalname: string;
+  mimetype: string;
+  size: number;
+};
+
+type ScormImportJobDataBase = {
+  packageId: UUIDType;
+  scormPackage: QueuedScormPackageFile;
+  currentUser: CurrentUserType;
+  result: ScormImportResult;
+};
+
+export type CreateScormCourseImportJobData = ScormImportJobDataBase & {
+  action: typeof SCORM_IMPORT_ACTION.CREATE_COURSE;
+  metadata: CreateScormCourseBody;
+  isPlaywrightTest: boolean;
+};
+
+export type CreateScormLessonImportJobData = ScormImportJobDataBase & {
+  action: typeof SCORM_IMPORT_ACTION.CREATE_LESSON;
+  metadata: CreateScormLessonBody;
+};
+
+export type AttachScormLessonPackageJobData = ScormImportJobDataBase & {
+  action: typeof SCORM_IMPORT_ACTION.ATTACH_LESSON_PACKAGE;
+  lessonId: UUIDType;
+  metadata: Omit<CreateScormLessonBody, "chapterId">;
+};
+
+export type ScormImportJobData =
+  | CreateScormCourseImportJobData
+  | CreateScormLessonImportJobData
+  | AttachScormLessonPackageJobData;
+
+export type ScormImportJobSuccess = {
+  success: true;
+  data: ScormImportResult;
+};
+
+export type ScormImportJobFailure = {
+  success: false;
+  statusCode: number;
+  message: string;
+  response?: unknown;
+};
+
+export type ScormImportJobResult = ScormImportJobSuccess | ScormImportJobFailure;
 
 export type ScormResourceManifest = {
   identifier: string;

--- a/apps/web/app/api/mutations/admin/useAttachScormLessonPackage.ts
+++ b/apps/web/app/api/mutations/admin/useAttachScormLessonPackage.ts
@@ -28,11 +28,9 @@ export function useAttachScormLessonPackage() {
 
       return response.data;
     },
-    onSuccess: async (data) => {
+    onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: [COURSE_QUERY_KEY] });
       await queryClient.invalidateQueries({ queryKey: ["course"] });
-
-      toast({ description: t(data.data.message) });
     },
     onError: (error: AxiosError) => {
       toast({

--- a/apps/web/app/api/mutations/admin/useCreateScormLesson.ts
+++ b/apps/web/app/api/mutations/admin/useCreateScormLesson.ts
@@ -24,11 +24,9 @@ export function useCreateScormLesson() {
 
       return response.data;
     },
-    onSuccess: async (data) => {
+    onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: [COURSE_QUERY_KEY] });
       await queryClient.invalidateQueries({ queryKey: ["course"] });
-
-      toast({ description: t(data.data.message) });
     },
     onError: (error: AxiosError) => {
       toast({

--- a/apps/web/app/api/mutations/useCreateScormCourse.ts
+++ b/apps/web/app/api/mutations/useCreateScormCourse.ts
@@ -27,10 +27,9 @@ export function useCreateScormCourse() {
 
       return response.data;
     },
-    onSuccess: (data) => {
+    onSuccess: () => {
       queryClient.invalidateQueries(currentUserQueryOptions);
       queryClient.invalidateQueries({ queryKey: ALL_COURSES_QUERY_KEY });
-      toast({ description: t(data.data.message) });
     },
     onError: (error: AxiosError) => {
       toast({

--- a/apps/web/app/api/queries/admin/useHasMissingTranslations.ts
+++ b/apps/web/app/api/queries/admin/useHasMissingTranslations.ts
@@ -1,4 +1,4 @@
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 
 import { ApiClient } from "~/api/api-client";
 
@@ -9,6 +9,7 @@ export const COURSE_TRANSLATIONS_QUERY_KEY = ["missing-translations"];
 export const missingTranslationsQueryOptions = (
   courseId: string,
   language: SupportedLanguages,
+  enabled = true,
 ) => ({
   queryKey: [COURSE_TRANSLATIONS_QUERY_KEY, { id: courseId, language }],
   queryFn: async () => {
@@ -19,8 +20,13 @@ export const missingTranslationsQueryOptions = (
 
     return data;
   },
+  enabled,
 });
 
-export function useMissingTranslations(courseId: string, language: SupportedLanguages) {
-  return useSuspenseQuery(missingTranslationsQueryOptions(courseId, language));
+export function useMissingTranslations(
+  courseId: string,
+  language: SupportedLanguages,
+  enabled = true,
+) {
+  return useQuery(missingTranslationsQueryOptions(courseId, language, enabled));
 }

--- a/apps/web/app/api/queries/index.ts
+++ b/apps/web/app/api/queries/index.ts
@@ -4,6 +4,7 @@ export {
   useAvailableCoursesSuspense,
 } from "./useAvailableCourses";
 export { categoriesQueryOptions, useCategories, useCategoriesSuspense } from "./useCategories";
+export { courseLookupQueryOptions, getCourseLookupQueryKey } from "./useCourseLookup";
 export { courseQueryOptions, useCourse, useCourseSuspense } from "./useCourse";
 export { allCoursesQueryOptions, useCourses, useCoursesSuspense } from "./useCourses";
 export { currentUserQueryOptions, useCurrentUser, useCurrentUserSuspense } from "./useCurrentUser";

--- a/apps/web/app/api/queries/useCourseLookup.ts
+++ b/apps/web/app/api/queries/useCourseLookup.ts
@@ -1,0 +1,23 @@
+import { queryOptions } from "@tanstack/react-query";
+
+import { ApiClient } from "../api-client";
+
+import type { SupportedLanguages } from "@repo/shared";
+
+export const getCourseLookupQueryKey = (idOrSlug: string, language: SupportedLanguages) => [
+  "courseLookup",
+  { idOrSlug, language },
+];
+
+export const courseLookupQueryOptions = (idOrSlug: string, language: SupportedLanguages) =>
+  queryOptions({
+    queryKey: getCourseLookupQueryKey(idOrSlug, language),
+    queryFn: async () => {
+      const response = await ApiClient.api.courseControllerLookupCourse({
+        id: idOrSlug,
+        language,
+      });
+
+      return response.data.data;
+    },
+  });

--- a/apps/web/app/hooks/useGlobalScormImportNotifications.ts
+++ b/apps/web/app/hooks/useGlobalScormImportNotifications.ts
@@ -1,0 +1,114 @@
+import { useLocation, useNavigate } from "@remix-run/react";
+import { SCORM_IMPORT_ACTION, SCORM_IMPORT_SOCKET, SCORM_PACKAGE_STATUS } from "@repo/shared";
+import { useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+
+import { COURSE_QUERY_KEY } from "~/api/queries/admin/useBetaCourse";
+import { ALL_COURSES_QUERY_KEY } from "~/api/queries/useCourses";
+import { queryClient } from "~/api/queryClient";
+import { acquireSocket, releaseSocket } from "~/api/socket";
+import { useToast } from "~/components/ui/use-toast";
+
+import type { ScormImportAction, ScormPackageStatus, SupportedLanguages } from "@repo/shared";
+
+type ScormImportNotification = {
+  action: ScormImportAction;
+  status: ScormPackageStatus;
+  courseId?: string;
+  lessonId?: string;
+  packageId: string;
+  language: SupportedLanguages;
+  messageKey?: string;
+};
+
+const SCORM_IMPORT_PROCESSING_TOAST_DURATION = Number.POSITIVE_INFINITY;
+const SCORM_IMPORT_FAILURE_TOAST_DURATION = Number.POSITIVE_INFINITY;
+
+export function useGlobalScormImportNotifications() {
+  const { t } = useTranslation();
+  const { toast } = useToast();
+
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const processingToastRef = useRef<ReturnType<typeof toast> | null>(null);
+  const processingPackageIdsRef = useRef(new Set<string>());
+
+  useEffect(() => {
+    const socket = acquireSocket();
+
+    const handleConnect = () => socket.emit("join:user");
+
+    const invalidateScormImportQueries = () => {
+      void queryClient.invalidateQueries({ queryKey: ALL_COURSES_QUERY_KEY });
+      void queryClient.invalidateQueries({ queryKey: [COURSE_QUERY_KEY] });
+      void queryClient.invalidateQueries({ queryKey: ["course"] });
+    };
+
+    const showProcessingToast = () => {
+      if (processingToastRef.current) return;
+
+      processingToastRef.current = toast({
+        description: t(SCORM_IMPORT_SOCKET.MESSAGE_KEYS.PROCESSING),
+        variant: "loading",
+        duration: SCORM_IMPORT_PROCESSING_TOAST_DURATION,
+      });
+    };
+
+    const dismissProcessingToastIfIdle = () => {
+      if (processingPackageIdsRef.current.size > 0) return;
+
+      processingToastRef.current?.dismiss();
+      processingToastRef.current = null;
+    };
+
+    const handleImportStatusChange = (notification: ScormImportNotification) => {
+      invalidateScormImportQueries();
+
+      if (notification.status === SCORM_PACKAGE_STATUS.PROCESSING) {
+        processingPackageIdsRef.current.add(notification.packageId);
+        showProcessingToast();
+        return;
+      }
+
+      processingPackageIdsRef.current.delete(notification.packageId);
+      dismissProcessingToastIfIdle();
+
+      if (notification.status === SCORM_PACKAGE_STATUS.READY) {
+        toast({
+          description: t(notification.messageKey ?? SCORM_IMPORT_SOCKET.MESSAGE_KEYS.READY),
+          variant: "success",
+        });
+
+        return;
+      }
+
+      toast({
+        description: t(notification.messageKey ?? SCORM_IMPORT_SOCKET.MESSAGE_KEYS.FAILED_LESSON),
+        variant: "destructive",
+        duration: SCORM_IMPORT_FAILURE_TOAST_DURATION,
+      });
+
+      const failedCourseEditPath =
+        notification.action === SCORM_IMPORT_ACTION.CREATE_COURSE && notification.courseId
+          ? `/admin/beta-courses/${notification.courseId}`
+          : null;
+
+      if (failedCourseEditPath && location.pathname === failedCourseEditPath) {
+        navigate("/admin/courses");
+      }
+    };
+
+    socket.on("connect", handleConnect);
+    socket.on(SCORM_IMPORT_SOCKET.EVENTS.STATUS_CHANGED, handleImportStatusChange);
+    socket.connect();
+
+    if (socket.connected) handleConnect();
+
+    return () => {
+      socket.off("connect", handleConnect);
+      socket.off(SCORM_IMPORT_SOCKET.EVENTS.STATUS_CHANGED, handleImportStatusChange);
+      releaseSocket();
+    };
+  }, [location.pathname, navigate, t, toast]);
+}

--- a/apps/web/app/locales/cs/translation.json
+++ b/apps/web/app/locales/cs/translation.json
@@ -173,8 +173,15 @@
       "creatingCourse": "Vytváření kurzu...",
       "createCourse": "Vytvořit kurz"
     },
-    "toast": {
-      "scormUploadedSuccessfully": "Balíček SCORM byl úspěšně nahrán"
+    "importFailure": {
+      "courseDescription": "Kurz byl odstraněn, protože balíček SCORM se nepodařilo importovat.",
+      "lessonDescription": "Lekce SCORM nebo balíček byly odstraněny, protože balíček se nepodařilo importovat."
+    },
+    "importProcessing": {
+      "description": "Balíček se stále importuje. Během dokončování importu můžete pokračovat v práci."
+    },
+    "importSuccess": {
+      "description": "Balíček SCORM je připraven."
     },
     "errors": {
       "packageRequired": "Balíček SCORM je povinný.",
@@ -191,6 +198,9 @@
       "packageAlreadyAttached": "Tato lekce SCORM již má balíček pro vybraný jazyk.",
       "invalidPackagePath": "Balíček SCORM obsahuje neplatnou cestu k souboru.",
       "externalPackagePath": "Balíček SCORM obsahuje externí cestu k souboru.",
+      "importFailed": "Import balíčku SCORM se nezdařil.",
+      "unknownImportJob": "Úloha importu SCORM nebyla rozpoznána.",
+      "unsupportedImportAction": "Akce importu SCORM není podporována.",
       "runtime": {
         "launchNotFound": "Spouštěcí obsah SCORM nebyl nalezen.",
         "unsupportedStandard": "Tento standard SCORM není podporován.",

--- a/apps/web/app/locales/cs/translation.json
+++ b/apps/web/app/locales/cs/translation.json
@@ -809,6 +809,7 @@
       "category": "Kategorie",
       "price": "Cena",
       "type": "Typ",
+      "scorm": "SCORM",
       "state": "Stát",
       "status": "Postavení",
       "sharedCourse": "Sdíleno",

--- a/apps/web/app/locales/de/translation.json
+++ b/apps/web/app/locales/de/translation.json
@@ -809,6 +809,7 @@
       "category": "Kategorie",
       "price": "Preis",
       "type": "Typ",
+      "scorm": "SCORM",
       "state": "Zustand",
       "status": "Status",
       "sharedCourse": "Geteilt",

--- a/apps/web/app/locales/de/translation.json
+++ b/apps/web/app/locales/de/translation.json
@@ -173,8 +173,15 @@
       "creatingCourse": "Kurs erstellen...",
       "createCourse": "Kurs erstellen"
     },
-    "toast": {
-      "scormUploadedSuccessfully": "SCORM-Paket erfolgreich hochgeladen"
+    "importFailure": {
+      "courseDescription": "Der Kurs wurde entfernt, weil das SCORM-Paket nicht importiert werden konnte.",
+      "lessonDescription": "Die SCORM-Lektion oder das Paket wurde entfernt, weil das Paket nicht importiert werden konnte."
+    },
+    "importProcessing": {
+      "description": "Das Paket wird noch importiert. Sie können weiterarbeiten, während der Import abgeschlossen wird."
+    },
+    "importSuccess": {
+      "description": "Das SCORM-Paket ist bereit."
     },
     "errors": {
       "packageRequired": "SCORM-Paket ist erforderlich.",
@@ -191,6 +198,9 @@
       "packageAlreadyAttached": "Diese SCORM-Lektion hat bereits ein Paket für die ausgewählte Sprache.",
       "invalidPackagePath": "SCORM-Paket enthält einen ungültigen Dateipfad.",
       "externalPackagePath": "SCORM-Paket enthält einen externen Dateipfad.",
+      "importFailed": "SCORM-Paketimport fehlgeschlagen.",
+      "unknownImportJob": "SCORM-Importauftrag wurde nicht erkannt.",
+      "unsupportedImportAction": "SCORM-Importaktion wird nicht unterstützt.",
       "runtime": {
         "launchNotFound": "SCORM-Startinhalt wurde nicht gefunden.",
         "unsupportedStandard": "Dieser SCORM-Standard wird nicht unterstützt.",

--- a/apps/web/app/locales/en/translation.json
+++ b/apps/web/app/locales/en/translation.json
@@ -173,8 +173,15 @@
       "creatingCourse": "Creating Course...",
       "createCourse": "Create Course"
     },
-    "toast": {
-      "scormUploadedSuccessfully": "SCORM package uploaded successfully"
+    "importFailure": {
+      "courseDescription": "The course was removed because the SCORM package could not be imported.",
+      "lessonDescription": "The SCORM lesson or package was removed because the package could not be imported."
+    },
+    "importProcessing": {
+      "description": "The package is still being imported. You can keep working while it finishes."
+    },
+    "importSuccess": {
+      "description": "The SCORM package is ready."
     },
     "errors": {
       "packageRequired": "SCORM package is required.",
@@ -191,6 +198,9 @@
       "packageAlreadyAttached": "This SCORM lesson already has a package for the selected language.",
       "invalidPackagePath": "SCORM package contains an invalid file path.",
       "externalPackagePath": "SCORM package contains an external file path.",
+      "importFailed": "SCORM package import failed.",
+      "unknownImportJob": "SCORM import job is not recognized.",
+      "unsupportedImportAction": "SCORM import action is not supported.",
       "runtime": {
         "launchNotFound": "SCORM launch content was not found.",
         "unsupportedStandard": "This SCORM standard is not supported.",

--- a/apps/web/app/locales/en/translation.json
+++ b/apps/web/app/locales/en/translation.json
@@ -810,6 +810,7 @@
       "category": "Category",
       "price": "Price",
       "type": "Type",
+      "scorm": "SCORM",
       "state": "State",
       "status": "Status",
       "sharedCourse": "Shared",

--- a/apps/web/app/locales/lt/translation.json
+++ b/apps/web/app/locales/lt/translation.json
@@ -173,8 +173,15 @@
       "creatingCourse": "Kuriamas kursas...",
       "createCourse": "Sukurti kursą"
     },
-    "toast": {
-      "scormUploadedSuccessfully": "SCORM paketas sėkmingai įkeltas"
+    "importFailure": {
+      "courseDescription": "Kursas pašalintas, nes SCORM paketo nepavyko importuoti.",
+      "lessonDescription": "SCORM pamoka arba paketas pašalinti, nes paketo nepavyko importuoti."
+    },
+    "importProcessing": {
+      "description": "Paketas vis dar importuojamas. Galite tęsti darbą, kol importas baigsis."
+    },
+    "importSuccess": {
+      "description": "SCORM paketas paruoštas."
     },
     "errors": {
       "packageRequired": "SCORM paketas yra privalomas.",
@@ -191,6 +198,9 @@
       "packageAlreadyAttached": "Ši SCORM pamoka jau turi paketą pasirinktai kalbai.",
       "invalidPackagePath": "SCORM pakete yra neteisingas failo kelias.",
       "externalPackagePath": "SCORM pakete yra išorinis failo kelias.",
+      "importFailed": "SCORM paketo importuoti nepavyko.",
+      "unknownImportJob": "SCORM importavimo užduotis neatpažinta.",
+      "unsupportedImportAction": "SCORM importavimo veiksmas nepalaikomas.",
       "runtime": {
         "launchNotFound": "SCORM paleidimo turinys nerastas.",
         "unsupportedStandard": "Šis SCORM standartas nepalaikomas.",

--- a/apps/web/app/locales/lt/translation.json
+++ b/apps/web/app/locales/lt/translation.json
@@ -809,6 +809,7 @@
       "category": "Kategorija",
       "price": "Kaina",
       "type": "Tipas",
+      "scorm": "SCORM",
       "state": "valstybė",
       "status": "Būsena",
       "sharedCourse": "Bendrinama",

--- a/apps/web/app/locales/pl/translation.json
+++ b/apps/web/app/locales/pl/translation.json
@@ -174,8 +174,15 @@
       "creatingCourse": "Tworzenie kursu...",
       "createCourse": "Utwórz kurs"
     },
-    "toast": {
-      "scormUploadedSuccessfully": "Pakiet SCORM został pomyślnie przesłany"
+    "importFailure": {
+      "courseDescription": "Kurs został usunięty, ponieważ nie udało się zaimportować pakietu SCORM.",
+      "lessonDescription": "Lekcja SCORM lub pakiet zostały usunięte, ponieważ nie udało się zaimportować pakietu."
+    },
+    "importProcessing": {
+      "description": "Pakiet nadal się importuje. Możesz kontynuować pracę, gdy import się zakończy."
+    },
+    "importSuccess": {
+      "description": "Pakiet SCORM jest gotowy."
     },
     "errors": {
       "packageRequired": "Pakiet SCORM jest wymagany.",
@@ -192,6 +199,9 @@
       "packageAlreadyAttached": "Ta lekcja SCORM ma już pakiet dla wybranego języka.",
       "invalidPackagePath": "Pakiet SCORM zawiera nieprawidłową ścieżkę pliku.",
       "externalPackagePath": "Pakiet SCORM zawiera zewnętrzną ścieżkę pliku.",
+      "importFailed": "Import pakietu SCORM nie powiódł się.",
+      "unknownImportJob": "Zadanie importu SCORM nie zostało rozpoznane.",
+      "unsupportedImportAction": "Akcja importu SCORM nie jest obsługiwana.",
       "runtime": {
         "launchNotFound": "Nie znaleziono treści startowej SCORM.",
         "unsupportedStandard": "Ten standard SCORM nie jest obsługiwany.",

--- a/apps/web/app/locales/pl/translation.json
+++ b/apps/web/app/locales/pl/translation.json
@@ -1020,6 +1020,7 @@
       "category": "Kategoria",
       "price": "Cena",
       "type": "Typ",
+      "scorm": "SCORM",
       "state": "Stan",
       "status": "Status",
       "sharedCourse": "Udostępniony",

--- a/apps/web/app/modules/Admin/Courses/Courses.page.tsx
+++ b/apps/web/app/modules/Admin/Courses/Courses.page.tsx
@@ -61,7 +61,7 @@ import { handleRowSelectionRange } from "~/utils/tableRangeSelection";
 
 import { COURSES_PAGE_HANDLES } from "../../../../e2e/data/courses/handles";
 
-import { getCourseBadgeVariant, getCourseStatus, getCourseTypeLabel } from "./utils";
+import { getCourseBadgeVariant, getCourseStatus } from "./utils";
 
 import type { ClientLoaderFunctionArgs, MetaFunction } from "@remix-run/react";
 import type { CourseType } from "@repo/shared";
@@ -203,17 +203,28 @@ const Courses = () => {
     },
     {
       accessorKey: "courseType",
-      header: t("adminCoursesView.field.type"),
+      header: t("adminCoursesView.field.scorm"),
       cell: ({ row }) => {
         const courseType = row.original.courseType ?? COURSE_TYPE.DEFAULT;
+
+        if (courseType !== COURSE_TYPE.SCORM) {
+          return (
+            <span
+              className="block w-full text-center"
+              data-testid={COURSES_PAGE_HANDLES.rowTypeBadge(row.original.id)}
+            >
+              -
+            </span>
+          );
+        }
 
         return (
           <Badge
             data-testid={COURSES_PAGE_HANDLES.rowTypeBadge(row.original.id)}
-            variant={courseType === COURSE_TYPE.SCORM ? "success" : "secondaryWithOutline"}
+            variant="success"
             className="w-max"
           >
-            {getCourseTypeLabel(courseType as CourseType, t)}
+            {t("adminCoursesView.field.scorm")}
           </Badge>
         );
       },

--- a/apps/web/app/modules/Admin/EditCourse/EditCourse.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/EditCourse.tsx
@@ -7,6 +7,7 @@ import {
   isCourseFeatureEnabledForCourseType,
   type SupportedLanguages,
 } from "@repo/shared";
+import { isAxiosError } from "axios";
 import { Building } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -134,7 +135,11 @@ const EditCourse = () => {
   const [isCourseGeneratedOverride, setIsCourseGeneratedOverride] = useState(false);
   const isCourseGenerated = Boolean(draft?.isCourseGenerated) || isCourseGeneratedOverride;
 
-  const { data: hasMissingTranslations } = useMissingTranslations(id, courseLanguage);
+  const { data: hasMissingTranslations } = useMissingTranslations(
+    id,
+    courseLanguage,
+    Boolean(course),
+  );
   const { data: exportCandidates } = useMasterCourseExportCandidates(id, canShowTenantSharing);
   const { previousDataUpdatedAt, currentDataUpdatedAt } = useTrackDataUpdatedAt(dataUpdatedAt);
 
@@ -265,7 +270,7 @@ const EditCourse = () => {
 
   useEffect(() => {
     if (error) {
-      navigate("/");
+      navigate(isAxiosError(error) && error.response?.status === 404 ? "/courses" : "/");
     }
   }, [error, navigate]);
 

--- a/apps/web/app/modules/Admin/EditCourse/EditCourse.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/EditCourse.tsx
@@ -328,14 +328,16 @@ const EditCourse = () => {
                   {t("common.other.private")}
                 </Badge>
               )}
-              <Badge
-                data-testid={EDIT_COURSE_PAGE_HANDLES.COURSE_TYPE_BADGE}
-                variant={courseType === COURSE_TYPE.SCORM ? "success" : "secondaryWithOutline"}
-                fontWeight="bold"
-                className="ml-2"
-              >
-                {getCourseTypeLabel(courseType, t)}
-              </Badge>
+              {courseType === COURSE_TYPE.SCORM && (
+                <Badge
+                  data-testid={EDIT_COURSE_PAGE_HANDLES.COURSE_TYPE_BADGE}
+                  variant="success"
+                  fontWeight="bold"
+                  className="ml-2"
+                >
+                  {getCourseTypeLabel(courseType, t)}
+                </Badge>
+              )}
               {isMasterCourse && (
                 <Badge variant="secondaryWithOutline" fontWeight="bold" className="ml-2">
                   <Building className="size-3.5" />

--- a/apps/web/app/modules/Courses/CourseView/CourseView.page.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseView.page.tsx
@@ -1,5 +1,6 @@
 import { redirect, useNavigate, useParams, useSearchParams } from "@remix-run/react";
 import { ACCESS_GUARD, PERMISSIONS, SUPPORTED_LANGUAGES } from "@repo/shared";
+import { isAxiosError } from "axios";
 import { useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -64,10 +65,18 @@ export const clientLoader = async ({
   const url = new URL(request.url);
   const language = resolvePreferredLanguage(url);
 
-  const lookupResponse = await ApiClient.api.courseControllerLookupCourse({
-    id: idOrSlug,
-    language,
-  });
+  const lookupResponse = await ApiClient.api
+    .courseControllerLookupCourse({
+      id: idOrSlug,
+      language,
+    })
+    .catch((error: unknown) => {
+      if (isAxiosError(error) && error.response?.status === 404) {
+        throw redirect("/courses", 302);
+      }
+
+      throw error;
+    });
 
   const { status, slug } = lookupResponse.data.data;
 
@@ -90,7 +99,13 @@ export default function CourseViewPage() {
   const language =
     previewLanguage && isSupportedLanguage(previewLanguage) ? previewLanguage : defaultLanguage;
 
-  const { data: course } = useCourse(id, language);
+  const { data: course, error } = useCourse(id, language);
+
+  useEffect(() => {
+    if (isAxiosError(error) && error.response?.status === 404) {
+      navigate("/courses", { replace: true });
+    }
+  }, [error, navigate]);
 
   useEffect(() => {
     const shouldCorrectUrl = course?.slug && course.slug !== id;

--- a/apps/web/app/modules/Courses/CourseView/CourseView.page.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseView.page.tsx
@@ -4,8 +4,8 @@ import { isAxiosError } from "axios";
 import { useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
-import { ApiClient } from "~/api/api-client";
-import { useCourse, useCurrentUser } from "~/api/queries";
+import { courseLookupQueryOptions, useCourse, useCurrentUser } from "~/api/queries";
+import { queryClient } from "~/api/queryClient";
 import { hasPermission } from "~/common/permissions/permission.utils";
 import { PageWrapper } from "~/components/PageWrapper";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
@@ -65,11 +65,8 @@ export const clientLoader = async ({
   const url = new URL(request.url);
   const language = resolvePreferredLanguage(url);
 
-  const lookupResponse = await ApiClient.api
-    .courseControllerLookupCourse({
-      id: idOrSlug,
-      language,
-    })
+  const lookupCourse = await queryClient
+    .fetchQuery(courseLookupQueryOptions(idOrSlug, language))
     .catch((error: unknown) => {
       if (isAxiosError(error) && error.response?.status === 404) {
         throw redirect("/courses", 302);
@@ -78,7 +75,7 @@ export const clientLoader = async ({
       throw error;
     });
 
-  const { status, slug } = lookupResponse.data.data;
+  const { status, slug } = lookupCourse;
 
   if (status === "redirect" && slug) {
     const redirectUrl = new URL(`/course/${slug}`, request.url);

--- a/apps/web/app/modules/Courses/Lesson/ScormLesson/ScormLesson.tsx
+++ b/apps/web/app/modules/Courses/Lesson/ScormLesson/ScormLesson.tsx
@@ -26,10 +26,17 @@ type ScormNavigationProps = {
   title: string;
   previousScoId: string | null;
   nextScoId: string | null;
+  isSaving: boolean;
   onSelectSco: (scoId: string | null) => void;
 };
 
-function ScormNavigation({ title, previousScoId, nextScoId, onSelectSco }: ScormNavigationProps) {
+function ScormNavigation({
+  title,
+  previousScoId,
+  nextScoId,
+  isSaving,
+  onSelectSco,
+}: ScormNavigationProps) {
   const { t } = useTranslation();
 
   return (
@@ -41,7 +48,7 @@ function ScormNavigation({ title, previousScoId, nextScoId, onSelectSco }: Scorm
         data-testid={LEARNING_HANDLES.SCORM_PREVIOUS_SECTION_BUTTON}
         variant="outline"
         className="justify-self-start"
-        disabled={!previousScoId}
+        disabled={isSaving || !previousScoId}
         onClick={() => onSelectSco(previousScoId)}
       >
         <ChevronLeft className="size-4" />
@@ -52,7 +59,7 @@ function ScormNavigation({ title, previousScoId, nextScoId, onSelectSco }: Scorm
         data-testid={LEARNING_HANDLES.SCORM_NEXT_SECTION_BUTTON}
         variant="outline"
         className="justify-self-end"
-        disabled={!nextScoId}
+        disabled={isSaving || !nextScoId}
         onClick={() => onSelectSco(nextScoId)}
       >
         {t("studentLessonView.scorm.nextSco")}
@@ -66,6 +73,7 @@ export function ScormLesson({ lessonId }: ScormLessonProps) {
   const { t } = useTranslation();
   const { language } = useLanguageStore();
   const [selectedScoId, setSelectedScoId] = useState<string | null>(null);
+  const [isRuntimeSaving, setIsRuntimeSaving] = useState(false);
   const {
     data: launch,
     isLoading,
@@ -118,10 +126,11 @@ export function ScormLesson({ lessonId }: ScormLessonProps) {
           title={launch.scoTitle}
           previousScoId={launch.navigation.previousScoId}
           nextScoId={launch.navigation.nextScoId}
+          isSaving={isRuntimeSaving}
           onSelectSco={setSelectedScoId}
         />
       )}
-      <ScormPlayer launch={launch} language={language} />
+      <ScormPlayer launch={launch} language={language} onSavingChange={setIsRuntimeSaving} />
     </div>
   );
 }

--- a/apps/web/app/modules/Courses/Lesson/ScormLesson/ScormPlayer.tsx
+++ b/apps/web/app/modules/Courses/Lesson/ScormLesson/ScormPlayer.tsx
@@ -14,14 +14,15 @@ import type { SupportedLanguages } from "@repo/shared";
 type ScormPlayerProps = {
   launch: ScormLaunchData;
   language: SupportedLanguages;
+  onSavingChange?: (isSaving: boolean) => void;
 };
 
-export function ScormPlayer({ launch, language }: ScormPlayerProps) {
+export function ScormPlayer({ launch, language, onSavingChange }: ScormPlayerProps) {
   const { t } = useTranslation();
   const fullscreenRef = useRef<HTMLDivElement | null>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
 
-  useScormRuntime({ launch, language });
+  useScormRuntime({ launch, language, onSavingChange });
 
   const toggleFullscreen = () => {
     if (document.fullscreenElement) {

--- a/apps/web/app/modules/Courses/Lesson/ScormLesson/useScormRuntime.ts
+++ b/apps/web/app/modules/Courses/Lesson/ScormLesson/useScormRuntime.ts
@@ -21,13 +21,15 @@ import {
 import type { ScormLaunchData, ScormRuntimeValues } from "./ScormLesson.types";
 import type { SupportedLanguages } from "@repo/shared";
 import type { Scorm12API } from "scorm-again";
+import type { LaunchScormAttemptResponse } from "~/api/generated-api";
 
 type UseScormRuntimeParams = {
   launch: ScormLaunchData;
   language: SupportedLanguages;
+  onSavingChange?: (isSaving: boolean) => void;
 };
 
-export function useScormRuntime({ launch, language }: UseScormRuntimeParams) {
+export function useScormRuntime({ launch, language, onSavingChange }: UseScormRuntimeParams) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const { mutateAsync: commitRuntime } = useCommitScormRuntime();
@@ -36,6 +38,7 @@ export function useScormRuntime({ launch, language }: UseScormRuntimeParams) {
   const finishRuntimeRef = useRef(finishRuntime);
   const dirtyValuesRef = useRef<ScormRuntimeValues>({});
   const apiRef = useRef<Scorm12API | null>(null);
+  const pendingSavesRef = useRef(0);
 
   useEffect(() => {
     commitRuntimeRef.current = commitRuntime;
@@ -56,6 +59,19 @@ export function useScormRuntime({ launch, language }: UseScormRuntimeParams) {
       language,
     });
 
+    const beginRuntimeSave = () => {
+      pendingSavesRef.current += 1;
+      onSavingChange?.(true);
+    };
+
+    const endRuntimeSave = () => {
+      pendingSavesRef.current = Math.max(0, pendingSavesRef.current - 1);
+
+      if (pendingSavesRef.current === 0) {
+        onSavingChange?.(false);
+      }
+    };
+
     const handleProgressUpdate = async (lessonCompleted: boolean) => {
       if (!lessonCompleted) {
         return;
@@ -65,6 +81,28 @@ export function useScormRuntime({ launch, language }: UseScormRuntimeParams) {
         queryClient.invalidateQueries({ queryKey: ["lesson"] }),
         queryClient.invalidateQueries({ queryKey: ["course"] }),
       ]);
+    };
+
+    const updateLaunchRuntimeCache = (values: ScormRuntimeValues) => {
+      queryClient.setQueriesData<LaunchScormAttemptResponse>(
+        { queryKey: ["scorm", "launch", launch.lessonId] },
+        (cachedLaunch) => {
+          if (!cachedLaunch || cachedLaunch.data.attemptId !== launch.attemptId) {
+            return cachedLaunch;
+          }
+
+          return {
+            ...cachedLaunch,
+            data: {
+              ...cachedLaunch.data,
+              runtime: {
+                ...asRuntimeValues(cachedLaunch.data.runtime),
+                ...values,
+              },
+            },
+          };
+        },
+      );
     };
 
     const commitDirtyValues = async () => {
@@ -77,11 +115,15 @@ export function useScormRuntime({ launch, language }: UseScormRuntimeParams) {
 
       dirtyValuesRef.current = {};
 
+      beginRuntimeSave();
       try {
         const result = await commitRuntimeRef.current({ data: buildRuntimePayload(values) });
+        updateLaunchRuntimeCache(values);
         await handleProgressUpdate(result.lessonCompleted);
       } catch {
         dirtyValuesRef.current = { ...values, ...dirtyValuesRef.current };
+      } finally {
+        endRuntimeSave();
       }
     };
 
@@ -98,14 +140,18 @@ export function useScormRuntime({ launch, language }: UseScormRuntimeParams) {
 
       dirtyValuesRef.current = {};
 
+      beginRuntimeSave();
       try {
         const result = await finishRuntimeRef.current({ data: buildRuntimePayload(values) });
+        updateLaunchRuntimeCache(values);
         await handleProgressUpdate(result.lessonCompleted);
         if (showToast) {
           toast({ description: t("studentLessonView.scorm.lessonFinished") });
         }
       } catch {
         dirtyValuesRef.current = { ...values, ...dirtyValuesRef.current };
+      } finally {
+        endRuntimeSave();
       }
     };
 
@@ -137,6 +183,7 @@ export function useScormRuntime({ launch, language }: UseScormRuntimeParams) {
     launch.packageId,
     launch.runtime,
     launch.scoId,
+    onSavingChange,
     queryClient,
     t,
   ]);

--- a/apps/web/app/modules/Global/Providers.tsx
+++ b/apps/web/app/modules/Global/Providers.tsx
@@ -4,6 +4,7 @@ import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { useCallback, useEffect } from "react";
 import { I18nextProvider } from "react-i18next";
 
+import { useGlobalScormImportNotifications } from "~/hooks/useGlobalScormImportNotifications";
 import { useGlobalVideoUploadNotifications } from "~/hooks/useGlobalVideoUploadNotifications";
 import { useSessionRevocationNotifications } from "~/hooks/useSessionRevocationNotifications";
 import { useVideoUploadResumeStore } from "~/modules/common/store/useVideoUploadResumeStore";
@@ -53,6 +54,7 @@ function TourKeyboardHandler({
 
 export function Providers({ children }: { children: React.ReactNode }) {
   useGlobalVideoUploadNotifications();
+  useGlobalScormImportNotifications();
   useSessionRevocationNotifications();
   const { pruneExpiredUploads } = useVideoUploadResumeStore();
 

--- a/packages/scorm-export-runtime/src/player/main.ts
+++ b/packages/scorm-export-runtime/src/player/main.ts
@@ -117,6 +117,7 @@ type RuntimeLabels = {
   yourAnswer: string;
   correctAnswer: string;
   expectedAnswer: string;
+  retakeQuiz: string;
 };
 
 const DEFAULT_PRIMARY_COLOR = "#4596FD";
@@ -135,6 +136,7 @@ const RUNTIME_LABELS: Record<string, RuntimeLabels> = {
     yourAnswer: "Your answer",
     correctAnswer: "Correct answer",
     expectedAnswer: "Expected answer",
+    retakeQuiz: "Retake quiz",
   },
   pl: {
     passed: "Zaliczono",
@@ -148,6 +150,7 @@ const RUNTIME_LABELS: Record<string, RuntimeLabels> = {
     yourAnswer: "Twoja odpowiedz",
     correctAnswer: "Poprawna odpowiedz",
     expectedAnswer: "Oczekiwana odpowiedz",
+    retakeQuiz: "Podejdz ponownie",
   },
   de: {
     passed: "Bestanden",
@@ -161,6 +164,7 @@ const RUNTIME_LABELS: Record<string, RuntimeLabels> = {
     yourAnswer: "Deine Antwort",
     correctAnswer: "Richtige Antwort",
     expectedAnswer: "Erwartete Antwort",
+    retakeQuiz: "Quiz wiederholen",
   },
   cs: {
     passed: "Splneno",
@@ -174,6 +178,7 @@ const RUNTIME_LABELS: Record<string, RuntimeLabels> = {
     yourAnswer: "Vase odpoved",
     correctAnswer: "Spravna odpoved",
     expectedAnswer: "Ocekavana odpoved",
+    retakeQuiz: "Opakovat kviz",
   },
   lt: {
     passed: "Islaikyta",
@@ -187,6 +192,7 @@ const RUNTIME_LABELS: Record<string, RuntimeLabels> = {
     yourAnswer: "Jusu atsakymas",
     correctAnswer: "Teisingas atsakymas",
     expectedAnswer: "Tiketinas atsakymas",
+    retakeQuiz: "Kartoti testa",
   },
 };
 const QUESTION_TYPE = {
@@ -309,6 +315,19 @@ function createRuntimeState(api: ScormApi | null, lesson: Lesson) {
       api?.LMSSetValue("cmi.core.score.min", "0");
       api?.LMSSetValue("cmi.core.score.max", "100");
       api?.LMSSetValue("cmi.core.lesson_status", passed ? "passed" : "failed");
+      persist();
+    },
+    resetQuiz() {
+      const state = suspendData.lessons![lesson.id];
+      delete state.completed;
+      delete state.submitted;
+      delete state.correct;
+      delete state.scorePercent;
+      delete state.answers;
+      api?.LMSSetValue("cmi.core.score.raw", "0");
+      api?.LMSSetValue("cmi.core.score.min", "0");
+      api?.LMSSetValue("cmi.core.score.max", "100");
+      api?.LMSSetValue("cmi.core.lesson_status", "incomplete");
       persist();
     },
   };
@@ -537,11 +556,14 @@ function renderQuizLesson(
   const form = element("form", "quiz-form") as HTMLFormElement;
   const feedback = element("div", "quiz-feedback");
   const actions = element("div", "quiz-actions");
+  const retake = element("button", "secondary-button", labels.retakeQuiz) as HTMLButtonElement;
   const submit = element(
     "button",
     "primary-button",
     submitted ? labels.submitted : labels.submitQuiz,
   ) as HTMLButtonElement;
+  retake.type = "button";
+  retake.hidden = !submitted;
   submit.type = "submit";
   submit.disabled = submitted;
 
@@ -557,7 +579,7 @@ function renderQuizLesson(
       ),
     );
   });
-  actions.append(submit);
+  actions.append(retake, submit);
   form.append(feedback, actions);
 
   form.addEventListener("submit", (event) => {
@@ -569,6 +591,7 @@ function renderQuizLesson(
     feedback.replaceChildren(renderScore(result, lesson, labels));
     submit.textContent = labels.submitted;
     submit.disabled = true;
+    retake.hidden = false;
     form
       .querySelectorAll<
         HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
@@ -584,6 +607,12 @@ function renderQuizLesson(
         if (card) updateQuestionFeedback(card, question, answers[question.id], labels, true);
       });
     }
+  });
+
+  retake.addEventListener("click", () => {
+    runtime.resetQuiz();
+    container.replaceChildren();
+    renderQuizLesson(container, lesson, courseJson, runtime);
   });
 
   container.append(form);

--- a/packages/scorm-export-runtime/src/player/styles.css
+++ b/packages/scorm-export-runtime/src/player/styles.css
@@ -385,20 +385,33 @@ input[type="checkbox"] {
 
 .quiz-actions {
   display: flex;
+  gap: 10px;
   justify-content: flex-end;
+  flex-wrap: wrap;
 }
 
-.primary-button {
+.primary-button,
+.secondary-button {
   border: 0;
   border-radius: 8px;
   padding: 12px 18px;
-  color: var(--contrast);
-  background: var(--primary);
-  font-weight: 800;
+  font: inherit;
   cursor: pointer;
 }
 
-.primary-button:disabled {
+.primary-button {
+  color: var(--contrast);
+  background: var(--primary);
+}
+
+.secondary-button {
+  border: 1px solid color-mix(in srgb, var(--primary) 24%, transparent);
+  color: var(--primary-900);
+  background: #fff;
+}
+
+.primary-button:disabled,
+.secondary-button:disabled {
   opacity: 0.55;
   cursor: not-allowed;
 }

--- a/packages/shared/src/constants/scorm.ts
+++ b/packages/shared/src/constants/scorm.ts
@@ -21,6 +21,26 @@ export const SCORM_PACKAGE_STATUS = {
 
 export type ScormPackageStatus = (typeof SCORM_PACKAGE_STATUS)[keyof typeof SCORM_PACKAGE_STATUS];
 
+export const SCORM_IMPORT_ACTION = {
+  CREATE_COURSE: "create-course",
+  CREATE_LESSON: "create-lesson",
+  ATTACH_LESSON_PACKAGE: "attach-lesson-package",
+} as const;
+
+export type ScormImportAction = (typeof SCORM_IMPORT_ACTION)[keyof typeof SCORM_IMPORT_ACTION];
+
+export const SCORM_IMPORT_SOCKET = {
+  EVENTS: {
+    STATUS_CHANGED: "scorm-import-status-change",
+  },
+  MESSAGE_KEYS: {
+    PROCESSING: "adminScorm.importProcessing.description",
+    READY: "adminScorm.importSuccess.description",
+    FAILED_COURSE: "adminScorm.importFailure.courseDescription",
+    FAILED_LESSON: "adminScorm.importFailure.lessonDescription",
+  },
+} as const;
+
 export const SCORM_COMPLETION_STATUS = {
   COMPLETED: "completed",
   INCOMPLETE: "incomplete",


### PR DESCRIPTION
## Issue(s)

- #1526 
- #1527 
- #1498 

## Overview

Improves SCORM import and runtime handling across API, web, shared constants, and the exported SCORM player.

- Moves SCORM package processing into a BullMQ worker so course creation, lesson creation, and lesson package attachment can return after staging the upload.
- Adds SCORM import socket events and shared action/message constants so the web app can show global processing, success, and failure toasts.
- Stages uploaded packages in S3, processes them asynchronously, marks packages ready when extraction succeeds, and cleans up staged files or failed entities when imports fail.
- Updates course and lesson queries after SCORM import status changes so admins see fresh course/lesson data without manual refresh.
- Handles missing SCORM courses more gracefully by redirecting users back to course lists instead of the generic home page.
- Prevents SCORM section navigation while runtime progress is saving and keeps launch runtime cache in sync after commit/finish.
- Adds a retake action to the exported SCORM quiz runtime and adjusts quiz action styling.
- Simplifies SCORM labeling in course admin views so only SCORM courses show the SCORM badge/column marker.

## Business Value

Admins can upload SCORM packages without waiting for all package extraction and file uploads to finish in the request cycle. This makes large SCORM imports more reliable, gives clear feedback while processing continues, and automatically removes failed imports so users are not left with broken courses or lessons.

Students get more reliable SCORM progress behavior, especially for multi-SCO packages, and exported quiz content can be retaken after submission.


