### PR TITLE
chore: adjust enrolled students filtering and course learning requirements

### DIFF
--- a/apps/api/src/common/utils/lessonLearningAccess.ts
+++ b/apps/api/src/common/utils/lessonLearningAccess.ts
@@ -1,2 +1,37 @@
+import { PERMISSIONS, type PermissionKey } from "@repo/shared";
+
 export const LEARNING_MODE_REQUIRED_ERROR_KEY =
   "studentCourseView.studentMode.learningModeRequired";
+
+type LessonProgressAccess = {
+  hasEnrollment: boolean;
+  isCourseAuthor: boolean;
+  isLearningModeActive: boolean;
+};
+
+export const canTrackLessonProgress = (
+  permissions: PermissionKey[],
+  access: LessonProgressAccess,
+) => {
+  const canUpdateLearningProgress = permissions.includes(PERMISSIONS.LEARNING_PROGRESS_UPDATE);
+  const canUseLearningMode = permissions.includes(PERMISSIONS.LEARNING_MODE_USE);
+
+  if (canUseLearningMode && !canUpdateLearningProgress) return access.isLearningModeActive;
+
+  if (canUseLearningMode && access.isCourseAuthor) return access.isLearningModeActive;
+
+  if (canUpdateLearningProgress) return access.hasEnrollment || access.isLearningModeActive;
+
+  return false;
+};
+
+export const shouldRequireLearningModeForProgress = (
+  permissions: PermissionKey[],
+  access: Pick<LessonProgressAccess, "isCourseAuthor">,
+) => {
+  const canUseLearningMode = permissions.includes(PERMISSIONS.LEARNING_MODE_USE);
+  if (!canUseLearningMode) return false;
+
+  const canUpdateLearningProgress = permissions.includes(PERMISSIONS.LEARNING_PROGRESS_UPDATE);
+  return access.isCourseAuthor || !canUpdateLearningProgress;
+};

--- a/apps/api/src/courses/__tests__/course.controller.e2e-spec.ts
+++ b/apps/api/src/courses/__tests__/course.controller.e2e-spec.ts
@@ -1103,6 +1103,92 @@ describe("CourseController (e2e)", () => {
           });
         });
 
+        it("should include course managers and exclude the course author", async () => {
+          const admin = await userFactory
+            .withCredentials({ password })
+            .withAdminSettings(db)
+            .withAdminRole()
+            .create({
+              email: "course-author@example.com",
+              firstName: "Course",
+              lastName: "Author",
+            });
+          const cookies = await cookieFor(admin, app);
+
+          const adminCandidate = await userFactory.withAdminRole().create({
+            email: "admin-candidate@example.com",
+            firstName: "Admin",
+            lastName: "Candidate",
+          });
+          const contentCreatorCandidate = await userFactory.create({
+            email: "content-creator-candidate@example.com",
+            firstName: "Content",
+            lastName: "Creator",
+            role: SYSTEM_ROLE_SLUGS.CONTENT_CREATOR,
+          });
+          const studentCandidate = await userFactory.create({
+            email: "student-candidate@example.com",
+            firstName: "Student",
+            lastName: "Candidate",
+            role: SYSTEM_ROLE_SLUGS.STUDENT,
+          });
+
+          const course = await courseFactory.create({
+            authorId: admin.id,
+            status: "published",
+          });
+
+          const [adminEnrollment] = await db
+            .insert(studentCourses)
+            .values({
+              studentId: adminCandidate.id,
+              courseId: course.id,
+              finishedChapterCount: 0,
+            })
+            .returning();
+
+          const response = await request(app.getHttpServer())
+            .get(`/api/course/${course.id}/students?sort=email`)
+            .set("Cookie", cookies);
+
+          expect(response.status).toBe(200);
+          expect(response.body.data).toEqual([
+            {
+              firstName: adminCandidate.firstName,
+              lastName: adminCandidate.lastName,
+              email: adminCandidate.email,
+              id: adminCandidate.id,
+              enrolledAt: adminEnrollment.enrolledAt,
+              groups: [],
+              isEnrolledByGroup: false,
+            },
+            {
+              firstName: contentCreatorCandidate.firstName,
+              lastName: contentCreatorCandidate.lastName,
+              email: contentCreatorCandidate.email,
+              id: contentCreatorCandidate.id,
+              enrolledAt: null,
+              groups: [],
+              isEnrolledByGroup: false,
+            },
+            {
+              firstName: studentCandidate.firstName,
+              lastName: studentCandidate.lastName,
+              email: studentCandidate.email,
+              id: studentCandidate.id,
+              enrolledAt: null,
+              groups: [],
+              isEnrolledByGroup: false,
+            },
+          ]);
+          expect(response.body.data.map(({ id }: { id: string }) => id)).not.toContain(admin.id);
+          expect(response.body.pagination).toEqual({
+            totalItems: 3,
+            page: 1,
+            perPage: DEFAULT_PAGE_SIZE,
+          });
+        });
+
         it("should return list filtered by firstName", async () => {
           const admin = await userFactory
             .withCredentials({ password })

--- a/apps/api/src/courses/course.service.ts
+++ b/apps/api/src/courses/course.service.ts
@@ -457,17 +457,10 @@ export class CourseService {
 
     const { sortOrder, sortedField } = getSortOptions(sort);
 
-    const hasCourseUpdatePermissions = userHasAnyPermissionsCondition(
-      this.db,
-      users.id,
-      users.tenantId,
-      [PERMISSIONS.COURSE_UPDATE, PERMISSIONS.COURSE_UPDATE_OWN],
-    );
-
     const conditions = [
       eq(users.archived, false),
       isNull(users.deletedAt),
-      not(hasCourseUpdatePermissions),
+      ne(users.id, courses.authorId),
     ];
 
     if (keyword) {
@@ -509,6 +502,7 @@ export class CourseService {
         isEnrolledByGroup: sql<boolean>`${studentCourses.enrolledByGroupId} IS NOT NULL`,
       })
       .from(users)
+      .innerJoin(courses, eq(courses.id, courseId))
       .leftJoin(
         studentCourses,
         and(eq(studentCourses.studentId, users.id), eq(studentCourses.courseId, courseId)),
@@ -531,6 +525,7 @@ export class CourseService {
     const [{ totalItems }] = await this.db
       .select({ totalItems: countDistinct(users.id) })
       .from(users)
+      .innerJoin(courses, eq(courses.id, courseId))
       .leftJoin(
         studentCourses,
         and(eq(studentCourses.studentId, users.id), eq(studentCourses.courseId, courseId)),

--- a/apps/api/src/lesson/__tests__/lesson.controller.e2e-spec.ts
+++ b/apps/api/src/lesson/__tests__/lesson.controller.e2e-spec.ts
@@ -3,6 +3,7 @@ import { and, eq, inArray } from "drizzle-orm";
 import request from "supertest";
 
 import { buildJsonbField } from "src/common/helpers/sqlHelpers";
+import { LEARNING_MODE_REQUIRED_ERROR_KEY } from "src/common/utils/lessonLearningAccess";
 import { FileService } from "src/file/file.service";
 import { LESSON_TYPES } from "src/lesson/lesson.type";
 import { QUESTION_TYPE } from "src/questions/schema/question.types";
@@ -12,6 +13,7 @@ import {
   quizAttempts,
   questions,
   questionAnswerOptions,
+  courseStudentMode,
   studentCourses,
   studentLessonProgress,
   studentQuestionAnswers,
@@ -78,6 +80,7 @@ describe("LessonController (e2e) - quiz feedback redaction", () => {
   afterEach(async () => {
     await truncateTables(baseDb, [
       "quiz_attempts",
+      "course_student_mode",
       "courses",
       "chapters",
       "lessons",
@@ -168,6 +171,27 @@ describe("LessonController (e2e) - quiz feedback redaction", () => {
     return { lesson, question: question1, correctOption: options[1] };
   };
 
+  const createContentLesson = async (chapterId: UUIDType) => {
+    const [lesson] = await db
+      .insert(lessons)
+      .values({
+        id: crypto.randomUUID(),
+        chapterId,
+        type: LESSON_TYPES.CONTENT,
+        title: buildJsonbField("en", "Test Content Lesson"),
+        description: buildJsonbField("en", "Test content"),
+        displayOrder: 1,
+        fileS3Key: null,
+        fileType: null,
+        isExternal: false,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      })
+      .returning();
+
+    return lesson;
+  };
+
   const buildQuizAnswers = async (lessonId: UUIDType) => {
     const quizQuestions = await db
       .select({ id: questions.id })
@@ -213,6 +237,32 @@ describe("LessonController (e2e) - quiz feedback redaction", () => {
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     });
+  };
+
+  const enableStudentMode = async (studentId: UUIDType, courseId: UUIDType) => {
+    await db
+      .insert(studentCourses)
+      .values({
+        id: crypto.randomUUID(),
+        studentId,
+        courseId,
+        status: COURSE_ENROLLMENT.ENROLLED,
+        enrolledAt: new Date().toISOString(),
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      })
+      .onConflictDoNothing();
+
+    await db
+      .insert(courseStudentMode)
+      .values({
+        id: crypto.randomUUID(),
+        userId: studentId,
+        courseId,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      })
+      .onConflictDoNothing();
   };
 
   const resetQuizAttemptState = async (studentId: UUIDType, lessonId: UUIDType) => {
@@ -420,6 +470,176 @@ describe("LessonController (e2e) - quiz feedback redaction", () => {
     });
   });
 
+  describe("POST /api/studentLessonProgress", () => {
+    it("allows an enrolled content creator to complete another author's lesson without learning mode", async () => {
+      const category = await categoryFactory.create();
+      const author = await userFactory.create({ role: SYSTEM_ROLE_SLUGS.CONTENT_CREATOR });
+      const contentCreator = await userFactory
+        .withCredentials({ password })
+        .withContentCreatorSettings(db)
+        .create();
+      const cookies = await cookieFor(contentCreator, app);
+
+      const course = await courseFactory.create({
+        authorId: author.id,
+        categoryId: category.id,
+        status: "published",
+        chapterCount: 1,
+      });
+      const chapter = await chapterFactory.create({
+        courseId: course.id,
+        authorId: author.id,
+        lessonCount: 1,
+      });
+      const lesson = await createContentLesson(chapter.id);
+      await enrollStudentToCourse(contentCreator.id, course.id);
+
+      await request(app.getHttpServer())
+        .post("/api/studentLessonProgress")
+        .query({ id: lesson.id, language: "en" })
+        .set("Cookie", cookies)
+        .expect(201);
+
+      const [progress] = await db
+        .select()
+        .from(studentLessonProgress)
+        .where(
+          and(
+            eq(studentLessonProgress.studentId, contentCreator.id),
+            eq(studentLessonProgress.lessonId, lesson.id),
+          ),
+        );
+
+      expect(progress?.completedAt).toBeTruthy();
+    });
+
+    it("does not complete a course author's lesson unless learning mode is active", async () => {
+      const category = await categoryFactory.create();
+      const author = await userFactory
+        .withCredentials({ password })
+        .withContentCreatorSettings(db)
+        .create();
+      const cookies = await cookieFor(author, app);
+
+      const course = await courseFactory.create({
+        authorId: author.id,
+        categoryId: category.id,
+        status: "published",
+        chapterCount: 1,
+      });
+      const chapter = await chapterFactory.create({
+        courseId: course.id,
+        authorId: author.id,
+        lessonCount: 1,
+      });
+      const lesson = await createContentLesson(chapter.id);
+      await enrollStudentToCourse(author.id, course.id);
+
+      await request(app.getHttpServer())
+        .post("/api/studentLessonProgress")
+        .query({ id: lesson.id, language: "en" })
+        .set("Cookie", cookies)
+        .expect(201);
+
+      const progress = await db
+        .select()
+        .from(studentLessonProgress)
+        .where(
+          and(
+            eq(studentLessonProgress.studentId, author.id),
+            eq(studentLessonProgress.lessonId, lesson.id),
+          ),
+        );
+
+      expect(progress).toHaveLength(0);
+    });
+
+    it("does not complete a lesson for an admin unless learning mode is active", async () => {
+      const category = await categoryFactory.create();
+      const author = await userFactory.create({ role: SYSTEM_ROLE_SLUGS.CONTENT_CREATOR });
+      const admin = await userFactory
+        .withCredentials({ password })
+        .withAdminSettings(db)
+        .withAdminRole()
+        .create();
+      const cookies = await cookieFor(admin, app);
+
+      const course = await courseFactory.create({
+        authorId: author.id,
+        categoryId: category.id,
+        status: "published",
+        chapterCount: 1,
+      });
+      const chapter = await chapterFactory.create({
+        courseId: course.id,
+        authorId: author.id,
+        lessonCount: 1,
+      });
+      const lesson = await createContentLesson(chapter.id);
+
+      await request(app.getHttpServer())
+        .post("/api/studentLessonProgress")
+        .query({ id: lesson.id, language: "en" })
+        .set("Cookie", cookies)
+        .expect(201);
+
+      const progress = await db
+        .select()
+        .from(studentLessonProgress)
+        .where(
+          and(
+            eq(studentLessonProgress.studentId, admin.id),
+            eq(studentLessonProgress.lessonId, lesson.id),
+          ),
+        );
+
+      expect(progress).toHaveLength(0);
+    });
+
+    it("allows an admin to complete a lesson in learning mode on any course", async () => {
+      const category = await categoryFactory.create();
+      const author = await userFactory.create({ role: SYSTEM_ROLE_SLUGS.CONTENT_CREATOR });
+      const admin = await userFactory
+        .withCredentials({ password })
+        .withAdminSettings(db)
+        .withAdminRole()
+        .create();
+      const cookies = await cookieFor(admin, app);
+
+      const course = await courseFactory.create({
+        authorId: author.id,
+        categoryId: category.id,
+        status: "published",
+        chapterCount: 1,
+      });
+      const chapter = await chapterFactory.create({
+        courseId: course.id,
+        authorId: author.id,
+        lessonCount: 1,
+      });
+      const lesson = await createContentLesson(chapter.id);
+      await enableStudentMode(admin.id, course.id);
+
+      await request(app.getHttpServer())
+        .post("/api/studentLessonProgress")
+        .query({ id: lesson.id, language: "en" })
+        .set("Cookie", cookies)
+        .expect(201);
+
+      const [progress] = await db
+        .select()
+        .from(studentLessonProgress)
+        .where(
+          and(
+            eq(studentLessonProgress.studentId, admin.id),
+            eq(studentLessonProgress.lessonId, lesson.id),
+          ),
+        );
+
+      expect(progress?.completedAt).toBeTruthy();
+    });
+  });
+
   describe("POST /api/lesson/evaluation-quiz - quiz feedback redaction", () => {
     it("should redact quiz results for student when quizFeedbackEnabled is false", async () => {
       const category = await categoryFactory.create();
@@ -487,6 +707,7 @@ describe("LessonController (e2e) - quiz feedback redaction", () => {
       const { lesson } = await createQuizLesson(course.id, chapter.id, contentCreator.id);
 
       const questionsAnswers = await buildQuizAnswers(lesson.id);
+      await resetQuizAttemptState(student.id, lesson.id);
 
       const response = await request(app.getHttpServer())
         .post("/api/lesson/evaluation-quiz")
@@ -501,6 +722,235 @@ describe("LessonController (e2e) - quiz feedback redaction", () => {
       expect(response.body.data.data.correctAnswerCount).toBeGreaterThan(0);
       expect(response.body.data.data.score).toBeGreaterThan(0);
       expect(response.body.data.data.questionCount).toBeGreaterThan(0);
+    });
+
+    it("allows an enrolled content creator to submit another author's quiz without learning mode", async () => {
+      const category = await categoryFactory.create();
+      const author = await userFactory.create({ role: SYSTEM_ROLE_SLUGS.CONTENT_CREATOR });
+      const contentCreator = await userFactory
+        .withCredentials({ password })
+        .withContentCreatorSettings(db)
+        .create();
+      const cookies = await cookieFor(contentCreator, app);
+
+      const course = await courseFactory.create({
+        authorId: author.id,
+        categoryId: category.id,
+        status: "published",
+        settings: {
+          lessonSequenceEnabled: false,
+          quizFeedbackEnabled: true,
+        },
+      });
+      const chapter = await chapterFactory.create({ courseId: course.id, authorId: author.id });
+      await enrollStudentToCourse(contentCreator.id, course.id);
+
+      const { lesson } = await createQuizLesson(course.id, chapter.id, author.id);
+      const questionsAnswers = await buildQuizAnswers(lesson.id);
+      await resetQuizAttemptState(contentCreator.id, lesson.id);
+
+      const response = await request(app.getHttpServer())
+        .post("/api/lesson/evaluation-quiz")
+        .set("Cookie", cookies)
+        .send({
+          lessonId: lesson.id,
+          language: "en",
+          questionsAnswers,
+        })
+        .expect(201);
+
+      expect(response.body.data.data.score).toBe(100);
+
+      const [progress] = await db
+        .select()
+        .from(studentLessonProgress)
+        .where(
+          and(
+            eq(studentLessonProgress.studentId, contentCreator.id),
+            eq(studentLessonProgress.lessonId, lesson.id),
+          ),
+        );
+
+      expect(progress?.completedAt).toBeTruthy();
+      expect(progress?.isQuizPassed).toBe(true);
+    });
+
+    it("requires learning mode when the course author submits their own quiz", async () => {
+      const category = await categoryFactory.create();
+      const author = await userFactory
+        .withCredentials({ password })
+        .withContentCreatorSettings(db)
+        .create();
+      const cookies = await cookieFor(author, app);
+
+      const course = await courseFactory.create({
+        authorId: author.id,
+        categoryId: category.id,
+        status: "published",
+        settings: {
+          lessonSequenceEnabled: false,
+          quizFeedbackEnabled: true,
+        },
+      });
+      const chapter = await chapterFactory.create({ courseId: course.id, authorId: author.id });
+      await enrollStudentToCourse(author.id, course.id);
+
+      const { lesson } = await createQuizLesson(course.id, chapter.id, author.id);
+      const questionsAnswers = await buildQuizAnswers(lesson.id);
+      await resetQuizAttemptState(author.id, lesson.id);
+
+      const response = await request(app.getHttpServer())
+        .post("/api/lesson/evaluation-quiz")
+        .set("Cookie", cookies)
+        .send({
+          lessonId: lesson.id,
+          language: "en",
+          questionsAnswers,
+        })
+        .expect(403);
+
+      expect(response.body.message).toBe(LEARNING_MODE_REQUIRED_ERROR_KEY);
+    });
+
+    it("allows the course author to submit their own quiz in learning mode", async () => {
+      const category = await categoryFactory.create();
+      const author = await userFactory
+        .withCredentials({ password })
+        .withContentCreatorSettings(db)
+        .create();
+      const cookies = await cookieFor(author, app);
+
+      const course = await courseFactory.create({
+        authorId: author.id,
+        categoryId: category.id,
+        status: "published",
+        settings: {
+          lessonSequenceEnabled: false,
+          quizFeedbackEnabled: true,
+        },
+      });
+      const chapter = await chapterFactory.create({ courseId: course.id, authorId: author.id });
+      await enrollStudentToCourse(author.id, course.id);
+      await enableStudentMode(author.id, course.id);
+
+      const { lesson } = await createQuizLesson(course.id, chapter.id, author.id);
+      const questionsAnswers = await buildQuizAnswers(lesson.id);
+      await resetQuizAttemptState(author.id, lesson.id);
+
+      const response = await request(app.getHttpServer())
+        .post("/api/lesson/evaluation-quiz")
+        .set("Cookie", cookies)
+        .send({
+          lessonId: lesson.id,
+          language: "en",
+          questionsAnswers,
+        })
+        .expect(201);
+
+      expect(response.body.data.data.score).toBe(100);
+
+      const [progress] = await db
+        .select()
+        .from(studentLessonProgress)
+        .where(
+          and(
+            eq(studentLessonProgress.studentId, author.id),
+            eq(studentLessonProgress.lessonId, lesson.id),
+          ),
+        );
+
+      expect(progress?.completedAt).toBeTruthy();
+      expect(progress?.isQuizPassed).toBe(true);
+    });
+
+    it("requires learning mode when an admin submits a quiz", async () => {
+      const category = await categoryFactory.create();
+      const author = await userFactory.create({ role: SYSTEM_ROLE_SLUGS.CONTENT_CREATOR });
+      const admin = await userFactory
+        .withCredentials({ password })
+        .withAdminSettings(db)
+        .withAdminRole()
+        .create();
+      const cookies = await cookieFor(admin, app);
+
+      const course = await courseFactory.create({
+        authorId: author.id,
+        categoryId: category.id,
+        status: "published",
+        settings: {
+          lessonSequenceEnabled: false,
+          quizFeedbackEnabled: true,
+        },
+      });
+      const chapter = await chapterFactory.create({ courseId: course.id, authorId: author.id });
+
+      const { lesson } = await createQuizLesson(course.id, chapter.id, author.id);
+      const questionsAnswers = await buildQuizAnswers(lesson.id);
+      await resetQuizAttemptState(admin.id, lesson.id);
+
+      const response = await request(app.getHttpServer())
+        .post("/api/lesson/evaluation-quiz")
+        .set("Cookie", cookies)
+        .send({
+          lessonId: lesson.id,
+          language: "en",
+          questionsAnswers,
+        })
+        .expect(403);
+
+      expect(response.body.message).toBe(LEARNING_MODE_REQUIRED_ERROR_KEY);
+    });
+
+    it("allows an admin to submit a quiz in learning mode on any course", async () => {
+      const category = await categoryFactory.create();
+      const author = await userFactory.create({ role: SYSTEM_ROLE_SLUGS.CONTENT_CREATOR });
+      const admin = await userFactory
+        .withCredentials({ password })
+        .withAdminSettings(db)
+        .withAdminRole()
+        .create();
+      const cookies = await cookieFor(admin, app);
+
+      const course = await courseFactory.create({
+        authorId: author.id,
+        categoryId: category.id,
+        status: "published",
+        settings: {
+          lessonSequenceEnabled: false,
+          quizFeedbackEnabled: true,
+        },
+      });
+      const chapter = await chapterFactory.create({ courseId: course.id, authorId: author.id });
+      await enableStudentMode(admin.id, course.id);
+
+      const { lesson } = await createQuizLesson(course.id, chapter.id, author.id);
+      const questionsAnswers = await buildQuizAnswers(lesson.id);
+      await resetQuizAttemptState(admin.id, lesson.id);
+
+      const response = await request(app.getHttpServer())
+        .post("/api/lesson/evaluation-quiz")
+        .set("Cookie", cookies)
+        .send({
+          lessonId: lesson.id,
+          language: "en",
+          questionsAnswers,
+        })
+        .expect(201);
+
+      expect(response.body.data.data.score).toBe(100);
+
+      const [progress] = await db
+        .select()
+        .from(studentLessonProgress)
+        .where(
+          and(
+            eq(studentLessonProgress.studentId, admin.id),
+            eq(studentLessonProgress.lessonId, lesson.id),
+          ),
+        );
+
+      expect(progress?.completedAt).toBeTruthy();
+      expect(progress?.isQuizPassed).toBe(true);
     });
 
     it("should update quiz feedback redaction after changing course settings", async () => {

--- a/apps/api/src/lesson/__tests__/lesson.controller.e2e-spec.ts
+++ b/apps/api/src/lesson/__tests__/lesson.controller.e2e-spec.ts
@@ -10,6 +10,7 @@ import { QUESTION_TYPE } from "src/questions/schema/question.types";
 import { DB, DB_ADMIN } from "src/storage/db/db.providers";
 import {
   lessons,
+  chapters,
   quizAttempts,
   questions,
   questionAnswerOptions,
@@ -101,6 +102,11 @@ describe("LessonController (e2e) - quiz feedback redaction", () => {
   });
 
   const createQuizLesson = async (courseId: UUIDType, chapterId: UUIDType, authorId: UUIDType) => {
+    await db
+      .update(chapters)
+      .set({ lessonCount: 1, updatedAt: new Date().toISOString() })
+      .where(eq(chapters.id, chapterId));
+
     const [lesson] = await db
       .insert(lessons)
       .values({

--- a/apps/api/src/lesson/services/lesson.service.ts
+++ b/apps/api/src/lesson/services/lesson.service.ts
@@ -20,7 +20,11 @@ import { THREAD_STATUS } from "src/ai/utils/ai.type";
 import { DatabasePg } from "src/common";
 import { hasAnyPermission } from "src/common/permissions/permission.utils";
 import { injectResourcesIntoContent } from "src/common/utils/injectResourcesIntoContent";
-import { LEARNING_MODE_REQUIRED_ERROR_KEY } from "src/common/utils/lessonLearningAccess";
+import {
+  canTrackLessonProgress,
+  LEARNING_MODE_REQUIRED_ERROR_KEY,
+  shouldRequireLearningModeForProgress,
+} from "src/common/utils/lessonLearningAccess";
 import { QuizCompletedEvent } from "src/events";
 import { RESOURCE_RELATIONSHIP_TYPES } from "src/file/file.constants";
 import { FileService } from "src/file/file.service";
@@ -34,6 +38,7 @@ import { QuestionRepository } from "src/questions/question.repository";
 import { QuestionService } from "src/questions/question.service";
 import {
   chapters,
+  courses,
   courseStudentMode,
   lessons,
   studentCourses,
@@ -494,15 +499,15 @@ export class LessonService {
   ) {
     const { permissions } = await this.permissionsService.getUserAccess(currentUser.userId);
 
-    if (this.isLearnerOnly(permissions)) return;
-
     const [access] = await this.db
       .select({
         isAssigned: studentCourses.id,
+        isCourseAuthor: eq(courses.authorId, currentUser.userId),
         isStudentMode: courseStudentMode.id,
       })
       .from(lessons)
       .innerJoin(chapters, eq(lessons.chapterId, chapters.id))
+      .innerJoin(courses, eq(courses.id, chapters.courseId))
       .leftJoin(
         studentCourses,
         and(
@@ -521,10 +526,17 @@ export class LessonService {
 
     const hasLearnerAccess = this.canUseLearnerProgress(permissions, {
       hasEnrollment: !!access?.isAssigned,
+      isCourseAuthor: !!access?.isCourseAuthor,
       isLearningModeActive: !!access?.isStudentMode,
     });
 
     if (!hasLearnerAccess) {
+      const shouldRequireLearningMode = shouldRequireLearningModeForProgress(permissions, {
+        isCourseAuthor: !!access?.isCourseAuthor,
+      });
+
+      if (!shouldRequireLearningMode) return;
+
       throw new ForbiddenException(LEARNING_MODE_REQUIRED_ERROR_KEY);
     }
   }
@@ -620,12 +632,9 @@ export class LessonService {
 
   private canUseLearnerProgress(
     permissions: PermissionKey[],
-    access: { hasEnrollment: boolean; isLearningModeActive: boolean },
+    access: { hasEnrollment: boolean; isCourseAuthor: boolean; isLearningModeActive: boolean },
   ) {
-    const canUseLearningMode = permissions.includes(PERMISSIONS.LEARNING_MODE_USE);
-    if (canUseLearningMode) return access.isLearningModeActive;
-
-    return true;
+    return canTrackLessonProgress(permissions, access);
   }
 
   // async studentAnswerOnQuestion(

--- a/apps/api/src/studentLessonProgress/studentLessonProgress.service.ts
+++ b/apps/api/src/studentLessonProgress/studentLessonProgress.service.ts
@@ -5,12 +5,13 @@ import {
   NotFoundException,
   UnauthorizedException,
 } from "@nestjs/common";
-import { COURSE_ENROLLMENT, PERMISSIONS } from "@repo/shared";
+import { COURSE_ENROLLMENT } from "@repo/shared";
 import { and, eq, isNotNull, isNull, sql } from "drizzle-orm";
 
 import { CertificatesService } from "src/certificates/certificates.service";
 import { DatabasePg } from "src/common";
 import { setJsonbField } from "src/common/helpers/sqlHelpers";
+import { canTrackLessonProgress } from "src/common/utils/lessonLearningAccess";
 import { CourseCompletedEvent, LessonCompletedEvent } from "src/events";
 import { UserChapterFinishedEvent } from "src/events/user/user-chapter-finished.event";
 import { UserCourseFinishedEvent } from "src/events/user/user-course-finished.event";
@@ -89,6 +90,7 @@ export class StudentLessonProgressService {
 
     const canTrackProgress = this.canUseLearnerProgressByPermissions(userPermissions, {
       hasEnrollment: Boolean(accessCourseLessonWithDetails.isAssigned),
+      isCourseAuthor: accessCourseLessonWithDetails.isCourseAuthor,
       isLearningModeActive,
     });
 
@@ -275,6 +277,7 @@ export class StudentLessonProgressService {
 
     const canTrackProgress = this.canUseLearnerProgressByPermissions(userPermissions, {
       hasEnrollment: !!accessCourseLessonWithDetails.isAssigned,
+      isCourseAuthor: accessCourseLessonWithDetails.isCourseAuthor,
       isLearningModeActive,
     });
 
@@ -396,19 +399,14 @@ export class StudentLessonProgressService {
     userPermissions: PermissionKey[],
     dbInstance: DatabasePg = this.db,
   ) {
-    if (!userPermissions.includes(PERMISSIONS.LEARNING_MODE_USE)) return false;
-
     return this.isLessonStudentModeEnabled(lessonId, userId, dbInstance);
   }
 
   private canUseLearnerProgressByPermissions(
     userPermissions: PermissionKey[],
-    access: { hasEnrollment: boolean; isLearningModeActive: boolean },
+    access: { hasEnrollment: boolean; isCourseAuthor: boolean; isLearningModeActive: boolean },
   ) {
-    const canUseLearningMode = userPermissions.includes(PERMISSIONS.LEARNING_MODE_USE);
-    if (canUseLearningMode) return access.isLearningModeActive;
-
-    return true;
+    return canTrackLessonProgress(userPermissions, access);
   }
 
   private async isLessonStudentModeEnabled(
@@ -736,6 +734,7 @@ export class StudentLessonProgressService {
         lessonType: lessons.type,
         chapterId: sql<string>`${chapters.id}`,
         courseId: sql<string>`${chapters.courseId}`,
+        isCourseAuthor: sql<boolean>`${courses.authorId} = ${userId}`,
       })
       .from(lessons)
       .leftJoin(users, eq(users.id, userId))
@@ -747,6 +746,7 @@ export class StudentLessonProgressService {
         ),
       )
       .leftJoin(chapters, eq(lessons.chapterId, chapters.id))
+      .leftJoin(courses, eq(courses.id, chapters.courseId))
       .leftJoin(
         studentCourses,
         and(eq(studentCourses.courseId, chapters.courseId), eq(studentCourses.studentId, userId)),

--- a/apps/api/src/test-config/test-config.service.ts
+++ b/apps/api/src/test-config/test-config.service.ts
@@ -1,5 +1,5 @@
 import { ForbiddenException, Injectable, NotImplementedException } from "@nestjs/common";
-import { SUPPORTED_LANGUAGES } from "@repo/shared";
+import { PERMISSIONS, SUPPORTED_LANGUAGES } from "@repo/shared";
 
 import { StudentLessonProgressService } from "src/studentLessonProgress/studentLessonProgress.service";
 
@@ -45,7 +45,7 @@ export class TestConfigService {
       id: lessonId,
       language,
       studentId,
-      userPermissions: [],
+      userPermissions: [PERMISSIONS.LEARNING_PROGRESS_UPDATE],
     });
   }
 

--- a/apps/web/app/modules/Courses/context/CourseAccessProvider.tsx
+++ b/apps/web/app/modules/Courses/context/CourseAccessProvider.tsx
@@ -18,8 +18,7 @@ type CourseExperienceResolverParams = {
   course: GetCourseResponse["data"];
   forcePreviewMode: boolean;
   currentUserId?: string;
-  canManageCourses: boolean;
-  canManageOwnCourses: boolean;
+  canUseLearningMode: boolean;
   canUpdateLearningProgress: boolean;
   activeLearningModeCourseIds: string[];
 };
@@ -35,26 +34,25 @@ function resolveCourseExperienceState({
   course,
   forcePreviewMode,
   currentUserId,
-  canManageCourses,
-  canManageOwnCourses,
+  canUseLearningMode,
   canUpdateLearningProgress,
   activeLearningModeCourseIds,
 }: CourseExperienceResolverParams): CourseExperienceContextValue {
   const isCourseStudentModeActive =
-    !forcePreviewMode && canManageCourses && activeLearningModeCourseIds.includes(course.id);
+    !forcePreviewMode && canUseLearningMode && activeLearningModeCourseIds.includes(course.id);
 
   const isCourseAuthor = currentUserId === course.authorId;
 
-  const canContentCreatorLearn =
-    canManageOwnCourses && (isCourseStudentModeActive || (!isCourseAuthor && !!course.enrolled));
+  const canLearnByEnrollment =
+    canUpdateLearningProgress && !isCourseAuthor && Boolean(course.enrolled);
 
-  const canAdminLearn = canManageCourses && isCourseStudentModeActive;
+  const canLearnByLearningMode = canUseLearningMode && isCourseStudentModeActive;
 
   const isPreviewMode =
-    forcePreviewMode || (canManageCourses && !canAdminLearn && !canContentCreatorLearn);
+    forcePreviewMode || (canUseLearningMode && !canLearnByLearningMode && !canLearnByEnrollment);
 
   const isEffectiveStudentExperience =
-    !isPreviewMode && (canUpdateLearningProgress || canAdminLearn || canContentCreatorLearn);
+    !isPreviewMode && (canLearnByEnrollment || canLearnByLearningMode || canUpdateLearningProgress);
 
   return {
     course,
@@ -70,11 +68,8 @@ export function CourseAccessProvider({
   children,
 }: CourseAccessProviderProps) {
   const { data: currentUser } = useCurrentUser();
-  const { hasAccess: canManageOwnCourses } = usePermissions({
-    required: PERMISSIONS.COURSE_UPDATE_OWN,
-  });
-  const { hasAccess: canManageCourses } = usePermissions({
-    required: [PERMISSIONS.COURSE_UPDATE, PERMISSIONS.COURSE_UPDATE_OWN],
+  const { hasAccess: canUseLearningMode } = usePermissions({
+    required: PERMISSIONS.LEARNING_MODE_USE,
   });
   const { hasAccess: canUpdateLearningProgress } = usePermissions({
     required: PERMISSIONS.LEARNING_PROGRESS_UPDATE,
@@ -85,8 +80,7 @@ export function CourseAccessProvider({
       course,
       forcePreviewMode,
       currentUserId: currentUser?.id,
-      canManageCourses,
-      canManageOwnCourses,
+      canUseLearningMode,
       canUpdateLearningProgress,
       activeLearningModeCourseIds: currentUser?.studentModeCourseIds ?? [],
     });
@@ -95,8 +89,7 @@ export function CourseAccessProvider({
     currentUser?.id,
     currentUser?.studentModeCourseIds,
     forcePreviewMode,
-    canManageCourses,
-    canManageOwnCourses,
+    canUseLearningMode,
     canUpdateLearningProgress,
   ]);
 


### PR DESCRIPTION
## Issue(s)
[1429](https://github.com/Selleo/mentingo/issues/1429)

## Overview
Adjusts course student filtering and learning progress access rules so managers and creators can be handled correctly in learner-facing course flows.

- Updates the enrolled students list to exclude only the course author instead of filtering out all users with course management permissions.
- Centralizes lesson progress access checks around enrollment, learning mode, and course authorship.
- Allows enrolled content creators to complete lessons and quizzes in courses authored by someone else without requiring learning mode.
- Keeps course authors and admins in preview mode unless learning mode is active, preventing accidental progress tracking from management views.
- Aligns the web course access provider with the backend permission model by using learning mode and learning progress permissions.
- Adds e2e coverage for enrolled student filtering, content lesson completion, and quiz submission across student, content creator, course author, and admin scenarios.

## Business Value
This makes course management and learner behavior more predictable for users with mixed roles. Admins and content creators can appear in enrollment lists and participate as learners when appropriate, while course authors and admins are protected from accidentally creating learner progress unless they explicitly switch into learning mode.

## Screenshots / Video

https://github.com/user-attachments/assets/2047f643-554b-4c11-b9f4-c52fbe490567

