### PR TITLE
fix: allow discount values to be cleared in promotion code forms

### DIFF
--- a/apps/web/app/modules/Admin/PromotionCodes/CreatePromotionCode.page.tsx
+++ b/apps/web/app/modules/Admin/PromotionCodes/CreatePromotionCode.page.tsx
@@ -196,7 +196,7 @@ const CreatePromotionCode = () => {
                     id="discountValue"
                     {...field}
                     type="number"
-                    onChange={(e) => field.onChange(Number(e.target.value))}
+                    onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : "")}
                     onWheel={(e) => e.currentTarget.blur()}
                   />
                 </FormControl>


### PR DESCRIPTION
## Issue(s)
[#1278](https://github.com/Selleo/mentingo/issues/1278)

## Overview 
Fixes the discount value input field in the promotion code creation form that could not be cleared after entering a value. Previously, the onChange handler always converted the input to Number, which coerced an empty string to 0.

## Screenshots / Video
https://github.com/user-attachments/assets/1f8e0018-2612-41c9-a3fd-653893b07387
