### PR TITLE
fix: improve course management in support mode and resolve magic link issues for sub-tenants

### DIFF
--- a/apps/api/src/auth/__tests__/auth.controller.e2e-spec.ts
+++ b/apps/api/src/auth/__tests__/auth.controller.e2e-spec.ts
@@ -15,6 +15,7 @@ import { createTokens, formFieldAnswers, magicLinkTokens, resetTokens } from "sr
 import { createE2ETest } from "../../../test/create-e2e-test";
 import { createSettingsFactory } from "../../../test/factory/settings.factory";
 import { createUserFactory } from "../../../test/factory/user.factory";
+import { DEFAULT_TEST_TENANT_HOST } from "../../../test/helpers/tenant-helpers";
 import { truncateTables } from "../../../test/helpers/test-helpers";
 import { AuthService } from "../auth.service";
 
@@ -963,6 +964,7 @@ describe("AuthController (e2e)", () => {
       expect(email?.to).toBe(user.email);
       expect(email?.subject).toBeDefined();
       expect(email?.html || email?.text).toContain("/auth/login?token=");
+      expect(email?.html || email?.text).toContain(`${DEFAULT_TEST_TENANT_HOST}/auth/login?token=`);
 
       const tokenMatch = (email?.html ?? email?.text ?? "").match(
         /\/auth\/login\?token=([^"&\s]+)/,

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -887,8 +887,12 @@ export class AuthService {
         user.id,
       );
 
+      const tenantOrigin = await this.resolveTenantOrigin(user.tenantId);
+      const magicLinkUrl = new URL("/auth/login", tenantOrigin);
+      magicLinkUrl.searchParams.set("token", magicLinkToken);
+
       const magicLinkEmail = new MagicLinkEmail({
-        magicLink: `${CORS_ORIGIN}/auth/login?token=${magicLinkToken}`,
+        magicLink: magicLinkUrl.toString(),
         ...defaultEmailSettings,
       });
 

--- a/apps/api/src/courses/__tests__/course.controller.e2e-spec.ts
+++ b/apps/api/src/courses/__tests__/course.controller.e2e-spec.ts
@@ -1,7 +1,9 @@
 import { faker } from "@faker-js/faker";
+import { JwtService } from "@nestjs/jwt";
 import {
   COURSE_ENROLLMENT,
   ENTITY_TYPES,
+  PERMISSIONS,
   SUPPORTED_LANGUAGES,
   SYSTEM_ROLE_SLUGS,
 } from "@repo/shared";
@@ -337,6 +339,51 @@ describe("CourseController (e2e)", () => {
           expect(response.body.data.length).toBe(1);
           expect(response.body.data[0].author).toBe(
             `${contentCreator.firstName} ${contentCreator.lastName}`,
+          );
+        });
+      });
+
+      describe("when user has own and any course update permissions", () => {
+        it("returns all courses instead of applying the own-course filter", async () => {
+          const category = await categoryFactory.create();
+          const user = await userFactory
+            .withCredentials({ password })
+            .withContentCreatorSettings(db)
+            .create({ role: SYSTEM_ROLE_SLUGS.CONTENT_CREATOR });
+          const otherAuthor = await userFactory
+            .withCredentials({ password })
+            .withContentCreatorSettings(db)
+            .create({ role: SYSTEM_ROLE_SLUGS.CONTENT_CREATOR });
+
+          const ownCourse = await courseFactory.create({
+            authorId: user.id,
+            categoryId: category.id,
+            status: "published",
+            thumbnailS3Key: null,
+          });
+          const otherCourse = await courseFactory.create({
+            authorId: otherAuthor.id,
+            categoryId: category.id,
+            status: "published",
+            thumbnailS3Key: null,
+          });
+
+          const accessToken = app.get(JwtService).sign({
+            userId: user.id,
+            email: user.email,
+            roleSlugs: [SYSTEM_ROLE_SLUGS.ADMIN],
+            permissions: Object.values(PERMISSIONS),
+            tenantId: user.tenantId,
+          });
+
+          const response = await request(app.getHttpServer())
+            .get("/api/course/all")
+            .set("Cookie", `access_token=${accessToken}`)
+            .expect(200);
+
+          expect(response.body.data).toBeDefined();
+          expect(response.body.data.map((course: CourseTest) => course.id)).toEqual(
+            expect.arrayContaining([ownCourse.id, otherCourse.id]),
           );
         });
       });

--- a/apps/api/src/courses/course.service.ts
+++ b/apps/api/src/courses/course.service.ts
@@ -229,7 +229,10 @@ export class CourseService {
     const conditions = this.getFiltersConditions(filters, false, language);
     const orderConditions = this.getOrderConditions(filters);
 
-    if (currentUserId && hasPermission(currentUserPermissions, PERMISSIONS.COURSE_UPDATE_OWN)) {
+    const canUpdateAnyCourse = hasPermission(currentUserPermissions, PERMISSIONS.COURSE_UPDATE);
+    const canUpdateOwnCourse = hasPermission(currentUserPermissions, PERMISSIONS.COURSE_UPDATE_OWN);
+
+    if (currentUserId && canUpdateOwnCourse && !canUpdateAnyCourse) {
       conditions.push(eq(courses.authorId, currentUserId));
     }
 


### PR DESCRIPTION
## Issue(s)
- #1584 

## Overview
Fixes two tenant/support-mode edge cases:

- The admin/manage course list no longer returns empty in support mode when the user has both `COURSE_UPDATE` and `COURSE_UPDATE_OWN`; full course update permission now takes precedence over the own-course filter.
- Magic-link emails now resolve login links against the user tenant host instead of `CORS_ORIGIN`, so sub-tenant users receive links for the correct domain.

## Business Value
Support users can inspect and manage tenant course lists without being blocked by an incorrect own-course filter.

Sub-tenant users can log in from magic-link emails without being redirected to the wrong host, reducing failed login flows and tenant confusion.

## Screenshots / Video

https://github.com/user-attachments/assets/59f32903-b87f-4181-97f3-5ace777d3a51

