### PR TITLE
chore: include lesson files in global search results

### DIFF
--- a/apps/api/src/courses/utils/courses.utils.ts
+++ b/apps/api/src/courses/utils/courses.utils.ts
@@ -1,6 +1,15 @@
+import { ENTITY_TYPES } from "@repo/shared";
 import { sql } from "drizzle-orm";
 
-import { courses, lessons, questionAnswerOptions, questions } from "src/storage/schema";
+import { RESOURCE_RELATIONSHIP_TYPES } from "src/file/file.constants";
+import {
+  courses,
+  lessons,
+  questionAnswerOptions,
+  questions,
+  resourceEntity,
+  resources,
+} from "src/storage/schema";
 
 export function getCourseTsVector() {
   return sql`
@@ -37,6 +46,23 @@ export function getLessonTsVector() {
           )
         FROM ${questions} q
         WHERE q.lesson_id = ${lessons.id}
+      ), ''::text)::tsvector ||
+      COALESCE((
+        SELECT
+          string_agg(
+            (
+              setweight(to_tsvector('english', COALESCE(r.metadata->>'originalFilename', '')), 'D') ||
+              setweight(jsonb_to_tsvector('english', COALESCE(r.title, '{}'::jsonb), '["string"]'), 'D') ||
+              setweight(to_tsvector('english', regexp_replace(r.reference, '^.*/', '')), 'D')
+            )::text,
+            ' '
+          )
+        FROM ${resourceEntity} re
+        INNER JOIN ${resources} r ON r.id = re.resource_id
+        WHERE re.entity_id = ${lessons.id}
+          AND re.entity_type = ${ENTITY_TYPES.LESSON}
+          AND re.relationship_type = ${RESOURCE_RELATIONSHIP_TYPES.ATTACHMENT}
+          AND r.archived = false
       ), ''::text)::tsvector
     )
   `;

--- a/apps/api/src/lesson/lesson.schema.ts
+++ b/apps/api/src/lesson/lesson.schema.ts
@@ -371,6 +371,7 @@ export const enrolledLessonSchema = Type.Object({
   chapterTitle: Type.String(),
   chapterDisplayOrder: Type.Number(),
   searchRank: Type.Optional(Type.Number()),
+  matchedAttachmentFileName: Type.Optional(Type.Union([Type.String(), Type.Null()])),
 });
 
 export const initializeLessonContextSchema = Type.Object({

--- a/apps/api/src/lesson/repositories/lesson.repository.ts
+++ b/apps/api/src/lesson/repositories/lesson.repository.ts
@@ -1,11 +1,12 @@
 import { Inject, Injectable } from "@nestjs/common";
-import { COURSE_ENROLLMENT, PERMISSIONS } from "@repo/shared";
+import { COURSE_ENROLLMENT, ENTITY_TYPES, PERMISSIONS } from "@repo/shared";
 import { and, desc, eq, getTableColumns, type SQL, sql } from "drizzle-orm";
 
 import { DatabasePg, type UUIDType } from "src/common";
 import { hasPermission } from "src/common/permissions/permission.utils";
 import { normalizeSearchTerm } from "src/common/utils/normalizeSearchTerm";
 import { getCourseTsVector, getLessonTsVector } from "src/courses/utils/courses.utils";
+import { RESOURCE_RELATIONSHIP_TYPES } from "src/file/file.constants";
 import { LocalizationService } from "src/localization/localization.service";
 import { ENTITY_TYPE } from "src/localization/localization.types";
 import {
@@ -45,6 +46,7 @@ export type EnrolledLessonWithSearch = {
   chapterTitle: string;
   chapterDisplayOrder: number;
   searchRank?: number;
+  matchedAttachmentFileName?: string | null;
 };
 
 @Injectable()
@@ -436,10 +438,12 @@ export class LessonRepository {
 
       const tsQuery = sql`to_tsquery('english', ${normalizeSearchTerm(searchTerm)})`;
       const unifiedVector = sql`${getLessonTsVector()} || ${getCourseTsVector()}`;
+      const matchedAttachments = this.getMatchedAttachmentsCte(tsQuery);
 
       conditions.push(sql`${unifiedVector} @@ ${tsQuery}`);
 
       return this.db
+        .with(matchedAttachments)
         .select({
           id: lessons.id,
           title: this.localizationService.getLocalizedSqlField(lessons.title, language),
@@ -453,6 +457,7 @@ export class LessonRepository {
           chapterTitle: this.localizationService.getLocalizedSqlField(chapters.title, language),
           chapterDisplayOrder: sql<number>`${chapters.displayOrder}`,
           searchRank: sql<number>`ts_rank(${unifiedVector}, ${tsQuery})`,
+          matchedAttachmentFileName: matchedAttachments.fileName,
         })
         .from(lessons)
         .innerJoin(chapters, eq(chapters.id, lessons.chapterId))
@@ -464,6 +469,10 @@ export class LessonRepository {
             eq(studentLessonProgress.lessonId, lessons.id),
             eq(studentLessonProgress.studentId, currentUser.userId),
           ),
+        )
+        .leftJoin(
+          matchedAttachments,
+          and(eq(matchedAttachments.lessonId, lessons.id), eq(matchedAttachments.matchRank, 1)),
         )
         .where(and(...conditions))
         .groupBy(
@@ -477,6 +486,7 @@ export class LessonRepository {
           chapters.title,
           chapters.displayOrder,
           lessons.description,
+          matchedAttachments.fileName,
         )
         .orderBy(
           desc(sql`ts_rank(${unifiedVector}, ${tsQuery})`),
@@ -525,6 +535,45 @@ export class LessonRepository {
         lessons.description,
       )
       .orderBy(lessons.id, chapters.displayOrder, lessons.displayOrder);
+  }
+
+  private getMatchedAttachmentsCte(tsQuery: SQL) {
+    const attachmentVector = sql`
+      (
+        setweight(to_tsvector('english', COALESCE(${resources.metadata}->>'originalFilename', '')), 'D') ||
+        setweight(jsonb_to_tsvector('english', COALESCE(${resources.title}, '{}'::jsonb), '["string"]'), 'D') ||
+        setweight(to_tsvector('english', regexp_replace(${resources.reference}, '^.*/', '')), 'D')
+      )
+    `;
+
+    return this.db.$with("matched_lesson_attachments").as(
+      this.db
+        .select({
+          lessonId: resourceEntity.entityId,
+          fileName: sql<string | null>`
+            COALESCE(
+              NULLIF(${resources.metadata}->>'originalFilename', ''),
+              NULLIF(regexp_replace(${resources.reference}, '^.*/', ''), '')
+            )
+          `.as("fileName"),
+          matchRank: sql<number>`
+            ROW_NUMBER() OVER (
+              PARTITION BY ${resourceEntity.entityId}
+              ORDER BY ts_rank(${attachmentVector}, ${tsQuery}) DESC, ${resources.id}
+            )
+          `.as("matchRank"),
+        })
+        .from(resourceEntity)
+        .innerJoin(resources, eq(resources.id, resourceEntity.resourceId))
+        .where(
+          and(
+            eq(resourceEntity.entityType, ENTITY_TYPES.LESSON),
+            eq(resourceEntity.relationshipType, RESOURCE_RELATIONSHIP_TYPES.ATTACHMENT),
+            eq(resources.archived, false),
+            sql`${attachmentVector} @@ ${tsQuery}`,
+          ),
+        ),
+    );
   }
 
   async getLessonProgress(lessonId: UUIDType, userId: UUIDType, conditions?: SQL[]) {

--- a/apps/api/src/swagger/api-schema.json
+++ b/apps/api/src/swagger/api-schema.json
@@ -26784,6 +26784,16 @@
                 },
                 "searchRank": {
                   "type": "number"
+                },
+                "matchedAttachmentFileName": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 }
               },
               "required": [

--- a/apps/web/app/api/generated-api.ts
+++ b/apps/web/app/api/generated-api.ts
@@ -2603,6 +2603,7 @@ export interface GetLessonsResponse {
     chapterTitle: string;
     chapterDisplayOrder: number;
     searchRank?: number;
+    matchedAttachmentFileName?: string | null;
   }[];
 }
 

--- a/apps/web/app/components/Navigation/GlobalSearch/LessonEntry.tsx
+++ b/apps/web/app/components/Navigation/GlobalSearch/LessonEntry.tsx
@@ -1,4 +1,5 @@
 import { Link } from "@remix-run/react";
+import { FileText } from "lucide-react";
 
 import type { GetLessonsResponse } from "~/api/generated-api";
 
@@ -15,8 +16,16 @@ export const LessonEntry = ({
       onClick={onSelect}
       className="group focus:outline-none focus-visible:outline-none"
     >
-      <li className="rounded-md px-[8px] py-[6px] text-sm text-neutral-800 hover:bg-primary-50 group-focus:bg-primary-100">
+      <li className="rounded-md px-2 py-1.5 text-sm text-neutral-800 hover:bg-primary-50 group-focus:bg-primary-100">
         <span className="line-clamp-1">{item.title}</span>
+        {item.matchedAttachmentFileName && (
+          <span className="mt-0.5 flex min-w-0 items-center gap-1 text-xs leading-4 text-neutral-600">
+            <FileText className="size-3.5 shrink-0" aria-hidden />
+            <span className="line-clamp-1 leading-4 block py-1">
+              {item.matchedAttachmentFileName}
+            </span>
+          </span>
+        )}
       </li>
     </Link>
   );


### PR DESCRIPTION
## Issue(s)
- #1493 

## Overview
This PR enhances global search so lesson attachments are included in lesson search matching.

The API now adds non-archived lesson attachment data to the lesson search vector, matching against the original filename, localized resource title, and resource reference filename. When an attachment is the reason a lesson matches the query, the response includes the best matched attachment filename.

The web global search lesson entry now displays the matched attachment filename under the lesson title with a file icon, making it clear why the lesson appeared in search results.

## Business Value
Users can find lessons by searching for files attached to those lessons, not only by lesson, course, chapter, or question content. This makes course materials easier to rediscover and helps users navigate directly to relevant lessons when they remember an attachment name.

## Screenshots / Video
https://github.com/user-attachments/assets/58c0714f-0188-4d57-8389-b73d160adda5
