### PR TITLE
fix: display lesson statuses correctly in learning mode

### DIFF
--- a/apps/web/app/api/mutations/useToggleCourseStudentMode.ts
+++ b/apps/web/app/api/mutations/useToggleCourseStudentMode.ts
@@ -21,8 +21,10 @@ export const useToggleCourseStudentMode = (courseId: string) => {
       return response.data.data;
     },
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: currentUserQueryOptions.queryKey });
-      await queryClient.invalidateQueries({ queryKey: ["course"] });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: currentUserQueryOptions.queryKey }),
+        queryClient.invalidateQueries({ queryKey: ["course"], refetchType: "active" }),
+      ]);
     },
     onError: (error: AxiosError) => {
       const { message } = error.response?.data as ApiErrorResponse;

--- a/apps/web/app/hooks/useLessonsSequence.ts
+++ b/apps/web/app/hooks/useLessonsSequence.ts
@@ -1,17 +1,9 @@
-import { PERMISSIONS } from "@repo/shared";
-
 import { useLessonSequence } from "~/api/queries/useLessonSequence";
 
-import { usePermissions } from "./usePermissions";
-
 export function useLessonsSequence(courseId?: string) {
-  const { data: lessonSequence } = useLessonSequence({ courseId });
+  const { data: lessonSequence, isLoading } = useLessonSequence({ courseId });
 
-  const { hasAccess: canUpdateLearningProgress } = usePermissions({
-    required: PERMISSIONS.LEARNING_PROGRESS_UPDATE,
-  });
+  const sequenceEnabled = lessonSequence?.data.lessonSequenceEnabled ?? false;
 
-  const sequenceEnabled = canUpdateLearningProgress && lessonSequence?.data.lessonSequenceEnabled;
-
-  return { sequenceEnabled };
+  return { sequenceEnabled, isLoading };
 }

--- a/apps/web/app/modules/Courses/CourseView/CourseChapter.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseChapter.tsx
@@ -32,6 +32,7 @@ export const CourseChapter = ({ chapter }: CourseChapterProps) => {
   const { id: courseSlug } = useParams();
   const {
     course: { enrolled },
+    isCourseStudentModeActive,
     isPreviewMode,
   } = useCourseAccessProvider();
   const lessonText = formatWithPlural(
@@ -129,8 +130,11 @@ export const CourseChapter = ({ chapter }: CourseChapterProps) => {
                 {lessons?.map((lesson: Lesson) => {
                   if (!lesson) return null;
 
+                  const hasCourseLearningAccess =
+                    chapter.isFreemium || enrolled || isCourseStudentModeActive;
+
                   const canOpenLesson =
-                    isPreviewMode || ((chapter.isFreemium || enrolled) && lesson.hasAccess);
+                    isPreviewMode || (hasCourseLearningAccess && lesson.hasAccess);
 
                   return canOpenLesson ? (
                     <Link to={`/course/${courseSlug}/lesson/${lesson.id}`}>

--- a/apps/web/app/modules/Courses/CourseView/CourseChapterLesson.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseChapterLesson.tsx
@@ -29,14 +29,15 @@ type CourseChapterLessonProps = {
 export const CourseChapterLesson = ({ lesson }: CourseChapterLessonProps) => {
   const { t } = useTranslation();
   const { isCourseStudentModeActive, isPreviewMode } = useCourseAccessProvider();
+
   const hasAccess = isPreviewMode || lesson.hasAccess;
 
-  const shouldIgnoreBlockedStatus =
+  const shouldIgnoreEnrollmentBlockedStatus =
     isCourseStudentModeActive &&
     lesson.hasAccess &&
     lesson.status === LESSON_PROGRESS_STATUSES.BLOCKED;
 
-  const effectiveStatus = shouldIgnoreBlockedStatus
+  const effectiveStatus = shouldIgnoreEnrollmentBlockedStatus
     ? LESSON_PROGRESS_STATUSES.NOT_STARTED
     : lesson.status;
 

--- a/apps/web/app/modules/Courses/CourseView/CourseChapterLesson.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseChapterLesson.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from "react-i18next";
+import { match } from "ts-pattern";
 
 import { ProgressBadge } from "~/components/Badges/ProgressBadge";
 import { Icon } from "~/components/Icon";
@@ -12,6 +13,7 @@ import {
 import { LESSON_PROGRESS_STATUSES } from "../Lesson/types";
 
 import type { Lesson } from "./CourseChapter";
+import type { ProgressStatus } from "../Lesson/types";
 
 const progressBadge = {
   completed: "completed",
@@ -26,13 +28,22 @@ type CourseChapterLessonProps = {
 
 export const CourseChapterLesson = ({ lesson }: CourseChapterLessonProps) => {
   const { t } = useTranslation();
-  const { isPreviewMode } = useCourseAccessProvider();
+  const { isCourseStudentModeActive, isPreviewMode } = useCourseAccessProvider();
   const hasAccess = isPreviewMode || lesson.hasAccess;
-  const badgeProgress = isPreviewMode
+
+  const shouldIgnoreBlockedStatus =
+    isCourseStudentModeActive &&
+    lesson.hasAccess &&
+    lesson.status === LESSON_PROGRESS_STATUSES.BLOCKED;
+
+  const effectiveStatus = shouldIgnoreBlockedStatus
     ? LESSON_PROGRESS_STATUSES.NOT_STARTED
-    : hasAccess
-      ? lesson.status
-      : LESSON_PROGRESS_STATUSES.BLOCKED;
+    : lesson.status;
+
+  const badgeProgress: ProgressStatus = match({ isPreviewMode, hasAccess })
+    .with({ isPreviewMode: true }, () => LESSON_PROGRESS_STATUSES.NOT_STARTED)
+    .with({ hasAccess: true }, () => effectiveStatus)
+    .otherwise(() => LESSON_PROGRESS_STATUSES.BLOCKED);
 
   const lessonElement = (
     <div

--- a/apps/web/app/modules/Courses/Lesson/LessonSidebar.tsx
+++ b/apps/web/app/modules/Courses/Lesson/LessonSidebar.tsx
@@ -141,23 +141,23 @@ export const LessonSidebar = ({ course, lessonId }: LessonSidebarProps) => {
                       </AccordionTrigger>
                       <AccordionContent className="flex flex-col rounded-b-lg border border-t-0">
                         {lessons?.map(({ id, title, status, type, hasAccess }) => {
-                          const shouldIgnoreBlockedStatus =
+                          const shouldIgnoreEnrollmentBlockedStatus =
                             isCourseStudentModeActive &&
                             hasAccess &&
                             status === LESSON_PROGRESS_STATUSES.BLOCKED;
 
-                          const effectiveStatus = shouldIgnoreBlockedStatus
+                          const effectiveStatus = shouldIgnoreEnrollmentBlockedStatus
                             ? LESSON_PROGRESS_STATUSES.NOT_STARTED
                             : status;
 
                           const isBlocked = match({
                             isPreviewMode,
-                            shouldIgnoreBlockedStatus,
+                            shouldIgnoreEnrollmentBlockedStatus,
                             hasAccess,
                             status,
                           })
                             .with({ isPreviewMode: true }, () => false)
-                            .with({ shouldIgnoreBlockedStatus: true }, () => false)
+                            .with({ shouldIgnoreEnrollmentBlockedStatus: true }, () => false)
                             .with({ status: LESSON_PROGRESS_STATUSES.BLOCKED }, () => true)
                             .with({ hasAccess: false }, () => true)
                             .otherwise(() => false);

--- a/apps/web/app/modules/Courses/Lesson/LessonSidebar.tsx
+++ b/apps/web/app/modules/Courses/Lesson/LessonSidebar.tsx
@@ -2,6 +2,7 @@ import { Link, useLocation } from "@remix-run/react";
 import { last } from "lodash-es";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { match } from "ts-pattern";
 
 import CourseProgress from "~/components/CourseProgress";
 import { Icon } from "~/components/Icon";
@@ -25,7 +26,7 @@ import {
 import { LEARNING_HANDLES } from "../../../../e2e/data/learning/handles";
 import { getChaptersWithAccess } from "../utils";
 
-import { LESSON_PROGRESS_STATUSES } from "./types";
+import { LESSON_PROGRESS_STATUSES, type ProgressStatus } from "./types";
 import { getCurrentChapterId } from "./utils";
 
 import type { GetCourseResponse } from "~/api/generated-api";
@@ -45,7 +46,7 @@ const progressBadge = {
 export const LessonSidebar = ({ course, lessonId }: LessonSidebarProps) => {
   const { t } = useTranslation();
   const { state } = useLocation();
-  const { isPreviewMode } = useCourseAccessProvider();
+  const { isCourseStudentModeActive, isPreviewMode } = useCourseAccessProvider();
 
   const [activeChapter, setActiveChapter] = useState<string | undefined>(
     state?.chapterId ?? getCurrentChapterId(course, lessonId),
@@ -140,9 +141,34 @@ export const LessonSidebar = ({ course, lessonId }: LessonSidebarProps) => {
                       </AccordionTrigger>
                       <AccordionContent className="flex flex-col rounded-b-lg border border-t-0">
                         {lessons?.map(({ id, title, status, type, hasAccess }) => {
-                          const isBlocked =
-                            !isPreviewMode &&
-                            (status === LESSON_PROGRESS_STATUSES.BLOCKED || !hasAccess);
+                          const shouldIgnoreBlockedStatus =
+                            isCourseStudentModeActive &&
+                            hasAccess &&
+                            status === LESSON_PROGRESS_STATUSES.BLOCKED;
+
+                          const effectiveStatus = shouldIgnoreBlockedStatus
+                            ? LESSON_PROGRESS_STATUSES.NOT_STARTED
+                            : status;
+
+                          const isBlocked = match({
+                            isPreviewMode,
+                            shouldIgnoreBlockedStatus,
+                            hasAccess,
+                            status,
+                          })
+                            .with({ isPreviewMode: true }, () => false)
+                            .with({ shouldIgnoreBlockedStatus: true }, () => false)
+                            .with({ status: LESSON_PROGRESS_STATUSES.BLOCKED }, () => true)
+                            .with({ hasAccess: false }, () => true)
+                            .otherwise(() => false);
+
+                          const badgeStatus: ProgressStatus = isBlocked
+                            ? LESSON_PROGRESS_STATUSES.BLOCKED
+                            : effectiveStatus;
+
+                          const badgeIcon = isPreviewMode
+                            ? getPreviewIcon()
+                            : progressBadge[badgeStatus];
 
                           return (
                             <Link
@@ -162,13 +188,7 @@ export const LessonSidebar = ({ course, lessonId }: LessonSidebarProps) => {
                                     : undefined
                                 }
                                 variant="icon"
-                                icon={
-                                  isPreviewMode
-                                    ? getPreviewIcon()
-                                    : progressBadge[
-                                        isBlocked ? LESSON_PROGRESS_STATUSES.BLOCKED : status
-                                      ]
-                                }
+                                icon={badgeIcon}
                                 iconClasses="w-6 h-auto shrink-0"
                               />{" "}
                               <div className="flex flex-1 flex-col break-words overflow-x-hidden">

--- a/apps/web/e2e/specs/courses/course-student-mode.spec.ts
+++ b/apps/web/e2e/specs/courses/course-student-mode.spec.ts
@@ -1,6 +1,6 @@
 import { USER_ROLE } from "~/config/userRoles";
 
-import { COURSE_TAB_VALUES } from "../../data/courses/handles";
+import { COURSE_OVERVIEW_HANDLES, COURSE_TAB_VALUES } from "../../data/courses/handles";
 import { expect, test } from "../../fixtures/test.fixture";
 import { openCoursePreviewFlow } from "../../flows/courses/open-course-preview.flow";
 import { openEditCoursePageFlow } from "../../flows/courses/open-edit-course-page.flow";
@@ -14,11 +14,25 @@ test("admin can toggle student mode from course preview", async ({
   await withWorkerPage(USER_ROLE.admin, async ({ page }) => {
     const categoryFactory = factories.createCategoryFactory();
     const courseFactory = factories.createCourseFactory();
+    const curriculumFactory = factories.createCurriculumFactory();
     const category = await categoryFactory.create(`Student Mode Course Category ${Date.now()}`);
     const course = await courseFactory.create({
       title: `student-mode-course-${Date.now()}`,
       categoryId: category.id,
       status: "private",
+    });
+    await courseFactory.updateSettings(course.id, { lessonSequenceEnabled: false });
+    const chapter = await curriculumFactory.createChapter({
+      courseId: course.id,
+      title: `student-mode-chapter-${Date.now()}`,
+    });
+    const firstLesson = await curriculumFactory.createContentLesson(course.id, {
+      chapterId: chapter.id,
+      title: `student-mode-first-lesson-${Date.now()}`,
+    });
+    const secondLesson = await curriculumFactory.createContentLesson(course.id, {
+      chapterId: chapter.id,
+      title: `student-mode-second-lesson-${Date.now()}`,
     });
 
     cleanup.add(async () => {
@@ -33,6 +47,15 @@ test("admin can toggle student mode from course preview", async ({
     await expect(page).not.toHaveURL(/\/auth\/login/);
 
     await toggleCourseStudentModeFlow(page);
+    await expect(page.getByTestId(COURSE_OVERVIEW_HANDLES.STUDENT_MODE_BUTTON)).toContainText(
+      "Exit learning mode",
+    );
+    await page.getByTestId(chapter.title).click();
+    await expect(page.getByText(firstLesson.title)).toBeVisible();
+    await expect(page.getByText(secondLesson.title)).toBeVisible();
+    await expect(page.getByText("Blocked")).toHaveCount(0);
+    await page.getByText(firstLesson.title).click();
+    await expect(page).toHaveURL(new RegExp(`/course/.+/lesson/${firstLesson.id}$`));
 
     await expect
       .poll(async () => {


### PR DESCRIPTION
## Issue(s)
- #1548 

## Overview
Fixes lesson availability and progress badge handling in course preview/student learning mode.

The change updates course lesson cards and the lesson sidebar so student mode can open accessible lessons without showing enrollment-related blocked states as blocked. It still preserves blocking when lesson sequence rules mark a lesson as unavailable.

It also refreshes active course queries after toggling student mode so lesson access/status UI updates immediately.

## Business Value
Admins can reliably use student mode to verify the learner experience from the course preview. Lessons that should be available are no longer hidden behind incorrect blocked statuses, while sequence-based progression rules remain enforced.

This reduces confusion when reviewing courses before publication and helps admins validate lesson order and access behavior accurately.

## Screenshots / Video

https://github.com/user-attachments/assets/a294b229-427e-47b0-991d-778048b608c8
