### PR TITLE
chore: allow formatting in AI mentor task descriptions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,14 +51,14 @@ on:
 
 jobs:
   playwright:
-    name: Playwright Tests (shard ${{ matrix.shard }}/3)
+    name: Playwright Tests (shard ${{ matrix.shard }}/5)
     runs-on: ubuntu-latest
     environment:
       name: e2e
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3]
+        shard: [1, 2, 3, 4, 5]
     env:
       E2E_BROWSER: ${{ github.event_name == 'push' && github.ref_name == 'staging' && 'chromium' || (github.event_name == 'push' && 'all' || (inputs.browser || 'all')) }}
       PLAYWRIGHT_SHARD: ${{ matrix.shard }}
@@ -219,13 +219,13 @@ jobs:
         run: |
           case "$E2E_BROWSER" in
             chromium)
-              VITE_TEST=true pnpm playwright test --project chromium --shard="${PLAYWRIGHT_SHARD}/3"
+              VITE_TEST=true pnpm playwright test --project chromium --shard="${PLAYWRIGHT_SHARD}/5"
               ;;
             firefox)
-              VITE_TEST=true pnpm playwright test --project firefox --shard="${PLAYWRIGHT_SHARD}/3"
+              VITE_TEST=true pnpm playwright test --project firefox --shard="${PLAYWRIGHT_SHARD}/5"
               ;;
             all)
-              VITE_TEST=true pnpm playwright test --shard="${PLAYWRIGHT_SHARD}/3"
+              VITE_TEST=true pnpm playwright test --shard="${PLAYWRIGHT_SHARD}/5"
               ;;
             *)
               echo "Unsupported E2E_BROWSER value: $E2E_BROWSER" >&2

--- a/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/AiMentorLessonForm/AiMentorLessonForm.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/AiMentorLessonForm/AiMentorLessonForm.tsx
@@ -38,7 +38,6 @@ import {
   SelectValue,
 } from "~/components/ui/select";
 import { Separator } from "~/components/ui/separator";
-import { Textarea } from "~/components/ui/textarea";
 import {
   Tooltip,
   TooltipContent,
@@ -352,12 +351,16 @@ const AiMentorLessonForm = ({
                         </Tooltip>
                       </Label>
                       <FormControl>
-                        <Textarea
-                          data-testid={AI_MENTOR_LESSON_FORM_HANDLES.DESCRIPTION_INPUT}
-                          {...field}
-                          id="description"
-                          className="placeholder:body-base h-[164px] resize-none placeholder:text-neutral-600"
-                        />
+                        <div data-testid={AI_MENTOR_LESSON_FORM_HANDLES.DESCRIPTION_INPUT}>
+                          <BaseEditor
+                            id="description"
+                            content={field.value}
+                            placeholder={t(
+                              "adminCourseView.curriculum.lesson.placeholder.taskDescription",
+                            )}
+                            {...field}
+                          />
+                        </div>
                       </FormControl>
                       <FormMessage />
                     </FormItem>

--- a/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/AiMentorLessonForm/validators/useAiMentorLessonFormSchema.ts
+++ b/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/AiMentorLessonForm/validators/useAiMentorLessonFormSchema.ts
@@ -26,7 +26,7 @@ export const aiMentorLessonFormSchema = (t: TFunction) =>
         .max(255, { message: t("adminCourseView.curriculum.lesson.validation.titleMaxLength") }),
       description: z
         .string()
-        .max(MAX_AI_MENTOR_TEXT_LENGTH, {
+        .refine((val) => stripHtmlTags(val).length <= MAX_AI_MENTOR_TEXT_LENGTH, {
           message: t("adminCourseView.curriculum.lesson.validation.taskDescriptionMaxLength", {
             count: MAX_AI_MENTOR_TEXT_LENGTH,
           }),

--- a/apps/web/app/modules/Courses/Lesson/AiMentorLesson/AiMentorLesson.tsx
+++ b/apps/web/app/modules/Courses/Lesson/AiMentorLesson/AiMentorLesson.tsx
@@ -13,6 +13,7 @@ import {
 import { queryClient } from "~/api/queryClient";
 import { Icon } from "~/components/Icon";
 import { LoaderWithTextSequence } from "~/components/LoaderWithTextSequence";
+import Viewer from "~/components/RichText/Viever";
 import {
   Accordion,
   AccordionContent,
@@ -210,7 +211,9 @@ const AiMentorLesson = ({
             </div>
           </div>
           <div className="border-t border-neutral-100 px-4 py-4 text-neutral-800">
-            <div className="max-h-24 overflow-y-auto">{lesson.description}</div>
+            <div className="max-h-24 overflow-y-auto">
+              <Viewer content={lesson.description ?? ""} />
+            </div>
           </div>
         </div>
       )}
@@ -248,7 +251,9 @@ const AiMentorLesson = ({
               />
             </AccordionTrigger>
             <AccordionContent className="px-4 py-4 text-neutral-800 border-t border-neutral-100">
-              <div className="max-h-24 overflow-y-auto">{lesson.description}</div>
+              <div className="max-h-24 overflow-y-auto">
+                <Viewer content={lesson.description ?? ""} />
+              </div>
             </AccordionContent>
           </AccordionItem>
         </Accordion>

--- a/apps/web/e2e/flows/curriculum/fill-ai-mentor-lesson-form.flow.ts
+++ b/apps/web/e2e/flows/curriculum/fill-ai-mentor-lesson-form.flow.ts
@@ -17,7 +17,11 @@ export const fillAiMentorLessonFormFlow = async (
 ) => {
   await page.getByTestId(AI_MENTOR_LESSON_FORM_HANDLES.TITLE_INPUT).fill(input.title);
   await page.getByTestId(AI_MENTOR_LESSON_FORM_HANDLES.NAME_INPUT).fill(input.name);
-  await page.getByTestId(AI_MENTOR_LESSON_FORM_HANDLES.DESCRIPTION_INPUT).fill(input.description);
+  await fillRichTextEditorFlow(
+    page,
+    AI_MENTOR_LESSON_FORM_HANDLES.DESCRIPTION_INPUT,
+    input.description,
+  );
   await fillRichTextEditorFlow(
     page,
     AI_MENTOR_LESSON_FORM_HANDLES.INSTRUCTIONS_INPUT,

--- a/apps/web/e2e/specs/curriculum/ai-mentor-lesson.spec.ts
+++ b/apps/web/e2e/specs/curriculum/ai-mentor-lesson.spec.ts
@@ -29,6 +29,8 @@ test("admin can create and preview an AI mentor lesson", async ({
       title: `ai-mentor-chapter-${Date.now()}`,
     });
     const lessonTitle = `ai-mentor-lesson-${Date.now()}`;
+    const formattedDescriptionText = "Practice the topic with a mentor.";
+    const boldShortcut = process.platform === "darwin" ? "Meta+B" : "Control+B";
 
     cleanup.add(async () => {
       await courseFactory.delete(course.id);
@@ -40,10 +42,18 @@ test("admin can create and preview an AI mentor lesson", async ({
     await fillAiMentorLessonFormFlow(page, {
       title: lessonTitle,
       name: "Ada",
-      description: "Practice the topic with a mentor.",
+      description: formattedDescriptionText,
       instructions: "Ask concise questions.",
       completionConditions: "Learner answers two questions.",
     });
+    const descriptionEditor = page
+      .getByTestId(AI_MENTOR_LESSON_FORM_HANDLES.DESCRIPTION_INPUT)
+      .locator(".ProseMirror");
+    await descriptionEditor.fill("");
+    await descriptionEditor.click();
+    await page.keyboard.press(boldShortcut);
+    await page.keyboard.type(formattedDescriptionText);
+    await page.keyboard.press(boldShortcut);
     await saveAiMentorLessonFormFlow(page);
 
     await expect
@@ -58,10 +68,16 @@ test("admin can create and preview an AI mentor lesson", async ({
     const lessonId = updatedCourse.chapters[0]!.lessons!.find(
       (lesson) => lesson.title === lessonTitle,
     )!.id;
+    const savedLesson = updatedCourse.chapters[0]!.lessons!.find(
+      (lesson) => lesson.title === lessonTitle,
+    )!;
+
+    expect(savedLesson.description).toContain("<strong>");
 
     await openExistingLessonFlow(page, chapter.id, lessonId);
     await page.getByTestId(AI_MENTOR_LESSON_FORM_HANDLES.PREVIEW_BUTTON).click();
     await expect(page.getByText("Ada").first()).toBeVisible();
+    await expect(page.getByText(formattedDescriptionText).first()).toBeVisible();
   });
 });
 


### PR DESCRIPTION
## Issue(s)
- #1540 

## Overview
Allows AI Mentor task descriptions to be formatted with the existing rich text editor instead of a plain textarea.

This change:
- replaces the AI Mentor task description textarea with `BaseEditor`;
- validates the task description length against stripped text content, so HTML formatting does not count against the text limit;
- renders AI Mentor task descriptions through the rich text viewer in both student lesson and preview/read-only contexts;
- updates the curriculum E2E form flow to fill the rich text editor;
- extends the AI Mentor lesson E2E test to verify bold formatting is saved and visible in preview.

## Business Value
Admins can create clearer AI Mentor task descriptions with formatting such as bold text and rich text structure. Learners then see the intended formatted task instructions in the AI Mentor lesson, improving readability and preserving authoring intent.

## Screenshots / Video


https://github.com/user-attachments/assets/a3c136bb-496f-4281-999f-4f52b59d68c3


