### PR TITLE
chore: improve password reset and change experience

### DIFF
--- a/apps/api/src/auth/__tests__/auth.controller.e2e-spec.ts
+++ b/apps/api/src/auth/__tests__/auth.controller.e2e-spec.ts
@@ -654,6 +654,43 @@ describe("AuthController (e2e)", () => {
         .expect(201);
     });
 
+    it("should create password credentials when resetting password for a user without credentials", async () => {
+      const user = await userFactory.withUserSettings(db).create({
+        email: `resetpassword-without-credentials-${nanoid(8)}@example.com`,
+      });
+      const resetToken = nanoid(64);
+      const expiryDate = new Date(Date.now() + 60 * 60 * 1000);
+
+      await db.insert(resetTokens).values({
+        userId: user.id,
+        tokenHash: hashToken(resetToken),
+        expiryDate,
+      });
+
+      await request(app.getHttpServer())
+        .post("/api/auth/reset-password")
+        .send({
+          resetToken,
+          newPassword: "Newpassword123@",
+        })
+        .expect(201);
+
+      const [remainingToken] = await db
+        .select()
+        .from(resetTokens)
+        .where(eq(resetTokens.userId, user.id));
+
+      expect(remainingToken).toBeUndefined();
+
+      await request(app.getHttpServer())
+        .post("/api/auth/login")
+        .send({
+          email: user.email,
+          password: "Newpassword123@",
+        })
+        .expect(201);
+    });
+
     it("should return 400 if new password does not match criteria", async () => {
       const response = await request(app.getHttpServer())
         .post("/api/auth/reset-password")

--- a/apps/api/src/swagger/api-schema.json
+++ b/apps/api/src/swagger/api-schema.json
@@ -1956,6 +1956,23 @@
         }
       }
     },
+    "/api/user/password-status": {
+      "get": {
+        "operationId": "UserController_getPasswordStatus",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetPasswordStatusResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/user/change-password": {
       "patch": {
         "operationId": "UserController_changePassword",
@@ -18392,6 +18409,25 @@
           "data"
         ]
       },
+      "GetPasswordStatusResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "hasPassword": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "hasPassword"
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
       "ChangePasswordBody": {
         "type": "object",
         "properties": {
@@ -18440,8 +18476,7 @@
         },
         "required": [
           "newPassword",
-          "confirmPassword",
-          "oldPassword"
+          "confirmPassword"
         ]
       },
       "ChangePasswordResponse": {

--- a/apps/api/src/user/__tests__/user.controller.e2e-spec.ts
+++ b/apps/api/src/user/__tests__/user.controller.e2e-spec.ts
@@ -53,6 +53,16 @@ describe("UsersController (e2e)", () => {
     testCookies = await cookieFor(testUser, app);
   });
 
+  const magicLinkCookiesFor = async (user: UserWithCredentials) => {
+    const token = await authService.createMagicLinkToken(user.id);
+    const response = await request(app.getHttpServer())
+      .get("/api/auth/magic-link/verify")
+      .query({ token })
+      .expect(200);
+
+    return response.headers["set-cookie"];
+  };
+
   describe("GET /user/all", () => {
     it("should return all users", async () => {
       const response = await request(app.getHttpServer())
@@ -144,6 +154,29 @@ describe("UsersController (e2e)", () => {
     });
   });
 
+  describe("GET /user/password-status", () => {
+    it("should return true when current user has password credentials", async () => {
+      const response = await request(app.getHttpServer())
+        .get("/api/user/password-status")
+        .set("Cookie", testCookies)
+        .expect(200);
+
+      expect(response.body.data).toEqual({ hasPassword: true });
+    });
+
+    it("should return false when current user has no password credentials", async () => {
+      const userWithoutPassword = await userFactory.withAdminSettings(db).withAdminRole().create();
+      const cookies = await magicLinkCookiesFor(userWithoutPassword);
+
+      const response = await request(app.getHttpServer())
+        .get("/api/user/password-status")
+        .set("Cookie", cookies)
+        .expect(200);
+
+      expect(response.body.data).toEqual({ hasPassword: false });
+    });
+  });
+
   describe("PATCH /user/change-password?id=:id", () => {
     it("should change password when old password is correct", async () => {
       const newPassword = "newPassword123@";
@@ -174,6 +207,28 @@ describe("UsersController (e2e)", () => {
         .set("Cookie", testCookies)
         .send({ oldPassword: incorrectOldPassword, newPassword, confirmPassword: newPassword })
         .expect(401);
+    });
+
+    it("should set password without old password when user has no credentials", async () => {
+      const userWithoutPassword = await userFactory.withAdminSettings(db).withAdminRole().create();
+      const cookies = await magicLinkCookiesFor(userWithoutPassword);
+      const newPassword = "newPassword123@";
+
+      await request(app.getHttpServer())
+        .patch(`/api/user/change-password?id=${userWithoutPassword.id}`)
+        .set("Cookie", cookies)
+        .send({ newPassword, confirmPassword: newPassword })
+        .expect(200);
+
+      const loginResponse = await request(app.getHttpServer())
+        .post("/api/auth/login")
+        .send({
+          email: userWithoutPassword.email,
+          password: newPassword,
+        })
+        .expect(201);
+
+      expect(loginResponse.headers["set-cookie"]).toBeDefined();
     });
 
     it("should return 403 when changing another user's password", async () => {

--- a/apps/api/src/user/schemas/changePassword.schema.ts
+++ b/apps/api/src/user/schemas/changePassword.schema.ts
@@ -5,7 +5,12 @@ import { passwordSchema } from "src/auth/schemas/password.schema";
 export const changePasswordSchema = Type.Object({
   newPassword: passwordSchema,
   confirmPassword: Type.String(),
-  oldPassword: Type.String({ minLength: 8, maxLength: 64 }),
+  oldPassword: Type.Optional(Type.String({ minLength: 8, maxLength: 64 })),
+});
+
+export const passwordStatusSchema = Type.Object({
+  hasPassword: Type.Boolean(),
 });
 
 export type ChangePasswordBody = Static<typeof changePasswordSchema>;
+export type PasswordStatusResponse = Static<typeof passwordStatusSchema>;

--- a/apps/api/src/user/user.controller.ts
+++ b/apps/api/src/user/user.controller.ts
@@ -62,7 +62,12 @@ import {
   archiveUsersSchema,
   archiveUsersSchemaResponse,
 } from "./schemas/archiveUsers.schema";
-import { type ChangePasswordBody, changePasswordSchema } from "./schemas/changePassword.schema";
+import {
+  type ChangePasswordBody,
+  changePasswordSchema,
+  type PasswordStatusResponse,
+  passwordStatusSchema,
+} from "./schemas/changePassword.schema";
 import { deleteUsersSchema, type DeleteUsersSchema } from "./schemas/deleteUsers.schema";
 import {
   BulkAssignUserGroups,
@@ -303,6 +308,17 @@ export class UserController {
 
       return new BaseResponse(updatedUser);
     }
+  }
+
+  @Get("password-status")
+  @RequirePermission(PERMISSIONS.ACCOUNT_UPDATE_SELF)
+  @Validate({
+    response: baseResponse(passwordStatusSchema),
+  })
+  async getPasswordStatus(
+    @CurrentUser("userId") currentUserId: UUIDType,
+  ): Promise<BaseResponse<PasswordStatusResponse>> {
+    return new BaseResponse(await this.usersService.getPasswordStatus(currentUserId));
   }
 
   @Patch("change-password")

--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -489,7 +489,12 @@ export class UserService {
       return await this.createPasswordService.createUserPassword(id, newPassword);
     }
 
+    if (!oldPassword) {
+      throw new BadRequestException("changePasswordView.validation.oldPassword");
+    }
+
     const isOldPasswordValid = await bcrypt.compare(oldPassword, userCredentials.password);
+
     if (!isOldPasswordValid) {
       throw new UnauthorizedException("Invalid old password");
     }
@@ -499,6 +504,16 @@ export class UserService {
       .update(credentials)
       .set({ password: hashedNewPassword })
       .where(eq(credentials.userId, id));
+  }
+
+  async getPasswordStatus(id: UUIDType) {
+    const [userCredentials] = await this.db
+      .select({ id: credentials.id })
+      .from(credentials)
+      .where(eq(credentials.userId, id))
+      .limit(1);
+
+    return { hasPassword: Boolean(userCredentials) };
   }
 
   async resetPassword(id: UUIDType, newPassword: string) {
@@ -514,7 +529,7 @@ export class UserService {
       .where(eq(credentials.userId, id));
 
     if (!userCredentials) {
-      throw new NotFoundException("User credentials not found");
+      return await this.createPasswordService.createUserPassword(id, newPassword);
     }
 
     const hashedNewPassword = await hashPassword(newPassword);

--- a/apps/web/app/api/generated-api.ts
+++ b/apps/web/app/api/generated-api.ts
@@ -1153,6 +1153,12 @@ export interface AdminUpdateUserResponse {
   };
 }
 
+export interface GetPasswordStatusResponse {
+  data: {
+    hasPassword: boolean;
+  };
+}
+
 export interface ChangePasswordBody {
   newPassword: string;
   confirmPassword: string;
@@ -1160,7 +1166,7 @@ export interface ChangePasswordBody {
    * @minLength 8
    * @maxLength 64
    */
-  oldPassword: string;
+  oldPassword?: string;
 }
 
 export type ChangePasswordResponse = null;
@@ -7024,6 +7030,20 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
+     * @name UserControllerGetPasswordStatus
+     * @request GET:/api/user/password-status
+     */
+    userControllerGetPasswordStatus: (params: RequestParams = {}) =>
+      this.request<GetPasswordStatusResponse, any>({
+        path: `/api/user/password-status`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
      * @name UserControllerChangePassword
      * @request PATCH:/api/user/change-password
      */
@@ -8807,10 +8827,17 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @name LessonControllerGetLessonImage
      * @request GET:/api/lesson/lesson-image/{resourceId}
      */
-    lessonControllerGetLessonImage: (resourceId: string, params: RequestParams = {}) =>
+    lessonControllerGetLessonImage: (
+      resourceId: string,
+      query?: {
+        preview?: "pdf";
+      },
+      params: RequestParams = {},
+    ) =>
       this.request<void, any>({
         path: `/api/lesson/lesson-image/${resourceId}`,
         method: "GET",
+        query: query,
         ...params,
       }),
 
@@ -8820,10 +8847,17 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @name LessonControllerGetLessonResource
      * @request GET:/api/lesson/lesson-resource/{resourceId}
      */
-    lessonControllerGetLessonResource: (resourceId: string, params: RequestParams = {}) =>
+    lessonControllerGetLessonResource: (
+      resourceId: string,
+      query?: {
+        preview?: "pdf";
+      },
+      params: RequestParams = {},
+    ) =>
       this.request<void, any>({
         path: `/api/lesson/lesson-resource/${resourceId}`,
         method: "GET",
+        query: query,
         ...params,
       }),
 
@@ -11462,10 +11496,17 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @name NewsControllerGetNewsResource
      * @request GET:/api/news/news-resource/{resourceId}
      */
-    newsControllerGetNewsResource: (resourceId: string, params: RequestParams = {}) =>
+    newsControllerGetNewsResource: (
+      resourceId: string,
+      query?: {
+        preview?: "pdf";
+      },
+      params: RequestParams = {},
+    ) =>
       this.request<void, any>({
         path: `/api/news/news-resource/${resourceId}`,
         method: "GET",
+        query: query,
         ...params,
       }),
 
@@ -11795,10 +11836,17 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @name ArticlesControllerGetArticleResource
      * @request GET:/api/articles/articles-resource/{resourceId}
      */
-    articlesControllerGetArticleResource: (resourceId: string, params: RequestParams = {}) =>
+    articlesControllerGetArticleResource: (
+      resourceId: string,
+      query?: {
+        preview?: "pdf";
+      },
+      params: RequestParams = {},
+    ) =>
       this.request<void, any>({
         path: `/api/articles/articles-resource/${resourceId}`,
         method: "GET",
+        query: query,
         ...params,
       }),
 

--- a/apps/web/app/api/mutations/useChangePassword.ts
+++ b/apps/web/app/api/mutations/useChangePassword.ts
@@ -4,7 +4,9 @@ import { useTranslation } from "react-i18next";
 import { useToast } from "~/components/ui/use-toast";
 
 import { ApiClient } from "../api-client";
+import { passwordStatusQueryOptions } from "../queries";
 import { useCurrentUserSuspense } from "../queries/useCurrentUser";
+import { queryClient } from "../queryClient";
 
 import type { ChangePasswordBody } from "../generated-api";
 import type { AxiosError } from "axios";
@@ -12,6 +14,7 @@ import type { ApiErrorResponse } from "~/api/types";
 
 type ChangePasswordOptions = {
   data: ChangePasswordBody;
+  hasPassword: boolean;
 };
 
 export function useChangePassword() {
@@ -28,10 +31,16 @@ export function useChangePassword() {
 
       return response.data;
     },
-    onSuccess: () => {
+    onSuccess: async (_data, options) => {
+      await queryClient.invalidateQueries(passwordStatusQueryOptions);
+
       toast({
         variant: "default",
-        description: t("changePasswordView.toast.passwordChangedSuccessfully"),
+        description: t(
+          options.hasPassword
+            ? "changePasswordView.toast.passwordChangedSuccessfully"
+            : "changePasswordView.toast.passwordCreatedSuccessfully",
+        ),
       });
     },
     onError: (error: AxiosError) => {

--- a/apps/web/app/api/queries/index.ts
+++ b/apps/web/app/api/queries/index.ts
@@ -9,6 +9,7 @@ export { courseQueryOptions, useCourse, useCourseSuspense } from "./useCourse";
 export { allCoursesQueryOptions, useCourses, useCoursesSuspense } from "./useCourses";
 export { currentUserQueryOptions, useCurrentUser, useCurrentUserSuspense } from "./useCurrentUser";
 export { lessonQueryOptions, useLesson, useLessonSuspense } from "./useLesson";
+export { passwordStatusQueryOptions, usePasswordStatusSuspense } from "./usePasswordStatus";
 export { scormLaunchQueryOptions, useScormLaunch } from "./useScormLaunch";
 export {
   studentCoursesQueryOptions,

--- a/apps/web/app/api/queries/usePasswordStatus.ts
+++ b/apps/web/app/api/queries/usePasswordStatus.ts
@@ -1,0 +1,23 @@
+import { queryOptions, useSuspenseQuery } from "@tanstack/react-query";
+
+import { ApiClient } from "../api-client";
+
+import type { GetPasswordStatusResponse } from "../generated-api";
+
+const PASSWORD_STATUS_QUERY_KEY = "passwordStatus";
+
+export const passwordStatusQueryOptions = queryOptions({
+  queryKey: [PASSWORD_STATUS_QUERY_KEY],
+  queryFn: async () => {
+    const response = await ApiClient.api.userControllerGetPasswordStatus();
+
+    return response.data;
+  },
+});
+
+export function usePasswordStatusSuspense() {
+  return useSuspenseQuery({
+    ...passwordStatusQueryOptions,
+    select: (data: GetPasswordStatusResponse) => data.data,
+  });
+}

--- a/apps/web/app/locales/cs/translation.json
+++ b/apps/web/app/locales/cs/translation.json
@@ -593,6 +593,8 @@
   "changePasswordView": {
     "header": "Změňte heslo",
     "subHeader": "Aktualizujte své heslo zde.",
+    "setPasswordHeader": "Nastavit heslo",
+    "setPasswordSubHeader": "Vytvořte heslo ke svému účtu.",
     "field": {
       "oldPassword": "Staré heslo",
       "newPassword": "Nové heslo",

--- a/apps/web/app/locales/de/translation.json
+++ b/apps/web/app/locales/de/translation.json
@@ -593,6 +593,8 @@
   "changePasswordView": {
     "header": "Kennwort ändern",
     "subHeader": "Aktualisieren Sie hier Ihr Passwort.",
+    "setPasswordHeader": "Passwort festlegen",
+    "setPasswordSubHeader": "Erstellen Sie ein Passwort für Ihr Konto.",
     "field": {
       "oldPassword": "Altes Passwort",
       "newPassword": "Neues Passwort",

--- a/apps/web/app/locales/en/translation.json
+++ b/apps/web/app/locales/en/translation.json
@@ -594,6 +594,8 @@
   "changePasswordView": {
     "header": "Change password",
     "subHeader": "Update your password here.",
+    "setPasswordHeader": "Set password",
+    "setPasswordSubHeader": "Create a password for your account.",
     "field": {
       "oldPassword": "Old password",
       "newPassword": "New password",

--- a/apps/web/app/locales/lt/translation.json
+++ b/apps/web/app/locales/lt/translation.json
@@ -593,6 +593,8 @@
   "changePasswordView": {
     "header": "Keisti slaptažodį",
     "subHeader": "Atnaujinkite slaptažodį čia.",
+    "setPasswordHeader": "Nustatyti slaptažodį",
+    "setPasswordSubHeader": "Sukurkite savo paskyros slaptažodį.",
     "field": {
       "oldPassword": "Senas slaptažodis",
       "newPassword": "Naujas slaptažodis",

--- a/apps/web/app/locales/pl/translation.json
+++ b/apps/web/app/locales/pl/translation.json
@@ -809,6 +809,8 @@
   "changePasswordView": {
     "header": "Zmień hasło",
     "subHeader": "Zaktualizuj swoje hasło tutaj.",
+    "setPasswordHeader": "Ustaw hasło",
+    "setPasswordSubHeader": "Utwórz hasło do swojego konta.",
     "field": {
       "oldPassword": "Stare hasło",
       "newPassword": "Nowe hasło",

--- a/apps/web/app/modules/Dashboard/Settings/forms/ChangePasswordForm.tsx
+++ b/apps/web/app/modules/Dashboard/Settings/forms/ChangePasswordForm.tsx
@@ -1,9 +1,11 @@
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useMemo } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { z } from "zod";
 
 import { useChangePassword } from "~/api/mutations/useChangePassword";
+import { usePasswordStatusSuspense } from "~/api/queries";
 import PasswordValidationDisplay from "~/components/PasswordValidation/PasswordValidationDisplay";
 import { Button } from "~/components/ui/button";
 import {
@@ -24,19 +26,29 @@ import { passwordSchema } from "../schema/password.schema";
 
 import type { ChangePasswordBody } from "~/api/generated-api";
 
-const changePasswordSchema = z
-  .object({
-    oldPassword: z.string().min(1, "changePasswordView.validation.oldPassword"),
-    newPassword: passwordSchema,
-    confirmPassword: z.string(),
-  })
-  .refine(({ newPassword, confirmPassword }) => newPassword === confirmPassword, {
-    path: ["confirmPassword"],
-  });
+const getChangePasswordSchema = (hasPassword: boolean) =>
+  z
+    .object({
+      oldPassword: hasPassword
+        ? z.string().min(1, "changePasswordView.validation.oldPassword")
+        : z.string().optional(),
+      newPassword: passwordSchema,
+      confirmPassword: z.string(),
+    })
+    .refine(({ newPassword, confirmPassword }) => newPassword === confirmPassword, {
+      path: ["confirmPassword"],
+      message: "changePasswordView.validation.passwordsDontMatch",
+    });
 
 export default function ChangePasswordForm() {
   const { mutate: changePassword } = useChangePassword();
   const { t } = useTranslation();
+
+  const {
+    data: { hasPassword },
+  } = usePasswordStatusSuspense();
+
+  const changePasswordSchema = useMemo(() => getChangePasswordSchema(hasPassword), [hasPassword]);
 
   const methods = useForm<ChangePasswordBody>({
     resolver: zodResolver(changePasswordSchema),
@@ -56,7 +68,14 @@ export default function ChangePasswordForm() {
   } = methods;
 
   const onSubmit = (data: ChangePasswordBody) => {
-    changePassword({ data });
+    const passwordData = hasPassword
+      ? data
+      : {
+          newPassword: data.newPassword,
+          confirmPassword: data.confirmPassword,
+        };
+
+    changePassword({ data: passwordData, hasPassword });
     reset();
   };
 
@@ -65,26 +84,38 @@ export default function ChangePasswordForm() {
       <Card id="change-password">
         <form onSubmit={handleSubmit(onSubmit)}>
           <CardHeader>
-            <CardTitle className="h5">{t("changePasswordView.header")}</CardTitle>
+            <CardTitle className="h5">
+              {t(
+                hasPassword ? "changePasswordView.header" : "changePasswordView.setPasswordHeader",
+              )}
+            </CardTitle>
             <CardDescription className="body-lg-md">
-              {t("changePasswordView.subHeader")}
+              {t(
+                hasPassword
+                  ? "changePasswordView.subHeader"
+                  : "changePasswordView.setPasswordSubHeader",
+              )}
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-2">
-            <Label htmlFor="oldPassword" className="body-base-md">
-              {t("changePasswordView.field.oldPassword")}
-            </Label>
-            <Input
-              id="oldPassword"
-              type="password"
-              data-testid={SETTINGS_PAGE_HANDLES.PASSWORD_OLD}
-              className={cn({
-                "border-red-500 focus:!ring-red-500": errors.oldPassword,
-              })}
-              {...register("oldPassword")}
-            />
-            {errors.oldPassword?.message && (
-              <FormValidationError message={t(errors.oldPassword.message)} />
+            {hasPassword && (
+              <>
+                <Label htmlFor="oldPassword" className="body-base-md">
+                  {t("changePasswordView.field.oldPassword")}
+                </Label>
+                <Input
+                  id="oldPassword"
+                  type="password"
+                  data-testid={SETTINGS_PAGE_HANDLES.PASSWORD_OLD}
+                  className={cn({
+                    "border-red-500 focus:!ring-red-500": errors.oldPassword,
+                  })}
+                  {...register("oldPassword")}
+                />
+                {errors.oldPassword?.message && (
+                  <FormValidationError message={t(errors.oldPassword.message)} />
+                )}
+              </>
             )}
 
             <div className="space-y-2">


### PR DESCRIPTION
## Issue(s)
- #1566 

## Overview

Improves password reset and account password management for users who do not yet have password credentials.

This change adds a password status API endpoint, exposes it through the generated web client, and uses it on the settings change-password form to switch between changing an existing password and creating the first password for the account. When a user has no credentials, the old password field is hidden and the API can create credentials from either the account settings flow or the reset-password flow.

Key changes:

- Added `GET /api/user/password-status` returning whether the current user has password credentials.
- Made `oldPassword` optional in the change-password contract, while still requiring it for users who already have credentials.
- Updated password reset to create credentials when resetting for a user without existing credentials.
- Added a web query hook for password status and invalidation after password creation/change.
- Updated settings form copy and validation for set-password vs change-password states.
- Regenerated Swagger schema and web API client.
- Added API e2e coverage for password status, set-password, and reset-password credential creation flows.

## Business Value

Users who sign in through magic links or other passwordless paths can now set a password from account settings without needing a nonexistent old password. Reset-password links also work for users without existing credentials by creating credentials instead of failing.

This reduces account-access friction and keeps the settings screen aligned with the user's real account state.



