### PR TITLE
fix: preserve AI mentor lesson content when changing mentor avatars

### DIFF
--- a/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/AiMentorLessonForm/AiMentorLessonForm.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/AiMentorLessonForm/AiMentorLessonForm.tsx
@@ -156,7 +156,7 @@ const AiMentorLessonForm = ({
       revokeObjectUrl();
       setAvatarPreview(null);
       setSelectedAvatarFile(null);
-      setRemoveAvatar(true);
+      setRemoveAvatar(false);
       return;
     }
 
@@ -165,10 +165,13 @@ const AiMentorLessonForm = ({
       const objectUrl = URL.createObjectURL(file);
       objectUrlRef.current = objectUrl;
       setAvatarPreview(objectUrl);
-      setSelectedAvatarFile(file);
+      setSelectedAvatarFile(null);
       setRemoveAvatar(false);
       return;
     }
+
+    setSelectedAvatarFile(null);
+    setRemoveAvatar(false);
   };
 
   const handleRemoveAvatar = () => {

--- a/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/AiMentorLessonForm/hooks/useAiMentorLessonForm.helpers.ts
+++ b/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/AiMentorLessonForm/hooks/useAiMentorLessonForm.helpers.ts
@@ -1,0 +1,24 @@
+import { AI_MENTOR_TTS_PRESET, AI_MENTOR_TYPE, AI_MENTOR_VOICE_MODE } from "@repo/shared";
+
+import type { AiMentorLessonFormValues } from "../validators/useAiMentorLessonFormSchema";
+import type { SupportedLanguages } from "@repo/shared";
+import type { Lesson } from "~/modules/Admin/EditCourse/EditCourse.types";
+
+export type LessonFormScope = {
+  lessonId: string;
+  language: SupportedLanguages;
+};
+
+export const getAiMentorLessonFormDefaultValues = (
+  lessonToEdit: Lesson | null,
+): AiMentorLessonFormValues => ({
+  title: lessonToEdit?.title || "",
+  description: lessonToEdit?.description || "",
+  aiMentorInstructions: lessonToEdit?.aiMentor?.aiMentorInstructions || "",
+  completionConditions: lessonToEdit?.aiMentor?.completionConditions || "",
+  type: lessonToEdit?.aiMentor?.type || AI_MENTOR_TYPE.MENTOR,
+  name: lessonToEdit?.aiMentor?.name || "",
+  voiceMode: lessonToEdit?.aiMentor?.voiceMode || AI_MENTOR_VOICE_MODE.PRESET,
+  ttsPreset: lessonToEdit?.aiMentor?.ttsPreset || AI_MENTOR_TTS_PRESET.MALE,
+  customTtsReference: lessonToEdit?.aiMentor?.customTtsReference || "",
+});

--- a/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/AiMentorLessonForm/hooks/useAiMentorLessonForm.ts
+++ b/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/AiMentorLessonForm/hooks/useAiMentorLessonForm.ts
@@ -1,7 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useParams } from "@remix-run/react";
-import { AI_MENTOR_TTS_PRESET, AI_MENTOR_TYPE, AI_MENTOR_VOICE_MODE } from "@repo/shared";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 
@@ -22,6 +21,11 @@ import {
 } from "~/modules/Admin/EditCourse/EditCourse.types";
 
 import { aiMentorLessonFormSchema } from "../validators/useAiMentorLessonFormSchema";
+
+import {
+  getAiMentorLessonFormDefaultValues,
+  type LessonFormScope,
+} from "./useAiMentorLessonForm.helpers";
 
 import type { AiMentorLessonFormValues } from "../validators/useAiMentorLessonFormSchema";
 import type { SupportedLanguages } from "@repo/shared";
@@ -49,39 +53,29 @@ export const useAiMentorLessonForm = ({
   const { mutateAsync: updateAiMentorLesson } = useUpdateAiMentorLesson();
   const { mutateAsync: deleteAiMentorLesson } = useDeleteLesson();
   const { mutateAsync: uploadAvatar } = useUploadAiMentorAvatar();
+  const lessonFormScopeRef = useRef<LessonFormScope | null>(null);
 
   const form = useForm<AiMentorLessonFormValues>({
     resolver: zodResolver(aiMentorLessonFormSchema(t)),
-    defaultValues: {
-      title: lessonToEdit?.title || "",
-      description: lessonToEdit?.description || "",
-      aiMentorInstructions: lessonToEdit?.aiMentor?.aiMentorInstructions || "",
-      completionConditions: lessonToEdit?.aiMentor?.completionConditions || "",
-      type: lessonToEdit?.aiMentor?.type || AI_MENTOR_TYPE.MENTOR,
-      name: lessonToEdit?.aiMentor?.name || "",
-      voiceMode: lessonToEdit?.aiMentor?.voiceMode || AI_MENTOR_VOICE_MODE.PRESET,
-      ttsPreset: lessonToEdit?.aiMentor?.ttsPreset || AI_MENTOR_TTS_PRESET.MALE,
-      customTtsReference: lessonToEdit?.aiMentor?.customTtsReference || "",
-    },
+    defaultValues: getAiMentorLessonFormDefaultValues(lessonToEdit),
   });
 
   const { reset, setValue, watch } = form;
 
   useEffect(() => {
-    if (lessonToEdit) {
-      reset({
-        title: lessonToEdit.title,
-        description: lessonToEdit.description || "",
-        aiMentorInstructions: lessonToEdit.aiMentor?.aiMentorInstructions || "",
-        completionConditions: lessonToEdit.aiMentor?.completionConditions || "",
-        type: lessonToEdit.aiMentor?.type || AI_MENTOR_TYPE.MENTOR,
-        name: lessonToEdit.aiMentor?.name || "",
-        voiceMode: lessonToEdit.aiMentor?.voiceMode || AI_MENTOR_VOICE_MODE.PRESET,
-        ttsPreset: lessonToEdit.aiMentor?.ttsPreset || AI_MENTOR_TTS_PRESET.MALE,
-        customTtsReference: lessonToEdit.aiMentor?.customTtsReference || "",
-      });
-    }
-  }, [lessonToEdit, reset]);
+    if (!lessonToEdit) return;
+
+    const nextScope = { lessonId: lessonToEdit.id, language };
+    const shouldKeepDirtyValues =
+      lessonFormScopeRef.current?.lessonId === nextScope.lessonId &&
+      lessonFormScopeRef.current.language === nextScope.language;
+
+    reset(
+      getAiMentorLessonFormDefaultValues(lessonToEdit),
+      shouldKeepDirtyValues ? { keepDirtyValues: true } : undefined,
+    );
+    lessonFormScopeRef.current = nextScope;
+  }, [language, lessonToEdit, reset]);
 
   const handleSuggestionClick = (suggestionType: SuggestionType) => {
     const currentInstructions = watch("aiMentorInstructions");


### PR DESCRIPTION
## Issue(s)
- #1541 

## Overview
Fixes AI mentor lesson form fields being reset after changing the AI mentor avatar.

The form now:
- reuses a shared helper for AI mentor lesson default values;
- keeps dirty form values when the same lesson and language are refreshed;
- still resets form values when switching to a different lesson or language;
- avoids treating avatar preview changes as a selected avatar file upload/removal state change.

## Business Value
Admins can edit AI mentor lesson content without losing unsaved text after updating the mentor avatar. This reduces accidental data loss and keeps the course editing flow predictable.

## Screenshots / Video

https://github.com/user-attachments/assets/c8ede70d-a4c3-429d-a189-885633958e01

