### PR TITLE
fix: make certificate modal close properly

### DIFF
--- a/apps/web/app/modules/Admin/EditCourse/CourseSettings/components/CourseCertificateSetting.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/CourseSettings/components/CourseCertificateSetting.tsx
@@ -40,6 +40,7 @@ const CourseCertificateSetting = ({
   const { toast } = useToast();
   const [isCertificateEnabled, setIsCertificateEnabled] = useState(hasCertificate);
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+  const [isCertificateColorPickerOpen, setIsCertificateColorPickerOpen] = useState(false);
   const colorSaveTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastSavedColorRef = useRef<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -275,8 +276,11 @@ const CourseCertificateSetting = ({
       </div>
       <Dialog open={isPreviewOpen} onOpenChange={setIsPreviewOpen}>
         <DialogContent
-          className="w-[95vw] max-w-[1120px] border-none bg-transparent p-0 shadow-none"
+          className="w-auto max-w-[calc(100vw-2rem)] overflow-visible p-0"
           noCloseButton
+          onInteractOutside={(event) => {
+            if (isCertificateColorPickerOpen) event.preventDefault();
+          }}
         >
           <CertificatePreview
             studentName={t("adminCourseView.settings.other.certificatePreviewStudentName")}
@@ -291,6 +295,7 @@ const CourseCertificateSetting = ({
             showDownloadButton={false}
             initialColor={settings?.certificateFontColor}
             onColorChange={handleCertificateColorChange}
+            onColorPickerOpenChange={setIsCertificateColorPickerOpen}
           />
         </DialogContent>
       </Dialog>

--- a/apps/web/app/modules/Profile/Certificates/CertificateControls.tsx
+++ b/apps/web/app/modules/Profile/Certificates/CertificateControls.tsx
@@ -1,12 +1,15 @@
+import * as PopoverPrimitive from "@radix-ui/react-popover";
 import { HEX_COLOR_REGEX } from "@repo/shared";
 import { Download, Loader2, Palette, X } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { HexColorPicker } from "react-colorful";
 import { useTranslation } from "react-i18next";
 
 import { Linkedin } from "~/assets/svgs";
 import RectangularSwitch from "~/components/RectangularSwitch";
+import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
+import { cn } from "~/lib/utils";
 
 import { applyUniformCertificateColor } from "./certificateTheme";
 
@@ -23,6 +26,7 @@ interface CertificateControlsProps {
   colorTheme: CertificateColorTheme;
   setColorTheme: React.Dispatch<React.SetStateAction<CertificateColorTheme>>;
   onColorChange?: (color: string) => void;
+  onColorPickerOpenChange?: (isOpen: boolean) => void;
   showColorPicker?: boolean;
   showDownloadButton?: boolean;
   showShareButton?: boolean;
@@ -42,6 +46,7 @@ const CertificateControls = ({
   colorTheme,
   setColorTheme,
   onColorChange,
+  onColorPickerOpenChange,
   showColorPicker = false,
   showDownloadButton = true,
   showShareButton = false,
@@ -49,13 +54,30 @@ const CertificateControls = ({
   const { t } = useTranslation();
   const [isColorPickerOpen, setIsColorPickerOpen] = useState(false);
 
+  useEffect(() => {
+    return () => onColorPickerOpenChange?.(false);
+  }, [onColorPickerOpenChange]);
+
   const handleDownload = () => {
     void downloadCertificatePdf();
+  };
+
+  const handleColorPickerOpenChange = (isOpen: boolean) => {
+    setIsColorPickerOpen(isOpen);
+    onColorPickerOpenChange?.(isOpen);
   };
 
   const updateAllColors = (value: string) => {
     setColorTheme((previous) => applyUniformCertificateColor(value, previous));
     onColorChange?.(value);
+  };
+
+  const handleHexColorInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value.startsWith("#")
+      ? event.target.value
+      : `#${event.target.value}`;
+
+    if (HEX_COLOR_REGEX.test(value)) updateAllColors(value);
   };
 
   return (
@@ -69,49 +91,44 @@ const CertificateControls = ({
       />
 
       {showColorPicker && (
-        <div className="relative">
-          <button
-            type="button"
-            data-certificate-font-color-picker="true"
-            className="flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs font-medium text-gray-700 hover:bg-gray-50"
-            onClick={() => setIsColorPickerOpen((previous) => !previous)}
-          >
-            <Palette className="size-4" />
-            <span>{t("studentCertificateView.controls.fontColor")}</span>
-            <span
-              className="size-4 rounded border border-gray-300"
-              style={{ backgroundColor: colorTheme.titleColor }}
-            />
-            <span className="font-mono uppercase">{colorTheme.titleColor}</span>
-          </button>
-          {isColorPickerOpen && (
-            <div
-              data-certificate-font-color-picker="true"
-              className="absolute right-0 top-[calc(100%+8px)] z-20 w-[260px] rounded-lg border bg-white p-3 shadow-md"
+        <PopoverPrimitive.Root open={isColorPickerOpen} onOpenChange={handleColorPickerOpenChange}>
+          <PopoverPrimitive.Trigger asChild>
+            <Button
+              size="sm"
+              className="flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs font-medium text-gray-700 hover:bg-gray-50"
             >
-              <div className="flex flex-col items-center gap-3">
-                <HexColorPicker color={colorTheme.titleColor} onChange={updateAllColors} />
-                <div className="flex items-center justify-center space-x-1">
-                  <span className="text-sm text-gray-500">#</span>
-                  <Input
-                    type="text"
-                    value={colorTheme.titleColor.replace(/^#/, "").toLowerCase()}
-                    onChange={(event) => {
-                      const value = event.target.value.startsWith("#")
-                        ? event.target.value
-                        : `#${event.target.value}`;
-
-                      if (HEX_COLOR_REGEX.test(value)) {
-                        updateAllColors(value);
-                      }
-                    }}
-                    className="w-24"
-                  />
-                </div>
+              <Palette className="size-4" />
+              <span className="block mr-3">{t("studentCertificateView.controls.fontColor")}</span>
+              <span
+                className="size-4 rounded border border-gray-300"
+                style={{ backgroundColor: colorTheme.titleColor }}
+              />
+              <span className="font-mono uppercase">{colorTheme.titleColor}</span>
+            </Button>
+          </PopoverPrimitive.Trigger>
+          <PopoverPrimitive.Content
+            align="end"
+            sideOffset={8}
+            className={cn(
+              "z-[60] w-[260px] rounded-lg border bg-white p-3 text-popover-foreground shadow-md outline-none",
+              "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+              "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+            )}
+          >
+            <div className="flex flex-col items-center gap-3">
+              <HexColorPicker color={colorTheme.titleColor} onChange={updateAllColors} />
+              <div className="flex items-center justify-center space-x-1">
+                <span className="text-sm text-gray-500">#</span>
+                <Input
+                  type="text"
+                  value={colorTheme.titleColor.replace(/^#/, "").toLowerCase()}
+                  onChange={handleHexColorInputChange}
+                  className="w-24"
+                />
               </div>
             </div>
-          )}
-        </div>
+          </PopoverPrimitive.Content>
+        </PopoverPrimitive.Root>
       )}
 
       {showDownloadButton && (

--- a/apps/web/app/modules/Profile/Certificates/CertificatePreview.tsx
+++ b/apps/web/app/modules/Profile/Certificates/CertificatePreview.tsx
@@ -29,6 +29,7 @@ interface CertificatePreviewProps {
   minimalFrame?: boolean;
   initialColor?: string | null;
   onColorChange?: (color: string) => void;
+  onColorPickerOpenChange?: (isOpen: boolean) => void;
   certificateKind?: CertificateKind;
 }
 
@@ -47,6 +48,7 @@ const CertificatePreview = ({
   minimalFrame = false,
   initialColor,
   onColorChange,
+  onColorPickerOpenChange,
   certificateKind = CERTIFICATE_KIND.COURSE,
 }: CertificatePreviewProps) => {
   const { downloadCertificatePdf, isPreparingDownload } = useCertificatePDF(certificateKind);
@@ -87,11 +89,11 @@ const CertificatePreview = ({
   };
 
   return (
-    <div className="flex w-full justify-center">
-      <div className="w-full origin-center scale-100 md:scale-[0.8]">
+    <div className="flex w-[min(1120px,95vw)] justify-center">
+      <div className="w-full">
         <div
           className={cn("mx-auto w-full bg-white", {
-            "max-w-[98vw] rounded-t-lg sm:max-w-[95vw]": !minimalFrame,
+            "rounded-t-lg": !minimalFrame,
             "overflow-hidden": !minimalFrame && !showColorPicker,
             "overflow-visible": !minimalFrame && showColorPicker,
           })}
@@ -118,6 +120,7 @@ const CertificatePreview = ({
               colorTheme={colorTheme}
               setColorTheme={setColorTheme}
               onColorChange={onColorChange}
+              onColorPickerOpenChange={onColorPickerOpenChange}
               showColorPicker={showColorPicker}
               showDownloadButton={showDownloadButton}
               showShareButton={showShareButton && Boolean(certificateId)}


### PR DESCRIPTION
## Issue(s)
- #1529 

## Overview
Fixes certificate preview modal closing behavior when editing course certificate settings.

The certificate font color picker now uses the Radix popover primitive and reports its open state up to the parent certificate preview dialog. While the color picker is open, outside interactions are ignored by the dialog so selecting or typing a color does not close the certificate preview modal unexpectedly.

The certificate preview modal sizing was also adjusted so the preview renders at a stable width without the previous scale transform.

## Business Value
Course administrators can preview and customize certificate font colors without losing the modal state while interacting with the color picker. This makes certificate configuration less error-prone and avoids repeated reopening of the preview during setup.

## Screenshots / Video

https://github.com/user-attachments/assets/e6b5ff9a-72a5-47af-b2c0-7272bbcc54a4
