### PR TITLE
fix: display trailer videos correctly in the continue learning section

### DIFF
--- a/.github/workflows/license-new.yml
+++ b/.github/workflows/license-new.yml
@@ -21,6 +21,8 @@ jobs:
           cache: pnpm
 
       - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.3
 
       - name: Install dependencies
         run: |

--- a/apps/api/src/courses/__tests__/course.controller.e2e-spec.ts
+++ b/apps/api/src/courses/__tests__/course.controller.e2e-spec.ts
@@ -691,6 +691,66 @@ describe("CourseController (e2e)", () => {
         expect(response.body.data[0].id).toBe(enrolledCourse.id);
       });
 
+      it("returns trailer url for enrolled courses", async () => {
+        const student = await userFactory
+          .withCredentials({ password })
+          .withUserSettings(db)
+          .create({ role: SYSTEM_ROLE_SLUGS.STUDENT });
+        const cookies = await cookieFor(student, app);
+        const category = await categoryFactory.create();
+        const contentCreator = await userFactory.create({
+          role: SYSTEM_ROLE_SLUGS.CONTENT_CREATOR,
+        });
+
+        const enrolledCourse = await courseFactory.create({
+          authorId: contentCreator.id,
+          categoryId: category.id,
+          status: "published",
+          thumbnailS3Key: null,
+        });
+
+        const [trailerResource] = await db
+          .insert(resources)
+          .values({
+            reference: "course-trailers/trailer.mp4",
+            contentType: "video/mp4",
+            uploadedBy: contentCreator.id,
+          })
+          .returning();
+
+        await db.insert(resourceEntity).values({
+          resourceId: trailerResource.id,
+          entityId: enrolledCourse.id,
+          entityType: ENTITY_TYPES.COURSE,
+          relationshipType: RESOURCE_RELATIONSHIP_TYPES.TRAILER,
+        });
+
+        await db.insert(studentCourses).values({
+          studentId: student.id,
+          courseId: enrolledCourse.id,
+          finishedChapterCount: 0,
+        });
+
+        mockFileService.getFileUrl.mockImplementation(async (reference: string) => {
+          if (reference === "course-trailers/trailer.mp4") {
+            return "http://example.com/signed-trailer.mp4";
+          }
+
+          return "http://example.com/file";
+        });
+
+        const response = await request(app.getHttpServer())
+          .get("/api/course/get-student-courses")
+          .set("Cookie", cookies)
+          .expect(200);
+
+        expect(response.body.data).toHaveLength(1);
+        expect(response.body.data[0]).toMatchObject({
+          id: enrolledCourse.id,
+          trailerUrl: "http://example.com/signed-trailer.mp4",
+        });
+      });
+
       it("filters by title", async () => {
         const student = await userFactory
           .withCredentials({ password })

--- a/apps/api/src/courses/course.service.ts
+++ b/apps/api/src/courses/course.service.ts
@@ -409,30 +409,33 @@ export class CourseService {
         .leftJoin(users, eq(courses.authorId, users.id))
         .where(and(...conditions));
 
+      const courseIds = data.map((item) => item.id);
+      const trailerUrls = await this.getCourseTrailerUrls(courseIds);
+
       const dataWithS3SignedUrls = await Promise.all(
         data.map(async (item) => {
-          if (!item.thumbnailUrl) {
-            return item;
-          }
-
+          const trailerUrl = trailerUrls[item.id] ?? null;
           try {
-            const signedUrl = await this.fileService.getFileUrl(item.thumbnailUrl);
+            const signedUrl = item.thumbnailUrl
+              ? await this.fileService.getFileUrl(item.thumbnailUrl)
+              : item.thumbnailUrl;
+
             const authorAvatarSignedUrl = await this.userService.getUsersProfilePictureUrl(
               item.authorAvatarUrl,
             );
             return {
               ...item,
               thumbnailUrl: signedUrl,
+              trailerUrl,
               authorAvatarUrl: authorAvatarSignedUrl,
             };
           } catch (error) {
             console.error(`Failed to get signed URL for ${item.thumbnailUrl}:`, error);
-            return item;
+            return { ...item, trailerUrl };
           }
         }),
       );
 
-      const courseIds = dataWithS3SignedUrls.map((item) => item.id);
       const slugsMap = await this.courseSlugService.getCoursesSlugs(language || "en", courseIds);
 
       const dataWithSlugs = dataWithS3SignedUrls.map((item) => ({

--- a/apps/api/src/file/file.constants.ts
+++ b/apps/api/src/file/file.constants.ts
@@ -1,6 +1,7 @@
 export const REDIS_TTL = 59 * 60 * 1000;
 export const MAX_FILE_SIZE = 1024 * 1024 * 1024;
 export const MAX_VIDEO_SIZE = 5 * 1024 * 1024 * 1024;
+export const MAX_COURSE_TRAILER_VIDEO_SIZE = 200 * 1024 * 1024;
 
 export const ALLOWED_MIME_TYPES = [
   "image/jpeg",

--- a/apps/api/src/file/file.service.ts
+++ b/apps/api/src/file/file.service.ts
@@ -38,6 +38,7 @@ import { settingsToJSONBuildObject } from "src/utils/settings-to-json-build-obje
 
 import {
   ALLOWED_EXCEL_MIME_TYPES_MAP,
+  MAX_COURSE_TRAILER_VIDEO_SIZE,
   RESOURCE_RELATIONSHIP_TYPES,
   MAX_VIDEO_SIZE,
 } from "./file.constants";
@@ -202,12 +203,14 @@ export class FileService {
     placeholderKey: string,
     fileType: string | undefined,
     currentUserId?: UUIDType,
+    maxUploadSize?: number,
   ) {
     await this.videoProcessingStateService.initializeState(
       uploadId,
       placeholderKey,
       fileType,
       currentUserId,
+      { maxUploadSize },
     );
   }
 
@@ -312,8 +315,14 @@ export class FileService {
       throw new BadRequestException("Invalid video mime type");
     }
 
-    if (sizeBytes > MAX_VIDEO_SIZE) {
-      throw new BadRequestException("Video file exceeds maximum allowed size");
+    const isCourseTrailer =
+      entityType === ENTITY_TYPES.COURSE &&
+      relationshipType === RESOURCE_RELATIONSHIP_TYPES.TRAILER;
+
+    const maxUploadSize = isCourseTrailer ? MAX_COURSE_TRAILER_VIDEO_SIZE : MAX_VIDEO_SIZE;
+
+    if (sizeBytes > maxUploadSize) {
+      throw new BadRequestException("uploadFile.toast.videoTooLarge");
     }
 
     const { uploadId, placeholderKey, fileType } = this.buildVideoUploadContext(resource, filename);
@@ -337,7 +346,13 @@ export class FileService {
       }
     }
 
-    await this.initializeVideoUploadState(uploadId, placeholderKey, fileType, currentUser?.userId);
+    await this.initializeVideoUploadState(
+      uploadId,
+      placeholderKey,
+      fileType,
+      currentUser?.userId,
+      maxUploadSize,
+    );
 
     const provider = await this.resolveVideoProvider();
     const providerResponse = await this.initProviderUpload(

--- a/apps/api/src/file/tus/tus-upload.service.ts
+++ b/apps/api/src/file/tus/tus-upload.service.ts
@@ -37,14 +37,14 @@ export class TusUploadService {
       throw new BadRequestException("Missing upload length");
     }
 
-    if (uploadLength > MAX_VIDEO_SIZE) {
-      throw new BadRequestException("Video file exceeds maximum allowed size");
-    }
-
     const state = await this.videoProcessingStateService.getState(uploadId);
 
     if (!state || state.provider !== VIDEO_PROVIDERS.S3 || !state.fileKey) {
       throw new BadRequestException("S3 video upload not initialized");
+    }
+
+    if (uploadLength > (state.maxUploadSize ?? MAX_VIDEO_SIZE)) {
+      throw new BadRequestException("uploadFile.toast.videoTooLarge");
     }
 
     if (state.userId && currentUserId && state.userId !== currentUserId) {

--- a/apps/api/src/file/video-processing-state.service.ts
+++ b/apps/api/src/file/video-processing-state.service.ts
@@ -21,6 +21,7 @@ export type VideoUploadState = {
   fileType?: string;
   error?: string;
   userId?: string;
+  maxUploadSize?: number;
 };
 
 @Injectable()
@@ -71,6 +72,7 @@ export class VideoProcessingStateService {
       fileKey?: string;
       multipartUploadId?: string;
       partSize?: number;
+      maxUploadSize?: number;
     },
   ) {
     const state: VideoUploadState = {
@@ -83,6 +85,7 @@ export class VideoProcessingStateService {
       fileKey: options?.fileKey,
       multipartUploadId: options?.multipartUploadId,
       partSize: options?.partSize,
+      maxUploadSize: options?.maxUploadSize,
     };
 
     await this.retryOperation(

--- a/apps/web/app/components/VideoPlayer/videoPlayer.css
+++ b/apps/web/app/components/VideoPlayer/videoPlayer.css
@@ -22,6 +22,10 @@
   object-fit: contain;
 }
 
+.mentingo-video-js.mentingo-video-js--cover .vjs-tech {
+  object-fit: cover;
+}
+
 .mentingo-video-js .vjs-control-bar {
   position: absolute;
   left: 0;

--- a/apps/web/app/locales/cs/translation.json
+++ b/apps/web/app/locales/cs/translation.json
@@ -99,6 +99,7 @@
     "toast": {
       "fileUploadedSuccessfully": "Soubor byl úspěšně nahrán",
       "videoFailed": "Nahrání videa se nezdařilo",
+      "videoTooLarge": "Video soubor překračuje maximální povolenou velikost",
       "videoReady": "Video je připraveno k použití",
       "videoUploading": "Nahráváme vaše video. Záložku prosím nezavírejte.",
       "videoUploadedProcessing": "Vaše nahrávání bylo dokončeno. Nyní se vaše video zpracovává. Neváhejte a zavřete kartu."
@@ -1434,6 +1435,7 @@
         "charactersLeft": "Postavy odešly",
         "reachedCharactersLimit": "Dosáhli jste limitu počtu znaků.",
         "reachedCharactersLimitHtml": "Příliš mnoho formátování. Snižte prosím množství formátování, aby se vešlo do limitu.",
+        "trailerUploadDetails": "MP4, MOV, MPEG-2 nebo Hevc (max. 200 MB)",
         "enableCertificate": "Povolit certifikát",
         "enableCertificateDescription": "Zapněte toto, chcete-li vydávat certifikáty pro tento kurz a níže nakonfigurujte jejich podpis a náhled.",
         "certificateValidity": "Platnost certifikátu",

--- a/apps/web/app/locales/de/translation.json
+++ b/apps/web/app/locales/de/translation.json
@@ -99,6 +99,7 @@
     "toast": {
       "fileUploadedSuccessfully": "Datei erfolgreich hochgeladen",
       "videoFailed": "Das Hochladen des Videos ist fehlgeschlagen",
+      "videoTooLarge": "Die Videodatei überschreitet die maximal zulässige Größe",
       "videoReady": "Das Video ist einsatzbereit",
       "videoUploading": "Wir laden Ihr Video hoch. Bitte schließen Sie den Tab nicht.",
       "videoUploadedProcessing": "Ihr Upload ist abgeschlossen. Jetzt wird Ihr Video verarbeitet. Schließen Sie den Tab gerne."
@@ -1434,6 +1435,7 @@
         "charactersLeft": "Charaktere übrig",
         "reachedCharactersLimit": "Sie haben die Zeichenbeschränkung erreicht.",
         "reachedCharactersLimitHtml": "Zu viel Formatierung. Bitte reduzieren Sie die Formatierung, damit sie innerhalb des Limits liegt.",
+        "trailerUploadDetails": "MP4, MOV, MPEG-2 oder Hevc (max. 200 MB)",
         "enableCertificate": "Zertifikat aktivieren",
         "enableCertificateDescription": "Aktivieren Sie diese Option, um Zertifikate für diesen Kurs auszustellen und konfigurieren Sie unten deren Signatur und Vorschau.",
         "certificateValidity": "Zertifikatsgültigkeit",

--- a/apps/web/app/locales/en/translation.json
+++ b/apps/web/app/locales/en/translation.json
@@ -99,6 +99,7 @@
     "toast": {
       "fileUploadedSuccessfully": "File uploaded successfully",
       "videoFailed": "Video upload failed",
+      "videoTooLarge": "Video file exceeds the maximum allowed size",
       "videoReady": "Video is ready to use",
       "videoUploading": "We're uploading your video. Please don't close the tab.",
       "videoUploadedProcessing": "Your upload has been finished. Now your video is getting processed. Feel free to close the tab."
@@ -1497,6 +1498,7 @@
         "charactersLeft": "Characters left",
         "reachedCharactersLimit": "You have reached the character limit.",
         "reachedCharactersLimitHtml": "Too much formatting. Please reduce the amount of formatting to fit within the limit.",
+        "trailerUploadDetails": "MP4, MOV, MPEG-2 or Hevc (max. 200 MB)",
         "enableCertificate": "Enable certificate",
         "enableCertificateDescription": "Turn this on to issue certificates for this course and configure their signature and preview below.",
         "certificateValidity": "Certificate validity",

--- a/apps/web/app/locales/lt/translation.json
+++ b/apps/web/app/locales/lt/translation.json
@@ -99,6 +99,7 @@
     "toast": {
       "fileUploadedSuccessfully": "Failas sėkmingai įkeltas",
       "videoFailed": "Vaizdo įrašo įkėlimas nepavyko",
+      "videoTooLarge": "Vaizdo failas viršija didžiausią leistiną dydį",
       "videoReady": "Vaizdo įrašas paruoštas naudoti",
       "videoUploading": "Įkeliame jūsų vaizdo įrašą. Neuždarykite skirtuko.",
       "videoUploadedProcessing": "Jūsų įkėlimas baigtas. Dabar jūsų vaizdo įrašas apdorojamas. Nedvejodami uždarykite skirtuką."
@@ -1434,6 +1435,7 @@
         "charactersLeft": "Liko simbolių",
         "reachedCharactersLimit": "Pasiekėte simbolių limitą.",
         "reachedCharactersLimitHtml": "Per daug formatavimo. Sumažinkite formatavimo kiekį, kad tilptų į limitą.",
+        "trailerUploadDetails": "MP4, MOV, MPEG-2 arba Hevc (maks. 200 MB)",
         "enableCertificate": "Įgalinti sertifikatą",
         "enableCertificateDescription": "Įjunkite tai, kad išduotumėte šio kurso sertifikatus ir toliau sukonfigūruotumėte jų parašą bei peržiūrą.",
         "certificateValidity": "Sertifikato galiojimas",

--- a/apps/web/app/locales/pl/translation.json
+++ b/apps/web/app/locales/pl/translation.json
@@ -100,6 +100,7 @@
     "toast": {
       "fileUploadedSuccessfully": "Plik został pomyślnie przesłany",
       "videoFailed": "Nie udało się przesłać wideo",
+      "videoTooLarge": "Plik wideo przekracza maksymalny dozwolony rozmiar",
       "videoReady": "Wideo jest gotowe do użycia",
       "videoUploading": "Przesyłamy Twoje wideo. Proszę nie zamykaj karty.",
       "videoUploadedProcessing": "Przesyłanie zakończone. Twoje wideo jest teraz przetwarzane. Możesz zamknąć kartę."
@@ -1712,6 +1713,7 @@
         "charactersLeft": "Pozostało znaków",
         "reachedCharactersLimit": "Osiągnięto limit znaków.",
         "reachedCharactersLimitHtml": "Zbyt dużo formatowania. Zmniejsz ilość formatowania, aby zmieścić się w limicie.",
+        "trailerUploadDetails": "MP4, MOV, MPEG-2 lub Hevc (maksymalnie 200 MB)",
         "enableCertificate": "Włącz certyfikat",
         "enableCertificateDescription": "Włącz tę opcję, aby wystawiać certyfikaty dla tego kursu i móc skonfigurować podpis.",
         "certificateValidity": "Ważność certyfikatu",

--- a/apps/web/app/modules/Admin/EditCourse/CourseSettings/CourseSettings.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/CourseSettings/CourseSettings.tsx
@@ -1,4 +1,4 @@
-import { ALLOWED_VIDEO_FILE_TYPES, COURSE_TYPE, ENTITY_TYPES } from "@repo/shared";
+import { COURSE_TYPE, ENTITY_TYPES } from "@repo/shared";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -18,7 +18,6 @@ import { Icon } from "~/components/Icon";
 import { BaseEditor } from "~/components/RichText/Editor";
 import { Button } from "~/components/ui/button";
 import { Form, FormControl, FormField, FormItem, FormMessage } from "~/components/ui/form";
-import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
 import {
   Select,
@@ -41,6 +40,7 @@ import CourseCardPreview from "../components/CourseCardPreview";
 
 import CourseCertificateSetting from "./components/CourseCertificateSetting";
 import { CourseSettingsSwitches } from "./components/CourseSettingsSwitches";
+import { CourseTrailerUploadField } from "./components/CourseTrailerUploadField";
 import { useCourseSettingsForm } from "./hooks/useCourseSettingsForm";
 
 import type { CourseType, SupportedLanguages } from "@repo/shared";
@@ -353,45 +353,19 @@ const CourseSettings = ({
                   <Label htmlFor="course-trailer">
                     {t("adminCourseView.settings.field.trailer")}
                   </Label>
-                  <Input
-                    id="course-trailer"
-                    type="file"
-                    accept={ALLOWED_VIDEO_FILE_TYPES.join(",")}
-                    ref={trailerInputRef}
-                    disabled={isTrailerUploading}
-                    onChange={(event) => {
-                      const file = event.target.files?.[0];
-                      if (!file) return;
+                  <CourseTrailerUploadField
+                    inputId="course-trailer"
+                    trailerUrl={displayTrailerUrl}
+                    trailerEmbedUrl={trailerEmbedUrl}
+                    isUploading={isTrailerUploading}
+                    inputRef={trailerInputRef}
+                    onFileSelect={(file) => {
                       void handleTrailerUpload(file);
                     }}
+                    onDelete={() => {
+                      void removeTrailer();
+                    }}
                   />
-                  {isTrailerUploading && <p>{t("common.other.uploadingImage")}</p>}
-                  {displayTrailerUrl && (
-                    <div className="flex flex-col gap-3">
-                      <div className="overflow-hidden rounded-lg border border-neutral-200">
-                        {trailerEmbedUrl ? (
-                          <iframe
-                            src={trailerEmbedUrl}
-                            title={t("adminCourseView.settings.trailerPreview", {
-                              defaultValue: "Trailer preview",
-                            })}
-                            allow="autoplay; encrypted-media"
-                            allowFullScreen
-                            loading="lazy"
-                            className="aspect-video h-auto w-full border-none"
-                          />
-                        ) : (
-                          <video src={displayTrailerUrl} controls className="h-auto w-full">
-                            <track kind="captions" className="sr-only" />
-                          </video>
-                        )}
-                      </div>
-                      <Button type="button" onClick={removeTrailer} variant="destructive">
-                        <Icon name="TrashIcon" className="mr-2" />
-                        {t("adminCourseView.settings.button.removeTrailer")}
-                      </Button>
-                    </div>
-                  )}
                 </div>
                 <div className="flex space-x-5">
                   <Button

--- a/apps/web/app/modules/Admin/EditCourse/CourseSettings/components/CourseTrailerUploadField.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/CourseSettings/components/CourseTrailerUploadField.tsx
@@ -1,0 +1,103 @@
+import { ALLOWED_VIDEO_FILE_TYPES } from "@repo/shared";
+import { useTranslation } from "react-i18next";
+
+import { Icon } from "~/components/Icon";
+import { Button } from "~/components/ui/button";
+import { cn } from "~/lib/utils";
+
+import type { RefObject } from "react";
+
+type CourseTrailerUploadFieldProps = {
+  inputId: string;
+  trailerUrl?: string;
+  trailerEmbedUrl?: string;
+  isUploading: boolean;
+  inputRef: RefObject<HTMLInputElement>;
+  onFileSelect: (file: File) => void;
+  onDelete: () => void;
+};
+
+export const CourseTrailerUploadField = ({
+  inputId,
+  trailerUrl,
+  trailerEmbedUrl,
+  isUploading,
+  inputRef,
+  onFileSelect,
+  onDelete,
+}: CourseTrailerUploadFieldProps) => {
+  const { t } = useTranslation();
+
+  const actionText = trailerUrl ? t("uploadFile.replace") : t("uploadFile.header");
+  const statusText = isUploading ? t("uploadFile.toast.videoUploading") : t("uploadFile.subHeader");
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div
+        className={cn(
+          "relative flex aspect-video w-full overflow-hidden rounded-lg border border-neutral-300 bg-neutral-50",
+          isUploading && "opacity-70",
+        )}
+      >
+        {trailerUrl ? (
+          <div className="absolute inset-0 bg-neutral-950">
+            {trailerEmbedUrl ? (
+              <iframe
+                src={trailerEmbedUrl}
+                title={t("adminCourseView.settings.trailerPreview", {
+                  defaultValue: "Trailer preview",
+                })}
+                allow="autoplay; encrypted-media"
+                allowFullScreen
+                loading="lazy"
+                className="h-full w-full border-none"
+              />
+            ) : (
+              <video src={trailerUrl} className="h-full w-full object-cover" muted playsInline>
+                <track kind="captions" className="sr-only" />
+              </video>
+            )}
+          </div>
+        ) : null}
+        <div
+          className={cn(
+            "absolute inset-0 flex flex-col items-center justify-center gap-2 px-4 text-center",
+            trailerUrl
+              ? "bg-black/55 text-white backdrop-blur-[1px]"
+              : "bg-neutral-50 text-neutral-900",
+          )}
+        >
+          <Icon name="UploadImageIcon" className="size-8 text-primary-700" />
+          <div className="flex items-center justify-center rounded-md border bg-white px-2 py-1 text-sm font-semibold text-neutral-900 sm:text-base">
+            <span>{actionText}</span>
+            {!isUploading && <span className="ml-1">{statusText}</span>}
+          </div>
+          <div className="w-fit rounded-md border bg-white px-2 py-1 text-[13px] font-medium leading-5 text-neutral-900">
+            {isUploading ? statusText : t("adminCourseView.settings.other.trailerUploadDetails")}
+          </div>
+        </div>
+        <input
+          id={inputId}
+          ref={inputRef}
+          type="file"
+          accept={ALLOWED_VIDEO_FILE_TYPES.join(",")}
+          disabled={isUploading}
+          className={cn(
+            "absolute inset-0 opacity-0",
+            isUploading ? "cursor-not-allowed" : "cursor-pointer",
+          )}
+          onChange={(event) => {
+            const file = event.target.files?.[0];
+            if (file) onFileSelect(file);
+          }}
+        />
+      </div>
+      {trailerUrl && (
+        <Button type="button" onClick={onDelete} variant="destructive">
+          <Icon name="TrashIcon" className="mr-2" />
+          {t("adminCourseView.settings.button.removeTrailer")}
+        </Button>
+      )}
+    </div>
+  );
+};

--- a/apps/web/app/modules/Admin/EditCourse/CourseSettings/components/CourseTrailerUploadField.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/CourseSettings/components/CourseTrailerUploadField.tsx
@@ -39,7 +39,7 @@ export const CourseTrailerUploadField = ({
           isUploading && "opacity-70",
         )}
       >
-        {trailerUrl ? (
+        {trailerUrl && (
           <div className="absolute inset-0 bg-neutral-950">
             {trailerEmbedUrl ? (
               <iframe
@@ -58,7 +58,7 @@ export const CourseTrailerUploadField = ({
               </video>
             )}
           </div>
-        ) : null}
+        )}
         <div
           className={cn(
             "absolute inset-0 flex flex-col items-center justify-center gap-2 px-4 text-center",

--- a/apps/web/app/modules/Courses/components/modern/HeroBanner.tsx
+++ b/apps/web/app/modules/Courses/components/modern/HeroBanner.tsx
@@ -21,6 +21,7 @@ import { useLanguageStore } from "~/modules/Dashboard/Settings/Language/Language
 import { findFirstInProgressLessonId, findFirstNotStartedLessonId } from "../../Lesson/utils";
 import { navigateToNextLesson } from "../../utils/navigateToNextLesson";
 
+import { HeroTrailerVideo } from "./HeroTrailerVideo";
 import { formatDuration } from "./utils";
 
 type HeroBannerProps = {
@@ -116,14 +117,7 @@ const HeroBanner = ({
 
       {trailerUrl && (
         <div className="absolute inset-0 z-10 hidden md:block">
-          <video
-            src={trailerUrl}
-            autoPlay
-            muted
-            loop
-            playsInline
-            className="h-full w-full object-cover"
-          />
+          <HeroTrailerVideo src={trailerUrl} />
           <div className="absolute inset-0 bg-gradient-to-r from-primary-50/95 via-primary-50/70 to-transparent" />
           <div className="absolute inset-0 bg-gradient-to-t from-primary-50/80 via-primary-50/30 to-transparent" />
           <div className="absolute bottom-0 left-0 right-0 h-[50%] bg-gradient-to-t from-primary-50 via-primary-50/60 to-transparent" />

--- a/apps/web/app/modules/Courses/components/modern/HeroTrailerVideo.tsx
+++ b/apps/web/app/modules/Courses/components/modern/HeroTrailerVideo.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useRef, useState } from "react";
+import videojs from "video.js";
+
+import "video.js/dist/video-js.css";
+import "~/components/VideoPlayer/videoPlayer.css";
+import { cn } from "~/lib/utils";
+
+const MIN_HLS_RENDITION_HEIGHT = 720;
+const MAX_HLS_RENDITION_HEIGHT = 1080;
+
+type VideoJsPlayer = ReturnType<typeof videojs>;
+
+type VhsRepresentation = {
+  height?: number;
+  enabled: (enabled?: boolean) => boolean;
+};
+
+type VideoJsTechWithVhs = {
+  vhs?: {
+    representations?: () => VhsRepresentation[];
+  };
+};
+
+type HeroTrailerVideoProps = {
+  src: string;
+};
+
+const getVideoType = (src: string) =>
+  /\.m3u8($|\?)/i.test(src) ? "application/vnd.apple.mpegurl" : "video/mp4";
+
+const getFallbackRepresentation = (representations: VhsRepresentation[]) =>
+  representations
+    .filter((representation) => {
+      const height = representation.height;
+      return typeof height === "number" && height < MIN_HLS_RENDITION_HEIGHT;
+    })
+    .sort((a, b) => (b.height ?? 0) - (a.height ?? 0))[0];
+
+const enforceTargetHlsRepresentation = (player: VideoJsPlayer) => {
+  const tech = player.tech() as VideoJsTechWithVhs | undefined;
+  const representations = tech?.vhs?.representations?.() ?? [];
+  const fallbackRepresentation = getFallbackRepresentation(representations);
+
+  const hasTargetRangeRepresentation = representations.some((representation) => {
+    const height = representation.height;
+    return (
+      typeof height === "number" &&
+      height >= MIN_HLS_RENDITION_HEIGHT &&
+      height <= MAX_HLS_RENDITION_HEIGHT
+    );
+  });
+
+  if (!hasTargetRangeRepresentation && !fallbackRepresentation) return;
+
+  representations.forEach((representation) => {
+    const height = representation.height;
+    const isInTargetRange =
+      typeof height === "number" &&
+      height >= MIN_HLS_RENDITION_HEIGHT &&
+      height <= MAX_HLS_RENDITION_HEIGHT;
+
+    representation.enabled(
+      hasTargetRangeRepresentation ? isInTargetRange : representation === fallbackRepresentation,
+    );
+  });
+};
+
+export function HeroTrailerVideo({ src }: HeroTrailerVideoProps) {
+  const playerRef = useRef<VideoJsPlayer | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const [firstFrameLoaded, setFirstFrameLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!containerRef.current || playerRef.current) return;
+
+    setFirstFrameLoaded(false);
+
+    const videoElement = document.createElement("video-js");
+    videoElement.classList.add("mentingo-video-js", "mentingo-video-js--cover");
+    videoElement.setAttribute("playsinline", "true");
+    containerRef.current.appendChild(videoElement);
+
+    const player = (playerRef.current = videojs(videoElement, {
+      autoplay: "muted",
+      controls: false,
+      fill: true,
+      loop: true,
+      muted: true,
+      responsive: true,
+      techOrder: ["html5"],
+      html5: {
+        vhs: { overrideNative: true },
+        nativeAudioTracks: false,
+        nativeVideoTracks: false,
+      },
+    }));
+
+    const applyPreferredRepresentation = () => enforceTargetHlsRepresentation(player);
+    const markFirstFrameLoaded = () => setFirstFrameLoaded(true);
+
+    player.ready(() => {
+      player.muted(true);
+      player.loop(true);
+      player.src([{ src, type: getVideoType(src) }]);
+      player.load();
+      void player.play()?.catch(() => undefined);
+    });
+
+    player.on("loadedmetadata", applyPreferredRepresentation);
+    player.on("loadedplaylist", applyPreferredRepresentation);
+    player.on("loadeddata", markFirstFrameLoaded);
+    player.on("playing", markFirstFrameLoaded);
+
+    return () => {
+      player.off("loadedmetadata", applyPreferredRepresentation);
+      player.off("loadedplaylist", applyPreferredRepresentation);
+      player.off("loadeddata", markFirstFrameLoaded);
+      player.off("playing", markFirstFrameLoaded);
+
+      if (!player.isDisposed()) player.dispose();
+
+      playerRef.current = null;
+    };
+  }, [src]);
+
+  return (
+    <div
+      ref={containerRef}
+      data-vjs-player
+      className={cn(
+        "size-full transition-opacity duration-300",
+        firstFrameLoaded ? "opacity-100" : "opacity-0",
+      )}
+    />
+  );
+}


### PR DESCRIPTION
## Issue(s)

- #1431
- #1535

## Overview

Fixes course trailer playback across student course cards and improves trailer quality in the modern course hero.

The student courses endpoint now includes signed trailer URLs for enrolled courses, so course cards loaded through `/api/course/get-student-courses` receive the same trailer data as other course sections. The video upload flow also keeps the per-upload size limit in the upload state, allowing course trailers to use a dedicated 200 MB limit while other video uploads keep the existing 5 GB limit.

On the admin side, the course trailer field was extracted into a dedicated upload component with preview, replace, delete, upload progress, accepted video MIME types, and localized copy for the 200 MB trailer limit.

The modern course hero now plays Bunny HLS trailers through Video.js and limits adaptive renditions to the 720p-1080p range. The thumbnail remains visible until the first video frame is ready, avoiding the initial black screen during trailer startup.

## Business Value

Students can now preview trailer videos from the Continue Learning section, making it easier to recognize and resume the right course. The hero trailer also appears sharper on large displays while keeping HLS streaming behavior. Content creators get a clearer trailer upload experience with explicit file size guidance and consistent validation feedback.

## Screenshots / Video

https://github.com/user-attachments/assets/c8624020-adc3-47cc-ba77-5b133a9af215

