### PR TITLE
chore: make import button disabled while processing

### DIFF
--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -689,12 +689,7 @@ export class UserService {
   ) {
     const db = dbInstance ?? this.db;
 
-    const [existingUser] = await db
-      .select()
-      .from(users)
-      .where(and(eq(users.email, data.email)));
-
-    if (existingUser) throw new ConflictException("User already exists");
+    await this.assertUserEmailAvailable(data.email);
 
     const { createdUser, token, newUsersLanguage } = await this.createUserTransaction(
       db,
@@ -761,6 +756,16 @@ export class UserService {
     );
 
     return createdUser;
+  }
+
+  private async assertUserEmailAvailable(email: string) {
+    const [existingUser] = await this.dbAdmin
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.email, email))
+      .limit(1);
+
+    if (existingUser) throw new ConflictException("registerView.toast.userAlreadyExists");
   }
 
   private async createUserTransaction(
@@ -955,10 +960,11 @@ export class UserService {
     );
 
     for (const userData of usersData) {
-      const [existingUser] = await this.db
-        .select()
+      const [existingUser] = await this.dbAdmin
+        .select({ email: users.email })
         .from(users)
-        .where(eq(users.email, userData.email));
+        .where(eq(users.email, userData.email))
+        .limit(1);
 
       if (existingUser) {
         importStats.skippedUsersAmount++;

--- a/apps/web/app/api/mutations/admin/useCreateUser.ts
+++ b/apps/web/app/api/mutations/admin/useCreateUser.ts
@@ -1,11 +1,11 @@
 import { useMutation } from "@tanstack/react-query";
-import { AxiosError } from "axios";
 import { useTranslation } from "react-i18next";
 
 import { ApiClient } from "~/api/api-client";
 import { COURSE_OWNERSHIP_CANDIDATES_QUERY_KEY } from "~/api/queries/admin/useCourseOwnershipCandidates";
 import { globalSettingsQueryOptions } from "~/api/queries/useGlobalSettings";
 import { queryClient } from "~/api/queryClient";
+import { getTranslatedApiErrorMessage } from "~/api/utils/getTranslatedApiErrorMessage";
 import { invalidateLearningPathEnrollmentData } from "~/api/utils/invalidateLearningPathEnrollmentData";
 import { useToast } from "~/components/ui/use-toast";
 
@@ -36,14 +36,8 @@ export function useCreateUser() {
       toast({ description: t("adminUserView.toast.userCreatedSuccessfully") });
     },
     onError: (error) => {
-      if (error instanceof AxiosError) {
-        return toast({
-          description: error.response?.data.message,
-          variant: "destructive",
-        });
-      }
       toast({
-        description: error.message,
+        description: getTranslatedApiErrorMessage(error, t, t("common.toast.somethingWentWrong")),
         variant: "destructive",
       });
     },

--- a/apps/web/app/api/mutations/admin/useImportUsers.ts
+++ b/apps/web/app/api/mutations/admin/useImportUsers.ts
@@ -27,6 +27,12 @@ export const useImportUsers = (searchParams?: UsersParams) => {
 
       return response.data;
     },
+    onMutate: () => {
+      toast({
+        variant: "loading",
+        description: t("adminUsersView.import.toast.processing"),
+      });
+    },
     onSuccess: async ({ data }) => {
       const { importedUsersAmount, skippedUsersAmount } = data;
 

--- a/apps/web/app/locales/cs/translation.json
+++ b/apps/web/app/locales/cs/translation.json
@@ -1322,6 +1322,7 @@
     },
     "import": {
       "toast": {
+        "processing": "Import uživatelů se zpracovává...",
         "success": "Import byl úspěšně dokončen.\nPočet importovaných uživatelů: {{ importedUsersAmount }}.\nPřeskočeno {{ skippedUsersAmount }} stávajících uživatelů."
       }
     },

--- a/apps/web/app/locales/de/translation.json
+++ b/apps/web/app/locales/de/translation.json
@@ -1316,6 +1316,7 @@
     },
     "import": {
       "toast": {
+        "processing": "Benutzerimport wird verarbeitet...",
         "success": "Der Import wurde erfolgreich abgeschlossen.\nImportierte {{ importedUsersAmount }} Benutzer.\n{{ skippedUsersAmount }} vorhandene Benutzer wurden übersprungen."
       }
     },

--- a/apps/web/app/locales/en/translation.json
+++ b/apps/web/app/locales/en/translation.json
@@ -2468,7 +2468,7 @@
       "requiredCheckbox": "This consent is required."
     },
     "toast": {
-      "userAlreadyExists": "User with this email already exists.",
+      "userAlreadyExists": "User with this email already exists",
       "createAccountFailed": "Unable to create account. Please try again.",
       "requiredFormFieldMissing": "Please accept all required consents.",
       "invalidFormField": "One of the submitted registration fields is invalid."

--- a/apps/web/app/locales/en/translation.json
+++ b/apps/web/app/locales/en/translation.json
@@ -1317,6 +1317,7 @@
     },
     "import": {
       "toast": {
+        "processing": "User import is processing...",
         "success": "Import completed successfully.\nImported {{ importedUsersAmount }} users.\nSkipped {{ skippedUsersAmount }} existing users."
       }
     },

--- a/apps/web/app/locales/lt/translation.json
+++ b/apps/web/app/locales/lt/translation.json
@@ -1322,6 +1322,7 @@
     },
     "import": {
       "toast": {
+        "processing": "Naudotojų importavimas apdorojamas...",
         "success": "Importavimas sėkmingai baigtas.\nImportuota {{ importedUsersAmount }} naudotojų.\nPraleista {{ skippedUsersAmount }} esamų naudotojų."
       }
     },

--- a/apps/web/app/locales/pl/translation.json
+++ b/apps/web/app/locales/pl/translation.json
@@ -1527,6 +1527,7 @@
     },
     "import": {
       "toast": {
+        "processing": "Import użytkowników jest przetwarzany...",
         "success": "Import zakończony pomyślnie.\nZaimportowano {{ importedUsersAmount }} użytkowników.\nPominieto {{ skippedUsersAmount }} istniejących użytkowników."
       }
     },

--- a/apps/web/app/modules/Admin/Users/components/ImportUsersModal/ImportUsersModal.tsx
+++ b/apps/web/app/modules/Admin/Users/components/ImportUsersModal/ImportUsersModal.tsx
@@ -21,10 +21,10 @@ export const ImportUsersModal = ({ open, onClose, searchParams }: ImportUsersMod
 
   const [importUsersResult, setImportUsersResult] = useState<ImportUsersResponse | null>(null);
 
-  const { mutate: importUsers } = useImportUsers(searchParams);
+  const { mutate: importUsers, isPending: isImportingUsers } = useImportUsers(searchParams);
 
   const handleUsersImport = () => {
-    if (!file) return;
+    if (!file || isImportingUsers) return;
 
     importUsers(file, {
       onSuccess: (data) => {
@@ -46,6 +46,7 @@ export const ImportUsersModal = ({ open, onClose, searchParams }: ImportUsersMod
           fileUrl={fileUrl}
           setFileUrl={setFileUrl}
           handleUsersImport={handleUsersImport}
+          isImportingUsers={isImportingUsers}
         />
       )}
     </Dialog>

--- a/apps/web/app/modules/Admin/Users/components/ImportUsersModal/ImportUsersUpload.test.tsx
+++ b/apps/web/app/modules/Admin/Users/components/ImportUsersModal/ImportUsersUpload.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { vi } from "vitest";
+
+import { Dialog } from "~/components/ui/dialog";
+import { renderWith } from "~/utils/testUtils";
+
+import { USERS_IMPORT_MODAL_HANDLES } from "../../../../../../e2e/data/users/handles";
+
+import { ImportUsersUpload } from "./ImportUsersUpload";
+
+vi.mock("~/components/FileUploadInput/FileUploadInput", () => ({
+  default: () => <div data-testid="mock-file-upload" />,
+}));
+
+const importFile = new File(["firstName,lastName,email"], "users.csv", {
+  type: "text/csv",
+});
+
+const renderImportUsersUpload = ({
+  file = importFile,
+  isImportingUsers = false,
+  handleUsersImport = vi.fn(),
+}: {
+  file?: File | null;
+  isImportingUsers?: boolean;
+  handleUsersImport?: () => void;
+} = {}) => {
+  renderWith().render(
+    <Dialog open>
+      <ImportUsersUpload
+        file={file}
+        setFile={vi.fn()}
+        fileUrl={undefined}
+        setFileUrl={vi.fn()}
+        handleUsersImport={handleUsersImport}
+        isImportingUsers={isImportingUsers}
+      />
+    </Dialog>,
+  );
+
+  return { handleUsersImport };
+};
+
+describe("ImportUsersUpload", () => {
+  it("disables the import button while the import request is pending", () => {
+    renderImportUsersUpload({ isImportingUsers: true });
+
+    expect(screen.getByTestId(USERS_IMPORT_MODAL_HANDLES.SUBMIT)).toBeDisabled();
+  });
+
+  it("keeps the import button enabled when a file is selected and no request is pending", () => {
+    renderImportUsersUpload();
+
+    expect(screen.getByTestId(USERS_IMPORT_MODAL_HANDLES.SUBMIT)).toBeEnabled();
+  });
+
+  it("does not submit again while the import button is disabled", () => {
+    const { handleUsersImport } = renderImportUsersUpload({ isImportingUsers: true });
+
+    fireEvent.click(screen.getByTestId(USERS_IMPORT_MODAL_HANDLES.SUBMIT));
+
+    expect(handleUsersImport).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/modules/Admin/Users/components/ImportUsersModal/ImportUsersUpload.tsx
+++ b/apps/web/app/modules/Admin/Users/components/ImportUsersModal/ImportUsersUpload.tsx
@@ -18,6 +18,7 @@ interface ImportUsersUploadProps {
   fileUrl: string | undefined;
   setFileUrl: (url: string | undefined) => void;
   handleUsersImport: () => void;
+  isImportingUsers: boolean;
 }
 
 export const ImportUsersUpload = ({
@@ -26,6 +27,7 @@ export const ImportUsersUpload = ({
   fileUrl,
   setFileUrl,
   handleUsersImport,
+  isImportingUsers,
 }: ImportUsersUploadProps) => {
   const { t } = useTranslation();
   return (
@@ -34,9 +36,9 @@ export const ImportUsersUpload = ({
         <DialogTitle>{t("adminUsersView.modal.title.import")}</DialogTitle>
       </DialogHeader>
       <DialogDescription>
-        <div className="body-sm text-muted-foreground">
+        <span className="body-sm block text-muted-foreground">
           {t("adminUsersView.modal.description.import")}
-        </div>
+        </span>
       </DialogDescription>
 
       <div className="py-4">
@@ -65,7 +67,7 @@ export const ImportUsersUpload = ({
       <DialogFooter>
         <Button
           data-testid={USERS_IMPORT_MODAL_HANDLES.SUBMIT}
-          disabled={!file}
+          disabled={!file || isImportingUsers}
           onClick={handleUsersImport}
         >
           {t("adminUsersView.modal.title.import")}

--- a/apps/web/e2e/flows/courses/dismiss-generate-missing-translations-dialog.flow.ts
+++ b/apps/web/e2e/flows/courses/dismiss-generate-missing-translations-dialog.flow.ts
@@ -3,13 +3,23 @@ import { waitForDialogOverlaysHiddenFlow } from "../common/wait-for-dialog-overl
 
 import type { Page } from "@playwright/test";
 
-export const dismissGenerateMissingTranslationsDialogFlow = async (page: Page) => {
+export const dismissGenerateMissingTranslationsDialogFlow = async (
+  page: Page,
+  options: { timeout?: number } = {},
+) => {
+  const { timeout = 10_000 } = options;
+
   const generateDialog = page.getByTestId(COURSE_LANGUAGE_DIALOG_HANDLES.GENERATE_DIALOG);
   const generateCancelButton = page.getByTestId(
     COURSE_LANGUAGE_DIALOG_HANDLES.GENERATE_CANCEL_BUTTON,
   );
 
-  if (!(await generateDialog.isVisible({ timeout: 10_000 }).catch(() => false))) {
+  const isGenerateDialogVisible = await generateDialog
+    .waitFor({ state: "visible", timeout })
+    .then(() => true)
+    .catch(() => false);
+
+  if (!isGenerateDialogVisible) {
     await waitForDialogOverlaysHiddenFlow(page);
     return;
   }

--- a/apps/web/e2e/specs/users/create-user.spec.ts
+++ b/apps/web/e2e/specs/users/create-user.spec.ts
@@ -90,6 +90,6 @@ test("admin sees a conflict when creating a duplicate email", async ({
     await submitCreateUserFormFlow(page);
 
     await expect(page).toHaveURL(/\/admin\/users\/new$/);
-    await assertToastVisible(page, "User already exists");
+    await assertToastVisible(page, "User with this email already exists");
   });
 });


### PR DESCRIPTION
## Issue(s)
- #1605 

## Overview

Disables the users import submit button while the import request is in progress, preventing duplicate import requests for larger batches.

Adds a loading toast when the import starts so admins get immediate feedback that the import is being processed. The import flow now also checks existing user emails through the global admin DB connection, so users that already exist anywhere in the app are handled as skipped imports instead of falling through to the global email unique constraint.

## Business Value

Admins can safely import larger batches without accidentally submitting the same file multiple times while waiting for the API response. This prevents avoidable 500 errors and gives clearer feedback during long-running imports.

## Screenshots / Video

https://github.com/user-attachments/assets/48f1bc0e-0d83-47b5-8f1b-e9110606d8f0
