### PR TITLE
fix: restore proper color picker rendering across the platform

### DIFF
--- a/apps/web/app/components/ColorPickerField.tsx
+++ b/apps/web/app/components/ColorPickerField.tsx
@@ -1,0 +1,35 @@
+import { HexColorInput, HexColorPicker } from "react-colorful";
+
+import { cn } from "~/lib/utils";
+
+interface ColorPickerFieldProps {
+  color: string;
+  inputId?: string;
+  inputTestId?: string;
+  onChange: (color: string) => void;
+  className?: string;
+}
+
+export const ColorPickerField = ({
+  color,
+  inputId,
+  inputTestId,
+  onChange,
+  className,
+}: ColorPickerFieldProps) => (
+  <div className={cn("color-picker-field flex flex-col", className)}>
+    <HexColorPicker className="color-picker-field__picker" color={color} onChange={onChange} />
+    <div className="relative w-full">
+      <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm text-neutral-500">
+        #
+      </span>
+      <HexColorInput
+        color={color}
+        id={inputId}
+        onChange={onChange}
+        className="body-base !mt-0 flex h-[42px] w-full rounded-b-lg rounded-t-none border border-t-0 border-neutral-300 bg-white py-2 pl-7 pr-3 text-sm text-neutral-950 accent-accent-foreground placeholder:text-neutral-600 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+        data-testid={inputTestId}
+      />
+    </div>
+  </div>
+);

--- a/apps/web/app/index.css
+++ b/apps/web/app/index.css
@@ -259,6 +259,92 @@ html {
   .subtle {
     @apply text-sm leading-5;
   }
+
+  .color-picker-field {
+    width: 200px;
+  }
+
+  .color-picker-field .react-colorful {
+    position: relative;
+    display: flex;
+    width: 100%;
+    height: 200px;
+    flex-direction: column;
+    cursor: default;
+    user-select: none;
+  }
+
+  .color-picker-field .react-colorful__saturation {
+    position: relative;
+    flex-grow: 1;
+    border-color: transparent;
+    border-bottom: 12px solid #000;
+    border-radius: 8px 8px 0 0;
+    background-image: linear-gradient(0deg, #000, transparent),
+      linear-gradient(90deg, #fff, hsl(0 0% 100% / 0));
+    box-shadow: inset 0 0 0 1px rgb(0 0 0 / 5%);
+  }
+
+  .color-picker-field .react-colorful__hue {
+    position: relative;
+    height: 24px;
+    border-radius: 0;
+    background: linear-gradient(
+      90deg,
+      red 0,
+      #ff0 17%,
+      #0f0 33%,
+      #0ff 50%,
+      #00f 67%,
+      #f0f 83%,
+      red
+    );
+  }
+
+  .color-picker-field .react-colorful__last-control {
+    border-radius: 0;
+  }
+
+  .color-picker-field .react-colorful__interactive {
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    outline: none;
+    touch-action: none;
+  }
+
+  .color-picker-field .react-colorful__pointer {
+    position: absolute;
+    z-index: 1;
+    box-sizing: border-box;
+    width: 28px;
+    height: 28px;
+    border: 2px solid #fff;
+    border-radius: 9999px;
+    background-color: #fff;
+    box-shadow: 0 2px 4px rgb(0 0 0 / 20%);
+    transform: translate(-50%, -50%);
+  }
+
+  .color-picker-field .react-colorful__interactive:focus .react-colorful__pointer {
+    transform: translate(-50%, -50%) scale(1.1);
+  }
+
+  .color-picker-field .react-colorful__pointer-fill {
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    content: "";
+    pointer-events: none;
+  }
+
+  .color-picker-field .react-colorful__saturation-pointer {
+    z-index: 3;
+  }
+
+  .color-picker-field .react-colorful__hue-pointer {
+    z-index: 2;
+  }
 }
 
 /* css for lesson-item question type presentation -> Presentation.tsx  */

--- a/apps/web/app/modules/Dashboard/Settings/components/admin/OrganizationTheme.tsx
+++ b/apps/web/app/modules/Dashboard/Settings/components/admin/OrganizationTheme.tsx
@@ -1,11 +1,10 @@
-import { HEX_COLOR_REGEX } from "@repo/shared";
 import lowerCase from "lodash-es/lowerCase";
 import { useRef } from "react";
-import { HexColorPicker } from "react-colorful";
 import { useTranslation } from "react-i18next";
 import { useUnmount } from "react-use";
 
 import { useUpdateColorSchema } from "~/api/mutations";
+import { ColorPickerField } from "~/components/ColorPickerField";
 import { Button } from "~/components/ui/button";
 import {
   Card,
@@ -15,7 +14,6 @@ import {
   CardHeader,
   CardTitle,
 } from "~/components/ui/card";
-import { Input } from "~/components/ui/input";
 import { useTheme } from "~/modules/Theme";
 
 import { SETTINGS_PAGE_HANDLES } from "../../../../../../e2e/data/settings/handles";
@@ -46,56 +44,18 @@ export const OrganizationTheme = () => {
       </CardHeader>
       <CardContent>
         <div className="flex flex-col items-center md:flex-row justify-center gap-4">
-          <div className="flex flex-col gap-2">
-            <HexColorPicker
-              color={primaryColor}
-              onChange={(color) => setColorSchema(color, contrastColor)}
-            />
-            <div className="flex items-center justify-center space-x-1">
-              <span className="text-sm text-gray-500">#</span>
-              <Input
-                type="text"
-                id="primary-color-input"
-                value={primaryColor.replace(/^#/, "")}
-                onChange={(event) => {
-                  const value = event.target.value.startsWith("#")
-                    ? event.target.value
-                    : `#${event.target.value}`;
-
-                  if (HEX_COLOR_REGEX.test(value)) {
-                    setColorSchema(value, contrastColor);
-                  }
-                }}
-                className="w-24"
-                data-testid={SETTINGS_PAGE_HANDLES.THEME_PRIMARY_INPUT}
-              />
-            </div>
-          </div>
-          <div className="flex flex-col gap-2">
-            <HexColorPicker
-              color={contrastColor}
-              onChange={(color) => setColorSchema(primaryColor, color)}
-            />
-            <div className="flex items-center justify-center space-x-1">
-              <span className="text-sm text-gray-500">#</span>
-              <Input
-                type="text"
-                id="contrast-color-input"
-                value={contrastColor.replace(/^#/, "")}
-                onChange={(event) => {
-                  const value = event.target.value.startsWith("#")
-                    ? event.target.value
-                    : `#${event.target.value}`;
-
-                  if (HEX_COLOR_REGEX.test(value)) {
-                    setColorSchema(primaryColor, value);
-                  }
-                }}
-                className="w-24"
-                data-testid={SETTINGS_PAGE_HANDLES.THEME_CONTRAST_INPUT}
-              />
-            </div>
-          </div>
+          <ColorPickerField
+            color={primaryColor}
+            inputId="primary-color-input"
+            inputTestId={SETTINGS_PAGE_HANDLES.THEME_PRIMARY_INPUT}
+            onChange={(color) => setColorSchema(color, contrastColor)}
+          />
+          <ColorPickerField
+            color={contrastColor}
+            inputId="contrast-color-input"
+            inputTestId={SETTINGS_PAGE_HANDLES.THEME_CONTRAST_INPUT}
+            onChange={(color) => setColorSchema(primaryColor, color)}
+          />
         </div>
       </CardContent>
       <CardFooter className="flex gap-4 border-t py-4">

--- a/apps/web/app/modules/Profile/Certificates/CertificateControls.tsx
+++ b/apps/web/app/modules/Profile/Certificates/CertificateControls.tsx
@@ -1,14 +1,12 @@
 import * as PopoverPrimitive from "@radix-ui/react-popover";
-import { HEX_COLOR_REGEX } from "@repo/shared";
 import { Download, Loader2, Palette, X } from "lucide-react";
 import { useEffect, useState } from "react";
-import { HexColorPicker } from "react-colorful";
 import { useTranslation } from "react-i18next";
 
 import { Linkedin } from "~/assets/svgs";
+import { ColorPickerField } from "~/components/ColorPickerField";
 import RectangularSwitch from "~/components/RectangularSwitch";
 import { Button } from "~/components/ui/button";
-import { Input } from "~/components/ui/input";
 import { cn } from "~/lib/utils";
 
 import { applyUniformCertificateColor } from "./certificateTheme";
@@ -72,14 +70,6 @@ const CertificateControls = ({
     onColorChange?.(value);
   };
 
-  const handleHexColorInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const value = event.target.value.startsWith("#")
-      ? event.target.value
-      : `#${event.target.value}`;
-
-    if (HEX_COLOR_REGEX.test(value)) updateAllColors(value);
-  };
-
   return (
     <div className="flex flex-wrap items-center justify-end gap-3">
       <RectangularSwitch
@@ -110,23 +100,12 @@ const CertificateControls = ({
             align="end"
             sideOffset={8}
             className={cn(
-              "z-[60] w-[260px] rounded-lg border bg-white p-3 text-popover-foreground shadow-md outline-none",
+              "z-[60] rounded-lg border bg-white p-3 text-popover-foreground shadow-md outline-none",
               "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
               "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
             )}
           >
-            <div className="flex flex-col items-center gap-3">
-              <HexColorPicker color={colorTheme.titleColor} onChange={updateAllColors} />
-              <div className="flex items-center justify-center space-x-1">
-                <span className="text-sm text-gray-500">#</span>
-                <Input
-                  type="text"
-                  value={colorTheme.titleColor.replace(/^#/, "").toLowerCase()}
-                  onChange={handleHexColorInputChange}
-                  className="w-24"
-                />
-              </div>
-            </div>
+            <ColorPickerField color={colorTheme.titleColor} onChange={updateAllColors} />
           </PopoverPrimitive.Content>
         </PopoverPrimitive.Root>
       )}


### PR DESCRIPTION
## Issue(s)
- #1549 

## Overview

Fixes color pickers not rendering in the web app by using the shared `ColorPickerField` component in:

- organization theme settings
- certificate color controls

Adds the missing `react-colorful` styling under the existing `.color-picker-field` wrapper so the saturation area, hue slider, and picker handles display correctly.

## Business Value

Users can customize organization theme colors and certificate colors again through the visual color picker UI. This restores expected configuration flows and avoids forcing users to rely only on manual hex input.

## Screenshots / Video

https://github.com/user-attachments/assets/ed9075f5-c5e3-4181-bd8b-be684844d475