### PR TITLE
fix: improve continue learning button behavior and navigation logic

### DIFF
--- a/apps/web/app/modules/Courses/Lesson/__tests__/utils.test.ts
+++ b/apps/web/app/modules/Courses/Lesson/__tests__/utils.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../Question/FillInTheBlanks/dnd/FillInTheBlanksDnd";
 import {
   findFirstInProgressLessonId,
+  findFirstNonCompletedLessonId,
   findFirstNotStartedLessonId,
   getEmptyQuizAnswers,
   getUserAnswers,
@@ -118,6 +119,99 @@ describe("findFirstInProgressLessonId", () => {
       chapters: [],
     } as unknown as GetCourseResponse["data"];
     const firstLessonId = findFirstInProgressLessonId(courseData);
+    expect(firstLessonId).toBe(undefined);
+  });
+});
+
+describe("findFirstNonCompletedLessonId", () => {
+  it("returns the first in-progress or not-started lesson in course order", () => {
+    const courseData = {
+      chapters: [
+        {
+          lessons: [
+            {
+              id: "1665722f-9dbe-48ca-8625-1669d92b9972",
+              status: "completed",
+            },
+            {
+              id: "805eca43-9162-4e19-b3f6-e2506b79f531",
+              status: "in_progress",
+            },
+          ],
+        },
+        {
+          lessons: [
+            {
+              id: "d3d82d8c-b16a-42f3-9d8f-9ea2ea1998e6",
+              status: "not_started",
+            },
+          ],
+        },
+      ],
+    } as GetCourseResponse["data"];
+
+    const firstLessonId = findFirstNonCompletedLessonId(courseData);
+
+    expect(firstLessonId).toBe("805eca43-9162-4e19-b3f6-e2506b79f531");
+  });
+
+  it("skips blocked lessons when choosing the next target", () => {
+    const courseData = {
+      chapters: [
+        {
+          lessons: [
+            {
+              id: "1665722f-9dbe-48ca-8625-1669d92b9972",
+              status: "completed",
+            },
+            {
+              id: "805eca43-9162-4e19-b3f6-e2506b79f531",
+              status: "blocked",
+            },
+            {
+              id: "d3d82d8c-b16a-42f3-9d8f-9ea2ea1998e6",
+              status: "not_started",
+            },
+          ],
+        },
+      ],
+    } as GetCourseResponse["data"];
+
+    const firstLessonId = findFirstNonCompletedLessonId(courseData);
+
+    expect(firstLessonId).toBe("d3d82d8c-b16a-42f3-9d8f-9ea2ea1998e6");
+  });
+
+  it("returns undefined when only completed or blocked lessons exist", () => {
+    const courseData = {
+      chapters: [
+        {
+          lessons: [
+            {
+              id: "1665722f-9dbe-48ca-8625-1669d92b9972",
+              status: "completed",
+            },
+            {
+              id: "805eca43-9162-4e19-b3f6-e2506b79f531",
+              status: "blocked",
+            },
+          ],
+        },
+      ],
+    } as GetCourseResponse["data"];
+
+    const firstLessonId = findFirstNonCompletedLessonId(courseData);
+
+    expect(firstLessonId).toBe(undefined);
+  });
+
+  it("returns undefined for empty chapters", () => {
+    const courseData = {
+      chapters: [],
+    } as unknown as GetCourseResponse["data"];
+
+    const firstLessonId = findFirstNonCompletedLessonId(courseData);
+
     expect(firstLessonId).toBe(undefined);
   });
 });

--- a/apps/web/app/modules/Courses/Lesson/utils.ts
+++ b/apps/web/app/modules/Courses/Lesson/utils.ts
@@ -373,3 +373,14 @@ export const getQuizTooltipText = (
 
   return t("studentLessonView.tooltip.noCooldown");
 };
+
+export const findFirstNonCompletedLessonId = (course: GetCourseResponse["data"]) => {
+  const allLessons = flatMap(course.chapters, (chapter) => chapter.lessons);
+
+  return find(
+    allLessons,
+    (lesson) =>
+      lesson.status === LESSON_PROGRESS_STATUSES.NOT_STARTED ||
+      lesson.status === LESSON_PROGRESS_STATUSES.IN_PROGRESS,
+  )?.id;
+};

--- a/apps/web/app/modules/Courses/utils/__tests__/navigateToNextLesson.test.ts
+++ b/apps/web/app/modules/Courses/utils/__tests__/navigateToNextLesson.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { navigateToNextLesson } from "../navigateToNextLesson";
+
+import type { NavigateFunction } from "@remix-run/react";
+import type { GetCourseResponse } from "~/api/generated-api";
+
+describe("navigateToNextLesson", () => {
+  it("navigates to the first accessible unfinished lesson with its chapter id", () => {
+    const courseData = {
+      slug: "course-slug",
+      chapters: [
+        {
+          id: "chapter-1",
+          lessons: [
+            {
+              id: "completed-lesson",
+              status: "completed",
+            },
+            {
+              id: "blocked-lesson",
+              status: "blocked",
+            },
+          ],
+        },
+        {
+          id: "chapter-2",
+          lessons: [
+            {
+              id: "target-lesson",
+              status: "in_progress",
+            },
+          ],
+        },
+      ],
+    } as GetCourseResponse["data"];
+    const navigate = vi.fn() as unknown as NavigateFunction;
+
+    navigateToNextLesson(courseData, navigate);
+
+    expect(navigate).toHaveBeenCalledWith("/course/course-slug/lesson/target-lesson", {
+      state: { chapterId: "chapter-2" },
+    });
+  });
+
+  it("does not navigate when no accessible unfinished lesson exists", () => {
+    const courseData = {
+      slug: "course-slug",
+      chapters: [
+        {
+          id: "chapter-1",
+          lessons: [
+            {
+              id: "completed-lesson",
+              status: "completed",
+            },
+            {
+              id: "blocked-lesson",
+              status: "blocked",
+            },
+          ],
+        },
+      ],
+    } as GetCourseResponse["data"];
+    const navigate = vi.fn() as unknown as NavigateFunction;
+
+    navigateToNextLesson(courseData, navigate);
+
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/modules/Courses/utils/navigateToNextLesson.ts
+++ b/apps/web/app/modules/Courses/utils/navigateToNextLesson.ts
@@ -1,4 +1,4 @@
-import { findFirstInProgressLessonId, findFirstNotStartedLessonId } from "../Lesson/utils";
+import { findFirstNonCompletedLessonId, getCurrentChapterId } from "../Lesson/utils";
 
 import type { NavigateFunction } from "@remix-run/react";
 import type { GetCourseResponse } from "~/api/generated-api";
@@ -7,21 +7,11 @@ export const navigateToNextLesson = (
   course: GetCourseResponse["data"],
   navigate: NavigateFunction,
 ) => {
-  const notStartedLessonId = findFirstNotStartedLessonId(course);
-  const notStartedChapterId = course.chapters.find((chapter) =>
-    chapter.lessons.some(({ id }) => id === notStartedLessonId),
-  )?.id;
-  const firstInProgressLessonId = findFirstInProgressLessonId(course);
-  const firstInProgressChapterId = course.chapters.find((chapter) =>
-    chapter.lessons.some(({ id }) => id === firstInProgressLessonId),
-  )?.id;
-  const firstLessonId = course.chapters[0]?.lessons[0]?.id;
+  const lessonId = findFirstNonCompletedLessonId(course);
 
-  if (!notStartedLessonId && !firstInProgressLessonId) {
-    return navigate(`/course/${course.slug}/lesson/${firstLessonId}`);
-  }
+  if (!lessonId) return;
 
-  navigate(`/course/${course.slug}/lesson/${notStartedLessonId ?? firstInProgressLessonId}`, {
-    state: { chapterId: notStartedChapterId ?? firstInProgressChapterId },
+  navigate(`/course/${course.slug}/lesson/${lessonId}`, {
+    state: { chapterId: getCurrentChapterId(course, lessonId) },
   });
 };


### PR DESCRIPTION
## Overview

Fixes the Continue Learning lesson navigation logic so it targets the first accessible unfinished lesson in course order. The navigation now:

- skips completed and blocked lessons
- preserves the target lesson's chapter id in navigation state
- does nothing when there is no accessible unfinished lesson

This also adds focused unit coverage for the new lesson selection helper and the Continue Learning navigation behavior.

## Business Value

Students using Continue Learning are taken to the correct next lesson without being redirected to completed or blocked content. This keeps the learning flow predictable and avoids dead ends when a course contains a mix of completed, blocked, not-started, and in-progress lessons.
