### PR TITLE
chore: hide AI mentor lesson actions in admin preview mode

### DIFF
--- a/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/components/LessonPreviewDialog.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/components/LessonPreviewDialog.tsx
@@ -134,6 +134,7 @@ export default function LessonPreviewDialog({
             <LessonContent
               lesson={lesson}
               course={course}
+              hideControls={isAiMentorLesson}
               previewUser={{
                 firstName,
                 lastName,

--- a/apps/web/app/modules/Courses/Lesson/AiMentorLesson/AiMentorLesson.tsx
+++ b/apps/web/app/modules/Courses/Lesson/AiMentorLesson/AiMentorLesson.tsx
@@ -40,9 +40,15 @@ interface AiMentorLessonProps {
   lesson: GetLessonByIdResponse["data"];
   lessonLoading: boolean;
   previewUser?: LessonPreviewUser;
+  hideControls?: boolean;
 }
 
-const AiMentorLesson = ({ lesson, lessonLoading, previewUser }: AiMentorLessonProps) => {
+const AiMentorLesson = ({
+  lesson,
+  lessonLoading,
+  previewUser,
+  hideControls = false,
+}: AiMentorLessonProps) => {
   const { t } = useTranslation();
   const { courseId = "" } = useParams();
   const courseExperience = useOptionalCourseAccessProvider();
@@ -188,7 +194,28 @@ const AiMentorLesson = ({ lesson, lessonLoading, previewUser }: AiMentorLessonPr
         <LoaderWithTextSequence preset="aiMentor" />
       ) : null}
 
-      {!lessonLoading && hasTaskDescription && (
+      {!lessonLoading && hasTaskDescription && hideControls && (
+        <div
+          data-testid={LEARNING_HANDLES.AI_MENTOR_TASK_DESCRIPTION}
+          className="w-full mb-10 rounded-xl border border-l-4 border-primary-600 bg-white shadow-sm"
+        >
+          <div className="flex w-full items-start gap-3 px-4 py-3 text-left">
+            <div className="text-primary-700">
+              <Icon name="BookOpen" className="size-5" />
+            </div>
+            <div className="flex-1">
+              <div className="font-semibold text-neutral-900">
+                {t("studentCourseView.lesson.aiMentorLesson.taskDescription")}
+              </div>
+            </div>
+          </div>
+          <div className="border-t border-neutral-100 px-4 py-4 text-neutral-800">
+            <div className="max-h-24 overflow-y-auto">{lesson.description}</div>
+          </div>
+        </div>
+      )}
+
+      {!lessonLoading && hasTaskDescription && !hideControls && (
         <Accordion
           data-testid={LEARNING_HANDLES.AI_MENTOR_TASK_DESCRIPTION}
           type="single"
@@ -253,7 +280,7 @@ const AiMentorLesson = ({ lesson, lessonLoading, previewUser }: AiMentorLessonPr
         )}
       </div>
 
-      {isThreadActive && !isJudgePending && (
+      {isThreadActive && !isJudgePending && !hideControls && (
         <LessonForm
           lessonId={lesson.id}
           mentorName={
@@ -272,32 +299,36 @@ const AiMentorLesson = ({ lesson, lessonLoading, previewUser }: AiMentorLessonPr
         />
       )}
 
-      <hr className="mt-4 w-full border-t border-[#EDEDED]" />
-      <div className="mt-4 flex w-full justify-center">
-        {isThreadActive && !isJudgePending ? (
-          <Button
-            data-testid={LEARNING_HANDLES.AI_MENTOR_CHECK_BUTTON}
-            variant="primary"
-            size="lg"
-            className="max-w-fit gap-2"
-            onClick={handleJudge}
-          >
-            {t("studentCourseView.lesson.aiMentorLesson.check")}
-            <Icon name="ArrowRight" className="size-5" />
-          </Button>
-        ) : (
-          <Button
-            data-testid={LEARNING_HANDLES.AI_MENTOR_RETAKE_BUTTON}
-            variant="outline"
-            size="lg"
-            className="max-w-fit gap-2"
-            onClick={() => setShowRetakeModal(true)}
-          >
-            {t("studentCourseView.lesson.aiMentorLesson.retake")}
-            <Icon name="ArrowRight" className="size-5" />
-          </Button>
-        )}
-      </div>
+      {!hideControls && (
+        <>
+          <hr className="mt-4 w-full border-t border-[#EDEDED]" />
+          <div className="mt-4 flex w-full justify-center">
+            {isThreadActive && !isJudgePending ? (
+              <Button
+                data-testid={LEARNING_HANDLES.AI_MENTOR_CHECK_BUTTON}
+                variant="primary"
+                size="lg"
+                className="max-w-fit gap-2"
+                onClick={handleJudge}
+              >
+                {t("studentCourseView.lesson.aiMentorLesson.check")}
+                <Icon name="ArrowRight" className="size-5" />
+              </Button>
+            ) : (
+              <Button
+                data-testid={LEARNING_HANDLES.AI_MENTOR_RETAKE_BUTTON}
+                variant="outline"
+                size="lg"
+                className="max-w-fit gap-2"
+                onClick={() => setShowRetakeModal(true)}
+              >
+                {t("studentCourseView.lesson.aiMentorLesson.retake")}
+                <Icon name="ArrowRight" className="size-5" />
+              </Button>
+            )}
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/apps/web/app/modules/Courses/Lesson/LessonContent.tsx
+++ b/apps/web/app/modules/Courses/Lesson/LessonContent.tsx
@@ -26,6 +26,7 @@ type LessonContentProps = {
   lesson: GetLessonByIdResponse["data"];
   course: GetCourseResponse["data"];
   previewUser?: LessonPreviewUser;
+  hideControls?: boolean;
   lessonsAmount: number;
   handlePrevious: () => void;
   handleNext: () => void;
@@ -38,6 +39,7 @@ export const LessonContent = ({
   lesson,
   course,
   previewUser,
+  hideControls = false,
   lessonsAmount,
   handlePrevious,
   handleNext,
@@ -223,7 +225,7 @@ export const LessonContent = ({
                 </p>
                 {lesson.type === LessonType.AI_MENTOR && (
                   <Tooltip>
-                    <TooltipTrigger>
+                    <TooltipTrigger asChild>
                       <Badge variant="secondary" className="uppercase">
                         Beta
                       </Badge>
@@ -241,33 +243,36 @@ export const LessonContent = ({
                 {lesson.title}
               </p>
             </div>
-            <div className="mt-4 flex flex-col gap-2 sm:ml-8 sm:mt-0 sm:items-end">
-              <div className="flex flex-row gap-x-4">
-                <Button
-                  variant="outline"
-                  className="w-full gap-x-1 sm:w-auto disabled:opacity-0"
-                  disabled={isPreviousDisabled || isFirstLesson}
-                  onClick={handlePrevious}
-                >
-                  <Icon name="ArrowRight" className="h-auto w-4 rotate-180" />
-                </Button>
-                <Button
-                  data-testid={LEARNING_HANDLES.NEXT_LESSON_BUTTON}
-                  variant="outline"
-                  disabled={isNextDisabled}
-                  className="w-full gap-x-1 sm:w-auto disabled:opacity-0"
-                  onClick={handleNext}
-                >
-                  <Icon name="ArrowRight" className="h-auto w-4" />
-                </Button>
+            {!hideControls && (
+              <div className="mt-4 flex flex-col gap-2 sm:ml-8 sm:mt-0 sm:items-end">
+                <div className="flex flex-row gap-x-4">
+                  <Button
+                    variant="outline"
+                    className="w-full gap-x-1 sm:w-auto disabled:opacity-0"
+                    disabled={isPreviousDisabled || isFirstLesson}
+                    onClick={handlePrevious}
+                  >
+                    <Icon name="ArrowRight" className="h-auto w-4 rotate-180" />
+                  </Button>
+                  <Button
+                    data-testid={LEARNING_HANDLES.NEXT_LESSON_BUTTON}
+                    variant="outline"
+                    disabled={isNextDisabled}
+                    className="w-full gap-x-1 sm:w-auto disabled:opacity-0"
+                    onClick={handleNext}
+                  >
+                    <Icon name="ArrowRight" className="h-auto w-4" />
+                  </Button>
+                </div>
               </div>
-            </div>
+            )}
           </div>
 
           <LessonContentRenderer
             lesson={lesson}
             user={user}
             previewUser={previewUser}
+            hideControls={hideControls}
             lessonLoading={lessonLoading}
             onVideoEnded={handleVideoEnded}
           />

--- a/apps/web/app/modules/Courses/Lesson/LessonContentRenderer.tsx
+++ b/apps/web/app/modules/Courses/Lesson/LessonContentRenderer.tsx
@@ -17,12 +17,20 @@ type LessonContentRendererProps = {
   lesson: GetLessonByIdResponse["data"];
   user: CurrentUserResponse["data"] | undefined;
   previewUser?: LessonPreviewUser;
+  hideControls?: boolean;
   lessonLoading: boolean;
   onVideoEnded?: (index: number | null) => void;
 };
 
 export const LessonContentRenderer = memo(
-  ({ lesson, user, previewUser, lessonLoading, onVideoEnded }: LessonContentRendererProps) => {
+  ({
+    lesson,
+    user,
+    previewUser,
+    hideControls = false,
+    lessonLoading,
+    onVideoEnded,
+  }: LessonContentRendererProps) => {
     return match(lesson.type)
       .with("content", () => (
         <Viewer
@@ -33,7 +41,12 @@ export const LessonContentRenderer = memo(
       ))
       .with("quiz", () => <Quiz lesson={lesson} userId={user?.id || ""} />)
       .with("ai_mentor", () => (
-        <AiMentorLesson lesson={lesson} lessonLoading={lessonLoading} previewUser={previewUser} />
+        <AiMentorLesson
+          lesson={lesson}
+          lessonLoading={lessonLoading}
+          previewUser={previewUser}
+          hideControls={hideControls}
+        />
       ))
       .with("embed", () => (
         <EmbedLesson lessonResources={lesson.lessonResources ?? []} lesson={lesson} />

--- a/apps/web/e2e/specs/statistics/ai-mentor-statistics.spec.ts
+++ b/apps/web/e2e/specs/statistics/ai-mentor-statistics.spec.ts
@@ -1,5 +1,6 @@
 import { USER_ROLE } from "~/config/userRoles";
 
+import { LEARNING_HANDLES } from "../../data/learning/handles";
 import { COURSE_STATISTICS_HANDLES } from "../../data/statistics/handles";
 import { expect, test } from "../../fixtures/test.fixture";
 import { openCourseStatisticsTabFlow } from "../../flows/statistics/open-course-statistics-tab.flow";
@@ -74,6 +75,22 @@ test("admin can view AI mentor statistics after prepared mentor progress", async
           COURSE_STATISTICS_HANDLES.aiMentorResultsPreviewButton(studentId, aiMentorLesson.id),
         ),
       ).toBeVisible();
+      await page
+        .getByTestId(
+          COURSE_STATISTICS_HANDLES.aiMentorResultsPreviewButton(studentId, aiMentorLesson.id),
+        )
+        .click();
+      const previewDialog = page.getByTestId(COURSE_STATISTICS_HANDLES.LESSON_PREVIEW_DIALOG);
+      await expect(previewDialog).toBeVisible();
+      await expect(page.getByTestId(LEARNING_HANDLES.NEXT_LESSON_BUTTON)).toBeHidden();
+      await expect(page.getByTestId(LEARNING_HANDLES.AI_MENTOR_MESSAGE_INPUT)).toBeHidden();
+      await expect(page.getByTestId(LEARNING_HANDLES.AI_MENTOR_MESSAGE_ACTION_BUTTON)).toBeHidden();
+      await expect(page.getByTestId(LEARNING_HANDLES.AI_MENTOR_MIC_BUTTON)).toBeHidden();
+      await expect(page.getByTestId(LEARNING_HANDLES.AI_MENTOR_CHECK_BUTTON)).toBeHidden();
+      await expect(page.getByTestId(LEARNING_HANDLES.AI_MENTOR_RETAKE_BUTTON)).toBeHidden();
+      await expect(previewDialog.getByRole("button")).toHaveCount(1);
+      await previewDialog.getByRole("button").click();
+      await expect(previewDialog).toBeHidden();
 
       await page.getByTestId(COURSE_STATISTICS_HANDLES.AI_MENTOR_LESSON_FILTER).click();
       await page


### PR DESCRIPTION
## Issue(s)
- #1434 

## Overview
Hides interactive AI Mentor lesson controls inside the admin statistics lesson preview dialog.

The change adds a `hideControls` flag through `LessonContent`, `LessonContentRenderer`, and `AiMentorLesson`, then enables it only for AI Mentor lessons opened from course statistics preview. In that preview mode, admins can still inspect the lesson title, task description, score details, and chat history, but cannot navigate lessons, send messages, use voice controls, check the lesson, or retake it.

The AI Mentor task description is rendered as static preview content when controls are hidden, so the preview does not expose accordion interaction as an extra control.

## Business Value
Admins reviewing AI Mentor results should see the student's submitted lesson state without being able to accidentally act on the lesson. This keeps the statistics preview read-only, reduces confusion, and avoids exposing student-facing actions in an admin reporting workflow.

## Screenshots / Video

https://github.com/user-attachments/assets/643cdc03-83e3-48c6-b33c-6a58f0acae50