### PR TITLE
chore: update development path URLs across the platform

### DIFF
--- a/apps/web/app/components/Navigation/GlobalSearch/LearningPathEntry.tsx
+++ b/apps/web/app/components/Navigation/GlobalSearch/LearningPathEntry.tsx
@@ -16,7 +16,7 @@ export const LearningPathEntry = ({
 
   return (
     <Link
-      to={`/learning-paths?${searchParams.toString()}`}
+      to={`/development-paths?${searchParams.toString()}`}
       onClick={onSelect}
       className="group focus:outline-none focus-visible:outline-none"
     >

--- a/apps/web/app/components/RichText/Editor.tsx
+++ b/apps/web/app/components/RichText/Editor.tsx
@@ -31,6 +31,8 @@ type EditorProps = {
   placeholder?: string;
   id?: string;
   parentClassName?: string;
+  contentClassName?: string;
+  editorClassName?: string;
   lessonId?: string;
   allowFiles?: boolean;
   acceptedFileTypes?: readonly string[];
@@ -48,6 +50,8 @@ const Editor = ({
   onCtrlSave,
   id,
   parentClassName,
+  contentClassName,
+  editorClassName,
   allowFiles = false,
   acceptedFileTypes = ALLOWED_LESSON_IMAGE_FILE_TYPES,
   assetLibrary,
@@ -139,7 +143,11 @@ const Editor = ({
       handleKeyDown,
       handlePaste: (_view, event) => handlePaste(event),
       attributes: {
-        class: `prose prose-xs sm:prose dark:prose-invert focus:outline-none max-w-full p-4 ${EMPTY_EDITOR_MIN_HEIGHT_CLASS} !max-w-full`,
+        class: cn(
+          "prose prose-xs sm:prose dark:prose-invert focus:outline-none max-w-full p-4 !max-w-full",
+          EMPTY_EDITOR_MIN_HEIGHT_CLASS,
+          editorClassName,
+        ),
       },
     },
   });
@@ -168,6 +176,7 @@ const Editor = ({
     defaultClasses.ul,
     defaultClasses.ol,
     defaultClasses.taskList,
+    contentClassName,
   );
 
   return (

--- a/apps/web/app/config/__tests__/navigationConfig.test.ts
+++ b/apps/web/app/config/__tests__/navigationConfig.test.ts
@@ -27,7 +27,7 @@ describe("findMatchingRoute", () => {
   });
 
   it("should find learning path routes", () => {
-    expect(findMatchingRoute("learning-paths")).toEqual({
+    expect(findMatchingRoute("development-paths")).toEqual({
       anyOf: [PERMISSIONS.LEARNING_PATH_READ],
     });
   });
@@ -39,7 +39,7 @@ describe("findMatchingRoute", () => {
   });
 
   it("should find admin learning path routes", () => {
-    expect(findMatchingRoute("admin/learning-paths/new")).toEqual({
+    expect(findMatchingRoute("admin/development-paths/new")).toEqual({
       allOf: [PERMISSIONS.LEARNING_PATH_CREATE],
     });
   });
@@ -213,18 +213,18 @@ describe("getNavigationConfig", () => {
   it("should hide learning paths when the feature is disabled", () => {
     const items = getCourseItems(false, true);
 
-    expect(items.some((item) => item.path === "learning-paths")).toBe(false);
+    expect(items.some((item) => item.path === "development-paths")).toBe(false);
   });
 
   it("should hide learning paths when students have no available paths", () => {
     const items = getCourseItems(true, false);
 
-    expect(items.some((item) => item.path === "learning-paths")).toBe(false);
+    expect(items.some((item) => item.path === "development-paths")).toBe(false);
   });
 
   it("should show learning paths when enabled and available", () => {
     const items = getCourseItems(true, true);
 
-    expect(items.some((item) => item.path === "learning-paths")).toBe(true);
+    expect(items.some((item) => item.path === "development-paths")).toBe(true);
   });
 });

--- a/apps/web/app/config/navigationConfig.ts
+++ b/apps/web/app/config/navigationConfig.ts
@@ -69,7 +69,7 @@ export const getNavigationConfig = (
           ? ([
               {
                 label: t("navigationSideBar.learningPaths"),
-                path: "learning-paths",
+                path: "development-paths",
                 iconName: "Route",
                 testId: NAVIGATION_HANDLES.LEARNING_PATHS_LINK,
               },

--- a/apps/web/app/config/routeAccessConfig.ts
+++ b/apps/web/app/config/routeAccessConfig.ts
@@ -106,7 +106,7 @@ export const routeAccessConfig = createRouteConfig({
   // Client and public
   "course/:id": PUBLIC,
   courses: PUBLIC,
-  "learning-paths": LEARNING_PATH_READ_ACCESS,
+  "development-paths": LEARNING_PATH_READ_ACCESS,
   calendar: CALENDAR_READ_ACCESS,
   "live-training/:id": LIVE_TRAINING_READ_ACCESS,
   "live-training/:id/room": LIVE_TRAINING_READ_ACCESS,
@@ -135,11 +135,11 @@ export const routeAccessConfig = createRouteConfig({
   },
   "admin/courses/:id": COURSE_EDIT_ACCESS,
   "admin/beta-courses/:id": COURSE_EDIT_ACCESS,
-  "admin/learning-paths": LEARNING_PATH_ADMIN_ACCESS,
-  "admin/learning-paths/new": {
+  "admin/development-paths": LEARNING_PATH_ADMIN_ACCESS,
+  "admin/development-paths/new": {
     allOf: [PERMISSIONS.LEARNING_PATH_CREATE],
   },
-  "admin/learning-paths/:id": LEARNING_PATH_ADMIN_ACCESS,
+  "admin/development-paths/:id": LEARNING_PATH_ADMIN_ACCESS,
   "admin/users/*": USER_MANAGEMENT_ACCESS,
   "admin/groups/*": {
     allOf: [PERMISSIONS.GROUP_MANAGE],

--- a/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/AiMentorLessonForm/AiMentorLessonForm.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/AiMentorLessonForm/AiMentorLessonForm.tsx
@@ -358,6 +358,9 @@ const AiMentorLessonForm = ({
                             placeholder={t(
                               "adminCourseView.curriculum.lesson.placeholder.taskDescription",
                             )}
+                            parentClassName="flex h-[11lh] flex-col"
+                            contentClassName="min-h-0 flex-1 overflow-y-auto"
+                            editorClassName="min-h-0"
                             {...field}
                           />
                         </div>

--- a/apps/web/app/modules/Admin/LearningPaths/LearningPathEditor.page.tsx
+++ b/apps/web/app/modules/Admin/LearningPaths/LearningPathEditor.page.tsx
@@ -37,7 +37,7 @@ export default function LearningPathEditorPage() {
   const { permissions } = usePermissions();
   const { data: currentUser } = useCurrentUserSuspense();
 
-  const isCreateMode = pathname.endsWith("/admin/learning-paths/new");
+  const isCreateMode = pathname.endsWith("/admin/development-paths/new");
   const appLanguage = useLanguageStore((state) => state.language);
 
   const [editorLanguage, setEditorLanguage] = useState<SupportedLanguages>(
@@ -69,13 +69,13 @@ export default function LearningPathEditorPage() {
       breadcrumbs={[
         {
           title: t("adminLearningPathsView.breadcrumbs.learningPaths"),
-          href: "/admin/learning-paths",
+          href: "/admin/development-paths",
         },
         {
           title: isCreateMode
             ? t("adminLearningPathsView.breadcrumbs.create")
             : t("adminLearningPathsView.breadcrumbs.edit"),
-          href: isCreateMode ? "/admin/learning-paths/new" : `/admin/learning-paths/${id}`,
+          href: isCreateMode ? "/admin/development-paths/new" : `/admin/development-paths/${id}`,
         },
       ]}
     >

--- a/apps/web/app/modules/Admin/LearningPaths/components/AdminLearningPathsPageContent.tsx
+++ b/apps/web/app/modules/Admin/LearningPaths/components/AdminLearningPathsPageContent.tsx
@@ -15,7 +15,7 @@ export function AdminLearningPathsPageContent() {
       breadcrumbs={[
         {
           title: t("adminLearningPathsView.breadcrumbs.learningPaths"),
-          href: "/learning-paths",
+          href: "/development-paths",
         },
       ]}
     >

--- a/apps/web/app/modules/Admin/LearningPaths/hooks/useLearningPathEditorActions.ts
+++ b/apps/web/app/modules/Admin/LearningPaths/hooks/useLearningPathEditorActions.ts
@@ -58,7 +58,7 @@ export function useLearningPathEditorActions({
     if (isCreateMode) {
       const createdLearningPath = await createLearningPath(payload);
 
-      navigate(`/admin/learning-paths/${createdLearningPath.data.id}`);
+      navigate(`/admin/development-paths/${createdLearningPath.data.id}`);
       return;
     }
 

--- a/apps/web/app/modules/Courses/Lesson/AiMentorLesson/AiMentorLesson.tsx
+++ b/apps/web/app/modules/Courses/Lesson/AiMentorLesson/AiMentorLesson.tsx
@@ -36,6 +36,7 @@ import type { LessonPreviewUser } from "~/modules/Courses/Lesson/types";
 
 const apiUrl = import.meta.env.VITE_API_URL;
 const chatUrl = apiUrl ? `${apiUrl}/api/ai/chat` : "/api/ai/chat";
+const taskDescriptionViewerClassName = "h-[11lh] overflow-y-auto";
 
 interface AiMentorLessonProps {
   lesson: GetLessonByIdResponse["data"];
@@ -211,7 +212,7 @@ const AiMentorLesson = ({
             </div>
           </div>
           <div className="border-t border-neutral-100 px-4 py-4 text-neutral-800">
-            <div className="max-h-24 overflow-y-auto">
+            <div className={taskDescriptionViewerClassName}>
               <Viewer content={lesson.description ?? ""} />
             </div>
           </div>
@@ -251,7 +252,7 @@ const AiMentorLesson = ({
               />
             </AccordionTrigger>
             <AccordionContent className="px-4 py-4 text-neutral-800 border-t border-neutral-100">
-              <div className="max-h-24 overflow-y-auto">
+              <div className={taskDescriptionViewerClassName}>
                 <Viewer content={lesson.description ?? ""} />
               </div>
             </AccordionContent>

--- a/apps/web/app/modules/Courses/Lesson/LessonContent.tsx
+++ b/apps/web/app/modules/Courses/Lesson/LessonContent.tsx
@@ -209,7 +209,7 @@ export const LessonContent = ({
   return (
     <TooltipProvider>
       <div className="flex w-full min-w-0 flex-col items-center h-auto py-10">
-        <div className="flex w-full min-w-0 flex-col gap-y-10 px-6 sm:px-10 max-w-full 3xl:max-w-[1024px] 3xl:px-8 h-auto">
+        <div className="flex w-full min-w-0 flex-col px-6 sm:px-10 max-w-full 3xl:max-w-[1024px] 3xl:px-8 h-auto">
           <div className="flex w-full flex-col pb-6">
             <div className="flex w-full min-w-0 flex-col gap-y-4 overflow-x-hidden">
               <div className="flex items-center gap-x-2">

--- a/apps/web/app/modules/LearningPaths/LearningPaths.page.tsx
+++ b/apps/web/app/modules/LearningPaths/LearningPaths.page.tsx
@@ -64,7 +64,7 @@ function StudentLearningPathsPage() {
       breadcrumbs={[
         {
           title: t("learningPathsView.breadcrumbs.learningPaths"),
-          href: "/learning-paths",
+          href: "/development-paths",
         },
       ]}
     >

--- a/apps/web/app/utils/__tests__/getDefaultAuthenticatedRedirect.test.ts
+++ b/apps/web/app/utils/__tests__/getDefaultAuthenticatedRedirect.test.ts
@@ -38,6 +38,6 @@ describe("getDefaultAuthenticatedRedirect", () => {
       getDefaultAuthenticatedRedirect(user, globalSettings({ learningPathsEnabled: true }), {
         exclude: ["/courses"],
       }),
-    ).toBe("/learning-paths");
+    ).toBe("/development-paths");
   });
 });

--- a/apps/web/app/utils/getDefaultAuthenticatedRedirect.ts
+++ b/apps/web/app/utils/getDefaultAuthenticatedRedirect.ts
@@ -45,11 +45,11 @@ export const getDefaultAuthenticatedRedirect = (
   }
 
   if (
-    isAvailableRoute("/learning-paths", excludedRoutes) &&
+    isAvailableRoute("/development-paths", excludedRoutes) &&
     globalSettings?.learningPathsEnabled !== false &&
     hasPermission(permissions, PERMISSIONS.LEARNING_PATH_READ)
   ) {
-    return "/learning-paths";
+    return "/development-paths";
   }
 
   return DEFAULT_AUTHENTICATED_ROUTE;

--- a/apps/web/routes.ts
+++ b/apps/web/routes.ts
@@ -18,7 +18,7 @@ export const routes: (
         route("", "modules/Dashboard/PublicDashboard.layout.tsx", () => {
           route("courses", "modules/Courses/Courses.page.tsx");
           route("course/:id", "modules/Courses/CourseView/CourseView.page.tsx");
-          route("learning-paths", "modules/LearningPaths/LearningPaths.page.tsx");
+          route("development-paths", "modules/LearningPaths/LearningPaths.page.tsx");
           route("calendar", "modules/Calendar/Calendar.page.tsx");
           route("live-training/:id/room", "modules/LiveTraining/LiveTraining.page.tsx", {
             id: "live-training-room",


### PR DESCRIPTION
## Issue(s)
- #1579 

## Overview
Updates the web app learning path URLs from `/learning-paths` to `/development-paths`.

The change covers:
- student learning path route registration and navigation links
- admin learning path list, create, and edit route access entries
- breadcrumbs and post-create editor navigation
- default authenticated redirect fallback for users with learning path access
- route matching tests for navigation and authenticated redirects

## Business Value
This aligns the user-facing URL structure with the updated product naming for development paths while keeping the existing learning path permissions and implementation behavior intact.