### PR TITLE
chore: refine live training email notifications and recipient management

### DIFF
--- a/apps/api/src/announcements/announcements.repository.ts
+++ b/apps/api/src/announcements/announcements.repository.ts
@@ -482,11 +482,7 @@ export class AnnouncementsRepository {
     }
 
     return this.db
-      .select({
-        id: users.id,
-        email: users.email,
-        language: sql<SupportedLanguages>`coalesce(${settingsTable.settings}->>'language', ${DEFAULT_STUDENT_SETTINGS.language})`,
-      })
+      .select(this.getAnnouncementEmailRecipientFields())
       .from(userAnnouncements)
       .innerJoin(users, eq(users.id, userAnnouncements.userId))
       .leftJoin(settingsTable, eq(settingsTable.userId, users.id))
@@ -498,11 +494,7 @@ export class AnnouncementsRepository {
     liveTrainingId: UUIDType,
   ) {
     return this.db
-      .selectDistinct({
-        id: users.id,
-        email: users.email,
-        language: sql<SupportedLanguages>`coalesce(${settingsTable.settings}->>'language', ${DEFAULT_STUDENT_SETTINGS.language})`,
-      })
+      .selectDistinct(this.getAnnouncementEmailRecipientFields())
       .from(userAnnouncements)
       .innerJoin(users, eq(users.id, userAnnouncements.userId))
       .innerJoin(
@@ -529,6 +521,14 @@ export class AnnouncementsRepository {
       )
       .leftJoin(settingsTable, eq(settingsTable.userId, users.id))
       .where(and(eq(userAnnouncements.announcementId, announcementId), isNull(users.deletedAt)));
+  }
+
+  private getAnnouncementEmailRecipientFields() {
+    return {
+      id: users.id,
+      email: users.email,
+      language: sql<SupportedLanguages>`coalesce(${settingsTable.settings}->>'language', ${DEFAULT_STUDENT_SETTINGS.language})`,
+    };
   }
 
   private getLocalizedAnnouncementFields(language?: SupportedLanguages) {

--- a/apps/api/src/announcements/announcements.repository.ts
+++ b/apps/api/src/announcements/announcements.repository.ts
@@ -1,5 +1,11 @@
 import { Inject, Injectable } from "@nestjs/common";
-import { ANNOUNCEMENT_STATUSES, PERMISSIONS } from "@repo/shared";
+import {
+  ANNOUNCEMENT_SOURCE_TYPES,
+  ANNOUNCEMENT_STATUSES,
+  COURSE_ENROLLMENT,
+  LIVE_TRAINING_LINK_ENTITY_TYPES,
+  PERMISSIONS,
+} from "@repo/shared";
 import {
   eq,
   and,
@@ -29,7 +35,10 @@ import {
   announcements,
   groupAnnouncements,
   groupUsers,
+  liveLessons,
+  liveTrainingLinks,
   settings as settingsTable,
+  studentCourses,
   userAnnouncements,
   users,
 } from "src/storage/schema";
@@ -463,6 +472,15 @@ export class AnnouncementsRepository {
   }
 
   async getAnnouncementEmailRecipients(announcementId: UUIDType) {
+    const [announcement] = await this.getAnnouncementById(announcementId);
+
+    if (
+      announcement?.sourceType === ANNOUNCEMENT_SOURCE_TYPES.LIVE_TRAINING &&
+      announcement.sourceId
+    ) {
+      return this.getLiveTrainingSessionEmailRecipients(announcementId, announcement.sourceId);
+    }
+
     return this.db
       .select({
         id: users.id,
@@ -471,6 +489,44 @@ export class AnnouncementsRepository {
       })
       .from(userAnnouncements)
       .innerJoin(users, eq(users.id, userAnnouncements.userId))
+      .leftJoin(settingsTable, eq(settingsTable.userId, users.id))
+      .where(and(eq(userAnnouncements.announcementId, announcementId), isNull(users.deletedAt)));
+  }
+
+  private async getLiveTrainingSessionEmailRecipients(
+    announcementId: UUIDType,
+    liveTrainingId: UUIDType,
+  ) {
+    return this.db
+      .selectDistinct({
+        id: users.id,
+        email: users.email,
+        language: sql<SupportedLanguages>`coalesce(${settingsTable.settings}->>'language', ${DEFAULT_STUDENT_SETTINGS.language})`,
+      })
+      .from(userAnnouncements)
+      .innerJoin(users, eq(users.id, userAnnouncements.userId))
+      .innerJoin(
+        studentCourses,
+        and(
+          eq(studentCourses.studentId, users.id),
+          eq(studentCourses.status, COURSE_ENROLLMENT.ENROLLED),
+        ),
+      )
+      .innerJoin(
+        liveTrainingLinks,
+        and(
+          eq(liveTrainingLinks.liveTrainingId, liveTrainingId),
+          eq(liveTrainingLinks.entityType, LIVE_TRAINING_LINK_ENTITY_TYPES.COURSE),
+          eq(liveTrainingLinks.entityId, studentCourses.courseId),
+        ),
+      )
+      .innerJoin(
+        liveLessons,
+        and(
+          eq(liveLessons.liveTrainingId, liveTrainingId),
+          eq(liveLessons.liveTrainingLinkId, liveTrainingLinks.id),
+        ),
+      )
       .leftJoin(settingsTable, eq(settingsTable.userId, users.id))
       .where(and(eq(userAnnouncements.announcementId, announcementId), isNull(users.deletedAt)));
   }

--- a/apps/api/src/live-training/__tests__/live-training.controller.e2e-spec.ts
+++ b/apps/api/src/live-training/__tests__/live-training.controller.e2e-spec.ts
@@ -14,6 +14,7 @@ import {
 import { and, eq, isNull } from "drizzle-orm";
 import request from "supertest";
 
+import { EmailAdapter } from "src/common/emails/adapters/email.adapter";
 import { buildJsonbField } from "src/common/helpers/sqlHelpers";
 import { DB, DB_ADMIN } from "src/storage/db/db.providers";
 import {
@@ -41,6 +42,7 @@ import { cookieFor, truncateAllTables } from "../../../test/helpers/test-helpers
 import type { INestApplication } from "@nestjs/common";
 import type { DatabasePg, UUIDType } from "src/common";
 import type { UserWithCredentials } from "test/factory/user.factory";
+import type { EmailTestingAdapter } from "test/helpers/test-email.adapter";
 
 describe("LiveTrainingController (e2e)", () => {
   let app: INestApplication;
@@ -50,6 +52,7 @@ describe("LiveTrainingController (e2e)", () => {
   let userFactory: ReturnType<typeof createUserFactory>;
   let courseFactory: ReturnType<typeof createCourseFactory>;
   let chapterFactory: ReturnType<typeof createChapterFactory>;
+  let emailAdapter: EmailTestingAdapter;
 
   const password = "password123";
   const language = SUPPORTED_LANGUAGES.EN;
@@ -74,9 +77,11 @@ describe("LiveTrainingController (e2e)", () => {
     userFactory = createUserFactory(db);
     courseFactory = createCourseFactory(db);
     chapterFactory = createChapterFactory(db);
+    emailAdapter = app.get(EmailAdapter) as EmailTestingAdapter;
   });
 
   afterEach(async () => {
+    emailAdapter.clearEmails();
     await truncateAllTables(baseDb, db);
   });
 
@@ -152,6 +157,18 @@ describe("LiveTrainingController (e2e)", () => {
       .returning();
 
     return resource;
+  };
+
+  const waitForEmails = async (count: number) => {
+    for (let attempt = 0; attempt < 25; attempt += 1) {
+      const emails = emailAdapter.getAllEmails();
+
+      if (emails.length >= count) return emails;
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+
+    return emailAdapter.getAllEmails();
   };
 
   const createOfflineLiveTraining = async (admin: UserWithCredentials, courseId?: UUIDType) => {
@@ -587,5 +604,104 @@ describe("LiveTrainingController (e2e)", () => {
     expect(liveLesson.liveTrainingLinkId).toBe(courseLink.id);
     expect(lessonProgress.completedAt).not.toBeNull();
     expect(lessonProgress.languageAnswered).toBe(language);
+  });
+
+  it("sends live training emails only to students enrolled in a course with the linked live lesson", async () => {
+    const admin = await createAdmin();
+    const enrolledStudent = await createStudent();
+    const linkedCourseWithoutLiveLessonStudent = await createStudent();
+    const unrelatedStudent = await createStudent();
+    const liveLessonCourse = await createTestCourse(admin.id);
+    const linkedCourseWithoutLiveLesson = await createTestCourse(admin.id);
+    const chapter = await chapterFactory.create({
+      courseId: liveLessonCourse.id,
+      authorId: admin.id,
+    });
+    const startsAt = getFutureDateOnScheduleStep(60);
+    const endsAt = getFutureDateOnScheduleStep(120);
+
+    await db.insert(studentCourses).values([
+      {
+        courseId: liveLessonCourse.id,
+        studentId: enrolledStudent.id,
+        status: COURSE_ENROLLMENT.ENROLLED,
+      },
+      {
+        courseId: linkedCourseWithoutLiveLesson.id,
+        studentId: linkedCourseWithoutLiveLessonStudent.id,
+        status: COURSE_ENROLLMENT.ENROLLED,
+      },
+    ]);
+
+    const lessonResponse = await request(app.getHttpServer())
+      .post("/api/lesson/beta-create-lesson/live")
+      .set("Cookie", await cookieFor(admin, app))
+      .send({
+        title: "Email scoped live lesson",
+        description: "Email scoped live lesson description",
+        chapterId: chapter.id,
+        language,
+        liveTraining: {
+          title: "Email scoped training",
+          description: "Linked from lesson",
+          startsAt,
+          endsAt,
+          timezone,
+          deliveryType: LIVE_TRAINING_DELIVERY_TYPES.OFFLINE,
+          location: "Room 40",
+        },
+      })
+      .expect(201);
+
+    const { liveTrainingId } = lessonResponse.body.data;
+
+    await db.insert(liveTrainingLinks).values({
+      liveTrainingId,
+      entityType: LIVE_TRAINING_LINK_ENTITY_TYPES.COURSE,
+      entityId: linkedCourseWithoutLiveLesson.id,
+    });
+
+    const [liveLesson] = await db
+      .select()
+      .from(liveLessons)
+      .where(eq(liveLessons.liveTrainingId, liveTrainingId));
+
+    await db.insert(liveLessons).values({
+      liveTrainingId,
+      liveTrainingLinkId: liveLesson.liveTrainingLinkId,
+      lessonId: liveLesson.lessonId,
+      language: SUPPORTED_LANGUAGES.PL,
+    });
+
+    emailAdapter.clearEmails();
+
+    const startResponse = await request(app.getHttpServer())
+      .post(`/api/live-training/${liveTrainingId}/sessions/start`)
+      .query({ language })
+      .set("Cookie", await cookieFor(admin, app))
+      .expect(201);
+
+    const startEmails = await waitForEmails(1);
+
+    expect(startEmails.map((email) => email.to)).toEqual([enrolledStudent.email]);
+
+    emailAdapter.clearEmails();
+
+    await request(app.getHttpServer())
+      .post(`/api/live-training/${liveTrainingId}/sessions/${startResponse.body.data.id}/end`)
+      .query({ language })
+      .set("Cookie", await cookieFor(admin, app))
+      .expect(201);
+
+    const endEmails = await waitForEmails(1);
+
+    expect(endEmails.map((email) => email.to)).toEqual([enrolledStudent.email]);
+    expect([...startEmails, ...endEmails].map((email) => email.to)).not.toEqual(
+      expect.arrayContaining([
+        linkedCourseWithoutLiveLessonStudent.email,
+        unrelatedStudent.email,
+        admin.email,
+      ]),
+    );
   });
 });


### PR DESCRIPTION
## Issue(s)
- #1577 

## Overview
Adjusts live training announcement email recipients so live training emails are sent only to users enrolled in a course where the live training is linked as a live lesson.

The change keeps regular/manual announcement email delivery unchanged and adds a live-training-specific recipient query based on `live_lessons`, `live_training_links`, and enrolled `student_courses`.

## Business Value
Users now receive live training emails only for trainings that are relevant to courses they are enrolled in. This reduces irrelevant notifications and keeps course-related communication aligned with actual student access.


https://github.com/user-attachments/assets/147c0bc7-b087-4cdb-9447-1707678a22b3

