### PR TITLE
fix: improve SCORM export reliability and error handling

### DIFF
--- a/apps/api/src/courses/__tests__/course.controller.e2e-spec.ts
+++ b/apps/api/src/courses/__tests__/course.controller.e2e-spec.ts
@@ -251,6 +251,123 @@ describe("CourseController (e2e)", () => {
       expect(courseJson.lessons[secondLesson.id].html).toContain(runtimeAssetPath);
       expect(manifestEntry!.getData().toString("utf8")).toContain(canonicalAssetPath);
     });
+
+    it("exports rich-text video, downloadable, and preview assets without keeping preview query params", async () => {
+      const category = await categoryFactory.create();
+      const admin = await userFactory
+        .withCredentials({ password })
+        .withAdminSettings(db)
+        .create({ role: SYSTEM_ROLE_SLUGS.ADMIN });
+      const course = await courseFactory.create({
+        authorId: admin.id,
+        categoryId: category.id,
+        title: "SCORM Export Rich Text Assets",
+        description: "SCORM export rich text asset test course",
+        thumbnailS3Key: null,
+        chapterCount: 1,
+      });
+      const chapter = await chapterFactory.create({
+        authorId: admin.id,
+        courseId: course.id,
+        title: "SCORM Export Chapter",
+        displayOrder: 1,
+        lessonCount: 2,
+      });
+      const [lesson, linkedLesson] = await db
+        .insert(lessons)
+        .values([
+          {
+            chapterId: chapter.id,
+            type: LESSON_TYPES.CONTENT,
+            title: buildJsonbField("en", "Content lesson with mixed assets"),
+            description: buildJsonbField("en", ""),
+            displayOrder: 1,
+          },
+          {
+            chapterId: chapter.id,
+            type: LESSON_TYPES.CONTENT,
+            title: buildJsonbField("en", "Lesson with stale asset relations"),
+            description: buildJsonbField("en", ""),
+            displayOrder: 2,
+          },
+        ])
+        .returning();
+      const [videoResource, downloadableResource, previewResource] = await db
+        .insert(resources)
+        .values([
+          {
+            title: buildJsonbField("en", "Content video"),
+            reference: "lesson-content/video.mp4",
+            contentType: "video/mp4",
+            uploadedBy: admin.id,
+          },
+          {
+            title: buildJsonbField("en", "Downloadable file"),
+            reference: "lesson-content/document.pdf",
+            contentType: "application/pdf",
+            uploadedBy: admin.id,
+          },
+          {
+            title: buildJsonbField("en", "Preview presentation"),
+            reference: "lesson-content/slides.pptx",
+            contentType:
+              "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            uploadedBy: admin.id,
+          },
+        ])
+        .returning();
+
+      await db.insert(resourceEntity).values(
+        [videoResource, downloadableResource, previewResource].map((resource) => ({
+          resourceId: resource.id,
+          entityId: linkedLesson.id,
+          entityType: ENTITY_TYPES.LESSON,
+          relationshipType: RESOURCE_RELATIONSHIP_TYPES.ATTACHMENT,
+        })),
+      );
+
+      await db
+        .update(lessons)
+        .set({
+          description: buildJsonbField(
+            "en",
+            [
+              `<div data-node-type="video" data-src="/api/lesson/lesson-resource/${videoResource.id}"></div>`,
+              `<div data-node-type="downloadable-file" data-src="/api/lesson/lesson-resource/${downloadableResource.id}" data-name="document.pdf"></div>`,
+              `<div data-node-type="pdf-preview" data-src="/api/lesson/lesson-resource/${previewResource.id}?preview=pdf" data-name="slides.pptx"></div>`,
+            ].join(""),
+          ),
+        })
+        .where(eq(lessons.id, lesson.id));
+
+      mockFileService.getRawFileBuffer.mockImplementation(async (reference: string) =>
+        Buffer.from(`file:${reference}`),
+      );
+
+      const response = await request(app.getHttpServer())
+        .post(`/api/course/${course.id}/scorm-export?language=en`)
+        .set("Cookie", await cookieFor(admin, app))
+        .responseType("arraybuffer")
+        .expect(201);
+
+      const zip = new AdmZip(response.body);
+      const courseJsonEntry = zip.getEntry("data/course.json");
+      expect(courseJsonEntry).toBeDefined();
+
+      const courseJson = JSON.parse(courseJsonEntry!.getData().toString("utf8"));
+      const exportedHtml = courseJson.lessons[lesson.id].html;
+      const videoAssetPath = `../assets/lessons/${lesson.id}/video.mp4`;
+      const downloadableAssetPath = `../assets/lessons/${lesson.id}/document.pdf`;
+      const previewAssetPath = `../assets/lessons/${lesson.id}/slides.pptx`;
+
+      expect(exportedHtml).toContain(`data-src="${videoAssetPath}"`);
+      expect(exportedHtml).toContain(`data-src="${downloadableAssetPath}"`);
+      expect(exportedHtml).toContain(`data-src="${previewAssetPath}"`);
+      expect(exportedHtml).not.toContain("?preview=pdf");
+      expect(zip.getEntry(`assets/lessons/${lesson.id}/video.mp4`)).toBeDefined();
+      expect(zip.getEntry(`assets/lessons/${lesson.id}/document.pdf`)).toBeDefined();
+      expect(zip.getEntry(`assets/lessons/${lesson.id}/slides.pptx`)).toBeDefined();
+    });
   });
 
   describe("GET /api/course/all", () => {

--- a/apps/api/src/courses/course-scorm-assets.service.ts
+++ b/apps/api/src/courses/course-scorm-assets.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable } from "@nestjs/common";
+import { BadRequestException, Injectable, Logger } from "@nestjs/common";
 import { importedScormPackagePath } from "@repo/scorm-export-generator";
 
 import { BunnyStreamService } from "src/bunny/bunnyStream.service";
@@ -20,6 +20,8 @@ import type {
 
 @Injectable()
 export class CourseScormAssetsService {
+  private readonly logger = new Logger(CourseScormAssetsService.name);
+
   constructor(
     private readonly fileService: FileService,
     private readonly bunnyStreamService: BunnyStreamService,
@@ -82,6 +84,14 @@ export class CourseScormAssetsService {
     const buffer = await this.fileService.getRawFileBuffer(asset.sourceReference);
 
     if (!buffer) {
+      this.logger.error({
+        message: "SCORM export missing asset: file buffer could not be resolved",
+        assetId: asset.id,
+        assetType: asset.type,
+        sourceReference: asset.sourceReference,
+        packagePath: asset.packagePath,
+        contentType: asset.contentType,
+      });
       throw new BadRequestException("adminCourseView.scormExport.error.missingAsset");
     }
 
@@ -100,6 +110,19 @@ export class CourseScormAssetsService {
     options: CourseScormCollectAssetsOptions,
   ): Promise<CourseScormAssetResolution> {
     const videoId = asset.sourceReference.replace("bunny-", "");
+    const isConfigured = await this.bunnyStreamService.isConfigured();
+
+    if (!isConfigured) {
+      this.logger.error({
+        message: "SCORM export failed: Bunny Stream is not configured",
+        assetId: asset.id,
+        assetType: asset.type,
+        sourceReference: asset.sourceReference,
+        packagePath: asset.packagePath,
+        contentType: asset.contentType,
+      });
+      throw new BadRequestException("adminCourseView.scormExport.error.bunnyNotConfigured");
+    }
 
     try {
       const file = await this.bunnyStreamService.downloadMp4Fallback(
@@ -116,7 +139,16 @@ export class CourseScormAssetsService {
           stream: file.stream,
         },
       };
-    } catch {
+    } catch (error) {
+      this.logger.error({
+        message: "SCORM export missing asset: Bunny video could not be downloaded",
+        assetId: asset.id,
+        assetType: asset.type,
+        sourceReference: asset.sourceReference,
+        packagePath: asset.packagePath,
+        contentType: asset.contentType,
+        error: error instanceof Error ? error.message : String(error),
+      });
       throw new BadRequestException("adminCourseView.scormExport.error.missingAsset");
     }
   }
@@ -270,7 +302,7 @@ export class CourseScormAssetsService {
 
   private resourceReferenceRegex(resourceId: string) {
     return new RegExp(
-      `(?:https?:\\/\\/[^"'\\s>]+)?(?:\\/api\\/lesson\\/)?lesson-resource\\/${resourceId}`,
+      `(?:https?:\\/\\/[^"'\\s>]+)?(?:\\/api\\/lesson\\/)?lesson-resource\\/${resourceId}(?:\\?[^"'\\s>]*)?`,
       "g",
     );
   }

--- a/apps/api/src/courses/course-scorm-snapshot.repository.ts
+++ b/apps/api/src/courses/course-scorm-snapshot.repository.ts
@@ -1,0 +1,42 @@
+import { Inject, Injectable } from "@nestjs/common";
+import { and, eq, inArray, sql } from "drizzle-orm";
+
+import { DatabasePg } from "src/common";
+import { LocalizationService } from "src/localization/localization.service";
+import { DB } from "src/storage/db/db.providers";
+import { resources } from "src/storage/schema";
+
+import type { CourseScormResourceAssetRow } from "./types/scorm-export.types";
+import type { SupportedLanguages } from "@repo/shared";
+import type { UUIDType } from "src/common";
+
+@Injectable()
+export class CourseScormSnapshotRepository {
+  constructor(
+    @Inject(DB) private readonly db: DatabasePg,
+    private readonly localizationService: LocalizationService,
+  ) {}
+
+  async getActiveResourceAssetsByIds(
+    resourceIds: UUIDType[],
+    language: SupportedLanguages,
+  ): Promise<CourseScormResourceAssetRow[]> {
+    if (!resourceIds.length) return [];
+
+    return this.db
+      .select({
+        id: resources.id,
+        reference: resources.reference,
+        contentType: resources.contentType,
+        metadata: resources.metadata,
+        title: sql<string>`COALESCE(
+          ${this.localizationService.getFieldByLanguage(resources.title, language)},
+          ${this.localizationService.getFirstValue(resources.title)},
+          ''
+        )`,
+      })
+      .from(resources)
+      .where(and(inArray(resources.id, resourceIds), eq(resources.archived, false)))
+      .orderBy(resources.createdAt);
+  }
+}

--- a/apps/api/src/courses/course-scorm-snapshot.service.ts
+++ b/apps/api/src/courses/course-scorm-snapshot.service.ts
@@ -1,15 +1,15 @@
-import { BadRequestException, Inject, Injectable, NotFoundException } from "@nestjs/common";
+import { BadRequestException, Inject, Injectable, Logger, NotFoundException } from "@nestjs/common";
 import { ENTITY_TYPES, SCORM_PACKAGE_ENTITY_TYPE, SCORM_PACKAGE_STATUS } from "@repo/shared";
 import { and, asc, eq, getTableColumns, inArray, sql } from "drizzle-orm";
 import { groupBy } from "lodash";
 
 import { DatabasePg } from "src/common";
 import { RESOURCE_RELATIONSHIP_TYPES } from "src/file/file.constants";
-import { extractLessonResourceIds } from "src/lesson/lesson-resource-references";
 import { LESSON_TYPES } from "src/lesson/lesson.type";
 import { LocalizationService } from "src/localization/localization.service";
 import { ENTITY_TYPE } from "src/localization/localization.types";
 import { QUESTION_TYPE } from "src/questions/schema/question.types";
+import { extractResourceIdsFromRichText } from "src/resource-library/resource-library.utils";
 import { SettingsService } from "src/settings/settings.service";
 import {
   categories,
@@ -25,6 +25,7 @@ import {
 } from "src/storage/schema";
 
 import { SCORM_EXPORTABLE_LESSON_TYPES } from "./course-scorm-export.constants";
+import { CourseScormSnapshotRepository } from "./course-scorm-snapshot.repository";
 
 import type {
   CourseScormBuildLessonsByIdOptions,
@@ -46,10 +47,13 @@ import type { UUIDType } from "src/common";
 
 @Injectable()
 export class CourseScormSnapshotService {
+  private readonly logger = new Logger(CourseScormSnapshotService.name);
+
   constructor(
     @Inject("DB") private readonly db: DatabasePg,
     private readonly localizationService: LocalizationService,
     private readonly settingsService: SettingsService,
+    private readonly courseScormSnapshotRepository: CourseScormSnapshotRepository,
   ) {}
 
   async buildSnapshot(
@@ -81,11 +85,22 @@ export class CourseScormSnapshotService {
     }
 
     const lessonIds = lessonRows.map((lesson) => lesson.id);
-    const [lessonAssets, quizQuestions, quizOptions, scormScoRows] = await Promise.all([
+    const [
+      linkedLessonAssets,
+      referencedContentLessonAssets,
+      quizQuestions,
+      quizOptions,
+      scormScoRows,
+    ] = await Promise.all([
       this.getLessonAssets(lessonIds, language),
+      this.getReferencedContentLessonAssets(lessonRows, language),
       this.getQuizQuestions(lessonIds, language),
       this.getQuizOptions(lessonIds, language),
       this.getScormScoRows(lessonIds, language),
+    ]);
+    const lessonAssets = this.dedupeLessonAssets([
+      ...linkedLessonAssets,
+      ...referencedContentLessonAssets,
     ]);
 
     this.validateRequiredAssets({
@@ -224,6 +239,47 @@ export class CourseScormSnapshotService {
         ),
       )
       .orderBy(resources.createdAt);
+  }
+
+  private async getReferencedContentLessonAssets(
+    lessonRows: CourseScormLessonRow[],
+    language: SupportedLanguages,
+  ): Promise<CourseScormLessonAssetRow[]> {
+    const resourceIdsByLessonId = new Map<UUIDType, UUIDType[]>();
+
+    for (const lesson of lessonRows) {
+      if (lesson.type !== LESSON_TYPES.CONTENT) continue;
+
+      const resourceIds = extractResourceIdsFromRichText(lesson.description ?? "") as UUIDType[];
+      if (resourceIds.length) resourceIdsByLessonId.set(lesson.id, [...new Set(resourceIds)]);
+    }
+
+    const resourceIds = [...new Set(Array.from(resourceIdsByLessonId.values()).flat())];
+    if (!resourceIds.length) return [];
+
+    const resourceRows = await this.courseScormSnapshotRepository.getActiveResourceAssetsByIds(
+      resourceIds,
+      language,
+    );
+    const resourcesById = new Map(resourceRows.map((resource) => [resource.id, resource]));
+
+    return Array.from(resourceIdsByLessonId.entries()).flatMap(([lessonId, ids]) =>
+      ids.flatMap((resourceId) => {
+        const resource = resourcesById.get(resourceId);
+        if (!resource) return [];
+
+        return {
+          lessonId,
+          ...resource,
+        };
+      }),
+    );
+  }
+
+  private dedupeLessonAssets(lessonAssets: CourseScormLessonAssetRow[]) {
+    return Array.from(
+      new Map(lessonAssets.map((asset) => [`${asset.lessonId}:${asset.id}`, asset])).values(),
+    );
   }
 
   private async getQuizQuestions(lessonIds: UUIDType[], language: SupportedLanguages) {
@@ -480,12 +536,25 @@ export class CourseScormSnapshotService {
 
     for (const asset of lessonAssets) {
       if (!asset.reference) {
+        this.logger.error({
+          message: "SCORM export missing asset: lesson asset row has no reference",
+          lessonId: asset.lessonId,
+          resourceId: asset.id,
+          contentType: asset.contentType,
+          title: asset.title,
+        });
         throw new BadRequestException("adminCourseView.scormExport.error.missingAsset");
       }
     }
 
     for (const question of quizQuestions) {
       if (question.photoS3Key === "") {
+        this.logger.error({
+          message: "SCORM export missing asset: quiz question photo reference is empty",
+          questionId: question.id,
+          lessonId: question.lessonId,
+          questionType: question.type,
+        });
         throw new BadRequestException("adminCourseView.scormExport.error.missingAsset");
       }
     }
@@ -498,11 +567,26 @@ export class CourseScormSnapshotService {
       if (lesson.type === LESSON_TYPES.EMBED) {
         const [embedResource] = lessonAssetsByLessonId[lesson.id] ?? [];
         if (!embedResource?.reference) {
+          this.logger.error({
+            message: "SCORM export missing asset: embed lesson has no attachment reference",
+            lessonId: lesson.id,
+            lessonTitle: lesson.title,
+            foundAssets: (lessonAssetsByLessonId[lesson.id] ?? []).map((asset) => ({
+              resourceId: asset.id,
+              reference: asset.reference,
+              contentType: asset.contentType,
+            })),
+          });
           throw new BadRequestException("adminCourseView.scormExport.error.missingAsset");
         }
       }
 
       if (lesson.type === LESSON_TYPES.SCORM && !scormScosByLessonId[lesson.id]?.length) {
+        this.logger.error({
+          message: "SCORM export missing asset: SCORM lesson has no ready SCO rows",
+          lessonId: lesson.id,
+          lessonTitle: lesson.title,
+        });
         throw new BadRequestException("adminCourseView.scormExport.error.missingAsset");
       }
     }
@@ -512,7 +596,7 @@ export class CourseScormSnapshotService {
     lesson: CourseScormLessonRow,
     lessonAssets: CourseScormLessonAssetRow[],
   ) {
-    const referencedResourceIds = extractLessonResourceIds(lesson.description ?? "");
+    const referencedResourceIds = extractResourceIdsFromRichText(lesson.description ?? "");
     if (!referencedResourceIds.length) return;
 
     const availableResourceIds = new Set(lessonAssets.map((asset) => asset.id));
@@ -521,6 +605,23 @@ export class CourseScormSnapshotService {
     );
 
     if (hasMissingResource) {
+      this.logger.error({
+        message:
+          "SCORM export missing asset: content references resources not linked as lesson attachments",
+        lessonId: lesson.id,
+        lessonTitle: lesson.title,
+        referencedResourceIds,
+        availableAttachmentResourceIds: [...availableResourceIds],
+        missingResourceIds: referencedResourceIds.filter(
+          (resourceId) => !availableResourceIds.has(resourceId),
+        ),
+        foundAssets: lessonAssets.map((asset) => ({
+          resourceId: asset.id,
+          reference: asset.reference,
+          contentType: asset.contentType,
+          title: asset.title,
+        })),
+      });
       throw new BadRequestException("adminCourseView.scormExport.error.missingAsset");
     }
   }

--- a/apps/api/src/courses/course.module.ts
+++ b/apps/api/src/courses/course.module.ts
@@ -23,6 +23,7 @@ import { UserModule } from "src/user/user.module";
 import { CourseFeaturePolicyService } from "./course-feature-policy.service";
 import { CourseScormAssetsService } from "./course-scorm-assets.service";
 import { CourseScormExportService } from "./course-scorm-export.service";
+import { CourseScormSnapshotRepository } from "./course-scorm-snapshot.repository";
 import { CourseScormSnapshotService } from "./course-scorm-snapshot.service";
 import { CourseSlugService } from "./course-slug.service";
 import { CourseController } from "./course.controller";
@@ -56,6 +57,7 @@ import { MasterCourseWorker } from "./master-course.worker";
     CourseService,
     CourseScormAssetsService,
     CourseScormExportService,
+    CourseScormSnapshotRepository,
     CourseScormSnapshotService,
     CourseFeaturePolicyService,
     CourseSlugService,

--- a/apps/api/src/courses/types/scorm-export.types.ts
+++ b/apps/api/src/courses/types/scorm-export.types.ts
@@ -43,6 +43,8 @@ export type CourseScormLessonAssetRow = {
   title: string;
 };
 
+export type CourseScormResourceAssetRow = Omit<CourseScormLessonAssetRow, "lessonId">;
+
 export type CourseScormQuizQuestionRow = {
   id: UUIDType;
   lessonId: UUIDType;

--- a/apps/api/src/lesson/services/lesson.service.ts
+++ b/apps/api/src/lesson/services/lesson.service.ts
@@ -592,8 +592,16 @@ export class LessonService {
       currentUser.userId,
     );
 
+    if (!lesson) {
+      if (isStudent) {
+        throw new ForbiddenException("common.toast.lessonAccessDenied");
+      }
+
+      throw new NotFoundException("common.toast.notFound");
+    }
+
     if (!lesson.isAssigned && isStudent && !lesson.isFreemium) {
-      throw new ForbiddenException("You are not allowed to access this lesson!");
+      throw new ForbiddenException("common.toast.lessonAccessDenied");
     }
 
     return this.streamResource(req, res, lessonResource.reference, {

--- a/apps/web/app/locales/cs/translation.json
+++ b/apps/web/app/locales/cs/translation.json
@@ -24,6 +24,7 @@
       "globalSettingsNotFound": "Globální nastavení nenalezeno",
       "somethingWentWrong": "Něco se pokazilo...",
       "notFound": "Zdroj nenalezen",
+      "lessonAccessDenied": "Nemáte oprávnění k přístupu k této lekci.",
       "tooManyRequests": "Příliš mnoho požadavků. Zkuste to znovu za {{seconds}} sekund."
     },
     "tooltip": {
@@ -2359,6 +2360,7 @@
         "noExportableLessons": "Tento kurz neobsahuje lekce, které lze exportovat do SCORM.",
         "unsupportedLessonType": "Tento kurz obsahuje typ lekce, který nelze exportovat do SCORM.",
         "missingAsset": "Tento kurz obsahuje soubor nebo zdroj, který se nepodařilo připravit pro export.",
+        "bunnyNotConfigured": "Export videa není nakonfigurován. Před exportem kurzů s video lekcemi nakonfigurujte Bunny Stream.",
         "invalidSnapshot": "Tento kurz se nepodařilo připravit pro export SCORM.",
         "fallback": "Export SCORM se nezdařil."
       }

--- a/apps/web/app/locales/de/translation.json
+++ b/apps/web/app/locales/de/translation.json
@@ -24,6 +24,7 @@
       "globalSettingsNotFound": "Globale Einstellungen nicht gefunden",
       "somethingWentWrong": "Etwas ist schiefgelaufen...",
       "notFound": "Ressource nicht gefunden",
+      "lessonAccessDenied": "Sie haben keine Berechtigung, auf diese Lektion zuzugreifen.",
       "tooManyRequests": "Zu viele Anfragen. Versuchen Sie es in {{seconds}} Sekunden erneut."
     },
     "tooltip": {
@@ -2353,6 +2354,7 @@
         "noExportableLessons": "Dieser Kurs enthält keine Lektionen, die nach SCORM exportiert werden können.",
         "unsupportedLessonType": "Dieser Kurs enthält einen Lektionstyp, der nicht nach SCORM exportiert werden kann.",
         "missingAsset": "Dieser Kurs enthält eine Datei oder Ressource, die für den Export nicht aufgelöst werden konnte.",
+        "bunnyNotConfigured": "Der Videoexport ist nicht konfiguriert. Konfigurieren Sie Bunny Stream, bevor Sie Kurse mit Videolektionen exportieren.",
         "invalidSnapshot": "Dieser Kurs konnte nicht für den SCORM-Export vorbereitet werden.",
         "fallback": "Der SCORM-Export ist fehlgeschlagen."
       }

--- a/apps/web/app/locales/en/translation.json
+++ b/apps/web/app/locales/en/translation.json
@@ -24,6 +24,7 @@
       "globalSettingsNotFound": "Global settings not found",
       "somethingWentWrong": "Something went wrong...",
       "notFound": "Resource not found",
+      "lessonAccessDenied": "You do not have permission to access this lesson.",
       "tooManyRequests": "Too many requests. Try again in {{seconds}} seconds."
     },
     "tooltip": {
@@ -2414,6 +2415,7 @@
         "noExportableLessons": "This course has no lessons that can be exported to SCORM.",
         "unsupportedLessonType": "This course contains a lesson type that cannot be exported to SCORM.",
         "missingAsset": "This course contains a file or resource that could not be resolved for export.",
+        "bunnyNotConfigured": "Video export is not configured. Configure Bunny Stream before exporting courses with video lessons.",
         "invalidSnapshot": "This course could not be prepared for SCORM export.",
         "fallback": "SCORM export failed."
       }

--- a/apps/web/app/locales/lt/translation.json
+++ b/apps/web/app/locales/lt/translation.json
@@ -24,6 +24,7 @@
       "globalSettingsNotFound": "Bendrieji nustatymai nerasta",
       "somethingWentWrong": "Kažkas ne taip...",
       "notFound": "Išteklius nerastas",
+      "lessonAccessDenied": "Neturite leidimo pasiekti šios pamokos.",
       "tooManyRequests": "Per daug prašymų. Bandykite dar kartą po {{seconds}} sekundžių."
     },
     "tooltip": {
@@ -2359,6 +2360,7 @@
         "noExportableLessons": "Šiame kurse nėra pamokų, kurias galima eksportuoti į SCORM.",
         "unsupportedLessonType": "Šiame kurse yra pamokos tipas, kurio negalima eksportuoti į SCORM.",
         "missingAsset": "Šiame kurse yra failas arba išteklius, kurio nepavyko paruošti eksportui.",
+        "bunnyNotConfigured": "Vaizdo įrašų eksportas nesukonfigūruotas. Prieš eksportuodami kursus su vaizdo pamokomis sukonfigūruokite Bunny Stream.",
         "invalidSnapshot": "Nepavyko paruošti šio kurso SCORM eksportui.",
         "fallback": "SCORM eksportas nepavyko."
       }

--- a/apps/web/app/locales/pl/translation.json
+++ b/apps/web/app/locales/pl/translation.json
@@ -25,6 +25,7 @@
       "globalSettingsNotFound": "Ustawienia globalne nie zostały znalezione",
       "somethingWentWrong": "Coś poszło nie tak...",
       "notFound": "Nie znaleziono zasobu",
+      "lessonAccessDenied": "Nie masz uprawnień do tej lekcji.",
       "tooManyRequests": "Zbyt wiele prób. Spróbuj ponownie za {{seconds}} sekund."
     },
     "tooltip": {
@@ -2649,6 +2650,7 @@
         "noExportableLessons": "Ten kurs nie zawiera lekcji, które można wyeksportować do SCORM.",
         "unsupportedLessonType": "Ten kurs zawiera typ lekcji, którego nie można wyeksportować do SCORM.",
         "missingAsset": "Ten kurs zawiera plik lub zasób, którego nie udało się przygotować do eksportu.",
+        "bunnyNotConfigured": "Eksport wideo nie jest skonfigurowany. Skonfiguruj Bunny Stream przed eksportem kursów z lekcjami wideo.",
         "invalidSnapshot": "Nie udało się przygotować tego kursu do eksportu SCORM.",
         "fallback": "Eksport SCORM nie powiódł się."
       }


### PR DESCRIPTION
<!--
 1. Make sure you have correct branch name i.e. `ab_prefix_123_task_name`, where `123` is a issue ID, and `ab` is an author
 2. Make sure you have meaningful title related to task with correct prefix: feat/fix/chore/style/docs/refactor
 3. Reference multiple issues in one PR by listing them in the issues section
 4. Make sure all necessary sections are filled, remove obsolete sections
 5. Do a self review first
 6. Check if your PR includes only code related to your task
 7. `Notes` is used for additional info but also to notify if any action is required
-->

## Issue(s)
[1591](https://github.com/Selleo/mentingo/issues/1591)

 ## Overview
  <!--
  General description what it does
  -->

  Fixes SCORM export asset resolution for content lessons that reference uploaded resources directly from rich-text HTML.

  Changes include:

  - Resolves content lesson assets from rich-text resource references, even when attachment relations are stale or linked to a different lesson.
  - Adds a dedicated repository query for active resource assets used by SCORM snapshot generation.
  - Deduplicates exported lesson assets by lesson/resource pair.
  - Rewrites preview asset URLs without keeping ?preview=pdf in packaged SCORM paths.
  - Adds detailed console diagnostics before SCORM export asset exceptions.
  - Adds a separate Bunny Stream configuration error instead of reporting it as a missing asset.
  - Prevents lesson-resource access from crashing when lesson assignment lookup returns no row.
  - Adds translations for the Bunny Stream configuration export error.
  - Adds E2E coverage for exporting rich-text video, downloadable file, and preview file assets.

  ## Business Value
  <!--
  Why are we doing this from a business perspective? What value does this bring to the project from end-users perspective?
  -->

  Course admins can reliably export SCORM packages for content lessons containing videos and files, including preview files, without false missing-asset failures caused by
  stale resource relations.

  When export still cannot proceed, the system now gives clearer failure reasons, making support and configuration issues easier to diagnose.