### PR TITLE
fix: exclude deleted users from course statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,25 +54,29 @@ A modern, scalable Learning Management System built with cutting-edge technologi
 </div>
 
 ### 🤖 AI-Powered Training
-* **Voice & Chat AI Mentor:** Immersive, real-time role-play simulations for sales, compliance, and customer support training with instant, automated AI evaluation.
-* **AI Course Architect:** Transform raw corporate knowledge bases, documentation, and internal policies into structured interactive courses in minutes.
-* **Automated Scenario Grading:** AI-driven analysis and actionable feedback for open-ended problem-solving and behavioral tasks, reducing manual L&D workload.
+
+- **Voice & Chat AI Mentor:** Immersive, real-time role-play simulations for sales, compliance, and customer support training with instant, automated AI evaluation.
+- **AI Course Architect:** Transform raw corporate knowledge bases, documentation, and internal policies into structured interactive courses in minutes.
+- **Automated Scenario Grading:** AI-driven analysis and actionable feedback for open-ended problem-solving and behavioral tasks, reducing manual L&D workload.
 
 ### 🏢 Enterprise & White-Label Readiness
-* **Full White-Label Architecture:** Complete rebranding capabilities (custom domains, logos, custom styles) to perfectly match corporate identity.
-* **Multi-Tenancy Infrastructure:** Secure, isolated multi-tenant architecture designed for large corporate environments, holding companies, or B2B training vendors.
-* **Enterprise Configuration Hub:** Centralized admin toggles for seamless, zero-code activation of corporate infrastructure, including Corporate SSO (Microsoft 365 & Google Workspace Sign-In) and AI API provider management (e.g., OpenAI).
-  
+
+- **Full White-Label Architecture:** Complete rebranding capabilities (custom domains, logos, custom styles) to perfectly match corporate identity.
+- **Multi-Tenancy Infrastructure:** Secure, isolated multi-tenant architecture designed for large corporate environments, holding companies, or B2B training vendors.
+- **Enterprise Configuration Hub:** Centralized admin toggles for seamless, zero-code activation of corporate infrastructure, including Corporate SSO (Microsoft 365 & Google Workspace Sign-In) and AI API provider management (e.g., OpenAI).
+
 ### 📊 Corporate L&D & Engagement Engine
-* **Dynamic Organization Mapping:** Advanced group and user management designed to seamlessly mirror complex corporate hierarchies (Departments, Branches, Teams) with automated course access inheritance.
-* **Automated Recertification & Compliance:** Set recurring expiration dates for mandatory corporate training (e.g., Compliance, Safety, Cyber Security) with automated re-enrollment and smart notification schedules.
-* **Consumer-Grade UI/UX:** A clean, distraction-free, modern interface inspired by top consumer apps to maximize employee adoption, engagement, and course completion rates.
-* **Next-Gen Assessment Engine:** Multi-format testing including behavioral scenarios, short/long-form text analysis, dynamic quizzes, and gamified consistency systems (Daily Streaks).
-* **Deep Analytics & Insights:** Granular tracking of user engagement, learning consistency, and practical training outcomes for L&D managers.
+
+- **Dynamic Organization Mapping:** Advanced group and user management designed to seamlessly mirror complex corporate hierarchies (Departments, Branches, Teams) with automated course access inheritance.
+- **Automated Recertification & Compliance:** Set recurring expiration dates for mandatory corporate training (e.g., Compliance, Safety, Cyber Security) with automated re-enrollment and smart notification schedules.
+- **Consumer-Grade UI/UX:** A clean, distraction-free, modern interface inspired by top consumer apps to maximize employee adoption, engagement, and course completion rates.
+- **Next-Gen Assessment Engine:** Multi-format testing including behavioral scenarios, short/long-form text analysis, dynamic quizzes, and gamified consistency systems (Daily Streaks).
+- **Deep Analytics & Insights:** Granular tracking of user engagement, learning consistency, and practical training outcomes for L&D managers.
 
 ### 🧠 Knowledge Management & CMS
-* **Corporate Knowledge Repository:** Centralized, secure storage for organization-wide documentation, internal playbooks, and assets.
-* **Internal Q&A & News Hub:** Keep remote and hybrid teams aligned with a built-in corporate blog, announcement modules, and dynamic internal FAQ sections.
+
+- **Corporate Knowledge Repository:** Centralized, secure storage for organization-wide documentation, internal playbooks, and assets.
+- **Internal Q&A & News Hub:** Keep remote and hybrid teams aligned with a built-in corporate blog, announcement modules, and dynamic internal FAQ sections.
 
 </br>
 <div align="center">

--- a/apps/api/src/courses/__tests__/course.controller.e2e-spec.ts
+++ b/apps/api/src/courses/__tests__/course.controller.e2e-spec.ts
@@ -25,6 +25,7 @@ import {
   coursesSummaryStats,
   courseStudentsStats,
   groupCourses,
+  lessonLearningTime,
   lessons,
   resourceEntity,
   resources,
@@ -141,6 +142,7 @@ describe("CourseController (e2e)", () => {
   afterEach(async () => {
     await truncateTables(baseDb, [
       "calendar_events",
+      "lesson_learning_time",
       "courses",
       "chapters",
       "lessons",
@@ -159,6 +161,147 @@ describe("CourseController (e2e)", () => {
 
   beforeEach(async () => {
     await settingsFactory.create({ userId: null });
+  });
+
+  describe("course statistics after student deletion", () => {
+    it("excludes soft-deleted students from statistics endpoints", async () => {
+      const admin = await userFactory
+        .withCredentials({ password })
+        .withAdminSettings(db)
+        .create({ role: SYSTEM_ROLE_SLUGS.ADMIN });
+      const student = await userFactory
+        .withCredentials({ password })
+        .withUserSettings(db)
+        .create({ role: SYSTEM_ROLE_SLUGS.STUDENT });
+      const cookies = await cookieFor(admin, app);
+      const category = await categoryFactory.create();
+      const course = await courseFactory.create({
+        authorId: admin.id,
+        categoryId: category.id,
+        status: "published",
+        thumbnailS3Key: null,
+        chapterCount: 1,
+      });
+      const chapter = await chapterFactory.create({
+        authorId: admin.id,
+        courseId: course.id,
+        title: "Deleted student statistics chapter",
+        displayOrder: 1,
+        lessonCount: 1,
+      });
+      const [quizLesson] = await db
+        .insert(lessons)
+        .values({
+          chapterId: chapter.id,
+          type: LESSON_TYPES.QUIZ,
+          title: buildJsonbField(SUPPORTED_LANGUAGES.EN, "Deleted student quiz"),
+          description: buildJsonbField(SUPPORTED_LANGUAGES.EN, ""),
+          thresholdScore: 0,
+          displayOrder: 1,
+        })
+        .returning();
+      const completedAt = new Date().toISOString();
+
+      await db.insert(coursesSummaryStats).values({
+        courseId: course.id,
+        authorId: admin.id,
+        freePurchasedCount: 1,
+        completedCourseStudentCount: 1,
+      });
+      await db.insert(studentCourses).values({
+        studentId: student.id,
+        courseId: course.id,
+        progress: "completed",
+        completedAt,
+        finishedChapterCount: 1,
+        status: COURSE_ENROLLMENT.ENROLLED,
+      });
+      await db.insert(studentLessonProgress).values({
+        studentId: student.id,
+        chapterId: chapter.id,
+        lessonId: quizLesson.id,
+        completedQuestionCount: 5,
+        quizScore: 80,
+        attempts: 1,
+        isQuizPassed: true,
+        isStarted: true,
+        completedAt,
+      });
+      await db.insert(lessonLearningTime).values({
+        userId: student.id,
+        lessonId: quizLesson.id,
+        courseId: course.id,
+        totalSeconds: 120,
+      });
+
+      await request(app.getHttpServer())
+        .get(`/api/course/${course.id}/statistics/students-quiz-results`)
+        .query({ language: SUPPORTED_LANGUAGES.EN, perPage: 100 })
+        .set("Cookie", cookies)
+        .expect(200)
+        .expect(({ body }) => {
+          expect(body.data).toEqual([
+            expect.objectContaining({
+              studentId: student.id,
+              lessonId: quizLesson.id,
+              quizScore: 80,
+            }),
+          ]);
+        });
+
+      await request(app.getHttpServer())
+        .delete("/api/user")
+        .send({ userIds: [student.id] })
+        .set("Cookie", cookies)
+        .expect(200);
+
+      await request(app.getHttpServer())
+        .get(`/api/course/${course.id}/statistics`)
+        .set("Cookie", cookies)
+        .expect(200)
+        .expect(({ body }) => {
+          expect(body.data.enrolledCount).toBe(0);
+          expect(body.data.completionPercentage).toBe(0);
+          expect(body.data.averageCompletionPercentage).toBe(0);
+          expect(body.data.averageSeconds).toBe(0);
+        });
+
+      await request(app.getHttpServer())
+        .get(`/api/course/${course.id}/statistics/students-progress`)
+        .query({ language: SUPPORTED_LANGUAGES.EN, perPage: 100 })
+        .set("Cookie", cookies)
+        .expect(200)
+        .expect(({ body }) => {
+          expect(body.data).toEqual([]);
+        });
+
+      await request(app.getHttpServer())
+        .get(`/api/course/${course.id}/statistics/students-quiz-results`)
+        .query({ language: SUPPORTED_LANGUAGES.EN, perPage: 100 })
+        .set("Cookie", cookies)
+        .expect(200)
+        .expect(({ body }) => {
+          expect(body.data).toEqual([]);
+        });
+
+      await request(app.getHttpServer())
+        .get(`/api/course/${course.id}/statistics/average-quiz-score`)
+        .query({ language: SUPPORTED_LANGUAGES.EN })
+        .set("Cookie", cookies)
+        .expect(200)
+        .expect(({ body }) => {
+          expect(body.data.averageScoresPerQuiz).toEqual([]);
+        });
+
+      await request(app.getHttpServer())
+        .get(`/api/course/${course.id}/statistics/learning-time`)
+        .query({ perPage: 100 })
+        .set("Cookie", cookies)
+        .expect(200)
+        .expect(({ body }) => {
+          expect(body.data.users).toEqual([]);
+        });
+    });
   });
 
   describe("POST /api/course/:courseId/scorm-export", () => {

--- a/apps/api/src/courses/course.service.ts
+++ b/apps/api/src/courses/course.service.ts
@@ -3526,6 +3526,7 @@ export class CourseService {
                 COUNT(DISTINCT CASE WHEN sc.progress = 'completed' THEN sc.student_id END) AS completed_count,
                 COUNT(DISTINCT sc.student_id) AS total_count
               FROM ${studentCourses} AS sc
+              JOIN ${users} AS active_users ON active_users.id = sc.student_id AND active_users.deleted_at IS NULL
               WHERE sc.course_id = ${id} AND sc.status = ${COURSE_ENROLLMENT.ENROLLED}
             ) AS stats
           ),
@@ -3543,6 +3544,7 @@ export class CourseService {
             JOIN ${lessons} AS l ON slp.lesson_id = l.id
             JOIN ${chapters} AS ch ON l.chapter_id = ch.id
             JOIN ${studentCourses} AS sc ON slp.student_id = sc.student_id AND ch.course_id = sc.course_id
+            JOIN ${users} AS active_users ON active_users.id = sc.student_id AND active_users.deleted_at IS NULL
             WHERE ch.course_id = ${id} AND sc.status = ${COURSE_ENROLLMENT.ENROLLED}
             ${userIds.length ? sql`AND sc.student_id IN ${userIds}` : sql``}
           ) AS stats
@@ -3556,6 +3558,7 @@ export class CourseService {
                 sc.progress AS progress,
                 COUNT(*) AS count
               FROM ${studentCourses} AS sc
+              JOIN ${users} AS active_users ON active_users.id = sc.student_id AND active_users.deleted_at IS NULL
               WHERE sc.course_id = ${id} AND sc.status = ${COURSE_ENROLLMENT.ENROLLED}
               ${userIds.length ? sql`AND sc.student_id IN ${userIds}` : sql``}
               GROUP BY sc.progress
@@ -3566,10 +3569,12 @@ export class CourseService {
       })
       .from(coursesSummaryStats)
       .leftJoin(studentCourses, eq(coursesSummaryStats.courseId, studentCourses.courseId))
+      .leftJoin(users, eq(studentCourses.studentId, users.id))
       .where(
         and(
           eq(coursesSummaryStats.courseId, id),
           eq(studentCourses.status, COURSE_ENROLLMENT.ENROLLED),
+          isNull(users.deletedAt),
           ...(userIds.length ? [inArray(studentCourses.studentId, userIds)] : []),
         ),
       );
@@ -3610,6 +3615,9 @@ export class CourseService {
             JOIN ${studentCourses} ON ${studentLessonProgress.studentId} = ${
               studentCourses.studentId
             } AND ${studentCourses.courseId} = ${chapters.courseId}
+            JOIN ${users} AS active_users ON active_users.id = ${
+              studentCourses.studentId
+            } AND active_users.deleted_at IS NULL
             JOIN ${courses} ON ${courses.id} = ${chapters.courseId}
             WHERE ${chapters.courseId} = ${courseId}
               AND ${lessons.type} = 'quiz'
@@ -3681,6 +3689,7 @@ export class CourseService {
       eq(studentCourses.courseId, courseId),
       this.getSearchQueryConditions(searchQuery, language),
       eq(studentCourses.status, COURSE_ENROLLMENT.ENROLLED),
+      isNull(users.deletedAt),
     ];
 
     conditions.push(...(await this.getStatisticsConditions({ groupId })));
@@ -3761,6 +3770,7 @@ export class CourseService {
       isNotNull(studentLessonProgress.attempts),
       eq(studentCourses.status, COURSE_ENROLLMENT.ENROLLED),
       eq(chapters.courseId, courseId),
+      isNull(users.deletedAt),
       or(
         sql`${quizNameExpression} ILIKE ${`%${searchQuery}%`}`,
         this.getSearchQueryConditions(searchQuery, language),
@@ -3857,6 +3867,7 @@ export class CourseService {
       eq(studentLessonProgress.id, aiMentorStudentLessonProgress.studentLessonProgressId),
       eq(studentCourses.status, COURSE_ENROLLMENT.ENROLLED),
       eq(chapters.courseId, courseId),
+      isNull(users.deletedAt),
       or(
         this.getSearchQueryConditions(searchQuery, language),
         sql`${lessonNameExpression} ILIKE ${`%${searchQuery}%`}`,

--- a/apps/api/src/learning-time/learning-time.repository.ts
+++ b/apps/api/src/learning-time/learning-time.repository.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from "@nestjs/common";
 import { COURSE_ENROLLMENT, type SupportedLanguages } from "@repo/shared";
-import { and, countDistinct, eq, ne, sql } from "drizzle-orm";
+import { and, countDistinct, eq, isNull, ne, sql } from "drizzle-orm";
 
 import { DatabasePg } from "src/common";
 import { addPagination, DEFAULT_PAGE_SIZE } from "src/common/pagination";
@@ -79,7 +79,7 @@ export class LearningTimeRepository {
       .innerJoin(users, eq(lessonLearningTime.userId, users.id))
       .innerJoin(lessons, eq(lessonLearningTime.lessonId, lessons.id))
       .innerJoin(courses, eq(lessonLearningTime.courseId, courses.id))
-      .where(eq(lessonLearningTime.courseId, courseId));
+      .where(and(eq(lessonLearningTime.courseId, courseId), isNull(users.deletedAt)));
   }
 
   async getAverageLearningTimePerLesson(courseId: UUIDType, conditions: SQL<unknown>[] = []) {
@@ -92,9 +92,10 @@ export class LearningTimeRepository {
         totalSeconds: sql<number>`SUM(${lessonLearningTime.totalSeconds})::INTEGER`,
       })
       .from(lessonLearningTime)
+      .innerJoin(users, eq(lessonLearningTime.userId, users.id))
       .innerJoin(lessons, eq(lessonLearningTime.lessonId, lessons.id))
       .innerJoin(courses, eq(lessonLearningTime.courseId, courses.id))
-      .where(and(eq(lessonLearningTime.courseId, courseId), ...conditions))
+      .where(and(eq(lessonLearningTime.courseId, courseId), isNull(users.deletedAt), ...conditions))
       .groupBy(
         lessonLearningTime.lessonId,
         lessons.title,
@@ -129,7 +130,9 @@ export class LearningTimeRepository {
       .leftJoin(users, eq(users.id, lessonLearningTime.userId))
       .leftJoin(groupUsers, eq(groupUsers.userId, users.id))
       .leftJoin(groups, eq(groups.id, groupUsers.groupId))
-      .where(and(eq(lessonLearningTime.courseId, courseId), ...conditions));
+      .where(
+        and(eq(lessonLearningTime.courseId, courseId), isNull(users.deletedAt), ...conditions),
+      );
 
     return totalItems ?? 0;
   }
@@ -141,7 +144,10 @@ export class LearningTimeRepository {
         uniqueUsers: sql<number>`COUNT(DISTINCT ${lessonLearningTime.userId})::INTEGER`,
       })
       .from(lessonLearningTime)
-      .where(and(eq(lessonLearningTime.courseId, courseId), ...conditions));
+      .innerJoin(users, eq(lessonLearningTime.userId, users.id))
+      .where(
+        and(eq(lessonLearningTime.courseId, courseId), isNull(users.deletedAt), ...conditions),
+      );
 
     return result[0] ?? { totalSeconds: 0, uniqueUsers: 0 };
   }
@@ -167,7 +173,7 @@ export class LearningTimeRepository {
       .innerJoin(users, eq(lessonLearningTime.userId, users.id))
       .leftJoin(groupUsers, eq(groupUsers.userId, users.id))
       .leftJoin(groups, eq(groups.id, groupUsers.groupId))
-      .where(and(eq(lessonLearningTime.courseId, courseId), ...conditions))
+      .where(and(eq(lessonLearningTime.courseId, courseId), isNull(users.deletedAt), ...conditions))
       .groupBy(
         lessonLearningTime.userId,
         users.firstName,
@@ -182,7 +188,8 @@ export class LearningTimeRepository {
     return this.db
       .select({ id: groupUsers.userId })
       .from(groupUsers)
-      .where(eq(groupUsers.groupId, groupId));
+      .innerJoin(users, eq(users.id, groupUsers.userId))
+      .where(and(eq(groupUsers.groupId, groupId), isNull(users.deletedAt)));
   }
 
   async getStudentsInCourse(courseId: UUIDType) {
@@ -197,6 +204,7 @@ export class LearningTimeRepository {
         and(
           eq(studentCourses.courseId, courseId),
           ne(studentCourses.status, COURSE_ENROLLMENT.NOT_ENROLLED),
+          isNull(users.deletedAt),
         ),
       );
   }
@@ -215,6 +223,7 @@ export class LearningTimeRepository {
         and(
           eq(studentCourses.courseId, courseId),
           ne(studentCourses.status, COURSE_ENROLLMENT.NOT_ENROLLED),
+          isNull(users.deletedAt),
         ),
       )
       .groupBy(groups.id);

--- a/apps/web/app/api/mutations/admin/useBulkDeleteUsers.ts
+++ b/apps/web/app/api/mutations/admin/useBulkDeleteUsers.ts
@@ -3,6 +3,7 @@ import { AxiosError } from "axios";
 import { useTranslation } from "react-i18next";
 
 import { globalSettingsQueryOptions } from "~/api/queries/useGlobalSettings";
+import { invalidateCourseStatisticsQueries } from "~/api/utils/courseStatisticsUtils";
 import { invalidateLearningPathEnrollmentData } from "~/api/utils/invalidateLearningPathEnrollmentData";
 import { useToast } from "~/components/ui/use-toast";
 
@@ -28,6 +29,7 @@ export function useBulkDeleteUsers() {
       await queryClient.invalidateQueries({ queryKey: ["users"] });
       await queryClient.invalidateQueries(globalSettingsQueryOptions);
       await invalidateLearningPathEnrollmentData();
+      await invalidateCourseStatisticsQueries();
 
       return response.data;
     },


### PR DESCRIPTION
## Issue(s)
- #996 

## Overview
Fixes course statistics after student soft delete by excluding deleted users from course statistics reads and refreshing statistics queries after bulk user deletion.

Main changes:
- Exclude soft-deleted users from course statistics overview, progress, quiz results, average quiz score, AI mentor results, and learning-time statistics.
- Exclude soft-deleted users from learning-time helper queries used by course statistics filters and aggregates.
- Invalidate course statistics queries after bulk deleting users so open statistics views refresh without a manual page reload.
- Add e2e coverage for statistics endpoints after a student is soft-deleted.

## Business Value
Admins see accurate course statistics immediately after deleting students. Deleted students no longer remain visible in statistics tables, which also prevents opening result previews for users that can no longer be loaded through the user API.