### PR TITLE
chore: allow only latin charactest in course links

### DIFF
--- a/apps/api/src/courses/__tests__/course.controller.e2e-spec.ts
+++ b/apps/api/src/courses/__tests__/course.controller.e2e-spec.ts
@@ -3860,6 +3860,76 @@ describe("CourseController (e2e)", () => {
       expect(courseAfterLookup.shortId).toHaveLength(5);
     });
 
+    it("generates ASCII-only slugs from titles with emoji", async () => {
+      const author = await userFactory
+        .withCredentials({ password })
+        .withAdminSettings(db)
+        .create({ role: SYSTEM_ROLE_SLUGS.ADMIN });
+      const category = await categoryFactory.create();
+      const course = await courseFactory.create({
+        authorId: author.id,
+        categoryId: category.id,
+        status: "published",
+        title: "Course 😀 title",
+      });
+
+      const response = await request(app.getHttpServer())
+        .get("/api/course/lookup")
+        .query({ id: course.id, language: "en" })
+        .set("Cookie", await cookieFor(author, app))
+        .expect(200);
+
+      expect(response.body.data.status).toBe("found");
+      expect(response.body.data.slug).toMatch(/^[a-z0-9]{5}-[a-z0-9-]+$/);
+      expect(response.body.data.slug).toMatch(/^[a-z0-9]{5}-course-title$/);
+    });
+
+    it("transliterates accented Latin characters in generated slugs", async () => {
+      const author = await userFactory
+        .withCredentials({ password })
+        .withAdminSettings(db)
+        .create({ role: SYSTEM_ROLE_SLUGS.ADMIN });
+      const category = await categoryFactory.create();
+      const course = await courseFactory.create({
+        authorId: author.id,
+        categoryId: category.id,
+        status: "published",
+        title: "Zażółć gęślą jaźń",
+      });
+
+      const response = await request(app.getHttpServer())
+        .get("/api/course/lookup")
+        .query({ id: course.id, language: "en" })
+        .set("Cookie", await cookieFor(author, app))
+        .expect(200);
+
+      expect(response.body.data.status).toBe("found");
+      expect(response.body.data.slug).toMatch(/^[a-z0-9]{5}-zazolc-gesla-jazn$/);
+    });
+
+    it("uses a fallback slug when the title has no URL-safe characters", async () => {
+      const author = await userFactory
+        .withCredentials({ password })
+        .withAdminSettings(db)
+        .create({ role: SYSTEM_ROLE_SLUGS.ADMIN });
+      const category = await categoryFactory.create();
+      const course = await courseFactory.create({
+        authorId: author.id,
+        categoryId: category.id,
+        status: "published",
+        title: "😀!!!",
+      });
+
+      const response = await request(app.getHttpServer())
+        .get("/api/course/lookup")
+        .query({ id: course.id, language: "en" })
+        .set("Cookie", await cookieFor(author, app))
+        .expect(200);
+
+      expect(response.body.data.status).toBe("found");
+      expect(response.body.data.slug).toMatch(/^[a-z0-9]{5}-course$/);
+    });
+
     it("returns found status when accessing with correct slug", async () => {
       const author = await userFactory
         .withCredentials({ password })

--- a/apps/api/src/courses/course-slug.service.ts
+++ b/apps/api/src/courses/course-slug.service.ts
@@ -17,6 +17,7 @@ export type CourseSlugResult =
   | { type: "uuid"; courseId: string; slug: string };
 
 const SLUG_MATCH = /^([a-z0-9]{5})-([^ ]+)$/;
+const COURSE_SLUG_FALLBACK = "course";
 
 @Injectable()
 export class CourseSlugService {
@@ -244,11 +245,14 @@ export class CourseSlugService {
   }
 
   private createSlugFromText(text: string): string {
-    return slugify(text, {
-      remove: /[*+~.()'"!:@_\[\]{}|#%^&><?`]/g,
+    const slug = slugify(text, {
       lower: true,
       replacement: "-",
+      strict: true,
+      trim: true,
     });
+
+    return slug || COURSE_SLUG_FALLBACK;
   }
 
   private parseSlug(slug?: string | null) {


### PR DESCRIPTION
## Issue(s)
- #1478 

## Overview
This PR updates course slug generation so course URLs are limited to URL-safe Latin lowercase letters, numbers, and hyphens.

The slug generation now:
- strips emoji and other non-URL-safe characters from course title slugs
- transliterates accented Latin characters before building the URL slug
- falls back to `course` when a title does not contain any usable slug characters

It also adds e2e coverage for emoji titles, accented Latin titles, and titles without URL-safe characters.

## Business Value
Course URLs stay readable, shareable, and predictable even when course titles contain emoji, punctuation, or localized Latin characters. This avoids malformed or confusing URLs while keeping links stable through the existing short ID prefix.

## Screenshots / Video

https://github.com/user-attachments/assets/19eb2e4a-1932-4dc2-90b2-7b909e980a48


