### PR TITLE
fix: restore reliable report downloads

### DIFF
--- a/apps/api/src/report/repositories/report.repository.spec.ts
+++ b/apps/api/src/report/repositories/report.repository.spec.ts
@@ -1,0 +1,48 @@
+import { sql } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+
+import { groups } from "src/storage/schema";
+
+import { ReportRepository } from "./report.repository";
+
+import type { DatabasePg } from "src/common";
+import type { LocalizationService } from "src/localization/localization.service";
+
+describe("ReportRepository", () => {
+  it("aggregates group names through the localization service", async () => {
+    const query = {
+      from: jest.fn().mockReturnThis(),
+      innerJoin: jest.fn().mockReturnThis(),
+      where: jest.fn().mockResolvedValue([]),
+    };
+    const db = {
+      select: jest.fn().mockReturnValue(query),
+    } as unknown as DatabasePg;
+    const localizationService = {
+      getLocalizedSqlField: jest.fn((field) =>
+        field === groups.name
+          ? sql<string>`localized_group_name`
+          : sql<string>`localized_course_title`,
+      ),
+    } as unknown as LocalizationService;
+
+    const repository = new ReportRepository(db, localizationService);
+
+    await repository.getAllStudentCourseData("pl", {
+      permissions: [],
+      userId: "user-id",
+    } as never);
+
+    const selectFields = (db.select as jest.Mock).mock.calls[0][0];
+    const renderedGroupNameSql = new PgDialect().sqlToQuery(selectFields.groupName).sql;
+
+    expect(localizationService.getLocalizedSqlField).toHaveBeenCalledWith(
+      groups.name,
+      "pl",
+      groups,
+    );
+    expect(renderedGroupNameSql).toMatch(/STRING_AGG\s*\(\s*DISTINCT\s+NULLIF/i);
+    expect(renderedGroupNameSql).toContain("localized_group_name");
+    expect(renderedGroupNameSql).not.toContain("STRING_AGG(DISTINCT g.name");
+  });
+});

--- a/apps/api/src/report/repositories/report.repository.ts
+++ b/apps/api/src/report/repositories/report.repository.ts
@@ -70,14 +70,20 @@ export class ReportRepository {
         AND slp.completed_at IS NOT NULL
     )`;
 
+    const localizedGroupNameQuery = this.localizationService.getLocalizedSqlField(
+      groups.name,
+      language,
+      groups,
+    );
+
     const reportData = await this.db
       .select({
         studentName: sql<string>`CONCAT(${users.firstName}, ' ', ${users.lastName})`,
         groupName: sql<string | null>`(
-          SELECT STRING_AGG(DISTINCT g.name, ', ')
-          FROM ${groups} g
-          JOIN ${groupUsers} gu ON gu.group_id = g.id
-          WHERE gu.user_id = ${users.id}
+          SELECT STRING_AGG(DISTINCT NULLIF(${localizedGroupNameQuery}, ''), ', ')
+          FROM ${groups}
+          JOIN ${groupUsers} ON ${groupUsers.groupId} = ${groups.id}
+          WHERE ${groupUsers.userId} = ${users.id}
         )`,
         courseName: this.localizationService.getLocalizedSqlField(courses.title, language),
         lessonCount: lessonCountQuery.as("lesson_count"),

--- a/apps/web/app/modules/Statistics/Admin/AdminStatistics.tsx
+++ b/apps/web/app/modules/Statistics/Admin/AdminStatistics.tsx
@@ -133,15 +133,27 @@ export const AdminStatistics = () => {
       </div>
       <div
         data-testid={ADMIN_STATISTICS_HANDLES.PAGE}
-        className="grid grid-cols-1 gap-y-4 md:grid-cols-2 md:gap-x-4 md:gap-y-6 xl:h-full xl:grid-cols-4 xl:grid-rows-[minmax(min-content,_auto)]"
+        className="grid grid-cols-1 gap-4 md:grid-cols-2 md:gap-6 lg:grid-cols-6 xl:h-full"
       >
-        <div data-testid={ADMIN_STATISTICS_HANDLES.MOST_POPULAR_COURSES_CHART}>
+        <div
+          data-testid={ADMIN_STATISTICS_HANDLES.MOST_POPULAR_COURSES_CHART}
+          className="md:col-span-1 lg:col-span-3"
+        >
           <FiveMostPopularCoursesChart
             data={statistics?.fiveMostPopularCourses}
             isLoading={isLoading}
           />
         </div>
-        <div data-testid={ADMIN_STATISTICS_HANDLES.COURSE_COMPLETION_CHART}>
+        <div
+          data-testid={ADMIN_STATISTICS_HANDLES.ENROLLMENT_CHART}
+          className="md:col-span-1 lg:col-span-3"
+        >
+          <EnrollmentChart isLoading={isLoading} data={statistics?.courseStudentsStats} />
+        </div>
+        <div
+          data-testid={ADMIN_STATISTICS_HANDLES.COURSE_COMPLETION_CHART}
+          className="md:col-span-1 lg:col-span-2"
+        >
           <CourseCompletionPercentageChart
             isLoading={isLoading}
             label={`${statistics?.totalCoursesCompletionStats.completionPercentage}`}
@@ -150,7 +162,10 @@ export const AdminStatistics = () => {
             chartData={coursesCompletionChartData}
           />
         </div>
-        <div data-testid={ADMIN_STATISTICS_HANDLES.FREEMIUM_CONVERSION_CHART}>
+        <div
+          data-testid={ADMIN_STATISTICS_HANDLES.FREEMIUM_CONVERSION_CHART}
+          className="md:col-span-1 lg:col-span-2"
+        >
           <ConversionsAfterFreemiumLessonChart
             isLoading={isLoading}
             label={`${statistics?.conversionAfterFreemiumLesson.conversionPercentage}`}
@@ -159,10 +174,10 @@ export const AdminStatistics = () => {
             chartData={conversionsChartData}
           />
         </div>
-        <div data-testid={ADMIN_STATISTICS_HANDLES.ENROLLMENT_CHART}>
-          <EnrollmentChart isLoading={isLoading} data={statistics?.courseStudentsStats} />
-        </div>
-        <div data-testid={ADMIN_STATISTICS_HANDLES.AVERAGE_QUIZ_SCORE_CHART}>
+        <div
+          data-testid={ADMIN_STATISTICS_HANDLES.AVERAGE_QUIZ_SCORE_CHART}
+          className="md:col-span-2 lg:col-span-2"
+        >
           <AvgScoreAcrossAllQuizzesChart
             isLoading={isLoading}
             label={`${correctAnswers}/${totalAnswers}`}


### PR DESCRIPTION
## Issue(s)
- #1597 

## Overview
Fixes report download failures caused by group names being aggregated from the raw group name column instead of the localized group name SQL expression.

This change:
- uses `LocalizationService.getLocalizedSqlField` for report group names,
- aggregates distinct non-empty localized group names in the student course report query,
- adds repository coverage for localized group name aggregation,
- adjusts the admin statistics grid layout so charts fit consistently after the report/statistics changes.

## Business Value
Admins can download reports with correctly localized group names, including Polish report output, without the export failing or falling back to raw group name handling. This keeps reporting usable for tenant administrators who rely on localized data when reviewing course progress.
