### PR TITLE
chore: disable enrollment actions until users are selected

### DIFF
--- a/apps/web/app/locales/cs/translation.json
+++ b/apps/web/app/locales/cs/translation.json
@@ -2250,7 +2250,7 @@
       },
       "confirmation": {
         "title": "Potvrďte registraci",
-        "description": "Opravdu chcete vybrané studenty zapsat do tohoto kurzu? Tuto akci nelze vrátit zpět."
+        "description": "Opravdu chcete vybrané studenty zapsat do tohoto kurzu?"
       },
       "enrollGroups": "Zaregistrujte skupiny",
       "enrollGroupsModal": {
@@ -2261,7 +2261,7 @@
       "members": "{{count}} členů",
       "unenrollConfirmation": {
         "title": "Potvrzení odhlášení",
-        "description": "Opravdu chcete zrušit zápis vybraných studentů z tohoto kurzu? Tuto akci nelze vrátit zpět."
+        "description": "Opravdu chcete zrušit zápis vybraných studentů z tohoto kurzu?"
       },
       "toast": {
         "someStudentsUnenrolled": "Tyto studenty nemůžete zrušit, protože {{count}} z nich není zapsáno.",

--- a/apps/web/app/locales/de/translation.json
+++ b/apps/web/app/locales/de/translation.json
@@ -2244,7 +2244,7 @@
       },
       "confirmation": {
         "title": "Bestätigen Sie die Anmeldung",
-        "description": "Sind Sie sicher, dass Sie die ausgewählten Studenten für diesen Kurs anmelden möchten? Diese Aktion kann nicht rückgängig gemacht werden."
+        "description": "Sind Sie sicher, dass Sie die ausgewählten Studenten für diesen Kurs anmelden möchten?"
       },
       "enrollGroups": "Melden Sie Gruppen an",
       "enrollGroupsModal": {
@@ -2255,7 +2255,7 @@
       "members": "{{count}} Mitglieder",
       "unenrollConfirmation": {
         "title": "Abmeldebestätigung",
-        "description": "Sind Sie sicher, dass Sie die ausgewählten Studenten von diesem Kurs abmelden möchten? Diese Aktion kann nicht rückgängig gemacht werden."
+        "description": "Sind Sie sicher, dass Sie die ausgewählten Studenten von diesem Kurs abmelden möchten?"
       },
       "toast": {
         "someStudentsUnenrolled": "Sie können diese Studenten nicht abmelden, da {{count}} von ihnen nicht eingeschrieben sind.",

--- a/apps/web/app/locales/en/translation.json
+++ b/apps/web/app/locales/en/translation.json
@@ -2305,7 +2305,7 @@
       },
       "confirmation": {
         "title": "Confirm enrollment",
-        "description": "Are you sure you want to enroll the selected students in this course? This action cannot be undone."
+        "description": "Are you sure you want to enroll the selected students in this course?"
       },
       "enrollGroups": "Enroll groups",
       "enrollGroupsModal": {
@@ -2316,7 +2316,7 @@
       "members": "{{count}} members",
       "unenrollConfirmation": {
         "title": "Unenroll confirmation",
-        "description": "Are you sure you want to unenroll the selected students from this course? This action cannot be undone."
+        "description": "Are you sure you want to unenroll the selected students from this course?"
       },
       "toast": {
         "someStudentsUnenrolled": "You cannot unenroll these students because {{count}} of them are not enrolled.",

--- a/apps/web/app/locales/lt/translation.json
+++ b/apps/web/app/locales/lt/translation.json
@@ -2250,7 +2250,7 @@
       },
       "confirmation": {
         "title": "Patvirtinti registraciją",
-        "description": "Ar tikrai norite įtraukti pasirinktus studentus į šį kursą? Šio veiksmo anuliuoti negalima."
+        "description": "Ar tikrai norite įtraukti pasirinktus studentus į šį kursą?"
       },
       "enrollGroups": "Registruokitės į grupes",
       "enrollGroupsModal": {
@@ -2261,7 +2261,7 @@
       "members": "{{count}} narių",
       "unenrollConfirmation": {
         "title": "Išsiregistravimo patvirtinimas",
-        "description": "Ar tikrai norite išregistruoti pasirinktus studentus iš šio kurso? Šio veiksmo anuliuoti negalima."
+        "description": "Ar tikrai norite išregistruoti pasirinktus studentus iš šio kurso?"
       },
       "toast": {
         "someStudentsUnenrolled": "Negalite atšaukti šių mokinių registracijos, nes {{count}} iš jų neužregistruoti.",

--- a/apps/web/app/locales/pl/translation.json
+++ b/apps/web/app/locales/pl/translation.json
@@ -2554,11 +2554,11 @@
       },
       "confirmation": {
         "title": "Potwierdź zapis",
-        "description": "Czy na pewno chcesz zapisać wybranych studentów do tego kursu? Tej operacji nie można cofnąć."
+        "description": "Czy na pewno chcesz zapisać wybranych studentów do tego kursu?"
       },
       "unenrollConfirmation": {
         "title": "Potwierdź wypisanie",
-        "description": "Czy na pewno chcesz wypisać wybranych studentów z tego kursu? Tej operacji nie można cofnąć."
+        "description": "Czy na pewno chcesz wypisać wybranych studentów z tego kursu?"
       },
       "successResponse": "studentów zostało zapisanych do kursu."
     },

--- a/apps/web/app/modules/Admin/EditCourse/CourseEnrolled/CourseEnrolled.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/CourseEnrolled/CourseEnrolled.tsx
@@ -385,6 +385,7 @@ export const CourseEnrolled = ({ language }: CourseEnrolledProps): ReactElement 
   const page = pagination?.page ?? searchParams.page ?? 1;
   const perPage = pagination?.perPage ?? searchParams.perPage ?? ITEMS_PER_PAGE_OPTIONS[0];
   const totalItems = pagination?.totalItems ?? usersData.length;
+  const hasSelectedUsers = Object.values(rowSelection).some(Boolean);
 
   const handlePageChange = (page: number) =>
     startTransition(() => setSearchParams((prev) => ({ ...prev, page })));
@@ -442,10 +443,11 @@ export const CourseEnrolled = ({ language }: CourseEnrolledProps): ReactElement 
               data-testid={COURSE_ENROLLED_HANDLES.USER_ACTIONS_TRIGGER}
               variant="outline"
               className="flex gap-2"
+              disabled={!hasSelectedUsers}
             >
               <User className="size-4" />
               {t("adminCourseView.enrolled.enroll")}
-              <Icon className="size-4 text-black" name={openDropdown ? "ArrowUp" : "ArrowDown"} />
+              <Icon className="size-4" name={openDropdown ? "ArrowUp" : "ArrowDown"} />
             </Button>
           </DropdownMenuTrigger>
 

--- a/apps/web/e2e/specs/course-enrollment/course-enrolled-users-list.spec.ts
+++ b/apps/web/e2e/specs/course-enrollment/course-enrolled-users-list.spec.ts
@@ -66,6 +66,11 @@ test("admin can verify enrolled users and filter by keyword and group", async ({
       ),
     ).toBeVisible();
 
+    const userActionsTrigger = page.getByTestId(COURSE_ENROLLED_HANDLES.USER_ACTIONS_TRIGGER);
+    await expect(userActionsTrigger).toBeDisabled();
+    await page.getByTestId(COURSE_ENROLLED_HANDLES.row(notEnrolledUser.id)).click();
+    await expect(userActionsTrigger).toBeEnabled();
+
     await page.getByTestId(COURSE_ENROLLED_HANDLES.sortButton("email")).click();
     await expect(page.getByTestId(COURSE_ENROLLED_HANDLES.row(directUser.id))).toBeVisible();
 


### PR DESCRIPTION
## Issue(s)
- #1269 

## Overview
This PR updates the course enrollment user actions so the enroll dropdown is disabled when no users are selected, matching the behavior used in the users list.

It also removes the inaccurate "cannot be undone" wording from course enroll and unenroll confirmation messages across all supported locale files.

## Business Value
Admins get clearer feedback when managing course enrollments: unavailable bulk actions are visibly disabled until a selection is made, which reduces accidental clicks and keeps the UI consistent across admin lists.

The confirmation copy is now more accurate because course enrollment changes can be reversed.

## Screenshots / Video

https://github.com/user-attachments/assets/8751ece9-a870-4e94-a617-c39917120532

