### PR TITLE
chore: improve the voice mentor audio player experience

### DIFF
--- a/apps/web/app/modules/Voice/audio-player.ts
+++ b/apps/web/app/modules/Voice/audio-player.ts
@@ -1,5 +1,9 @@
 export type StreamingAudioChunk = ArrayBuffer | Uint8Array;
 
+type StreamingAudioChunkOptions = {
+  sampleRate?: number | null;
+};
+
 type StreamingAudioPlayerOptions = {
   sampleRate?: number;
   channels?: number;
@@ -14,16 +18,16 @@ export class RealtimePCMPlayer {
   private readonly gain: number;
 
   private audioCtx: AudioContext | null = null;
+  private workletNode: AudioWorkletNode | null = null;
   private gainNode: GainNode | null = null;
-  private nextStartTime = 0;
-  private activeSources = new Set<AudioBufferSourceNode>();
   private onIdle: (() => void) | null = null;
+  private isPlayerIdle = true;
 
   constructor({
     sampleRate = 44100,
     channels = 1,
     gain = 1,
-    leadTimeSeconds = 0.02,
+    leadTimeSeconds = 0.15,
   }: StreamingAudioPlayerOptions = {}) {
     this.sampleRate = sampleRate;
     this.channels = channels;
@@ -34,68 +38,72 @@ export class RealtimePCMPlayer {
   async start() {
     if (!this.audioCtx) {
       this.audioCtx = new AudioContext({ sampleRate: this.sampleRate });
+      await this.audioCtx.audioWorklet.addModule("/pcm-worklet-processor.js");
+
+      this.workletNode = new AudioWorkletNode(this.audioCtx, "pcm-stream-player", {
+        numberOfInputs: 0,
+        numberOfOutputs: 1,
+        outputChannelCount: [this.channels],
+        processorOptions: {
+          channels: this.channels,
+          initialBufferSamples: Math.round(
+            this.audioCtx.sampleRate * this.leadTimeSeconds * this.channels,
+          ),
+          capacitySamples: Math.round(this.audioCtx.sampleRate * 10 * this.channels),
+        },
+      });
+      this.workletNode.port.onmessage = (event: MessageEvent) => {
+        if (event.data?.type !== "idle-state") {
+          return;
+        }
+
+        this.isPlayerIdle = Boolean(event.data.isIdle);
+        if (this.isPlayerIdle) {
+          this.onIdle?.();
+        }
+      };
+
       this.gainNode = this.audioCtx.createGain();
       this.gainNode.gain.value = this.gain;
+      this.workletNode.connect(this.gainNode);
       this.gainNode.connect(this.audioCtx.destination);
     }
 
     if (this.audioCtx.state === "suspended") {
       await this.audioCtx.resume();
     }
-
-    this.nextStartTime = Math.max(
-      this.nextStartTime,
-      this.audioCtx.currentTime + this.leadTimeSeconds,
-    );
   }
 
-  async enqueue(chunk: StreamingAudioChunk) {
-    if (!this.audioCtx || !this.gainNode) {
+  async enqueue(chunk: StreamingAudioChunk, options: StreamingAudioChunkOptions = {}) {
+    if (!this.audioCtx || !this.workletNode) {
       await this.start();
     }
 
-    if (!this.audioCtx || !this.gainNode) {
+    if (!this.audioCtx || !this.workletNode) {
       return;
     }
 
-    const samples = this.pcm16leToFloat32(chunk);
+    const inputSampleRate = options.sampleRate ?? this.sampleRate;
+    const samples = this.resampleIfNeeded(
+      this.pcm16leToFloat32(chunk),
+      inputSampleRate,
+      this.audioCtx.sampleRate,
+    );
     if (samples.length === 0) {
       return;
     }
 
-    const frameCount = Math.floor(samples.length / this.channels);
-    if (frameCount <= 0) {
+    this.isPlayerIdle = false;
+    if (samples.buffer instanceof ArrayBuffer) {
+      this.workletNode.port.postMessage({ type: "samples", samples }, [samples.buffer]);
       return;
     }
 
-    const audioBuffer = this.audioCtx.createBuffer(this.channels, frameCount, this.sampleRate);
-
-    for (let channelIndex = 0; channelIndex < this.channels; channelIndex += 1) {
-      const channelData = audioBuffer.getChannelData(channelIndex);
-      for (let frame = 0; frame < frameCount; frame += 1) {
-        channelData[frame] = samples[frame * this.channels + channelIndex] ?? 0;
-      }
-    }
-
-    const source = this.audioCtx.createBufferSource();
-    source.buffer = audioBuffer;
-    source.connect(this.gainNode);
-
-    const startAt = Math.max(this.nextStartTime, this.audioCtx.currentTime + 0.005);
-    source.start(startAt);
-    this.nextStartTime = startAt + audioBuffer.duration;
-
-    this.activeSources.add(source);
-    source.onended = () => {
-      this.activeSources.delete(source);
-      if (this.activeSources.size === 0) {
-        this.onIdle?.();
-      }
-    };
+    this.workletNode.port.postMessage({ type: "samples", samples });
   }
 
   isIdle() {
-    return this.activeSources.size === 0;
+    return this.isPlayerIdle;
   }
 
   setOnIdle(callback: (() => void) | null) {
@@ -103,31 +111,25 @@ export class RealtimePCMPlayer {
   }
 
   reset() {
-    if (!this.audioCtx) return;
-
-    for (const source of this.activeSources) {
-      try {
-        source.stop();
-      } catch {
-        // Source may already be stopped.
-      }
-    }
-
-    this.activeSources.clear();
-    this.nextStartTime = this.audioCtx.currentTime + this.leadTimeSeconds;
+    this.workletNode?.port.postMessage({ type: "reset" });
+    this.isPlayerIdle = true;
   }
 
   async destroy() {
     this.reset();
+
+    this.workletNode?.disconnect();
+    this.gainNode?.disconnect();
 
     if (this.audioCtx && this.audioCtx.state !== "closed") {
       await this.audioCtx.close();
     }
 
     this.audioCtx = null;
+    this.workletNode = null;
     this.gainNode = null;
-    this.nextStartTime = 0;
     this.onIdle = null;
+    this.isPlayerIdle = true;
   }
 
   private pcm16leToFloat32(chunk: StreamingAudioChunk): Float32Array {
@@ -147,5 +149,41 @@ export class RealtimePCMPlayer {
     }
 
     return out;
+  }
+
+  private resampleIfNeeded(
+    samples: Float32Array,
+    inputSampleRate: number,
+    outputSampleRate: number,
+  ): Float32Array {
+    if (!Number.isFinite(inputSampleRate) || inputSampleRate <= 0) {
+      return samples;
+    }
+
+    if (inputSampleRate === outputSampleRate) {
+      return samples;
+    }
+
+    const inputFrameCount = Math.floor(samples.length / this.channels);
+    const outputFrameCount = Math.floor((inputFrameCount * outputSampleRate) / inputSampleRate);
+    const output = new Float32Array(outputFrameCount * this.channels);
+    const ratio = inputSampleRate / outputSampleRate;
+
+    for (let outputFrame = 0; outputFrame < outputFrameCount; outputFrame += 1) {
+      const inputFramePosition = outputFrame * ratio;
+      const inputFrame = Math.floor(inputFramePosition);
+      const nextInputFrame = Math.min(inputFrame + 1, inputFrameCount - 1);
+      const fraction = inputFramePosition - inputFrame;
+
+      for (let channel = 0; channel < this.channels; channel += 1) {
+        const currentSample = samples[inputFrame * this.channels + channel] ?? 0;
+        const nextSample = samples[nextInputFrame * this.channels + channel] ?? currentSample;
+
+        output[outputFrame * this.channels + channel] =
+          currentSample * (1 - fraction) + nextSample * fraction;
+      }
+    }
+
+    return output;
   }
 }

--- a/apps/web/app/modules/Voice/audio-stream.ts
+++ b/apps/web/app/modules/Voice/audio-stream.ts
@@ -30,6 +30,7 @@ const VAD_CONFIG = {
   redemptionMs: 1400,
   preSpeechPadMs: 220,
 } as const;
+const POST_REDEMPTION_EMPTY_AUDIO_MS = VAD_CONFIG.redemptionMs;
 
 export class RealtimePCMStreamerWorklet {
   private readonly protocol: StreamProtocol<unknown, unknown>;
@@ -48,6 +49,7 @@ export class RealtimePCMStreamerWorklet {
   private pendingSamples: number[] = [];
   private preSpeechSamples: number[] = [];
   private isSpeaking = false;
+  private hasActiveSpeechSegment = false;
   private readonly onSocketConnect = () => {
     this.emitReadyChunks();
   };
@@ -56,6 +58,7 @@ export class RealtimePCMStreamerWorklet {
     this.pendingSamples = [];
     this.preSpeechSamples = [];
     this.isSpeaking = false;
+    this.hasActiveSpeechSegment = false;
   };
 
   constructor(
@@ -80,6 +83,7 @@ export class RealtimePCMStreamerWorklet {
     this.pendingSamples = [];
     this.preSpeechSamples = [];
     this.isSpeaking = false;
+    this.hasActiveSpeechSegment = false;
 
     if (!this.micVad) {
       this.micVad = await MicVAD.new({
@@ -132,6 +136,7 @@ export class RealtimePCMStreamerWorklet {
         onSpeechStart: () => undefined,
         onSpeechRealStart: () => {
           this.isSpeaking = true;
+          this.hasActiveSpeechSegment = true;
           if (this.preSpeechSamples.length > 0) {
             this.pendingSamples.push(...this.preSpeechSamples);
             this.preSpeechSamples = [];
@@ -142,14 +147,15 @@ export class RealtimePCMStreamerWorklet {
           this.isSpeaking = false;
           this.preSpeechSamples = [];
           if (this.socket?.connected) {
-            this.emitReadyChunks();
-            this.pendingSamples = [];
+            this.emitSpeechEndBoundary();
           }
+          this.hasActiveSpeechSegment = false;
         },
         onVADMisfire: () => {
           this.isSpeaking = false;
           this.pendingSamples = [];
           this.preSpeechSamples = [];
+          this.hasActiveSpeechSegment = false;
         },
       });
     }
@@ -217,6 +223,7 @@ export class RealtimePCMStreamerWorklet {
     this.pendingSamples = [];
     this.preSpeechSamples = [];
     this.isSpeaking = false;
+    this.hasActiveSpeechSegment = false;
 
     if (this.micVad) {
       await this.micVad.destroy().catch(() => undefined);
@@ -248,6 +255,21 @@ export class RealtimePCMStreamerWorklet {
       this.socket.emit(chunkEmit.event, ...chunkEmit.args);
       this.onChunkSent?.(meta);
     }
+  }
+
+  private emitSpeechEndBoundary() {
+    if (!this.hasActiveSpeechSegment) {
+      this.pendingSamples = [];
+      return;
+    }
+
+    const trailingSilenceSamples = (this.targetSr * POST_REDEMPTION_EMPTY_AUDIO_MS) / 1000;
+    const chunkBoundaryPadding =
+      (this.chunkSamples - (this.pendingSamples.length % this.chunkSamples)) % this.chunkSamples;
+
+    this.pendingSamples.push(...Array(chunkBoundaryPadding + trailingSilenceSamples).fill(0));
+    this.emitReadyChunks();
+    this.pendingSamples = [];
   }
 }
 

--- a/apps/web/app/modules/Voice/hooks/useVoiceMentor.ts
+++ b/apps/web/app/modules/Voice/hooks/useVoiceMentor.ts
@@ -181,7 +181,11 @@ export function useVoiceMentor({
       (level) => onLevelChangeRef.current(level),
       handleChunkSent,
     );
-    audioPlayerRef.current = new RealtimePCMPlayer({ sampleRate: 44100, channels: 1 });
+    audioPlayerRef.current = new RealtimePCMPlayer({
+      sampleRate: 44100,
+      channels: 1,
+      leadTimeSeconds: 0.15,
+    });
     audioPlayerRef.current.setOnIdle(() => {
       finalizeTurnIfReady();
     });

--- a/apps/web/app/modules/Voice/hooks/voiceMentorSocketHandlers.ts
+++ b/apps/web/app/modules/Voice/hooks/voiceMentorSocketHandlers.ts
@@ -117,7 +117,7 @@ export function createVoiceMentorSocketHandlers({
         return;
       }
 
-      await audioPlayerRef.current?.enqueue(bytes);
+      await audioPlayerRef.current?.enqueue(bytes, { sampleRate: data.sampleRate });
       onAudioChunkReceived?.();
       restartInactivityTimer();
     },

--- a/apps/web/public/pcm-worklet-processor.js
+++ b/apps/web/public/pcm-worklet-processor.js
@@ -162,3 +162,139 @@ class PcmVadProcessor extends AudioWorkletProcessor {
 }
 
 registerProcessor("pcm-vad-gate", PcmVadProcessor);
+
+class PcmStreamPlayerProcessor extends AudioWorkletProcessor {
+  constructor(options) {
+    super();
+
+    const processorOptions = options?.processorOptions ?? {};
+
+    this.channels = processorOptions.channels ?? 1;
+    this.initialBufferSamples = processorOptions.initialBufferSamples ?? 6615;
+    this.maxInitialWaitFrames = processorOptions.maxInitialWaitFrames ?? 30;
+    this.capacitySamples = processorOptions.capacitySamples ?? 44100 * 10;
+    this.buffer = new Float32Array(this.capacitySamples);
+    this.readIndex = 0;
+    this.writeIndex = 0;
+    this.availableSamples = 0;
+    this.hasStartedPlayback = false;
+    this.initialWaitFrames = 0;
+    this.lastIdleState = true;
+
+    this.port.onmessage = (event) => {
+      const message = event.data;
+
+      if (message?.type === "samples" && message.samples instanceof Float32Array) {
+        this.enqueueSamples(message.samples);
+        this.publishIdleState();
+        return;
+      }
+
+      if (message?.type === "reset") {
+        this.reset();
+      }
+    };
+  }
+
+  enqueueSamples(samples) {
+    this.initialWaitFrames = 0;
+
+    for (let i = 0; i < samples.length; i++) {
+      if (this.availableSamples === this.capacitySamples) {
+        this.readIndex = (this.readIndex + 1) % this.capacitySamples;
+        this.availableSamples -= 1;
+      }
+
+      this.buffer[this.writeIndex] = samples[i];
+      this.writeIndex = (this.writeIndex + 1) % this.capacitySamples;
+      this.availableSamples += 1;
+    }
+  }
+
+  readSample() {
+    if (this.availableSamples === 0) {
+      return 0;
+    }
+
+    const sample = this.buffer[this.readIndex];
+    this.readIndex = (this.readIndex + 1) % this.capacitySamples;
+    this.availableSamples -= 1;
+
+    return sample;
+  }
+
+  reset() {
+    this.readIndex = 0;
+    this.writeIndex = 0;
+    this.availableSamples = 0;
+    this.hasStartedPlayback = false;
+    this.initialWaitFrames = 0;
+    this.publishIdleState();
+  }
+
+  publishIdleState() {
+    const isIdle = this.availableSamples === 0 && !this.hasStartedPlayback;
+
+    if (isIdle === this.lastIdleState) {
+      return;
+    }
+
+    this.lastIdleState = isIdle;
+    this.port.postMessage({ type: "idle-state", isIdle });
+  }
+
+  process(_inputs, outputs) {
+    const output = outputs[0];
+
+    if (!output || output.length === 0) {
+      return true;
+    }
+
+    if (!this.hasStartedPlayback) {
+      if (this.availableSamples < this.initialBufferSamples) {
+        this.initialWaitFrames += 1;
+
+        if (this.initialWaitFrames >= this.maxInitialWaitFrames && this.availableSamples > 0) {
+          this.hasStartedPlayback = true;
+          this.publishIdleState();
+        } else {
+          for (let channelIndex = 0; channelIndex < output.length; channelIndex++) {
+            output[channelIndex].fill(0);
+          }
+
+          return true;
+        }
+      } else {
+        this.hasStartedPlayback = true;
+        this.publishIdleState();
+      }
+    }
+
+    let underrun = false;
+    const frameCount = output[0]?.length ?? 0;
+
+    for (let frame = 0; frame < frameCount; frame++) {
+      for (let channelIndex = 0; channelIndex < output.length; channelIndex++) {
+        if (this.availableSamples === 0) {
+          output[channelIndex][frame] = 0;
+          underrun = true;
+          continue;
+        }
+
+        output[channelIndex][frame] = this.readSample();
+      }
+    }
+
+    if (underrun) {
+      this.hasStartedPlayback = false;
+      this.initialWaitFrames = 0;
+      this.port.postMessage({ type: "underrun" });
+    }
+
+    this.publishIdleState();
+
+    return true;
+  }
+}
+
+registerProcessor("pcm-stream-player", PcmStreamPlayerProcessor);


### PR DESCRIPTION
<!--
 1. Make sure you have correct branch name i.e. `ab_prefix_123_task_name`, where `123` is a issue ID, and `ab` is an author
 2. Make sure you have meaningful title related to task with correct prefix: feat/fix/chore/style/docs/refactor
 3. Reference multiple issues in one PR by listing them in the issues section
 4. Make sure all necessary sections are filled, remove obsolete sections
 5. Do a self review first
 6. Check if your PR includes only code related to your task
 7. `Notes` is used for additional info but also to notify if any action is required
-->

## Issue(s)
[1560](https://github.com/Selleo/mentingo/issues/1560)

  ## Overview
  <!--
  General description what it does
  -->

  Improves the Voice Mentor frontend audio playback pipeline by replacing per-chunk AudioBufferSourceNode scheduling with an AudioWorklet ring-buffer player.

  The change adds buffered PCM playback with idle-state reporting, sample-rate-aware enqueueing and resampling, a larger playback lead time, and explicit speech-end
  padding from VAD redemption timing. Socket audio chunks now pass their backend-provided sampleRate into the player so playback stays aligned with the streamed audio
  format.

  ## Business Value
  <!--
  Why are we doing this from a business perspective? What value does this bring to the project from end-users perspective?
  -->

  This makes Voice Mentor conversations sound smoother and more reliable for learners by reducing playback gaps, underruns, cutoff speech, and sample-rate mismatch
  issues. A more stable voice experience improves the perceived quality of AI mentoring and helps users stay engaged in spoken practice sessions.