### PR TITLE
fix: correct signup redirection for imported users

### DIFF
--- a/apps/web/app/api/mutations/helpers/handleAuthSuccess.ts
+++ b/apps/web/app/api/mutations/helpers/handleAuthSuccess.ts
@@ -24,7 +24,7 @@ type HandleAuthSuccessOptions = {
   setHasVerifiedMFA: (value: boolean) => void;
 };
 
-export function handleAuthSuccess({
+export async function handleAuthSuccess({
   user,
   setLoggedIn,
   setCurrentUser,
@@ -38,12 +38,11 @@ export function handleAuthSuccess({
     roleSlugs: user.roleSlugs ?? [],
   };
 
-  queryClient.setQueryData(currentUserQueryOptions.queryKey, { data: normalizedUser });
-  queryClient.invalidateQueries(currentUserQueryOptions);
-  queryClient.invalidateQueries(userSettingsQueryOptions);
-  queryClient.invalidateQueries(mfaSetupQueryOptions);
-
   setLoggedIn(true);
   setCurrentUser(normalizedUser);
   setHasVerifiedMFA(!normalizedUser.shouldVerifyMFA);
+
+  await queryClient.invalidateQueries(currentUserQueryOptions);
+  queryClient.invalidateQueries(userSettingsQueryOptions);
+  queryClient.invalidateQueries(mfaSetupQueryOptions);
 }

--- a/apps/web/app/api/mutations/useCreatePassword.ts
+++ b/apps/web/app/api/mutations/useCreatePassword.ts
@@ -29,8 +29,8 @@ export function useCreatePassword() {
       const response = await ApiClient.api.authControllerCreatePassword(options.data);
       return response.data;
     },
-    onSuccess: ({ data }) => {
-      handleAuthSuccess({ user: data, setLoggedIn, setCurrentUser, setHasVerifiedMFA });
+    onSuccess: async ({ data }) => {
+      await handleAuthSuccess({ user: data, setLoggedIn, setCurrentUser, setHasVerifiedMFA });
     },
     onError: (error: AxiosError) => {
       const { message } = (error.response?.data as ApiErrorResponse) || {};

--- a/apps/web/app/api/mutations/useHandleMagicLink.ts
+++ b/apps/web/app/api/mutations/useHandleMagicLink.ts
@@ -6,11 +6,8 @@ import { useAuthStore } from "~/modules/Auth/authStore";
 import { useCurrentUserStore } from "~/modules/common/store/useCurrentUserStore";
 
 import { ApiClient } from "../api-client";
-import { currentUserQueryOptions } from "../queries/useCurrentUser";
-import { userSettingsQueryOptions } from "../queries/useUserSettings";
-import { queryClient } from "../queryClient";
 
-import { mfaSetupQueryOptions } from "./useSetupMFA";
+import { handleAuthSuccess } from "./helpers/handleAuthSuccess";
 
 import type { ApiErrorResponse } from "../types";
 import type { AxiosError } from "axios";
@@ -35,24 +32,8 @@ export function useHandleMagicLink() {
 
       return data;
     },
-    onSuccess: ({ data }) => {
-      const { shouldVerifyMFA } = data;
-      const normalizedUser = {
-        ...data,
-        isSupportMode: false,
-        studentModeCourseIds: [],
-        roleSlugs: [],
-        permissions: [],
-      };
-
-      queryClient.setQueryData(currentUserQueryOptions.queryKey, { data: normalizedUser });
-      queryClient.invalidateQueries(currentUserQueryOptions);
-      queryClient.invalidateQueries(userSettingsQueryOptions);
-      queryClient.invalidateQueries(mfaSetupQueryOptions);
-
-      setLoggedIn(true);
-      setCurrentUser(normalizedUser);
-      setHasVerifiedMFA(!shouldVerifyMFA);
+    onSuccess: async ({ data }) => {
+      await handleAuthSuccess({ user: data, setLoggedIn, setCurrentUser, setHasVerifiedMFA });
     },
     onError: (error: AxiosError) => {
       const { message } = error.response?.data as ApiErrorResponse;

--- a/apps/web/app/api/mutations/useLoginUser.ts
+++ b/apps/web/app/api/mutations/useLoginUser.ts
@@ -30,8 +30,8 @@ export function useLoginUser() {
 
       return response.data;
     },
-    onSuccess: ({ data }) => {
-      handleAuthSuccess({ user: data, setLoggedIn, setCurrentUser, setHasVerifiedMFA });
+    onSuccess: async ({ data }) => {
+      await handleAuthSuccess({ user: data, setLoggedIn, setCurrentUser, setHasVerifiedMFA });
     },
     onError: (error: AxiosError) => {
       const { message } = error.response?.data as ApiErrorResponse;

--- a/apps/web/app/api/mutations/useRegisterUser.ts
+++ b/apps/web/app/api/mutations/useRegisterUser.ts
@@ -34,8 +34,8 @@ export function useRegisterUser() {
 
       return response.data;
     },
-    onSuccess: ({ data }) => {
-      handleAuthSuccess({
+    onSuccess: async ({ data }) => {
+      await handleAuthSuccess({
         user: data as LoginResponse["data"],
         setLoggedIn,
         setCurrentUser,

--- a/apps/web/app/modules/Auth/CreateNewPassword.page.tsx
+++ b/apps/web/app/modules/Auth/CreateNewPassword.page.tsx
@@ -14,6 +14,7 @@ import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
 import { useToast } from "~/components/ui/use-toast";
 import { cn } from "~/lib/utils";
+import { LOGIN_REDIRECT_URL } from "~/modules/Auth/constants";
 import { passwordSchema } from "~/modules/Dashboard/Settings/schema/password.schema";
 import { detectBrowserLanguage } from "~/utils/browser-language";
 import { setPageTitle } from "~/utils/setPageTitle";
@@ -98,7 +99,7 @@ export default function CreateNewPasswordPage() {
         toast({
           description: t("changePasswordView.toast.passwordCreatedSuccessfully"),
         });
-        navigate("/auth/login");
+        navigate(LOGIN_REDIRECT_URL);
       });
     }
   };

--- a/apps/web/e2e/specs/auth/create-new-password.spec.ts
+++ b/apps/web/e2e/specs/auth/create-new-password.spec.ts
@@ -2,7 +2,6 @@ import { SYSTEM_ROLE_SLUGS } from "@repo/shared";
 
 import { USER_ROLE } from "~/config/userRoles";
 
-import { login } from "../../fixtures/auth.actions";
 import { expect, test } from "../../fixtures/test.fixture";
 import { fillCreateNewPasswordFormFlow } from "../../flows/auth/fill-create-new-password-form.flow";
 import { openCreateNewPasswordPageFlow } from "../../flows/auth/open-create-new-password-page.flow";
@@ -55,9 +54,6 @@ test("visitor can create a password from the invite email", async ({
     });
     await submitCreateNewPasswordFormFlow(page);
 
-    await expect(page).toHaveURL("/auth/login");
-
-    await login(page, email, NEW_PASSWORD);
     await expect(page).toHaveURL("/courses");
   } finally {
     await context.close();


### PR DESCRIPTION
<!--
 1. Make sure you have correct branch name i.e. `ab_prefix_123_task_name`, where `123` is a issue ID, and `ab` is an author
 2. Make sure you have meaningful title related to task with correct prefix: feat/fix/chore/style/docs/refactor
 3. Reference multiple issues in one PR by listing them in the issues section
 4. Make sure all necessary sections are filled, remove obsolete sections
 5. Do a self review first
 6. Check if your PR includes only code related to your task
 7. `Notes` is used for additional info but also to notify if any action is required
-->

## Issue(s)
[1594](https://github.com/Selleo/mentingo/issues/1594)

 ## Overview
  <!--
  General description what it does
  -->

  Fixes post-auth redirect handling after account creation and other authentication success flows.

  Changes include:

  - Makes handleAuthSuccess async so callers can wait for current-user query invalidation.
  - Updates login, registration, create-password, and magic-link mutations to await auth success handling.
  - Keeps auth state updates centralized in handleAuthSuccess.
  - Removes duplicated magic-link auth state/query handling and reuses the shared auth success helper.
  - Relies on current-user query invalidation instead of manually setting current-user query data, allowing the existing MFA guard and navigation-history flow to decide the
    final redirect.

  ## Business Value
  <!--
  Why are we doing this from a business perspective? What value does this bring to the project from end-users perspective?
  -->

  Imported users who create their password are redirected reliably without getting stuck on the login page until refresh.

  This preserves the existing MFA and navigation-history routing behavior while making authentication transitions more consistent across login, registration, magic-link, and
  account creation flows.
