### PR TITLE
chore: adjust live training notifications

### DIFF
--- a/apps/api/src/announcements/announcements.repository.ts
+++ b/apps/api/src/announcements/announcements.repository.ts
@@ -332,6 +332,23 @@ export class AnnouncementsRepository {
 
     if (!announcement) return;
 
+    if (
+      announcement.sourceType === ANNOUNCEMENT_SOURCE_TYPES.LIVE_TRAINING &&
+      announcement.sourceId
+    ) {
+      const recipients = await this.getLiveTrainingAnnouncementRecipientIds(
+        announcement.sourceId,
+        announcement.authorId,
+      );
+
+      await this.createUserAnnouncementRecords(
+        recipients.map((recipient) => recipient.id),
+        announcement.id,
+      );
+
+      return;
+    }
+
     if (announcement.groupId) {
       const usersRelatedToGroup = await this.db
         .select({ userId: groupUsers.userId })
@@ -362,6 +379,38 @@ export class AnnouncementsRepository {
       allUserIds.map((user) => user.id),
       announcement.id,
     );
+  }
+
+  private async getLiveTrainingAnnouncementRecipientIds(
+    liveTrainingId: UUIDType,
+    authorId: UUIDType,
+  ) {
+    return this.db
+      .selectDistinct({ id: users.id })
+      .from(users)
+      .innerJoin(
+        studentCourses,
+        and(
+          eq(studentCourses.studentId, users.id),
+          eq(studentCourses.status, COURSE_ENROLLMENT.ENROLLED),
+        ),
+      )
+      .innerJoin(
+        liveTrainingLinks,
+        and(
+          eq(liveTrainingLinks.liveTrainingId, liveTrainingId),
+          eq(liveTrainingLinks.entityType, LIVE_TRAINING_LINK_ENTITY_TYPES.COURSE),
+          eq(liveTrainingLinks.entityId, studentCourses.courseId),
+        ),
+      )
+      .innerJoin(
+        liveLessons,
+        and(
+          eq(liveLessons.liveTrainingId, liveTrainingId),
+          eq(liveLessons.liveTrainingLinkId, liveTrainingLinks.id),
+        ),
+      )
+      .where(and(not(eq(users.id, authorId)), isNull(users.deletedAt)));
   }
 
   async findTenantsWithDueScheduledAnnouncements(

--- a/apps/api/src/live-training/__tests__/live-training.controller.e2e-spec.ts
+++ b/apps/api/src/live-training/__tests__/live-training.controller.e2e-spec.ts
@@ -28,6 +28,7 @@ import {
   settings,
   studentCourses,
   studentLessonProgress,
+  userAnnouncements,
 } from "src/storage/schema";
 import { settingsToJSONBuildObject } from "src/utils/settings-to-json-build-object";
 
@@ -604,6 +605,29 @@ describe("LiveTrainingController (e2e)", () => {
     expect(liveLesson.liveTrainingLinkId).toBe(courseLink.id);
     expect(lessonProgress.completedAt).not.toBeNull();
     expect(lessonProgress.languageAnswered).toBe(language);
+  });
+
+  it("does not create in-app notifications when a live training has no linked course", async () => {
+    const admin = await createAdmin();
+    await createStudent();
+    await createStudent();
+    const liveTraining = await createOfflineLiveTraining(admin);
+
+    const startResponse = await request(app.getHttpServer())
+      .post(`/api/live-training/${liveTraining.id}/sessions/start`)
+      .query({ language })
+      .set("Cookie", await cookieFor(admin, app))
+      .expect(201);
+
+    await request(app.getHttpServer())
+      .post(`/api/live-training/${liveTraining.id}/sessions/${startResponse.body.data.id}/end`)
+      .query({ language })
+      .set("Cookie", await cookieFor(admin, app))
+      .expect(201);
+
+    const createdNotifications = await db.select().from(userAnnouncements);
+
+    expect(createdNotifications).toHaveLength(0);
   });
 
   it("sends live training emails only to students enrolled in a course with the linked live lesson", async () => {


### PR DESCRIPTION
## Issue(s)
- #1598 

## Overview

Fixes live training start/end in-app notifications for trainings that are not connected to any course.

Live-training source announcements now create user announcement records only for users enrolled in a course linked to the live training and backed by a live lesson. When a live training has no linked course, session start/end still creates the system announcement record, but no users receive in-app notifications. Existing email behavior remains aligned with the same recipient scope.

Added e2e regression coverage for starting and ending an unlinked offline live training and asserting that no `user_announcements` records are created.

## Business Value

Users should only receive live-training session notifications when the training is relevant to them through a course assignment. This removes noisy notifications for unrelated users and keeps in-app behavior consistent with email delivery.

