### PR TITLE
chore: improve modern course layout performance with faster loading

### DIFF
--- a/apps/api/src/courses/course.controller.ts
+++ b/apps/api/src/courses/course.controller.ts
@@ -103,6 +103,7 @@ import {
 } from "src/courses/schemas/updateCourseSettings.schema";
 import {
   allCoursesValidation,
+  availableCourseCategoriesValidation,
   coursesValidation,
   studentCoursesValidation,
   studentsWithEnrolmentValidation,
@@ -132,6 +133,7 @@ import {
 
 import type { GetCourseSettings } from "./schemas/coursesSettings.schema";
 import type { EnrolledStudent } from "./schemas/enrolledStudent.schema";
+import type { AllCategoriesResponse } from "src/category/schemas/category.schema";
 import type {
   AllCoursesForContentCreatorResponse,
   AllCoursesResponse,
@@ -299,6 +301,42 @@ export class CourseController {
     const query = { filters, page, perPage, sort, excludeCourseId, language };
 
     const data = await this.courseService.getAvailableCourses(query, currentUserId);
+
+    return new PaginatedResponse(data);
+  }
+
+  @Get("available-categories")
+  @Validate(availableCourseCategoriesValidation)
+  @Public()
+  async getAvailableCourseCategories(
+    @Query("title") title: string,
+    @Query("description") description: string,
+    @Query("searchQuery") searchQuery: string,
+    @Query("category") category: string,
+    @Query("author") author: string,
+    @Query("creationDateRange[0]") creationDateRangeStart: string,
+    @Query("creationDateRange[1]") creationDateRangeEnd: string,
+    @Query("page") page: number,
+    @Query("perPage") perPage: number,
+    @Query("sort") sort: SortCourseFieldsOptions,
+    @Query("excludeCourseId") excludeCourseId: UUIDType,
+    @Query("language") language: SupportedLanguages,
+    @CurrentUser("userId") currentUserId?: UUIDType,
+  ): Promise<PaginatedResponse<AllCategoriesResponse>> {
+    const filters: CoursesFilterSchema = {
+      title,
+      description,
+      searchQuery,
+      category,
+      author,
+      creationDateRange:
+        creationDateRangeStart && creationDateRangeEnd
+          ? [creationDateRangeStart, creationDateRangeEnd]
+          : undefined,
+    };
+    const query = { filters, page, perPage, sort, excludeCourseId, language };
+
+    const data = await this.courseService.getAvailableCourseCategories(query, currentUserId);
 
     return new PaginatedResponse(data);
   }

--- a/apps/api/src/courses/course.service.ts
+++ b/apps/api/src/courses/course.service.ts
@@ -328,7 +328,7 @@ export class CourseService {
           );
           return { ...item, thumbnailUrl: signedUrl, authorAvatarUrl: authorAvatarSignedUrl };
         } catch (error) {
-          console.error(`Failed to get signed URL for ${item.thumbnailUrl}:`, error);
+          this.logger.error(`Failed to get signed URL for ${item.thumbnailUrl}:`, error);
           return item;
         }
       }),
@@ -450,7 +450,7 @@ export class CourseService {
               authorAvatarUrl: authorAvatarSignedUrl,
             };
           } catch (error) {
-            console.error(`Failed to get signed URL for ${item.thumbnailUrl}:`, error);
+            this.logger.error(`Failed to get signed URL for ${item.thumbnailUrl}:`, error);
             return { ...item, trailerUrl };
           }
         }),
@@ -655,7 +655,7 @@ export class CourseService {
     try {
       return await this.fileService.getFileUrl(thumbnailReference);
     } catch (error) {
-      console.error(`Failed to get signed URL for ${thumbnailReference}:`, error);
+      this.logger.error(`Failed to get signed URL for ${thumbnailReference}:`, error);
       return thumbnailReference;
     }
   }
@@ -950,7 +950,7 @@ export class CourseService {
               authorAvatarUrl: authorAvatarSignedUrl,
             };
           } catch (error) {
-            console.error(`Failed to get signed URL for ${item.thumbnailUrl}:`, error);
+            this.logger.error(`Failed to get signed URL for ${item.thumbnailUrl}:`, error);
             return item;
           }
         }),
@@ -3269,7 +3269,7 @@ export class CourseService {
             const signedUrl = await this.fileService.getFileUrl(question.photoS3Key);
             return { ...question, photoS3SingedUrl: signedUrl };
           } catch (error) {
-            console.error(
+            this.logger.error(
               `Failed to get signed URL for question thumbnail ${question.photoS3Key}:`,
               error,
             );

--- a/apps/api/src/courses/course.service.ts
+++ b/apps/api/src/courses/course.service.ts
@@ -170,6 +170,7 @@ import type { CoursesSettings } from "./types/settings";
 import type { SQL } from "drizzle-orm";
 import type { AnyPgColumn } from "drizzle-orm/pg-core";
 import type { CourseActivityLogSnapshot } from "src/activity-logs/types";
+import type { AllCategoriesResponse } from "src/category/schemas/category.schema";
 import type { Pagination, UUIDType } from "src/common";
 import type { CurrentUserType } from "src/common/types/current-user.type";
 import type {
@@ -646,6 +647,19 @@ export class CourseService {
     return trailers[courseId] ?? null;
   }
 
+  private async getSignedCourseThumbnailUrl(
+    thumbnailReference: string | null,
+  ): Promise<string | null> {
+    if (!thumbnailReference) return thumbnailReference;
+
+    try {
+      return await this.fileService.getFileUrl(thumbnailReference);
+    } catch (error) {
+      console.error(`Failed to get signed URL for ${thumbnailReference}:`, error);
+      return thumbnailReference;
+    }
+  }
+
   private countWordsFromHtml(content: string): number {
     const $ = loadHtml(content);
     const text = $.text();
@@ -778,6 +792,30 @@ export class CourseService {
     return mins === 0 ? `${hours}h` : `${hours}h ${mins}m`;
   }
 
+  private async getAvailableCoursesConditions(
+    trx: DatabasePg,
+    query: CoursesQuery,
+    currentUserId?: UUIDType,
+  ) {
+    const { filters = {}, language } = query;
+
+    const availableCourseIds = await this.getAvailableCourseIds(
+      trx,
+      currentUserId,
+      undefined,
+      query.excludeCourseId,
+    );
+
+    const conditions = [eq(courses.status, "published")];
+    conditions.push(...(this.getFiltersConditions(filters, true, language) as SQL<unknown>[]));
+
+    if (availableCourseIds.length > 0) {
+      conditions.push(inArray(courses.id, availableCourseIds));
+    }
+
+    return conditions;
+  }
+
   async getAvailableCourses(
     query: CoursesQuery,
     currentUserId?: UUIDType,
@@ -792,13 +830,6 @@ export class CourseService {
     const { sortOrder, sortedField } = getSortOptions(sort);
 
     return this.db.transaction(async (trx) => {
-      const availableCourseIds = await this.getAvailableCourseIds(
-        trx,
-        currentUserId,
-        undefined,
-        query.excludeCourseId,
-      );
-
       const lessonCountSql = sql<number>`(
         SELECT COUNT(*)::int
         FROM ${lessons}
@@ -806,14 +837,8 @@ export class CourseService {
         WHERE ${chapters.courseId} = ${courses.id}
       )`;
 
-      const conditions = [eq(courses.status, "published")];
-      conditions.push(...(this.getFiltersConditions(filters, true, language) as SQL<unknown>[]));
-
+      const conditions = await this.getAvailableCoursesConditions(trx, query, currentUserId);
       const orderConditions = this.getOrderConditions(filters);
-
-      if (availableCourseIds.length > 0) {
-        conditions.push(inArray(courses.id, availableCourseIds));
-      }
 
       const queryDB = trx
         .select({
@@ -953,6 +978,56 @@ export class CourseService {
         data: dataWithDuration,
         pagination: {
           totalItems: totalItems || 0,
+          page,
+          perPage,
+        },
+      };
+    });
+  }
+
+  async getAvailableCourseCategories(
+    query: CoursesQuery,
+    currentUserId?: UUIDType,
+  ): Promise<{ data: AllCategoriesResponse; pagination: Pagination }> {
+    const { perPage = DEFAULT_PAGE_SIZE, page = 1, language } = query;
+
+    return this.db.transaction(async (trx) => {
+      const conditions = await this.getAvailableCoursesConditions(trx, query, currentUserId);
+
+      const availableCategories = trx
+        .select({ categoryId: courses.categoryId })
+        .from(courses)
+        .leftJoin(categories, eq(courses.categoryId, categories.id))
+        .leftJoin(users, eq(courses.authorId, users.id))
+        .where(and(...conditions, isNotNull(courses.categoryId)))
+        .groupBy(courses.categoryId)
+        .as("available_course_categories");
+
+      const queryDB = trx
+        .select({
+          ...getTableColumns(categories),
+          archived: sql<boolean | null>`NULL`,
+          createdAt: sql<string | null>`NULL`,
+          title: this.localizationService.getLocalizedSqlField(
+            categories.title,
+            language,
+            categories,
+          ),
+        })
+        .from(categories)
+        .innerJoin(availableCategories, eq(availableCategories.categoryId, categories.id))
+        .orderBy(
+          this.localizationService.getLocalizedSqlField(categories.title, language, categories),
+        );
+
+      const dynamicQuery = queryDB.$dynamic();
+      const data = await addPagination(dynamicQuery, page, perPage);
+      const [{ totalItems }] = await trx.select({ totalItems: count() }).from(availableCategories);
+
+      return {
+        data,
+        pagination: {
+          totalItems,
           page,
           perPage,
         },
@@ -3371,6 +3446,27 @@ export class CourseService {
         return count(studentCourses.courseId);
       default:
         return courses.title;
+    }
+  }
+
+  private getAvailableCourseSortExpression(sort: CourseSortField, language?: SupportedLanguages) {
+    switch (sort) {
+      case CourseSortFields.author:
+        return sql<string>`CONCAT(${users.firstName} || ' ' || ${users.lastName})`;
+      case CourseSortFields.category:
+        return this.localizationService.getLocalizedSqlField(
+          categories.title,
+          language,
+          categories,
+        );
+      case CourseSortFields.creationDate:
+        return sql`${courses.createdAt}`;
+      case CourseSortFields.chapterCount:
+        return count(studentCourses.courseId);
+      case CourseSortFields.enrolledParticipantsCount:
+        return count(studentCourses.courseId);
+      default:
+        return this.localizationService.getLocalizedSqlField(courses.title, language);
     }
   }
 

--- a/apps/api/src/courses/validations/validations.ts
+++ b/apps/api/src/courses/validations/validations.ts
@@ -1,5 +1,6 @@
 import { Type } from "@sinclair/typebox";
 
+import { categorySchema } from "src/category/schemas/category.schema";
 import { paginatedResponse, UUIDSchema } from "src/common";
 import {
   allCoursesSchema,
@@ -75,6 +76,36 @@ export const studentCoursesValidation = {
 
 export const coursesValidation = {
   response: paginatedResponse(allStudentCoursesSchema),
+  request: [
+    { type: "query" as const, name: "title", schema: Type.String() },
+    { type: "query" as const, name: "description", schema: Type.String() },
+    { type: "query" as const, name: "searchQuery", schema: Type.String() },
+    { type: "query" as const, name: "category", schema: Type.String() },
+    { type: "query" as const, name: "author", schema: Type.String() },
+    {
+      type: "query" as const,
+      name: "creationDateRange[0]",
+      schema: Type.String(),
+    },
+    {
+      type: "query" as const,
+      name: "creationDateRange[1]",
+      schema: Type.String(),
+    },
+    {
+      type: "query" as const,
+      name: "page",
+      schema: Type.Number({ minimum: 1 }),
+    },
+    { type: "query" as const, name: "perPage", schema: Type.Number() },
+    { type: "query" as const, name: "sort", schema: sortCourseFieldsOptions },
+    { type: "query" as const, name: "excludeCourseId", schema: UUIDSchema },
+    { type: "query" as const, name: "language", schema: supportedLanguagesSchema },
+  ],
+};
+
+export const availableCourseCategoriesValidation = {
+  response: paginatedResponse(Type.Array(categorySchema)),
   request: [
     { type: "query" as const, name: "title", schema: Type.String() },
     { type: "query" as const, name: "description", schema: Type.String() },

--- a/apps/api/src/learning-path/services/learning-path.service.ts
+++ b/apps/api/src/learning-path/services/learning-path.service.ts
@@ -4,6 +4,7 @@ import {
   ForbiddenException,
   Inject,
   Injectable,
+  Logger,
   NotFoundException,
   UnprocessableEntityException,
 } from "@nestjs/common";
@@ -66,6 +67,8 @@ import type { SortEnrolledStudentsOptions } from "src/courses/schemas/courseQuer
 
 @Injectable()
 export class LearningPathService {
+  private readonly logger = new Logger(LearningPathService.name);
+
   constructor(
     @Inject("DB") private readonly db: DatabasePg,
     private readonly learningPathRepository: LearningPathRepository,
@@ -1162,7 +1165,7 @@ export class LearningPathService {
     try {
       return await this.fileService.getFileUrl(reference);
     } catch (error) {
-      console.error(`Failed to get signed URL for ${reference}:`, error);
+      this.logger.error(`Failed to get signed URL for ${reference}:`, error);
       return reference;
     }
   }

--- a/apps/api/src/lesson/services/lesson.service.ts
+++ b/apps/api/src/lesson/services/lesson.service.ts
@@ -3,6 +3,7 @@ import {
   ForbiddenException,
   Inject,
   Injectable,
+  Logger,
   NotFoundException,
   UnauthorizedException,
 } from "@nestjs/common";
@@ -68,6 +69,8 @@ import type { FilePreviewFormat, FilePreviewOptions } from "src/file/types/file-
 
 @Injectable()
 export class LessonService {
+  private readonly logger = new Logger(LessonService.name);
+
   constructor(
     @Inject("DB") private readonly db: DatabasePg,
     private readonly lessonRepository: LessonRepository,
@@ -248,7 +251,7 @@ export class LessonService {
 
           return questionResult;
         } catch (error) {
-          console.error(`Failed to get signed URL for ${question.photoS3Key}:`, error);
+          this.logger.error(`Failed to get signed URL for ${question.photoS3Key}:`, error);
           return question;
         }
       }),

--- a/apps/api/src/swagger/api-schema.json
+++ b/apps/api/src/swagger/api-schema.json
@@ -3509,6 +3509,193 @@
         }
       }
     },
+    "/api/course/available-categories": {
+      "get": {
+        "operationId": "CourseController_getAvailableCourseCategories",
+        "parameters": [
+          {
+            "name": "title",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "description",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "searchQuery",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "category",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "author",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "creationDateRange[0]",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "creationDateRange[1]",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "minimum": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "perPage",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "anyOf": [
+                {
+                  "const": "title",
+                  "type": "string"
+                },
+                {
+                  "const": "category",
+                  "type": "string"
+                },
+                {
+                  "const": "creationDate",
+                  "type": "string"
+                },
+                {
+                  "const": "author",
+                  "type": "string"
+                },
+                {
+                  "const": "chapterCount",
+                  "type": "string"
+                },
+                {
+                  "const": "enrolledParticipantsCount",
+                  "type": "string"
+                },
+                {
+                  "const": "-title",
+                  "type": "string"
+                },
+                {
+                  "const": "-category",
+                  "type": "string"
+                },
+                {
+                  "const": "-creationDate",
+                  "type": "string"
+                },
+                {
+                  "const": "-author",
+                  "type": "string"
+                },
+                {
+                  "const": "-chapterCount",
+                  "type": "string"
+                },
+                {
+                  "const": "-enrolledParticipantsCount",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          {
+            "name": "excludeCourseId",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "language",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": "en",
+              "anyOf": [
+                {
+                  "const": "en",
+                  "type": "string"
+                },
+                {
+                  "const": "pl",
+                  "type": "string"
+                },
+                {
+                  "const": "de",
+                  "type": "string"
+                },
+                {
+                  "const": "lt",
+                  "type": "string"
+                },
+                {
+                  "const": "cs",
+                  "type": "string"
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetAvailableCourseCategoriesResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/course/top-courses": {
       "get": {
         "operationId": "CourseController_getTopCourses",
@@ -23351,6 +23538,134 @@
                 "completedChapterCount",
                 "dueDate",
                 "slug"
+              ]
+            }
+          },
+          "pagination": {
+            "type": "object",
+            "properties": {
+              "totalItems": {
+                "type": "number"
+              },
+              "page": {
+                "type": "number"
+              },
+              "perPage": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "totalItems",
+              "page",
+              "perPage"
+            ]
+          },
+          "appliedFilters": {
+            "type": "object",
+            "patternProperties": {
+              "^(.*)$": {}
+            }
+          }
+        },
+        "required": [
+          "data",
+          "pagination"
+        ]
+      },
+      "GetAvailableCourseCategoriesResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "availableLocales": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "const": "en",
+                        "type": "string"
+                      },
+                      {
+                        "const": "pl",
+                        "type": "string"
+                      },
+                      {
+                        "const": "de",
+                        "type": "string"
+                      },
+                      {
+                        "const": "lt",
+                        "type": "string"
+                      },
+                      {
+                        "const": "cs",
+                        "type": "string"
+                      }
+                    ]
+                  }
+                },
+                "baseLanguage": {
+                  "anyOf": [
+                    {
+                      "const": "en",
+                      "type": "string"
+                    },
+                    {
+                      "const": "pl",
+                      "type": "string"
+                    },
+                    {
+                      "const": "de",
+                      "type": "string"
+                    },
+                    {
+                      "const": "lt",
+                      "type": "string"
+                    },
+                    {
+                      "const": "cs",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "archived": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "createdAt": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "id",
+                "title",
+                "availableLocales",
+                "baseLanguage",
+                "archived",
+                "createdAt"
               ]
             }
           },

--- a/apps/web/app/Guards/AccessGuard.tsx
+++ b/apps/web/app/Guards/AccessGuard.tsx
@@ -9,12 +9,7 @@ import {
 import { useLayoutEffect } from "react";
 import { match } from "ts-pattern";
 
-import {
-  availableCoursesQueryOptions,
-  currentUserQueryOptions,
-  studentCoursesQueryOptions,
-} from "~/api/queries";
-import { categoriesQueryOptions } from "~/api/queries/useCategories";
+import { currentUserQueryOptions } from "~/api/queries";
 import { allCoursesQueryOptions } from "~/api/queries/useCourses";
 import { useCurrentUser } from "~/api/queries/useCurrentUser";
 import { useGlobalSettings } from "~/api/queries/useGlobalSettings";
@@ -25,8 +20,6 @@ import Loader from "~/modules/common/Loader/Loader";
 import type React from "react";
 
 const prefetchQueriesForUser = async (permissions: PermissionKey[] | undefined) => {
-  await queryClient.prefetchQuery(categoriesQueryOptions());
-
   const canManageCourses = hasAnyPermission(permissions, [
     PERMISSIONS.COURSE_UPDATE,
     PERMISSIONS.COURSE_UPDATE_OWN,
@@ -34,11 +27,7 @@ const prefetchQueriesForUser = async (permissions: PermissionKey[] | undefined) 
 
   if (canManageCourses) {
     await queryClient.prefetchQuery(allCoursesQueryOptions());
-    return;
   }
-
-  await queryClient.prefetchQuery(availableCoursesQueryOptions());
-  await queryClient.prefetchQuery(studentCoursesQueryOptions());
 };
 
 export const clientLoader = async () => {

--- a/apps/web/app/api/generated-api.ts
+++ b/apps/web/app/api/generated-api.ts
@@ -1872,6 +1872,24 @@ export interface GetAvailableCoursesResponse {
   appliedFilters?: object;
 }
 
+export interface GetAvailableCourseCategoriesResponse {
+  data: {
+    /** @format uuid */
+    id: string;
+    title: string;
+    availableLocales: ("en" | "pl" | "de" | "lt" | "cs")[];
+    baseLanguage: "en" | "pl" | "de" | "lt" | "cs";
+    archived: boolean | null;
+    createdAt: string | null;
+  }[];
+  pagination: {
+    totalItems: number;
+    page: number;
+    perPage: number;
+  };
+  appliedFilters?: object;
+}
+
 export interface GetTopCoursesResponse {
   data: {
     /** @format uuid */
@@ -8924,6 +8942,52 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     ) =>
       this.request<GetAvailableCoursesResponse, any>({
         path: `/api/course/available-courses`,
+        method: "GET",
+        query: query,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @name CourseControllerGetAvailableCourseCategories
+     * @request GET:/api/course/available-categories
+     */
+    courseControllerGetAvailableCourseCategories: (
+      query?: {
+        title?: string;
+        description?: string;
+        searchQuery?: string;
+        category?: string;
+        author?: string;
+        "creationDateRange[0]"?: string;
+        "creationDateRange[1]"?: string;
+        /** @min 1 */
+        page?: number;
+        perPage?: number;
+        sort?:
+          | "title"
+          | "category"
+          | "creationDate"
+          | "author"
+          | "chapterCount"
+          | "enrolledParticipantsCount"
+          | "-title"
+          | "-category"
+          | "-creationDate"
+          | "-author"
+          | "-chapterCount"
+          | "-enrolledParticipantsCount";
+        /** @format uuid */
+        excludeCourseId?: string;
+        /** @default "en" */
+        language?: "en" | "pl" | "de" | "lt" | "cs";
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<GetAvailableCourseCategoriesResponse, any>({
+        path: `/api/course/available-categories`,
         method: "GET",
         query: query,
         format: "json",

--- a/apps/web/app/api/mutations/admin/useChangeAgeLimit.ts
+++ b/apps/web/app/api/mutations/admin/useChangeAgeLimit.ts
@@ -4,9 +4,9 @@ import { useTranslation } from "react-i18next";
 import { ApiClient } from "~/api/api-client";
 import { globalSettingsQueryOptions } from "~/api/queries/useGlobalSettings";
 import { queryClient } from "~/api/queryClient";
+import { getTranslatedApiErrorMessage } from "~/api/utils/getTranslatedApiErrorMessage";
 import { useToast } from "~/components/ui/use-toast";
 
-import type { AxiosError } from "axios";
 import type { UpdateAgeLimitBody } from "~/api/generated-api";
 
 export function useChangeAgeLimit() {
@@ -24,10 +24,11 @@ export function useChangeAgeLimit() {
 
       await queryClient.invalidateQueries({ queryKey: globalSettingsQueryOptions.queryKey });
     },
-    onError: (error: AxiosError) => {
-      const { message } = error.response?.data as { message: string };
-
-      toast({ description: t(message), variant: "destructive" });
+    onError: (error) => {
+      toast({
+        description: getTranslatedApiErrorMessage(error, t, t("common.toast.somethingWentWrong")),
+        variant: "destructive",
+      });
     },
   });
 }

--- a/apps/web/app/api/mutations/admin/useChangeQASetting.ts
+++ b/apps/web/app/api/mutations/admin/useChangeQASetting.ts
@@ -4,10 +4,10 @@ import { useTranslation } from "react-i18next";
 import { ApiClient } from "~/api/api-client";
 import { globalSettingsQueryOptions } from "~/api/queries/useGlobalSettings";
 import { queryClient } from "~/api/queryClient";
+import { getTranslatedApiErrorMessage } from "~/api/utils/getTranslatedApiErrorMessage";
 import { useToast } from "~/components/ui/use-toast";
 
 import type { AllowedQASettings } from "@repo/shared";
-import type { AxiosError } from "axios";
 
 export function useChangeQASetting() {
   const { toast } = useToast();
@@ -24,10 +24,11 @@ export function useChangeQASetting() {
 
       queryClient.invalidateQueries({ queryKey: globalSettingsQueryOptions.queryKey });
     },
-    onError: (error: AxiosError) => {
-      const { message } = error.response?.data as { message: string };
-
-      toast({ description: t(message), variant: "destructive" });
+    onError: (error) => {
+      toast({
+        description: getTranslatedApiErrorMessage(error, t, t("common.toast.somethingWentWrong")),
+        variant: "destructive",
+      });
     },
   });
 }

--- a/apps/web/app/api/mutations/admin/useCreateLanguage.ts
+++ b/apps/web/app/api/mutations/admin/useCreateLanguage.ts
@@ -4,10 +4,10 @@ import { useTranslation } from "react-i18next";
 import { ApiClient } from "~/api/api-client";
 import { COURSE_QUERY_KEY } from "~/api/queries/admin/useBetaCourse";
 import { queryClient } from "~/api/queryClient";
+import { getTranslatedApiErrorMessage } from "~/api/utils/getTranslatedApiErrorMessage";
 import { useToast } from "~/components/ui/use-toast";
 
 import type { SupportedLanguages } from "@repo/shared";
-import type { AxiosError } from "axios";
 
 type CreateLanguageOptions = {
   language: SupportedLanguages;
@@ -31,10 +31,11 @@ export function useCreateLanguage() {
 
       await queryClient.invalidateQueries({ queryKey: [COURSE_QUERY_KEY] });
     },
-    onError: (error: AxiosError) => {
-      const { message } = error.response?.data as { message: string };
-
-      toast({ description: t(message), variant: "destructive" });
+    onError: (error) => {
+      toast({
+        description: getTranslatedApiErrorMessage(error, t, t("common.toast.somethingWentWrong")),
+        variant: "destructive",
+      });
     },
   });
 }

--- a/apps/web/app/api/mutations/admin/useGenerateMissingTranslations.ts
+++ b/apps/web/app/api/mutations/admin/useGenerateMissingTranslations.ts
@@ -5,10 +5,10 @@ import { ApiClient } from "~/api/api-client";
 import { COURSE_QUERY_KEY } from "~/api/queries/admin/useBetaCourse";
 import { COURSE_TRANSLATIONS_QUERY_KEY } from "~/api/queries/admin/useHasMissingTranslations";
 import { queryClient } from "~/api/queryClient";
+import { getTranslatedApiErrorMessage } from "~/api/utils/getTranslatedApiErrorMessage";
 import { useToast } from "~/components/ui/use-toast";
 
 import type { SupportedLanguages } from "@repo/shared";
-import type { AxiosError } from "axios";
 
 type GenerateTranslationsOptions = {
   courseId: string;
@@ -44,10 +44,11 @@ export default function useGenerateMissingTranslations() {
         description: t("adminCourseView.toast.translationsGeneratedSuccessfully"),
       });
     },
-    onError: (error: AxiosError) => {
-      const { message } = error.response?.data as { message: string };
-
-      toast({ description: t(message), variant: "destructive" });
+    onError: (error) => {
+      toast({
+        description: getTranslatedApiErrorMessage(error, t, t("common.toast.somethingWentWrong")),
+        variant: "destructive",
+      });
     },
   });
 }

--- a/apps/web/app/api/mutations/admin/useUnenrollGroupsFromCourse.ts
+++ b/apps/web/app/api/mutations/admin/useUnenrollGroupsFromCourse.ts
@@ -7,9 +7,9 @@ import { GROUPS_BY_COURSE_QUERY_KEY } from "~/api/queries/admin/useGroupsByCours
 import { ENROLLED_USERS_QUERY_KEY } from "~/api/queries/admin/useUsersEnrolled";
 import { queryClient } from "~/api/queryClient";
 import { invalidateCourseStatisticsQueries } from "~/api/utils/courseStatisticsUtils";
+import { getTranslatedApiErrorMessage } from "~/api/utils/getTranslatedApiErrorMessage";
 import { useToast } from "~/components/ui/use-toast";
 
-import type { AxiosError } from "axios";
 import type { UnenrollGroupsFromCourseBody } from "~/api/generated-api";
 
 export function useUnenrollGroupsFromCourse(courseId = "") {
@@ -37,12 +37,10 @@ export function useUnenrollGroupsFromCourse(courseId = "") {
 
       await invalidateCourseStatisticsQueries();
     },
-    onError: (error: AxiosError) => {
-      const { message } = error.response?.data as { message: string };
-
+    onError: (error) => {
       return toast({
         variant: "destructive",
-        description: t(message),
+        description: getTranslatedApiErrorMessage(error, t, t("common.toast.somethingWentWrong")),
       });
     },
   });

--- a/apps/web/app/api/mutations/admin/useUpdateCourse.ts
+++ b/apps/web/app/api/mutations/admin/useUpdateCourse.ts
@@ -2,27 +2,19 @@ import { useMutation } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 
 import { COURSE_QUERY_KEY } from "~/api/queries/admin/useBetaCourse";
-import { ALL_COURSES_QUERY_KEY } from "~/api/queries/useCourses";
 import { queryClient } from "~/api/queryClient";
+import { getTranslatedApiErrorMessage } from "~/api/utils/getTranslatedApiErrorMessage";
+import { invalidateCourseListData } from "~/api/utils/invalidateCourseListData";
 import { useToast } from "~/components/ui/use-toast";
 
 import { ApiClient } from "../../api-client";
 
 import type { UpdateCourseBody } from "../../generated-api";
-import type { AxiosError } from "axios";
 
 type UpdateCourseOptions = {
   data: UpdateCourseBody;
   courseId: string;
 };
-
-const COURSE_LIST_QUERY_KEYS = [
-  ALL_COURSES_QUERY_KEY,
-  ["available-courses"],
-  ["content-creator-courses"],
-  ["get-student-courses"],
-  ["top-courses"],
-] as const;
 
 export function useUpdateCourse() {
   const { toast } = useToast();
@@ -35,6 +27,9 @@ export function useUpdateCourse() {
         options.data,
       );
 
+      return response.data;
+    },
+    onSuccess: async (_data, options) => {
       await Promise.all([
         queryClient.invalidateQueries({
           queryKey: [COURSE_QUERY_KEY, { id: options.courseId }],
@@ -42,18 +37,16 @@ export function useUpdateCourse() {
         queryClient.invalidateQueries({
           queryKey: ["course"],
         }),
-        ...COURSE_LIST_QUERY_KEYS.map((queryKey) => queryClient.invalidateQueries({ queryKey })),
+        invalidateCourseListData(),
       ]);
 
-      return response.data;
-    },
-    onSuccess: () => {
       toast({ description: t("adminCourseView.toast.courseUpdatedSuccessfully") });
     },
-    onError: (error: AxiosError) => {
-      const { message } = error.response?.data as { message: string };
-
-      toast({ description: t(message), variant: "destructive" });
+    onError: (error) => {
+      toast({
+        description: getTranslatedApiErrorMessage(error, t, t("common.toast.somethingWentWrong")),
+        variant: "destructive",
+      });
     },
   });
 }

--- a/apps/web/app/api/mutations/useCreateCourse.ts
+++ b/apps/web/app/api/mutations/useCreateCourse.ts
@@ -7,6 +7,7 @@ import { useToast } from "~/components/ui/use-toast";
 
 import { ApiClient } from "../api-client";
 import { queryClient } from "../queryClient";
+import { invalidateCourseListData } from "../utils/invalidateCourseListData";
 
 import type { CreateCourseBody } from "../generated-api";
 
@@ -24,8 +25,12 @@ export function useCreateCourse() {
 
       return response.data;
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries(currentUserQueryOptions);
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries(currentUserQueryOptions),
+        invalidateCourseListData(),
+      ]);
+
       toast({ description: t("adminCourseView.toast.createCourseSuccessfully") });
     },
     onError: (error) => {

--- a/apps/web/app/api/mutations/useDeleteArticle.ts
+++ b/apps/web/app/api/mutations/useDeleteArticle.ts
@@ -4,13 +4,12 @@ import { useTranslation } from "react-i18next";
 
 import { ARTICLE_SECTION_QUERY_KEY } from "~/api/queries/useArticleSection";
 import { queryClient } from "~/api/queryClient";
+import { getTranslatedApiErrorMessage } from "~/api/utils/getTranslatedApiErrorMessage";
 import { useToast } from "~/components/ui/use-toast";
 
 import { ApiClient } from "../api-client";
 import { ARTICLE_QUERY_KEY } from "../queries/useArticle";
 import { ARTICLES_TOC_QUERY_KEY } from "../queries/useArticlesToc";
-
-import type { AxiosError } from "axios";
 
 export function useDeleteArticle() {
   const { toast } = useToast();
@@ -30,11 +29,9 @@ export function useDeleteArticle() {
 
       navigate("/articles");
     },
-    onError: (error: AxiosError) => {
-      const { message } = error.response?.data as { message: string };
-
+    onError: (error) => {
       toast({
-        description: t(message),
+        description: getTranslatedApiErrorMessage(error, t, t("common.toast.somethingWentWrong")),
         variant: "destructive",
       });
     },

--- a/apps/web/app/api/queries/index.ts
+++ b/apps/web/app/api/queries/index.ts
@@ -1,9 +1,20 @@
 export {
+  infiniteAvailableCoursesQueryOptions,
   availableCoursesQueryOptions,
+  useInfiniteAvailableCourses,
   useAvailableCourses,
   useAvailableCoursesSuspense,
 } from "./useAvailableCourses";
-export { categoriesQueryOptions, useCategories, useCategoriesSuspense } from "./useCategories";
+export {
+  infiniteAvailableCourseCategoriesQueryOptions,
+  categoriesQueryOptions,
+  infiniteCategoriesQueryOptions,
+  useCategories,
+  useCategoriesSuspense,
+  useInfiniteAvailableCourseCategories,
+  useInfiniteCategories,
+} from "./useCategories";
+export type { AvailableCourseCategorySearchParams } from "../types";
 export { courseLookupQueryOptions, getCourseLookupQueryKey } from "./useCourseLookup";
 export { courseQueryOptions, useCourse, useCourseSuspense } from "./useCourse";
 export { allCoursesQueryOptions, useCourses, useCoursesSuspense } from "./useCourses";
@@ -12,7 +23,9 @@ export { lessonQueryOptions, useLesson, useLessonSuspense } from "./useLesson";
 export { passwordStatusQueryOptions, usePasswordStatusSuspense } from "./usePasswordStatus";
 export { scormLaunchQueryOptions, useScormLaunch } from "./useScormLaunch";
 export {
+  infiniteStudentCoursesQueryOptions,
   studentCoursesQueryOptions,
+  useInfiniteStudentCourses,
   useStudentCourses,
   useStudentCoursesSuspense,
 } from "./useStudentCourses";

--- a/apps/web/app/api/queries/useAvailableCourses.ts
+++ b/apps/web/app/api/queries/useAvailableCourses.ts
@@ -1,4 +1,4 @@
-import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery, useSuspenseQuery } from "@tanstack/react-query";
 
 import { ApiClient } from "../api-client";
 
@@ -24,29 +24,65 @@ type CourseParams = {
 
 type QueryOptions = {
   enabled?: boolean;
+  notifyOnChangeProps?: Array<"data" | "isLoading" | "hasNextPage">;
 };
+
+export const AVAILABLE_COURSES_QUERY_KEY = "available-courses";
+export const AVAILABLE_COURSES_PAGE_SIZE = 5;
+
+const getAvailableCoursesRequestParams = (
+  searchParams: CourseParams | undefined,
+  page: number,
+  perPage: number,
+) => ({
+  page,
+  perPage,
+  ...(searchParams?.title && { title: searchParams.title }),
+  ...(searchParams?.description && { description: searchParams.description }),
+  ...(searchParams?.searchQuery && { searchQuery: searchParams.searchQuery }),
+  ...(searchParams?.category && { category: searchParams.category }),
+  ...(searchParams?.sort && { sort: searchParams.sort }),
+  ...(searchParams?.userId && { userId: searchParams.userId }),
+  ...(searchParams?.excludeCourseId && { excludeCourseId: searchParams.excludeCourseId }),
+  language: searchParams?.language,
+});
 
 export const availableCoursesQueryOptions = (
   searchParams?: CourseParams,
   options: QueryOptions = { enabled: true },
 ) => ({
-  queryKey: ["available-courses", searchParams],
+  queryKey: [AVAILABLE_COURSES_QUERY_KEY, searchParams],
   queryFn: async () => {
-    const response = await ApiClient.api.courseControllerGetAvailableCourses({
-      page: 1,
-      perPage: 100,
-      ...(searchParams?.title && { title: searchParams.title }),
-      ...(searchParams?.description && { description: searchParams.description }),
-      ...(searchParams?.searchQuery && { searchQuery: searchParams.searchQuery }),
-      ...(searchParams?.category && { category: searchParams.category }),
-      ...(searchParams?.sort && { sort: searchParams.sort }),
-      ...(searchParams?.userId && { userId: searchParams.userId }),
-      ...(searchParams?.excludeCourseId && { excludeCourseId: searchParams.excludeCourseId }),
-      language: searchParams?.language,
-    });
+    const response = await ApiClient.api.courseControllerGetAvailableCourses(
+      getAvailableCoursesRequestParams(searchParams, 1, 100),
+    );
     return response.data;
   },
   select: (data: GetAvailableCoursesResponse) => data.data,
+  ...options,
+});
+
+export const infiniteAvailableCoursesQueryOptions = (
+  searchParams?: CourseParams,
+  perPage = AVAILABLE_COURSES_PAGE_SIZE,
+  options: QueryOptions = { enabled: true },
+) => ({
+  queryKey: [AVAILABLE_COURSES_QUERY_KEY, "infinite", searchParams, perPage],
+  queryFn: async ({ pageParam }: { pageParam: number }) => {
+    const response = await ApiClient.api.courseControllerGetAvailableCourses(
+      getAvailableCoursesRequestParams(searchParams, pageParam, perPage),
+    );
+
+    return response.data;
+  },
+  getNextPageParam: (lastPage: GetAvailableCoursesResponse) => {
+    const loadedItems = lastPage.pagination.page * lastPage.pagination.perPage;
+
+    if (loadedItems >= lastPage.pagination.totalItems) return undefined;
+
+    return lastPage.pagination.page + 1;
+  },
+  initialPageParam: 1,
   ...options,
 });
 
@@ -56,4 +92,12 @@ export function useAvailableCourses(searchParams?: CourseParams) {
 
 export function useAvailableCoursesSuspense(searchParams?: CourseParams) {
   return useSuspenseQuery(availableCoursesQueryOptions(searchParams));
+}
+
+export function useInfiniteAvailableCourses(
+  searchParams?: CourseParams,
+  perPage = AVAILABLE_COURSES_PAGE_SIZE,
+  options: QueryOptions = { enabled: true },
+) {
+  return useInfiniteQuery(infiniteAvailableCoursesQueryOptions(searchParams, perPage, options));
 }

--- a/apps/web/app/api/queries/useCategories.ts
+++ b/apps/web/app/api/queries/useCategories.ts
@@ -1,8 +1,12 @@
-import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery, useSuspenseQuery } from "@tanstack/react-query";
 
 import { ApiClient } from "../api-client";
 
-import type { GetAllCategoriesResponse } from "../generated-api";
+import type {
+  GetAllCategoriesResponse,
+  GetAvailableCourseCategoriesResponse,
+} from "../generated-api";
+import type { AvailableCourseCategorySearchParams } from "../types";
 import type { SupportedLanguages } from "@repo/shared";
 
 type CategorySearchParams = {
@@ -12,10 +16,26 @@ type CategorySearchParams = {
 };
 
 export const CATEGORIES_QUERY_KEY = ["categories"];
+export const AVAILABLE_COURSE_CATEGORIES_QUERY_KEY = ["available-course-categories"];
+export const CATEGORIES_PAGE_SIZE = 4;
 
 type QueryOptions = {
   enabled?: boolean;
 };
+
+const getCategoriesRequestParams = (
+  searchParams: CategorySearchParams | undefined,
+  page: number,
+  perPage: number,
+) => ({
+  page,
+  perPage,
+  ...(searchParams?.title && { title: searchParams.title }),
+  ...(searchParams?.archived !== undefined && {
+    archived: String(searchParams.archived),
+  }),
+  ...(searchParams?.language && { language: searchParams.language }),
+});
 
 export const categoriesQueryOptions = (
   searchParams?: CategorySearchParams,
@@ -23,18 +43,77 @@ export const categoriesQueryOptions = (
 ) => ({
   queryKey: [...CATEGORIES_QUERY_KEY, searchParams],
   queryFn: async () => {
-    const response = await ApiClient.api.categoryControllerGetAllCategories({
-      page: 1,
-      perPage: 100,
-      ...(searchParams?.title && { title: searchParams.title }),
-      ...(searchParams?.archived !== undefined && {
-        archived: String(searchParams.archived),
-      }),
-      ...(searchParams?.language && { language: searchParams.language }),
-    });
+    const response = await ApiClient.api.categoryControllerGetAllCategories(
+      getCategoriesRequestParams(searchParams, 1, 100),
+    );
     return response.data;
   },
   select: (data: GetAllCategoriesResponse) => data.data,
+  ...options,
+});
+
+export const infiniteCategoriesQueryOptions = (
+  searchParams?: CategorySearchParams,
+  perPage = CATEGORIES_PAGE_SIZE,
+  options: QueryOptions = { enabled: true },
+) => ({
+  queryKey: [...CATEGORIES_QUERY_KEY, "infinite", searchParams, perPage],
+  queryFn: async ({ pageParam }: { pageParam: number }) => {
+    const response = await ApiClient.api.categoryControllerGetAllCategories(
+      getCategoriesRequestParams(searchParams, pageParam, perPage),
+    );
+
+    return response.data;
+  },
+  getNextPageParam: (lastPage: GetAllCategoriesResponse) => {
+    const loadedItems = lastPage.pagination.page * lastPage.pagination.perPage;
+
+    if (loadedItems >= lastPage.pagination.totalItems) return undefined;
+
+    return lastPage.pagination.page + 1;
+  },
+  initialPageParam: 1,
+  ...options,
+});
+
+const getAvailableCourseCategoriesRequestParams = (
+  searchParams: AvailableCourseCategorySearchParams | undefined,
+  page: number,
+  perPage: number,
+) => ({
+  page,
+  perPage,
+  ...(searchParams?.title && { title: searchParams.title }),
+  ...(searchParams?.description && { description: searchParams.description }),
+  ...(searchParams?.searchQuery && { searchQuery: searchParams.searchQuery }),
+  ...(searchParams?.category && { category: searchParams.category }),
+  ...(searchParams?.author && { author: searchParams.author }),
+  ...(searchParams?.sort && { sort: searchParams.sort }),
+  ...(searchParams?.excludeCourseId && { excludeCourseId: searchParams.excludeCourseId }),
+  ...(searchParams?.language && { language: searchParams.language }),
+});
+
+export const infiniteAvailableCourseCategoriesQueryOptions = (
+  searchParams?: AvailableCourseCategorySearchParams,
+  perPage = CATEGORIES_PAGE_SIZE,
+  options: QueryOptions = { enabled: true },
+) => ({
+  queryKey: [...AVAILABLE_COURSE_CATEGORIES_QUERY_KEY, "infinite", searchParams, perPage],
+  queryFn: async ({ pageParam }: { pageParam: number }) => {
+    const response = await ApiClient.api.courseControllerGetAvailableCourseCategories(
+      getAvailableCourseCategoriesRequestParams(searchParams, pageParam, perPage),
+    );
+
+    return response.data;
+  },
+  getNextPageParam: (lastPage: GetAvailableCourseCategoriesResponse) => {
+    const loadedItems = lastPage.pagination.page * lastPage.pagination.perPage;
+
+    if (loadedItems >= lastPage.pagination.totalItems) return undefined;
+
+    return lastPage.pagination.page + 1;
+  },
+  initialPageParam: 1,
   ...options,
 });
 
@@ -44,4 +123,22 @@ export function useCategories(searchParams?: CategorySearchParams) {
 
 export function useCategoriesSuspense(searchParams?: CategorySearchParams) {
   return useSuspenseQuery(categoriesQueryOptions(searchParams));
+}
+
+export function useInfiniteCategories(
+  searchParams?: CategorySearchParams,
+  perPage = CATEGORIES_PAGE_SIZE,
+  options: QueryOptions = { enabled: true },
+) {
+  return useInfiniteQuery(infiniteCategoriesQueryOptions(searchParams, perPage, options));
+}
+
+export function useInfiniteAvailableCourseCategories(
+  searchParams?: AvailableCourseCategorySearchParams,
+  perPage = CATEGORIES_PAGE_SIZE,
+  options: QueryOptions = { enabled: true },
+) {
+  return useInfiniteQuery(
+    infiniteAvailableCourseCategoriesQueryOptions(searchParams, perPage, options),
+  );
 }

--- a/apps/web/app/api/queries/useStudentCourses.ts
+++ b/apps/web/app/api/queries/useStudentCourses.ts
@@ -1,4 +1,4 @@
-import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery, useSuspenseQuery } from "@tanstack/react-query";
 
 import { ApiClient } from "../api-client";
 
@@ -23,26 +23,61 @@ type QueryOptions = {
   enabled?: boolean;
 };
 
+export const STUDENT_COURSES_QUERY_KEY = "get-student-courses";
+export const STUDENT_COURSES_PAGE_SIZE = 5;
+
+const getStudentCoursesRequestParams = (
+  searchParams: CourseParams | undefined,
+  page: number,
+  perPage: number,
+) => ({
+  page,
+  perPage,
+  ...(searchParams?.title && { title: searchParams.title }),
+  ...(searchParams?.description && { description: searchParams.description }),
+  ...(searchParams?.searchQuery && { searchQuery: searchParams.searchQuery }),
+  ...(searchParams?.category && { category: searchParams.category }),
+  ...(searchParams?.sort && { sort: searchParams.sort }),
+  ...(searchParams?.userId && { userId: searchParams.userId }),
+  ...(searchParams?.language && { language: searchParams.language }),
+});
+
 export const studentCoursesQueryOptions = (
   searchParams?: CourseParams,
   options: QueryOptions = { enabled: true },
 ) => ({
-  queryKey: ["get-student-courses", searchParams],
+  queryKey: [STUDENT_COURSES_QUERY_KEY, searchParams],
   queryFn: async () => {
-    const response = await ApiClient.api.courseControllerGetStudentCourses({
-      page: 1,
-      perPage: 100,
-      ...(searchParams?.title && { title: searchParams.title }),
-      ...(searchParams?.description && { description: searchParams.description }),
-      ...(searchParams?.searchQuery && { searchQuery: searchParams.searchQuery }),
-      ...(searchParams?.category && { category: searchParams.category }),
-      ...(searchParams?.sort && { sort: searchParams.sort }),
-      ...(searchParams?.userId && { userId: searchParams.userId }),
-      ...(searchParams?.language && { language: searchParams.language }),
-    });
+    const response = await ApiClient.api.courseControllerGetStudentCourses(
+      getStudentCoursesRequestParams(searchParams, 1, 100),
+    );
     return response.data;
   },
   select: (data: GetStudentCoursesResponse) => data.data,
+  ...options,
+});
+
+export const infiniteStudentCoursesQueryOptions = (
+  searchParams?: CourseParams,
+  perPage = STUDENT_COURSES_PAGE_SIZE,
+  options: QueryOptions = { enabled: true },
+) => ({
+  queryKey: [STUDENT_COURSES_QUERY_KEY, "infinite", searchParams, perPage],
+  queryFn: async ({ pageParam }: { pageParam: number }) => {
+    const response = await ApiClient.api.courseControllerGetStudentCourses(
+      getStudentCoursesRequestParams(searchParams, pageParam, perPage),
+    );
+
+    return response.data;
+  },
+  getNextPageParam: (lastPage: GetStudentCoursesResponse) => {
+    const loadedItems = lastPage.pagination.page * lastPage.pagination.perPage;
+
+    if (loadedItems >= lastPage.pagination.totalItems) return undefined;
+
+    return lastPage.pagination.page + 1;
+  },
+  initialPageParam: 1,
   ...options,
 });
 
@@ -52,4 +87,12 @@ export function useStudentCourses(searchParams?: CourseParams) {
 
 export function useStudentCoursesSuspense(searchParams?: CourseParams) {
   return useSuspenseQuery(studentCoursesQueryOptions(searchParams));
+}
+
+export function useInfiniteStudentCourses(
+  searchParams?: CourseParams,
+  perPage = STUDENT_COURSES_PAGE_SIZE,
+  options: QueryOptions = { enabled: true },
+) {
+  return useInfiniteQuery(infiniteStudentCoursesQueryOptions(searchParams, perPage, options));
 }

--- a/apps/web/app/api/types.ts
+++ b/apps/web/app/api/types.ts
@@ -1,3 +1,6 @@
+import type { SupportedLanguages } from "@repo/shared";
+import type { SortOption } from "~/types/sorting";
+
 export type ApiErrorResponse = {
   message: string;
   statusCode?: number;
@@ -9,4 +12,15 @@ export type EmbedLessonResource = {
   id?: string;
   fileUrl: string;
   allowFullscreen?: boolean;
+};
+
+export type AvailableCourseCategorySearchParams = {
+  title?: string;
+  description?: string;
+  searchQuery?: string;
+  category?: string;
+  author?: string;
+  sort?: SortOption;
+  excludeCourseId?: string;
+  language?: SupportedLanguages;
 };

--- a/apps/web/app/api/utils/invalidateCourseListData.ts
+++ b/apps/web/app/api/utils/invalidateCourseListData.ts
@@ -1,0 +1,24 @@
+import { AVAILABLE_COURSES_QUERY_KEY } from "~/api/queries/useAvailableCourses";
+import { AVAILABLE_COURSE_CATEGORIES_QUERY_KEY } from "~/api/queries/useCategories";
+import { ALL_COURSES_QUERY_KEY } from "~/api/queries/useCourses";
+import { STUDENT_COURSES_QUERY_KEY } from "~/api/queries/useStudentCourses";
+import { queryClient } from "~/api/queryClient";
+
+const COURSE_LIST_QUERY_KEYS = [
+  ALL_COURSES_QUERY_KEY,
+  AVAILABLE_COURSE_CATEGORIES_QUERY_KEY,
+  [AVAILABLE_COURSES_QUERY_KEY],
+  [STUDENT_COURSES_QUERY_KEY],
+  ["content-creator-courses"],
+  ["top-courses"],
+] as const;
+
+export async function invalidateCourseListData() {
+  await Promise.all(
+    COURSE_LIST_QUERY_KEYS.map((queryKey) =>
+      queryClient.invalidateQueries({
+        queryKey,
+      }),
+    ),
+  );
+}

--- a/apps/web/app/components/ui/carousel.tsx
+++ b/apps/web/app/components/ui/carousel.tsx
@@ -134,12 +134,29 @@ Carousel.displayName = "Carousel";
 
 type CarouselContentProps = React.HTMLAttributes<HTMLDivElement> & {
   viewportClassName?: string;
+  viewportRef?: React.MutableRefObject<HTMLDivElement | null> | React.RefCallback<HTMLDivElement>;
 };
 
 const CarouselContent = React.forwardRef<HTMLDivElement, CarouselContentProps>(
-  ({ className, viewportClassName, onWheel, ...props }, ref) => {
+  ({ className, viewportClassName, viewportRef, onWheel, ...props }, ref) => {
     const { carouselRef, orientation, scrollNext, scrollPrev } = useCarousel();
     const wheelState = React.useRef({ direction: 0, count: 0, timer: null as ReturnType<typeof setTimeout> | null });
+
+    const setViewportRefs = React.useCallback(
+      (node: HTMLDivElement | null) => {
+        carouselRef(node);
+
+        if (typeof viewportRef === "function") {
+          viewportRef(node);
+          return;
+        }
+
+        if (viewportRef) {
+          viewportRef.current = node;
+        }
+      },
+      [carouselRef, viewportRef],
+    );
 
     React.useEffect(() => {
       const timer = wheelState.current.timer;
@@ -191,7 +208,7 @@ const CarouselContent = React.forwardRef<HTMLDivElement, CarouselContentProps>(
 
     return (
       <div
-        ref={carouselRef}
+        ref={setViewportRefs}
         className={cn("overflow-y-visible", viewportClassName)}
         onWheel={handleWheel}
       >

--- a/apps/web/app/modules/Admin/AddCourse/hooks/useAddCourseForm.tsx
+++ b/apps/web/app/modules/Admin/AddCourse/hooks/useAddCourseForm.tsx
@@ -3,10 +3,6 @@ import { useNavigate } from "@remix-run/react";
 import { useForm } from "react-hook-form";
 
 import { useCreateCourse } from "~/api/mutations/useCreateCourse";
-import { availableCoursesQueryOptions, studentCoursesQueryOptions } from "~/api/queries";
-import { ALL_COURSES_QUERY_KEY } from "~/api/queries/useCourses";
-import { topCoursesQueryOptions } from "~/api/queries/useTopCourses";
-import { queryClient } from "~/api/queryClient";
 import { addCourseFormSchema } from "~/modules/Admin/AddCourse/validators/addCourseFormSchema";
 import { useLanguageStore } from "~/modules/Dashboard/Settings/Language/LanguageStore";
 
@@ -40,11 +36,6 @@ export const useAddCourseForm = () => {
     createCourse({
       data: { ...rest, description },
     }).then(({ data }) => {
-      queryClient.invalidateQueries({ queryKey: ALL_COURSES_QUERY_KEY });
-      queryClient.invalidateQueries(topCoursesQueryOptions({ language }));
-      queryClient.invalidateQueries(availableCoursesQueryOptions({ language }));
-      queryClient.invalidateQueries(studentCoursesQueryOptions({ language }));
-
       navigate(`/admin/beta-courses/${data.id}`);
     });
   };

--- a/apps/web/app/modules/Courses/components/modern/HeroBanner.tsx
+++ b/apps/web/app/modules/Courses/components/modern/HeroBanner.tsx
@@ -104,12 +104,12 @@ const HeroBanner = ({
           }}
         />
         <div
-          className="absolute inset-0 pointer-events-none"
+          className="absolute inset-0 pointer-events-none -bottom-0.5"
           style={{
             backgroundImage: `
-              linear-gradient(0deg, #f2f5fc 0%, rgba(242,245,252,0.95) 8%, rgba(242,245,252,0.4) 25%, rgba(242,245,252,0.08) 50%, rgba(242,245,252,0) 75%),
-              radial-gradient(80% 70% at 0% 100%, rgba(242,245,252,0.95) 0%, rgba(242,245,252,0.7) 30%, rgba(242,245,252,0.2) 55%, rgba(242,245,252,0) 100%),
-              radial-gradient(80% 70% at 100% 100%, rgba(242,245,252,0.95) 0%, rgba(242,245,252,0.7) 30%, rgba(242,245,252,0.2) 55%, rgba(242,245,252,0) 100%)
+              linear-gradient(0deg, var(--primary-50) 0%, color-mix(in srgb, var(--primary-50) 72%, var(--primary-200)) 8%, color-mix(in srgb, var(--primary-200) 24%, transparent) 25%, color-mix(in srgb, var(--primary-200) 5%, transparent) 50%, transparent 75%),
+              radial-gradient(80% 70% at 0% 100%, var(--primary-50) 0%, color-mix(in srgb, var(--primary-200) 42%, transparent) 30%, color-mix(in srgb, var(--primary-200) 12%, transparent) 55%, transparent 100%),
+              radial-gradient(80% 70% at 100% 100%, var(--primary-50) 0%, color-mix(in srgb, var(--primary-200) 42%, transparent) 30%, color-mix(in srgb, var(--primary-200) 12%, transparent) 55%, transparent 100%)
             `,
           }}
         />
@@ -118,9 +118,9 @@ const HeroBanner = ({
       {trailerUrl && (
         <div className="absolute inset-0 z-10 hidden md:block">
           <HeroTrailerVideo src={trailerUrl} />
-          <div className="absolute inset-0 bg-gradient-to-r from-primary-50/95 via-primary-50/70 to-transparent" />
-          <div className="absolute inset-0 bg-gradient-to-t from-primary-50/80 via-primary-50/30 to-transparent" />
-          <div className="absolute bottom-0 left-0 right-0 h-[50%] bg-gradient-to-t from-primary-50 via-primary-50/60 to-transparent" />
+          <div className="absolute inset-0 bg-gradient-to-r from-primary-200/75 via-primary-200/45 to-transparent" />
+          <div className="absolute inset-0 bg-gradient-to-t from-primary-200/55 via-primary-200/18 to-transparent" />
+          <div className="absolute bottom-0 left-0 right-0 h-[50%] bg-gradient-to-t from-primary-50 via-primary-200/32 to-transparent" />
         </div>
       )}
 

--- a/apps/web/app/modules/Courses/components/modern/HeroBannerSkeleton.tsx
+++ b/apps/web/app/modules/Courses/components/modern/HeroBannerSkeleton.tsx
@@ -1,0 +1,24 @@
+import { Skeleton } from "~/components/ui/skeleton";
+
+const HeroBannerSkeleton = () => (
+  <div className="relative min-h-[420px] h-[56vh] w-full overflow-hidden bg-neutral-950">
+    <Skeleton className="absolute inset-0 h-full w-full rounded-none bg-neutral-800" />
+    <div
+      className="absolute inset-0 pointer-events-none -bottom-0.5"
+      style={{
+        backgroundImage: `
+          linear-gradient(0deg, var(--primary-50) 0%, color-mix(in srgb, var(--primary-50) 72%, var(--primary-200)) 8%, color-mix(in srgb, var(--primary-200) 24%, transparent) 25%, color-mix(in srgb, var(--primary-200) 5%, transparent) 50%, transparent 75%),
+          radial-gradient(80% 70% at 0% 100%, var(--primary-50) 0%, color-mix(in srgb, var(--primary-200) 42%, transparent) 30%, color-mix(in srgb, var(--primary-200) 12%, transparent) 55%, transparent 100%),
+          radial-gradient(80% 70% at 100% 100%, var(--primary-50) 0%, color-mix(in srgb, var(--primary-200) 42%, transparent) 30%, color-mix(in srgb, var(--primary-200) 12%, transparent) 55%, transparent 100%)
+        `,
+      }}
+    />
+    <div className="absolute inset-x-0 bottom-0 z-10 space-y-4 px-4 pb-16 md:px-8">
+      <Skeleton className="h-10 w-3/4 max-w-2xl bg-neutral-700" />
+      <Skeleton className="h-5 w-1/2 max-w-xl bg-neutral-700" />
+      <Skeleton className="h-11 w-36 rounded-full bg-neutral-700" />
+    </div>
+  </div>
+);
+
+export default HeroBannerSkeleton;

--- a/apps/web/app/modules/Courses/components/modern/ModernCourseCard.tsx
+++ b/apps/web/app/modules/Courses/components/modern/ModernCourseCard.tsx
@@ -1,8 +1,9 @@
 import { Link } from "@remix-run/react";
 import { PERMISSIONS } from "@repo/shared";
 import { formatDate } from "date-fns";
+import { isEqual } from "lodash-es";
 import { BookOpen, Clock, Play } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import DefaultPhotoCourse from "~/assets/svgs/default-photo-course.svg";
@@ -390,4 +391,9 @@ const ModernCourseCard = ({
   );
 };
 
-export default ModernCourseCard;
+const areModernCourseCardPropsEqual = (
+  previousProps: ModernCourseCardProps,
+  nextProps: ModernCourseCardProps,
+) => isEqual(previousProps, nextProps);
+
+export default memo(ModernCourseCard, areModernCourseCardPropsEqual);

--- a/apps/web/app/modules/Courses/components/modern/ModernCourseCarousel.tsx
+++ b/apps/web/app/modules/Courses/components/modern/ModernCourseCarousel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { memo, type Ref, useCallback, useEffect, useRef, useState } from "react";
 
 import {
   type CarouselApi,
@@ -17,55 +17,166 @@ type CourseCarouselCourse =
   | GetAvailableCoursesResponse["data"][number]
   | GetStudentCoursesResponse["data"][number];
 
+const WATCHED_SLIDE_INTERSECTION_THRESHOLD = 0.25;
+const WATCHED_SLIDE_FALLBACK_DELAY_MS = 400;
+const CAROUSEL_OPTIONS = { align: "start" as const, slidesToScroll: 1, skipSnaps: false };
+
 type ModernCourseCarouselProps = {
   title: string;
   courses: CourseCarouselCourse[];
   progressByCourseId?: Record<string, number | undefined>;
+  hasNextPage?: boolean;
+  isFetchingNextPage?: boolean;
+  fetchNextPage?: () => void;
+  watchSlideIndex?: number;
+  onWatchedSlideVisible?: (index: number) => void;
+  rowRef?: Ref<HTMLElement>;
 };
 
 const ModernCourseCarousel = ({
   title,
   courses,
   progressByCourseId = {},
+  hasNextPage = false,
+  isFetchingNextPage = false,
+  fetchNextPage,
+  watchSlideIndex,
+  onWatchedSlideVisible,
+  rowRef,
 }: ModernCourseCarouselProps) => {
   const [carouselApi, setCarouselApi] = useState<CarouselApi | null>(null);
   const [canScrollPrev, setCanScrollPrev] = useState(false);
   const [canScrollNext, setCanScrollNext] = useState(false);
-  const popoutEnabled = true;
+  const viewportRef = useRef<HTMLDivElement | null>(null);
+  const watchedSlideRef = useRef<HTMLDivElement | null>(null);
+  const pendingWatchedSlideIndexRef = useRef<number | null>(null);
+  const pendingWatchedSlideTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearPendingWatchedSlideTimeout = useCallback(() => {
+    if (!pendingWatchedSlideTimeoutRef.current) return;
+
+    clearTimeout(pendingWatchedSlideTimeoutRef.current);
+    pendingWatchedSlideTimeoutRef.current = null;
+  }, []);
+
+  const flushPendingWatchedSlide = useCallback(() => {
+    const pendingWatchedSlideIndex = pendingWatchedSlideIndexRef.current;
+    if (pendingWatchedSlideIndex === null) return;
+
+    clearPendingWatchedSlideTimeout();
+    pendingWatchedSlideIndexRef.current = null;
+    onWatchedSlideVisible?.(pendingWatchedSlideIndex);
+  }, [clearPendingWatchedSlideTimeout, onWatchedSlideVisible]);
+
+  const queueWatchedSlide = useCallback(
+    (slideIndex: number) => {
+      pendingWatchedSlideIndexRef.current = slideIndex;
+      if (pendingWatchedSlideTimeoutRef.current) return;
+
+      pendingWatchedSlideTimeoutRef.current = setTimeout(
+        flushPendingWatchedSlide,
+        WATCHED_SLIDE_FALLBACK_DELAY_MS,
+      );
+    },
+    [flushPendingWatchedSlide],
+  );
 
   useEffect(() => {
     if (!carouselApi) return;
 
     const updateScrollState = () => {
-      setCanScrollPrev(carouselApi.canScrollPrev());
-      setCanScrollNext(carouselApi.canScrollNext());
+      const nextCanScrollPrev = carouselApi.canScrollPrev();
+      const nextCanScrollNext = carouselApi.canScrollNext();
+
+      setCanScrollPrev(nextCanScrollPrev);
+      setCanScrollNext(nextCanScrollNext);
+
+      return nextCanScrollNext;
+    };
+
+    const fetchNextPageAtEnd = (nextCanScrollNext: boolean) => {
+      if (onWatchedSlideVisible) return;
+      if (nextCanScrollNext) return;
+      if (!hasNextPage || isFetchingNextPage || !fetchNextPage) return;
+
+      fetchNextPage();
     };
 
     updateScrollState();
-    carouselApi.on("select", updateScrollState);
-    carouselApi.on("reInit", updateScrollState);
+    const handleSelect = () => updateScrollState();
+    const handleSettle = () => {
+      fetchNextPageAtEnd(updateScrollState());
+      flushPendingWatchedSlide();
+    };
+    const handleReInit = () => updateScrollState();
+
+    carouselApi.on("select", handleSelect);
+    carouselApi.on("settle", handleSettle);
+    carouselApi.on("reInit", handleReInit);
 
     return () => {
-      carouselApi.off("select", updateScrollState);
-      carouselApi.off("reInit", updateScrollState);
+      carouselApi.off("select", handleSelect);
+      carouselApi.off("settle", handleSettle);
+      carouselApi.off("reInit", handleReInit);
+      clearPendingWatchedSlideTimeout();
     };
-  }, [carouselApi]);
+  }, [
+    carouselApi,
+    clearPendingWatchedSlideTimeout,
+    fetchNextPage,
+    flushPendingWatchedSlide,
+    hasNextPage,
+    isFetchingNextPage,
+    onWatchedSlideVisible,
+  ]);
 
-  if (!courses?.length) return null;
+  useEffect(() => {
+    const viewportNode = viewportRef.current;
+    const watchedSlideNode = watchedSlideRef.current;
+
+    if (watchSlideIndex === undefined || !onWatchedSlideVisible) return;
+    if (!viewportNode || !watchedSlideNode) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry?.isIntersecting) return;
+        if (entry.intersectionRatio < WATCHED_SLIDE_INTERSECTION_THRESHOLD) return;
+
+        queueWatchedSlide(watchSlideIndex);
+      },
+      {
+        root: viewportNode,
+        threshold: WATCHED_SLIDE_INTERSECTION_THRESHOLD,
+      },
+    );
+
+    observer.observe(watchedSlideNode);
+
+    return () => {
+      observer.disconnect();
+      clearPendingWatchedSlideTimeout();
+    };
+  }, [
+    clearPendingWatchedSlideTimeout,
+    courses.length,
+    onWatchedSlideVisible,
+    queueWatchedSlide,
+    watchSlideIndex,
+  ]);
+
+  if (!courses.length) return null;
 
   return (
-    <section className="space-y-4 pb-6">
+    <section ref={rowRef} className="space-y-4 pb-6">
       <h2 className="h2 px-4 md:px-8">{title}</h2>
 
       <div className="group relative px-4 md:px-8 mt-10" data-course-row data-testid="course-row">
-        <Carousel
-          opts={{ align: "start", slidesToScroll: 1, skipSnaps: false }}
-          setApi={setCarouselApi}
-        >
-          <CarouselContent className="gap-4">
-            {courses.map((course) => (
+        <Carousel opts={CAROUSEL_OPTIONS} setApi={setCarouselApi}>
+          <CarouselContent className="gap-4" viewportRef={viewportRef}>
+            {courses.map((course, index) => (
               <CarouselItem
                 key={course.id}
+                ref={index === watchSlideIndex ? watchedSlideRef : undefined}
                 className="w-[320px] md:w-[380px] lg:w-[400px] !basis-auto"
               >
                 <ModernCourseCard
@@ -82,7 +193,6 @@ const ModernCourseCarousel = ({
                   enrolled={course.enrolled}
                   hasFreeChapters={course.hasFreeChapters}
                   dueDate={course.dueDate ? new Date(course.dueDate) : null}
-                  popoutEnabled={popoutEnabled}
                 />
               </CarouselItem>
             ))}
@@ -91,13 +201,13 @@ const ModernCourseCarousel = ({
           {canScrollPrev && (
             <CarouselPrevious
               iconSize={24}
-              className="absolute left-2 top-1/2 z-[160] border-none flex size-[52px] -translate-y-1/2 items-center justify-center rounded-full bg-black/70 shadow-lg transition-all hover:scale-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white md:opacity-0 md:group-hover:opacity-100 bg-white hover:border-none duration-200"
+              className=" left-2 absolute top-1/2 z-[160] border-none flex size-[52px] -translate-y-1/2 items-center justify-center rounded-full bg-black/70 shadow-lg transition-all hover:scale-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white md:opacity-0 md:group-hover:opacity-100 bg-white hover:border-none duration-200"
             />
           )}
           {canScrollNext && (
             <CarouselNext
               iconSize={24}
-              className="absolute right-2 top-1/2 z-[160] border-none flex size-[52px] -translate-y-1/2 items-center justify-center rounded-full bg-black/70 shadow-lg transition-all hover:scale-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white md:opacity-0 md:group-hover:opacity-100 bg-white hover:border-none duration-200"
+              className="right-2 absolute top-1/2 z-[160] border-none flex size-[52px] -translate-y-1/2 items-center justify-center rounded-full bg-black/70 shadow-lg transition-all hover:scale-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white md:opacity-0 md:group-hover:opacity-100 bg-white hover:border-none duration-200"
             />
           )}
         </Carousel>
@@ -130,4 +240,4 @@ const ModernCourseCarousel = ({
   );
 };
 
-export default ModernCourseCarousel;
+export default memo(ModernCourseCarousel);

--- a/apps/web/app/modules/Courses/components/modern/ModernCourseRowSkeleton.tsx
+++ b/apps/web/app/modules/Courses/components/modern/ModernCourseRowSkeleton.tsx
@@ -1,0 +1,26 @@
+import { Skeleton } from "~/components/ui/skeleton";
+
+type ModernCourseRowSkeletonProps = {
+  title?: string;
+  courseCount?: number;
+};
+
+const ModernCourseRowSkeleton = ({ title, courseCount = 5 }: ModernCourseRowSkeletonProps) => (
+  <section className="space-y-4 pb-6">
+    {title ? (
+      <h2 className="h2 px-4 md:px-8">{title}</h2>
+    ) : (
+      <Skeleton className="mx-4 h-8 w-48 md:mx-8" />
+    )}
+    <div className="flex gap-4 overflow-hidden px-4 md:px-8 mt-10">
+      {Array.from({ length: courseCount }).map((_, index) => (
+        <Skeleton
+          key={index}
+          className="aspect-video w-[320px] shrink-0 rounded-lg md:w-[380px] lg:w-[400px]"
+        />
+      ))}
+    </div>
+  </section>
+);
+
+export default ModernCourseRowSkeleton;

--- a/apps/web/app/modules/Courses/components/modern/ModernCoursesView.tsx
+++ b/apps/web/app/modules/Courses/components/modern/ModernCoursesView.tsx
@@ -1,22 +1,114 @@
 import { PERMISSIONS } from "@repo/shared";
-import { useMemo } from "react";
+import { type Ref, useCallback, useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
+import { match } from "ts-pattern";
 
-import { useCurrentUser } from "~/api/queries";
-import { useAvailableCourses } from "~/api/queries/useAvailableCourses";
-import { useStudentCourses } from "~/api/queries/useStudentCourses";
+import {
+  useCurrentUser,
+  useInfiniteAvailableCourseCategories,
+  useInfiniteAvailableCourses,
+  useInfiniteStudentCourses,
+} from "~/api/queries";
 import { useTopCourses } from "~/api/queries/useTopCourses";
 import { PageWrapper } from "~/components/PageWrapper";
 import { usePermissions } from "~/hooks/usePermissions";
-import Loader from "~/modules/common/Loader/Loader";
 import { useLanguageStore } from "~/modules/Dashboard/Settings/Language/LanguageStore";
 
 import CoursesHeader from "./CoursesHeader";
 import HeroBanner from "./HeroBanner";
+import HeroBannerSkeleton from "./HeroBannerSkeleton";
 import ModernCourseCarousel from "./ModernCourseCarousel";
+import ModernCourseRowSkeleton from "./ModernCourseRowSkeleton";
 import TopCoursesCarousel from "./TopCoursesCarousel";
 
-import type { GetAvailableCoursesResponse } from "~/api/generated-api";
+import type { GetAllCategoriesResponse } from "~/api/generated-api";
+
+const COURSE_PAGE_SIZE = 5;
+const CATEGORY_PAGE_SIZE = 4;
+
+type CategoryCoursesRowProps = {
+  category: GetAllCategoriesResponse["data"][number];
+  progressByCourseId: Record<string, number | undefined>;
+  rowRef?: Ref<HTMLElement>;
+};
+
+const CategoryCoursesRow = ({ category, progressByCourseId, rowRef }: CategoryCoursesRowProps) => {
+  const { language } = useLanguageStore();
+  const prefetchedAfterPageRef = useRef(0);
+  const hasNextPageRef = useRef(false);
+  const isCoursePageFetchQueuedRef = useRef(false);
+  const { data, isLoading, hasNextPage, fetchNextPage } = useInfiniteAvailableCourses(
+    {
+      category: category.title,
+      language,
+    },
+    COURSE_PAGE_SIZE,
+    { notifyOnChangeProps: ["data", "isLoading", "hasNextPage"] },
+  );
+  const fetchNextPageRef = useRef(fetchNextPage);
+
+  useEffect(() => {
+    hasNextPageRef.current = hasNextPage;
+    fetchNextPageRef.current = fetchNextPage;
+  }, [fetchNextPage, hasNextPage]);
+
+  const courses = useMemo(
+    () => data?.pages.flatMap((page) => page.data).filter((course) => !course.enrolled) ?? [],
+    [data],
+  );
+  const loadedCoursePages = data?.pages.length ?? 0;
+  const watchedSlideIndex =
+    loadedCoursePages > 1 ? (loadedCoursePages - 1) * COURSE_PAGE_SIZE : undefined;
+
+  const prefetchNextPageAfter = useCallback((currentPage: number) => {
+    if (prefetchedAfterPageRef.current >= currentPage) return;
+    if (!hasNextPageRef.current) return;
+    if (isCoursePageFetchQueuedRef.current) return;
+
+    prefetchedAfterPageRef.current = currentPage;
+    isCoursePageFetchQueuedRef.current = true;
+
+    requestAnimationFrame(() => {
+      void fetchNextPageRef.current().finally(() => {
+        isCoursePageFetchQueuedRef.current = false;
+      });
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!data?.pages.length) return;
+
+    prefetchNextPageAfter(1);
+  }, [data?.pages.length, prefetchNextPageAfter]);
+
+  const handleWatchedSlideVisible = useCallback(
+    (slideIndex: number) => {
+      const visiblePage = Math.floor(slideIndex / COURSE_PAGE_SIZE) + 1;
+
+      prefetchNextPageAfter(visiblePage);
+    },
+    [prefetchNextPageAfter],
+  );
+
+  if (isLoading) {
+    return <ModernCourseRowSkeleton title={category.title} />;
+  }
+
+  if (!courses.length) {
+    return rowRef ? <div ref={rowRef as Ref<HTMLDivElement>} className="h-px" /> : null;
+  }
+
+  return (
+    <ModernCourseCarousel
+      title={category.title}
+      courses={courses}
+      progressByCourseId={progressByCourseId}
+      watchSlideIndex={watchedSlideIndex}
+      onWatchedSlideVisible={handleWatchedSlideVisible}
+      rowRef={rowRef}
+    />
+  );
+};
 
 const ModernCoursesView = () => {
   const { t } = useTranslation();
@@ -27,10 +119,14 @@ const ModernCoursesView = () => {
     required: [PERMISSIONS.COURSE_UPDATE, PERMISSIONS.COURSE_UPDATE_OWN],
   });
 
-  const { data: availableCourses, isLoading: isAvailableCoursesLoading } = useAvailableCourses({
-    language,
-    userId: currentUser?.id,
-  });
+  const { data: availableHeroCoursesData, isLoading: isAvailableHeroCoursesLoading } =
+    useInfiniteAvailableCourses(
+      {
+        language,
+        userId: currentUser?.id,
+      },
+      COURSE_PAGE_SIZE,
+    );
 
   const { data: topCourses, isLoading: isTopCoursesLoading } = useTopCourses({
     limit: 5,
@@ -38,12 +134,42 @@ const ModernCoursesView = () => {
     language,
   });
 
-  const { data: studentCourses, isLoading: isStudentCoursesLoading } = useStudentCourses({
-    language,
-  });
+  const {
+    data: studentCoursesData,
+    isLoading: isStudentCoursesLoading,
+    hasNextPage: hasNextStudentCoursesPage,
+    isFetchingNextPage: isFetchingNextStudentCoursesPage,
+    fetchNextPage: fetchNextStudentCoursesPage,
+  } = useInfiniteStudentCourses({ language }, COURSE_PAGE_SIZE);
+
+  const {
+    data: categoriesData,
+    isLoading: isCategoriesLoading,
+    hasNextPage: hasNextCategoriesPage,
+    isFetchingNextPage: isFetchingNextCategoriesPage,
+    fetchNextPage: fetchNextCategoriesPage,
+  } = useInfiniteAvailableCourseCategories({ language }, CATEGORY_PAGE_SIZE);
+
+  const categories = useMemo(
+    () =>
+      categoriesData?.pages
+        .flatMap((page) => page.data)
+        .sort((a, b) => a.title.localeCompare(b.title)) ?? [],
+    [categoriesData],
+  );
+
+  const studentCourses = useMemo(
+    () => studentCoursesData?.pages.flatMap((page) => page.data) ?? [],
+    [studentCoursesData],
+  );
+
+  const availableHeroCourses = useMemo(
+    () => availableHeroCoursesData?.pages.flatMap((page) => page.data) ?? [],
+    [availableHeroCoursesData],
+  );
 
   const progressByCourseId = useMemo(() => {
-    if (!studentCourses) return {};
+    if (!studentCourses.length) return {};
 
     return studentCourses.reduce<Record<string, number | undefined>>((acc, course) => {
       const completed = course.completedChapterCount ?? 0;
@@ -54,35 +180,14 @@ const ModernCoursesView = () => {
     }, {});
   }, [studentCourses]);
 
-  const coursesInProgress = useMemo(() => studentCourses ?? [], [studentCourses]);
-
-  const groupedCourses = useMemo(() => {
-    const grouped = new Map<string, GetAvailableCoursesResponse["data"]>();
-
-    (availableCourses || []).forEach((course) => {
-      if (course.enrolled) return;
-      if (!course.category) return;
-      const bucket = grouped.get(course.category) || [];
-      bucket.push(course);
-      grouped.set(course.category, bucket);
-    });
-
-    return Array.from(grouped.entries())
-      .map(([category, courses]) => ({
-        category,
-        courses,
-      }))
-      .sort((a, b) => a.category.localeCompare(b.category));
-  }, [availableCourses]);
-
   const { heroCourse, isHeroLoading } = useMemo(() => {
     const topHero = topCourses?.[0];
     if (topHero) return { heroCourse: topHero, isHeroLoading: false };
     if (isTopCoursesLoading) return { heroCourse: undefined, isHeroLoading: true };
 
-    const availableHero = availableCourses?.[0];
+    const availableHero = availableHeroCourses.find((course) => !course.enrolled);
     if (availableHero) return { heroCourse: availableHero, isHeroLoading: false };
-    if (isAvailableCoursesLoading) return { heroCourse: undefined, isHeroLoading: true };
+    if (isAvailableHeroCoursesLoading) return { heroCourse: undefined, isHeroLoading: true };
 
     const studentHero = studentCourses?.[0];
     if (studentHero) return { heroCourse: studentHero, isHeroLoading: false };
@@ -91,24 +196,64 @@ const ModernCoursesView = () => {
     return { heroCourse: undefined, isHeroLoading: false };
   }, [
     topCourses,
-    availableCourses,
+    availableHeroCourses,
     studentCourses,
     isTopCoursesLoading,
-    isAvailableCoursesLoading,
+    isAvailableHeroCoursesLoading,
     isStudentCoursesLoading,
   ]);
 
-  if (isHeroLoading && !heroCourse) {
-    return (
-      <PageWrapper isBarebones className="w-full p-0">
-        <div className="flex h-full min-h-[60vh] items-center justify-center">
-          <Loader />
-        </div>
-      </PageWrapper>
-    );
-  }
+  const categoryObserverRef = useRef<IntersectionObserver | null>(null);
+  const isCategoryFetchQueuedRef = useRef(false);
+  const lastCategoryRowRef = useCallback(
+    (node: HTMLElement | null) => {
+      categoryObserverRef.current?.disconnect();
+      categoryObserverRef.current = null;
+
+      if (!node) return;
+      if (!hasNextCategoriesPage) return;
+
+      categoryObserverRef.current = new IntersectionObserver(
+        ([entry]) => {
+          if (!entry?.isIntersecting) return;
+          if (entry.intersectionRatio < 0.35) return;
+          if (isFetchingNextCategoriesPage) return;
+          if (isCategoryFetchQueuedRef.current) return;
+
+          isCategoryFetchQueuedRef.current = true;
+          void fetchNextCategoriesPage().finally(() => {
+            isCategoryFetchQueuedRef.current = false;
+          });
+        },
+        { threshold: 0.35 },
+      );
+
+      categoryObserverRef.current.observe(node);
+    },
+    [fetchNextCategoriesPage, hasNextCategoriesPage, isFetchingNextCategoriesPage],
+  );
+
+  useEffect(() => {
+    return () => {
+      categoryObserverRef.current?.disconnect();
+    };
+  }, []);
 
   const renderCourses = () => {
+    if (isHeroLoading && !heroCourse) {
+      return (
+        <>
+          <HeroBannerSkeleton />
+          <div className="relative z-30 -mt-8 space-y-3 py-6 pb-12 md:-mt-12 md:py-8 md:pb-8">
+            <ModernCourseRowSkeleton />
+            {Array.from({ length: CATEGORY_PAGE_SIZE }).map((_, index) => (
+              <ModernCourseRowSkeleton key={index} />
+            ))}
+          </div>
+        </>
+      );
+    }
+
     if (!heroCourse) {
       return (
         <div className="flex min-h-screen items-center justify-center text-neutral-600">
@@ -130,35 +275,52 @@ const ModernCoursesView = () => {
         />
 
         <div className="relative z-30 -mt-8 space-y-3 py-6 pb-12 md:-mt-12 md:py-8 md:pb-8">
-          {isStudentCoursesLoading ? (
-            <div className="flex h-full items-center justify-center py-6">
-              <Loader />
-            </div>
-          ) : (
-            coursesInProgress.length > 0 && (
+          {match({ hasCourses: studentCourses.length > 0, isLoading: isStudentCoursesLoading })
+            .with({ isLoading: true }, () => (
+              <ModernCourseRowSkeleton
+                title={t("studentCoursesView.modernView.continueLearning")}
+              />
+            ))
+            .with({ hasCourses: true }, () => (
               <ModernCourseCarousel
                 title={t("studentCoursesView.modernView.continueLearning")}
-                courses={coursesInProgress}
+                courses={studentCourses}
                 progressByCourseId={progressByCourseId}
+                hasNextPage={hasNextStudentCoursesPage}
+                isFetchingNextPage={isFetchingNextStudentCoursesPage}
+                fetchNextPage={() => void fetchNextStudentCoursesPage()}
               />
-            )
-          )}
+            ))
+            .otherwise(() => null)}
 
-          {topCourses?.length ? (
+          {topCourses?.length && (
             <section>
               <h2 className="h2 px-4 md:px-8">{t("studentCoursesView.modernView.topCourses")}</h2>
               <TopCoursesCarousel courses={topCourses ?? []} />
             </section>
-          ) : null}
+          )}
 
-          {groupedCourses.map(({ category, courses }) => (
-            <ModernCourseCarousel
-              key={category}
-              title={category}
-              courses={courses}
-              progressByCourseId={progressByCourseId}
-            />
-          ))}
+          {match({ isLoading: isCategoriesLoading })
+            .with({ isLoading: true }, () =>
+              Array.from({ length: CATEGORY_PAGE_SIZE }).map((_, index) => (
+                <ModernCourseRowSkeleton key={index} />
+              )),
+            )
+            .otherwise(() =>
+              categories.map((category, index) => (
+                <CategoryCoursesRow
+                  key={category.id}
+                  category={category}
+                  progressByCourseId={progressByCourseId}
+                  rowRef={index === categories.length - 1 ? lastCategoryRowRef : undefined}
+                />
+              )),
+            )}
+
+          {isFetchingNextCategoriesPage &&
+            Array.from({ length: CATEGORY_PAGE_SIZE }).map((_, index) => (
+              <ModernCourseRowSkeleton key={`next-category-skeleton-${index}`} />
+            ))}
         </div>
       </>
     );


### PR DESCRIPTION
## Issue(s)
- #1502 

## Overview

Improves the modern course layout loading strategy by replacing eager course/category prefetching with paginated, on-demand data loading.

- Adds a public API endpoint for available course categories, filtered by the same course filters used by available courses.
- Adds infinite query hooks for available courses, student courses, categories, and available course categories.
- Loads modern course rows by category in smaller pages and prefetches the next course/category pages as users approach them.
- Replaces the full-page loader with hero and course-row skeleton states.
- Memoizes modern course carousels/cards and exposes carousel viewport refs needed for intersection-based prefetching.
- Centralizes course list cache invalidation after course create/update flows.
- Updates generated Swagger and web API client artifacts for the new course category endpoint.

## Business Value

The modern courses page becomes faster to open and less expensive to render because it no longer fetches large course/category lists upfront. End users see meaningful skeleton states earlier, can start browsing sooner, and additional course rows load progressively as they scroll or navigate carousels.

This also keeps course list data fresher after course mutations by invalidating all related list queries from one shared utility.

## Screenshots / Video
https://github.com/user-attachments/assets/ecd080ca-1320-4e5f-afd6-df0508a281f9

