### PR TITLE
fix: hide the connector line on the last chapter step indicator

### DIFF
--- a/apps/web/app/modules/Courses/CourseView/CourseChapter.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseChapter.tsx
@@ -25,9 +25,10 @@ export type Lesson = GetCourseResponse["data"]["chapters"][0]["lessons"][0] & {
 type Chapter = GetCourseResponse["data"]["chapters"][0] & { lessons: Lesson[] };
 type CourseChapterProps = {
   chapter: Chapter;
+  isLast?: boolean;
 };
 
-export const CourseChapter = ({ chapter }: CourseChapterProps) => {
+export const CourseChapter = ({ chapter, isLast = false }: CourseChapterProps) => {
   const { t } = useTranslation();
   const { id: courseSlug } = useParams();
   const {
@@ -93,6 +94,7 @@ export const CourseChapter = ({ chapter }: CourseChapterProps) => {
             chapterProgress={chapter.chapterProgress}
             displayOrder={chapter.displayOrder}
             isPreviewMode={isPreviewMode}
+            showConnector={!isLast}
           />
           <div className="flex w-full flex-col">
             <AccordionTrigger

--- a/apps/web/app/modules/Courses/CourseView/components/ChapterCounter.tsx
+++ b/apps/web/app/modules/Courses/CourseView/components/ChapterCounter.tsx
@@ -10,6 +10,7 @@ type ChapterCounterProps = {
   chapterProgress: GetCourseResponse["data"]["chapters"][number]["chapterProgress"];
   displayOrder: GetCourseResponse["data"]["chapters"][number]["displayOrder"];
   isPreviewMode?: boolean;
+  showConnector?: boolean;
 };
 
 const chapterCounterIcon = {
@@ -22,6 +23,7 @@ export const ChapterCounter = ({
   chapterProgress = CHAPTER_PROGRESS_STATUSES.NOT_STARTED,
   displayOrder,
   isPreviewMode = false,
+  showConnector = true,
 }: ChapterCounterProps) => {
   const chapterNumber = formatNumberToTwoDigits(displayOrder);
 
@@ -32,11 +34,12 @@ export const ChapterCounter = ({
   return (
     <div
       className={cn(
-        "sr-only after:block after:h-full after:w-0.5 md:not-sr-only md:flex md:flex-col md:items-center md:gap-y-1 md:pt-4",
+        "sr-only md:not-sr-only md:flex md:flex-col md:items-center md:gap-y-1 md:pt-4",
         {
-          "after:bg-primary-200": !isPreviewMode || !isChapterStarted,
-          "after:bg-secondary-200": !isPreviewMode && isChapterStarted,
-          "after:bg-success-200": !isPreviewMode && isChapterCompleted,
+          "after:block after:h-full after:w-0.5": showConnector,
+          "after:bg-primary-200": showConnector && (!isPreviewMode || !isChapterStarted),
+          "after:bg-secondary-200": showConnector && !isPreviewMode && isChapterStarted,
+          "after:bg-success-200": showConnector && !isPreviewMode && isChapterCompleted,
         },
       )}
     >

--- a/apps/web/app/modules/Courses/CourseView/components/ChapterListOverview.tsx
+++ b/apps/web/app/modules/Courses/CourseView/components/ChapterListOverview.tsx
@@ -25,9 +25,15 @@ export function ChapterListOverview() {
         <h4 className="h6 text-neutral-950">{t("studentCourseView.header")}</h4>
         <p className="body-base-md text-neutral-800">{t("studentCourseView.subHeader")}</p>
       </div>
-      {chapters.map((chapter) => {
+      {chapters.map((chapter, index) => {
         if (!chapter) return null;
-        return <CourseChapter key={chapter.id} chapter={chapter} />;
+        return (
+          <CourseChapter
+            key={chapter.id}
+            chapter={chapter}
+            isLast={index === chapters.length - 1}
+          />
+        );
       })}
     </div>
   );


### PR DESCRIPTION
## Issue
[#1121](https://github.com/Selleo/mentingo/issues/1121)

## Overview 
Added a `showConnector` prop to `ChapterCounter` (defaults to `true`) and an `isLast` prop to `CourseChapter` (defaults to `false`). When mapping chapters in `ChapterListOverview`, the last item receives `isLast={true}`, which passes `showConnector={false}` down to `ChapterCounter` and suppresses the `::after` vertical line.

## Business Value
Users browsing a course outline get a clear visual signal that they have reached the end of the chapter list. Without this fix the trailing line creates ambiguity.

## Screenshot
<img width="989" height="525" alt="image" src="https://github.com/user-attachments/assets/45168fc0-f8ae-4e43-9334-8c9430325c45" />