### PR TITLE
fix: restore course preview navigation and course card opening

### DIFF
--- a/apps/web/app/modules/Courses/Lesson/LessonContent.tsx
+++ b/apps/web/app/modules/Courses/Lesson/LessonContent.tsx
@@ -241,29 +241,27 @@ export const LessonContent = ({
                 {lesson.title}
               </p>
             </div>
-            {!isPreviewMode && (
-              <div className="mt-4 flex flex-col gap-2 sm:ml-8 sm:mt-0 sm:items-end">
-                <div className="flex flex-row gap-x-4">
-                  <Button
-                    variant="outline"
-                    className="w-full gap-x-1 sm:w-auto disabled:opacity-0"
-                    disabled={isPreviousDisabled || isFirstLesson}
-                    onClick={handlePrevious}
-                  >
-                    <Icon name="ArrowRight" className="h-auto w-4 rotate-180" />
-                  </Button>
-                  <Button
-                    data-testid={LEARNING_HANDLES.NEXT_LESSON_BUTTON}
-                    variant="outline"
-                    disabled={isNextDisabled}
-                    className="w-full gap-x-1 sm:w-auto disabled:opacity-0"
-                    onClick={handleNext}
-                  >
-                    <Icon name="ArrowRight" className="h-auto w-4" />
-                  </Button>
-                </div>
+            <div className="mt-4 flex flex-col gap-2 sm:ml-8 sm:mt-0 sm:items-end">
+              <div className="flex flex-row gap-x-4">
+                <Button
+                  variant="outline"
+                  className="w-full gap-x-1 sm:w-auto disabled:opacity-0"
+                  disabled={isPreviousDisabled || isFirstLesson}
+                  onClick={handlePrevious}
+                >
+                  <Icon name="ArrowRight" className="h-auto w-4 rotate-180" />
+                </Button>
+                <Button
+                  data-testid={LEARNING_HANDLES.NEXT_LESSON_BUTTON}
+                  variant="outline"
+                  disabled={isNextDisabled}
+                  className="w-full gap-x-1 sm:w-auto disabled:opacity-0"
+                  onClick={handleNext}
+                >
+                  <Icon name="ArrowRight" className="h-auto w-4" />
+                </Button>
               </div>
-            )}
+            </div>
           </div>
 
           <LessonContentRenderer

--- a/apps/web/app/modules/Courses/components/modern/ModernCourseCard.tsx
+++ b/apps/web/app/modules/Courses/components/modern/ModernCourseCard.tsx
@@ -220,6 +220,9 @@ const ModernCourseCard = ({
       <Link
         to={`/course/${id}`}
         data-testid="modern-course-card-link"
+        discover="none"
+        prefetch="none"
+        reloadDocument
         className="absolute inset-0 transition-transform"
         style={{
           transform:


### PR DESCRIPTION
## Issue(s)

- #1518 
- #1550 

## Overview

Fixes lesson navigation controls in course preview mode and adjusts modern course card navigation so cards open reliably.

- Shows previous/next lesson buttons in preview mode instead of hiding the entire navigation block.
- Keeps existing disabled states for first, previous, and next lesson navigation.
- Forces modern course card links to use document navigation with Remix prefetch and discovery disabled.

## Business Value

Users reviewing course content can move through lessons directly from preview mode, which makes validation faster and less error-prone. Course cards also behave more predictably when opened, reducing friction for learners and administrators entering course details.

## Screenshots / Video

https://github.com/user-attachments/assets/5e3b2f1a-6a80-41e5-99b2-6c5a6701df12
