### PR TITLE
fix: enable proper SSO login in multi-tenant environments

### DIFF
--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -24,6 +24,7 @@ import { GoogleOAuthGuard } from "src/common/guards/google-oauth.guard";
 import { MicrosoftOAuthGuard } from "src/common/guards/microsoft-oauth.guard";
 import { RefreshTokenGuard } from "src/common/guards/refresh-token.guard";
 import { SlackOAuthGuard } from "src/common/guards/slack-oauth.guard";
+import { getRequestBaseUrl } from "src/common/helpers/getRequestBaseUrl";
 import {
   isSupportModeSession,
   shouldEmitUserScopedEvents,
@@ -34,6 +35,7 @@ import { USER_LOGIN_METHOD } from "src/events/user/user-login.event";
 import { OutboxPublisher } from "src/outbox/outbox.publisher";
 import { SettingsService } from "src/settings/settings.service";
 import { TenantDbRunnerService } from "src/storage/db/tenant-db-runner.service";
+import { TenantResolverService } from "src/storage/db/tenant-resolver.service";
 import { currentUserResponseSchema } from "src/user/schemas/user.schema";
 
 import { AuthService } from "./auth.service";
@@ -72,6 +74,7 @@ export class AuthController {
     private readonly outboxPublisher: OutboxPublisher,
     private readonly settingsService: SettingsService,
     private readonly tenantRunner: TenantDbRunnerService,
+    private readonly tenantResolver: TenantResolverService,
   ) {
     this.CORS_ORIGIN = process.env.CORS_ORIGIN || "http://localhost:5173";
   }
@@ -337,16 +340,14 @@ export class AuthController {
         ? this.tokenService.setTemporaryTokenCookies(response, accessToken, refreshToken)
         : this.tokenService.setTokenCookies(response, accessToken, refreshToken, true);
 
-      response.redirect(this.CORS_ORIGIN);
+      response.redirect(await this.getOAuthRedirectBaseUrl(request));
     } catch (e) {
       await this.authService.handleAuthFailed({
         email: googleUser.email,
         method: USER_LOGIN_METHOD.PROVIDER,
         error: (e as Error)?.message,
       });
-      response.redirect(
-        this.CORS_ORIGIN + "/auth/login?error=" + encodeURIComponent((e as Error).message),
-      );
+      response.redirect(await this.getOAuthErrorRedirectUrl(request, e as Error));
     }
   }
 
@@ -374,16 +375,14 @@ export class AuthController {
         ? this.tokenService.setTemporaryTokenCookies(response, accessToken, refreshToken)
         : this.tokenService.setTokenCookies(response, accessToken, refreshToken, true);
 
-      response.redirect(this.CORS_ORIGIN);
+      response.redirect(await this.getOAuthRedirectBaseUrl(request));
     } catch (e) {
       await this.authService.handleAuthFailed({
         email: microsoftUser.email,
         method: USER_LOGIN_METHOD.PROVIDER,
         error: (e as Error)?.message,
       });
-      response.redirect(
-        this.CORS_ORIGIN + "/auth/login?error=" + encodeURIComponent((e as Error).message),
-      );
+      response.redirect(await this.getOAuthErrorRedirectUrl(request, e as Error));
     }
   }
 
@@ -411,16 +410,14 @@ export class AuthController {
         ? this.tokenService.setTemporaryTokenCookies(response, accessToken, refreshToken)
         : this.tokenService.setTokenCookies(response, accessToken, refreshToken, true);
 
-      response.redirect(this.CORS_ORIGIN);
+      response.redirect(await this.getOAuthRedirectBaseUrl(request));
     } catch (e) {
       await this.authService.handleAuthFailed({
         email: slackUser.email,
         method: USER_LOGIN_METHOD.PROVIDER,
         error: (e as Error)?.message,
       });
-      response.redirect(
-        this.CORS_ORIGIN + "/auth/login?error=" + encodeURIComponent((e as Error).message),
-      );
+      response.redirect(await this.getOAuthErrorRedirectUrl(request, e as Error));
     }
   }
 
@@ -477,5 +474,20 @@ export class AuthController {
     const loginResponse = await this.authService.handleMagicLinkLogin(response, token);
 
     return new BaseResponse(loginResponse);
+  }
+
+  private async getOAuthRedirectBaseUrl(request: Request): Promise<string> {
+    return (
+      (await this.tenantResolver.resolveTenantHost(request)) ??
+      getRequestBaseUrl(request) ??
+      this.CORS_ORIGIN
+    );
+  }
+
+  private async getOAuthErrorRedirectUrl(request: Request, error: Error): Promise<string> {
+    const redirectUrl = new URL("/auth/login", await this.getOAuthRedirectBaseUrl(request));
+    redirectUrl.searchParams.set("error", error.message);
+
+    return redirectUrl.toString();
   }
 }

--- a/apps/api/src/auth/strategy/google.strategy.ts
+++ b/apps/api/src/auth/strategy/google.strategy.ts
@@ -3,6 +3,7 @@ import { ConfigService } from "@nestjs/config";
 import { PassportStrategy } from "@nestjs/passport";
 import { Strategy } from "passport-google-oauth20";
 
+import { getCallbackPath } from "src/common/configuration/callbackUrl";
 import { EnvService } from "src/env/services/env.service";
 
 import type { Request } from "express";
@@ -18,7 +19,7 @@ export class GoogleStrategy extends PassportStrategy(Strategy, "google") {
     super({
       clientID: "placeholder",
       clientSecret: "placeholder",
-      callbackURL: configService.get<string>("callback_url.GOOGLE"),
+      callbackURL: getCallbackPath("google"),
       scope: ["email", "profile"],
     });
   }
@@ -49,7 +50,7 @@ export class GoogleStrategy extends PassportStrategy(Strategy, "google") {
           {
             clientID: id,
             clientSecret: secret,
-            callbackURL: this.configService.get<string>("callback_url.GOOGLE"),
+            callbackURL: getCallbackPath("google"),
             scope: ["email", "profile"],
           },
           (accessToken: string, refreshToken: string, profile: Profile, done: VerifyCallback) =>

--- a/apps/api/src/auth/strategy/microsoft.strategy.ts
+++ b/apps/api/src/auth/strategy/microsoft.strategy.ts
@@ -3,6 +3,7 @@ import { ConfigService } from "@nestjs/config";
 import { PassportStrategy } from "@nestjs/passport";
 import { Strategy } from "passport-microsoft";
 
+import { getCallbackPath } from "src/common/configuration/callbackUrl";
 import { EnvService } from "src/env/services/env.service";
 
 import type { Request } from "express";
@@ -18,7 +19,7 @@ export class MicrosoftStrategy extends PassportStrategy(Strategy, "microsoft") {
     super({
       clientID: "placeholder",
       clientSecret: "placeholder",
-      callbackURL: configService.get<string>("callback_url.MICROSOFT"),
+      callbackURL: getCallbackPath("microsoft"),
       scope: ["user.read"],
       tenant: "common",
     });
@@ -51,7 +52,7 @@ export class MicrosoftStrategy extends PassportStrategy(Strategy, "microsoft") {
           {
             clientID: id,
             clientSecret: secret,
-            callbackURL: this.configService.get<string>("callback_url.MICROSOFT"),
+            callbackURL: getCallbackPath("microsoft"),
             scope: ["user.read"],
             tenant: "common",
           },

--- a/apps/api/src/auth/strategy/slack.strategy.ts
+++ b/apps/api/src/auth/strategy/slack.strategy.ts
@@ -4,6 +4,7 @@ import { PassportStrategy } from "@nestjs/passport";
 import axios from "axios";
 import { Strategy } from "passport-oauth2";
 
+import { getCallbackPath } from "src/common/configuration/callbackUrl";
 import { EnvService } from "src/env/services/env.service";
 
 import type { Request } from "express";
@@ -21,7 +22,7 @@ export class SlackStrategy extends PassportStrategy(Strategy, "slack") {
       tokenURL: "https://slack.com/api/openid.connect.token",
       clientID: "test_slack_client_id",
       clientSecret: "test_slack_client_secret",
-      callbackURL: configService.get<string>("callback_url.SLACK"),
+      callbackURL: getCallbackPath("slack"),
       scope: ["openid", "profile", "email"],
     });
   }
@@ -52,7 +53,7 @@ export class SlackStrategy extends PassportStrategy(Strategy, "slack") {
             tokenURL: "https://slack.com/api/openid.connect.token",
             clientID: id,
             clientSecret: secret,
-            callbackURL: this.configService.get<string>("callback_url.SLACK"),
+            callbackURL: getCallbackPath("slack"),
             scope: ["openid", "profile", "email"],
           },
           async (accessToken: string, refreshToken: string, profile: any, done: VerifyCallback) => {

--- a/apps/api/src/common/configuration/callbackUrl.ts
+++ b/apps/api/src/common/configuration/callbackUrl.ts
@@ -3,8 +3,12 @@ import { type Static, Type } from "@sinclair/typebox";
 
 import { configValidator } from "src/utils/configValidator";
 
-const baseUrl = process.env.CORS_ORIGIN || "http://localhost:5173";
-const getCallbackUrl = (name: string) => `${baseUrl}/api/auth/${name}/callback`;
+export const DEFAULT_CALLBACK_BASE_URL = process.env.CORS_ORIGIN || "http://localhost:5173";
+
+export const getCallbackPath = (name: string) => `/api/auth/${name}/callback`;
+
+export const getCallbackUrl = (name: string, baseUrl = DEFAULT_CALLBACK_BASE_URL) =>
+  `${baseUrl.replace(/\/$/, "")}${getCallbackPath(name)}`;
 
 const schema = Type.Object({
   MICROSOFT: Type.String(),

--- a/apps/api/src/common/guards/google-oauth.guard.ts
+++ b/apps/api/src/common/guards/google-oauth.guard.ts
@@ -2,6 +2,7 @@ import { Injectable } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 
 import { EnvService } from "src/env/services/env.service";
+import { TenantDbRunnerService } from "src/storage/db/tenant-db-runner.service";
 import { TenantResolverService } from "src/storage/db/tenant-resolver.service";
 import { TenantStateService } from "src/storage/db/tenant-state.service";
 
@@ -22,9 +23,10 @@ export class GoogleOAuthGuard extends GoogleOAuthGuardBase {
   constructor(
     envService: EnvService,
     configService: ConfigService,
+    tenantDbRunner: TenantDbRunnerService,
     tenantResolver: TenantResolverService,
     tenantState: TenantStateService,
   ) {
-    super(envService, configService, tenantResolver, tenantState);
+    super(envService, configService, tenantDbRunner, tenantResolver, tenantState);
   }
 }

--- a/apps/api/src/common/guards/microsoft-oauth.guard.ts
+++ b/apps/api/src/common/guards/microsoft-oauth.guard.ts
@@ -2,6 +2,7 @@ import { Injectable } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 
 import { EnvService } from "src/env/services/env.service";
+import { TenantDbRunnerService } from "src/storage/db/tenant-db-runner.service";
 import { TenantResolverService } from "src/storage/db/tenant-resolver.service";
 import { TenantStateService } from "src/storage/db/tenant-state.service";
 
@@ -20,9 +21,10 @@ export class MicrosoftOAuthGuard extends MicrosoftOAuthGuardBase {
   constructor(
     envService: EnvService,
     configService: ConfigService,
+    tenantDbRunner: TenantDbRunnerService,
     tenantResolver: TenantResolverService,
     tenantState: TenantStateService,
   ) {
-    super(envService, configService, tenantResolver, tenantState);
+    super(envService, configService, tenantDbRunner, tenantResolver, tenantState);
   }
 }

--- a/apps/api/src/common/guards/oauth-guard.factory.ts
+++ b/apps/api/src/common/guards/oauth-guard.factory.ts
@@ -2,6 +2,7 @@ import { ForbiddenException, type Type } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 
 import { EnvService } from "src/env/services/env.service";
+import { TenantDbRunnerService } from "src/storage/db/tenant-db-runner.service";
 import { TenantResolverService } from "src/storage/db/tenant-resolver.service";
 import { TenantStateService } from "src/storage/db/tenant-state.service";
 
@@ -26,10 +27,11 @@ export const createTenantOAuthGuard = (
     constructor(
       private readonly envService: EnvService,
       private readonly configService: ConfigService,
+      tenantDbRunner: TenantDbRunnerService,
       tenantResolver: TenantResolverService,
       tenantState: TenantStateService,
     ) {
-      super(tenantResolver, tenantState);
+      super(tenantResolver, tenantState, tenantDbRunner);
     }
 
     protected async isEnabled(): Promise<boolean> {
@@ -38,7 +40,7 @@ export const createTenantOAuthGuard = (
         .then((r) => r.value)
         .catch(() => this.configService.get<string>(envKey));
 
-      return enabled === "true";
+      return enabled?.trim().toLowerCase() === "true";
     }
 
     protected handleDisabled(): boolean {

--- a/apps/api/src/common/guards/slack-oauth.guard.ts
+++ b/apps/api/src/common/guards/slack-oauth.guard.ts
@@ -2,6 +2,7 @@ import { Injectable } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 
 import { EnvService } from "src/env/services/env.service";
+import { TenantDbRunnerService } from "src/storage/db/tenant-db-runner.service";
 import { TenantResolverService } from "src/storage/db/tenant-resolver.service";
 import { TenantStateService } from "src/storage/db/tenant-state.service";
 
@@ -20,9 +21,10 @@ export class SlackOAuthGuard extends SlackOAuthGuardBase {
   constructor(
     envService: EnvService,
     configService: ConfigService,
+    tenantDbRunner: TenantDbRunnerService,
     tenantResolver: TenantResolverService,
     tenantState: TenantStateService,
   ) {
-    super(envService, configService, tenantResolver, tenantState);
+    super(envService, configService, tenantDbRunner, tenantResolver, tenantState);
   }
 }

--- a/apps/api/src/common/guards/tenant-oauth.guard.ts
+++ b/apps/api/src/common/guards/tenant-oauth.guard.ts
@@ -1,6 +1,7 @@
 import { mixin, UnauthorizedException } from "@nestjs/common";
 import { AuthGuard } from "@nestjs/passport";
 
+import { TenantDbRunnerService } from "src/storage/db/tenant-db-runner.service";
 import { TenantResolverService } from "src/storage/db/tenant-resolver.service";
 import { TenantStateService } from "src/storage/db/tenant-state.service";
 
@@ -20,6 +21,7 @@ export function TenantOAuthGuard(
     constructor(
       private readonly tenantResolver: TenantResolverService,
       private readonly tenantState: TenantStateService,
+      private readonly tenantDbRunner: TenantDbRunnerService,
     ) {
       super();
     }
@@ -33,21 +35,23 @@ export function TenantOAuthGuard(
     }
 
     async canActivate(context: ExecutionContext) {
-      const enabled = await this.isEnabled();
-
-      if (!enabled) return this.handleDisabled();
-
       const req = context.switchToHttp().getRequest();
+      const isCallback = this.isCallbackRequest(req);
+      const tenantId = await this.tenantResolver.resolveTenantId(req);
 
-      if (!this.isCallbackRequest(req)) {
-        const tenantId = await this.tenantResolver.resolveTenantId(req);
+      if (!tenantId) throw new UnauthorizedException("Missing tenantId");
 
-        if (!tenantId) throw new UnauthorizedException("Missing tenantId");
+      return this.tenantDbRunner.runWithTenant(tenantId, async () => {
+        const enabled = await this.isEnabled();
 
-        req.oauthState = await this.tenantState.sign(tenantId);
-      }
+        if (!enabled) return this.handleDisabled();
 
-      return super.canActivate(context) as any;
+        if (!isCallback) {
+          req.oauthState = await this.tenantState.sign(tenantId);
+        }
+
+        return super.canActivate(context) as any;
+      });
     }
 
     getAuthenticateOptions(context: ExecutionContext) {

--- a/apps/api/src/storage/db/tenant-resolver.service.ts
+++ b/apps/api/src/storage/db/tenant-resolver.service.ts
@@ -72,6 +72,19 @@ export class TenantResolverService {
     return tenant?.id ?? null;
   }
 
+  async resolveTenantHost(req: Request): Promise<string | null> {
+    const tenantId = await this.resolveTenantId(req);
+    if (!tenantId) return null;
+
+    const [tenant] = await this.dbBase
+      .select({ host: tenants.host })
+      .from(tenants)
+      .where(eq(tenants.id, tenantId))
+      .limit(1);
+
+    return tenant?.host ?? null;
+  }
+
   private async resolveFromState(req: Request): Promise<string | null> {
     const path = (req.path ?? req.url ?? "") as string;
     if (!path.includes("/api/auth/") || !path.includes("/callback")) return null;
@@ -95,6 +108,9 @@ export class TenantResolverService {
   }
 
   private getRequestOrigin(req: Request): string | null {
+    const fromQuery = this.safeParseOrigin(this.getSingleQueryValue(req.query?.tenantOrigin));
+    if (fromQuery) return fromQuery;
+
     const fromHeader = this.safeParseOrigin(req.headers.referer ?? req.headers.origin);
     if (fromHeader) return fromHeader;
 
@@ -113,6 +129,10 @@ export class TenantResolverService {
     } catch {
       return null;
     }
+  }
+
+  private getSingleQueryValue(value: unknown): string | undefined {
+    return typeof value === "string" ? value : undefined;
   }
 
   private isInactiveAllowed(req: Request): boolean {

--- a/apps/web/app/modules/Auth/components/SocialLogin.tsx
+++ b/apps/web/app/modules/Auth/components/SocialLogin.tsx
@@ -24,8 +24,12 @@ export function SocialLogin({
 }: SocialLoginProps) {
   const { t } = useTranslation();
 
-  const handleProviderSignIn = (provider: string) => () =>
-    (window.location.href = `${baseUrl}/api/auth/${provider}`);
+  const handleProviderSignIn = (provider: string) => () => {
+    const authUrl = new URL(`${baseUrl}/api/auth/${provider}`);
+    authUrl.searchParams.set("tenantOrigin", window.location.origin);
+
+    window.location.href = authUrl.toString();
+  };
 
   return (
     <>


### PR DESCRIPTION
<!--
 1. Make sure you have correct branch name i.e. `ab_prefix_123_task_name`, where `123` is a issue ID, and `ab` is an author
 2. Make sure you have meaningful title related to task with correct prefix: feat/fix/chore/style/docs/refactor
 3. Reference multiple issues in one PR by listing them in the issues section
 4. Make sure all necessary sections are filled, remove obsolete sections
 5. Do a self review first
 6. Check if your PR includes only code related to your task
 7. `Notes` is used for additional info but also to notify if any action is required
-->

## Issue(s)
[1568](https://github.com/Selleo/mentingo/issues/1568)

  ## Overview
  <!--
  General description what it does
  -->

  Fixes SSO callback handling so Google, Microsoft, and Slack OAuth flows work correctly with
  tenant-specific hosts instead of relying on a hardcoded CORS_ORIGIN.

  - Resolves tenant context before OAuth provider guards and strategy execution so tenant-scoped
    secrets are available during SSO.

  - Passes the current tenant origin from the web login flow into OAuth startup for
    unauthenticated tenant resolution.

  - Uses relative provider callback paths so Passport resolves callback URLs from the active
    request host.

  - Redirects completed OAuth logins back to the resolved tenant host, with request base URL and
    CORS_ORIGIN as fallbacks.

  - Normalizes OAuth enabled flags before comparison.

  ## Business Value
  <!--
  Why are we doing this from a business perspective? What value does this bring to the project
  from end-users perspective?
  -->

  Users can complete SSO login reliably on tenant-specific domains, preview tunnels, and non-
  default hosts. This prevents OAuth redirects from sending users to the wrong tenant or failing
  because credentials and enablement flags are read outside the correct tenant context.