### PR TITLE
test: add coverage for course discussions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -60,7 +60,7 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4, 5]
     env:
-      E2E_BROWSER: ${{ github.event_name == 'push' && github.ref_name == 'staging' && 'chromium' || (github.event_name == 'push' && 'all' || (inputs.browser || 'all')) }}
+      E2E_BROWSER: ${{ github.event_name == 'push' && 'chromium' || (inputs.browser || 'all') }}
       PLAYWRIGHT_SHARD: ${{ matrix.shard }}
 
     services:

--- a/README.md
+++ b/README.md
@@ -54,25 +54,29 @@ A modern, scalable Learning Management System built with cutting-edge technologi
 </div>
 
 ### 🤖 AI-Powered Training
-* **Voice & Chat AI Mentor:** Immersive, real-time role-play simulations for sales, compliance, and customer support training with instant, automated AI evaluation.
-* **AI Course Architect:** Transform raw corporate knowledge bases, documentation, and internal policies into structured interactive courses in minutes.
-* **Automated Scenario Grading:** AI-driven analysis and actionable feedback for open-ended problem-solving and behavioral tasks, reducing manual L&D workload.
+
+- **Voice & Chat AI Mentor:** Immersive, real-time role-play simulations for sales, compliance, and customer support training with instant, automated AI evaluation.
+- **AI Course Architect:** Transform raw corporate knowledge bases, documentation, and internal policies into structured interactive courses in minutes.
+- **Automated Scenario Grading:** AI-driven analysis and actionable feedback for open-ended problem-solving and behavioral tasks, reducing manual L&D workload.
 
 ### 🏢 Enterprise & White-Label Readiness
-* **Full White-Label Architecture:** Complete rebranding capabilities (custom domains, logos, custom styles) to perfectly match corporate identity.
-* **Multi-Tenancy Infrastructure:** Secure, isolated multi-tenant architecture designed for large corporate environments, holding companies, or B2B training vendors.
-* **Enterprise Configuration Hub:** Centralized admin toggles for seamless, zero-code activation of corporate infrastructure, including Corporate SSO (Microsoft 365 & Google Workspace Sign-In) and AI API provider management (e.g., OpenAI).
-  
+
+- **Full White-Label Architecture:** Complete rebranding capabilities (custom domains, logos, custom styles) to perfectly match corporate identity.
+- **Multi-Tenancy Infrastructure:** Secure, isolated multi-tenant architecture designed for large corporate environments, holding companies, or B2B training vendors.
+- **Enterprise Configuration Hub:** Centralized admin toggles for seamless, zero-code activation of corporate infrastructure, including Corporate SSO (Microsoft 365 & Google Workspace Sign-In) and AI API provider management (e.g., OpenAI).
+
 ### 📊 Corporate L&D & Engagement Engine
-* **Dynamic Organization Mapping:** Advanced group and user management designed to seamlessly mirror complex corporate hierarchies (Departments, Branches, Teams) with automated course access inheritance.
-* **Automated Recertification & Compliance:** Set recurring expiration dates for mandatory corporate training (e.g., Compliance, Safety, Cyber Security) with automated re-enrollment and smart notification schedules.
-* **Consumer-Grade UI/UX:** A clean, distraction-free, modern interface inspired by top consumer apps to maximize employee adoption, engagement, and course completion rates.
-* **Next-Gen Assessment Engine:** Multi-format testing including behavioral scenarios, short/long-form text analysis, dynamic quizzes, and gamified consistency systems (Daily Streaks).
-* **Deep Analytics & Insights:** Granular tracking of user engagement, learning consistency, and practical training outcomes for L&D managers.
+
+- **Dynamic Organization Mapping:** Advanced group and user management designed to seamlessly mirror complex corporate hierarchies (Departments, Branches, Teams) with automated course access inheritance.
+- **Automated Recertification & Compliance:** Set recurring expiration dates for mandatory corporate training (e.g., Compliance, Safety, Cyber Security) with automated re-enrollment and smart notification schedules.
+- **Consumer-Grade UI/UX:** A clean, distraction-free, modern interface inspired by top consumer apps to maximize employee adoption, engagement, and course completion rates.
+- **Next-Gen Assessment Engine:** Multi-format testing including behavioral scenarios, short/long-form text analysis, dynamic quizzes, and gamified consistency systems (Daily Streaks).
+- **Deep Analytics & Insights:** Granular tracking of user engagement, learning consistency, and practical training outcomes for L&D managers.
 
 ### 🧠 Knowledge Management & CMS
-* **Corporate Knowledge Repository:** Centralized, secure storage for organization-wide documentation, internal playbooks, and assets.
-* **Internal Q&A & News Hub:** Keep remote and hybrid teams aligned with a built-in corporate blog, announcement modules, and dynamic internal FAQ sections.
+
+- **Corporate Knowledge Repository:** Centralized, secure storage for organization-wide documentation, internal playbooks, and assets.
+- **Internal Q&A & News Hub:** Keep remote and hybrid teams aligned with a built-in corporate blog, announcement modules, and dynamic internal FAQ sections.
 
 </br>
 <div align="center">

--- a/apps/web/app/modules/Courses/CourseView/CourseChat/ChatMessage.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseChat/ChatMessage.tsx
@@ -10,6 +10,8 @@ import {
 import { UserAvatar } from "~/components/UserProfile/UserAvatar";
 import { cn } from "~/lib/utils";
 
+import { COURSE_DISCUSSION_HANDLES } from "../../../../../e2e/data/courses/handles";
+
 import { ChatMessageActions } from "./ChatMessageActions";
 import { renderMessageContent } from "./courseChatUtils";
 import { DeleteCourseChatMessageDialog } from "./DeleteCourseChatMessageDialog";
@@ -65,7 +67,10 @@ export function ChatMessage({
   };
 
   return (
-    <div className="group flex w-full min-w-0 gap-2.5">
+    <div
+      className="group flex w-full min-w-0 gap-2.5"
+      data-testid={COURSE_DISCUSSION_HANDLES.message(message.id)}
+    >
       {showAvatar && !isDeleted ? (
         <MessageAvatar
           userName={authorName}
@@ -103,6 +108,7 @@ export function ChatMessage({
               "rounded-tl-md",
               messageBubbleClassName,
             )}
+            data-testid={COURSE_DISCUSSION_HANDLES.messageContent(message.id)}
           >
             <p className={cn("whitespace-pre-wrap break-words", { italic: isDeleted })}>
               {isDeleted
@@ -123,6 +129,10 @@ export function ChatMessage({
                 tooltip={t("studentCourseView.courseChat.reactWith", {
                   reaction: reactionSummary.reaction,
                 })}
+                testId={COURSE_DISCUSSION_HANDLES.messageReactionSummary(
+                  message.id,
+                  reactionSummary.reaction,
+                )}
                 onClick={() =>
                   toggleReaction.mutate({
                     messageId: message.id,

--- a/apps/web/app/modules/Courses/CourseView/CourseChat/ChatMessageActions.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseChat/ChatMessageActions.tsx
@@ -8,6 +8,8 @@ import {
 import { Button } from "~/components/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "~/components/ui/tooltip";
 
+import { COURSE_DISCUSSION_HANDLES } from "../../../../../e2e/data/courses/handles";
+
 import { ReactionButton } from "./ReactionButton";
 
 import type { CourseChatMessageReaction } from "~/api/queries/course-chat/courseChatTypes";
@@ -48,6 +50,7 @@ export function ChatMessageActions({
           disabled={toggleReaction.isPending}
           tooltip={reactWithLabel(reaction)}
           compact
+          testId={COURSE_DISCUSSION_HANDLES.messageReactionAction(messageId, reaction)}
           onClick={() => toggleReaction.mutate({ messageId, reaction })}
         />
       ))}
@@ -61,6 +64,7 @@ export function ChatMessageActions({
                 size="xs"
                 aria-label={t("studentCourseView.courseChat.reply")}
                 className="size-6 rounded-full p-0 text-neutral-600 hover:bg-primary-50 hover:text-primary-700"
+                data-testid={COURSE_DISCUSSION_HANDLES.messageReplyAction(messageId)}
                 onClick={onReply}
               >
                 <Reply className="size-3.5" />
@@ -81,6 +85,7 @@ export function ChatMessageActions({
                 aria-label={t("studentCourseView.courseChat.deleteMessage")}
                 className="size-6 rounded-full p-0 text-neutral-600 hover:bg-red-50 hover:text-red-700"
                 disabled={isDeleting}
+                data-testid={COURSE_DISCUSSION_HANDLES.messageDeleteAction(messageId)}
                 onClick={onDelete}
               >
                 <Trash2 className="size-3.5" />

--- a/apps/web/app/modules/Courses/CourseView/CourseChat/CourseChatMessageForm.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseChat/CourseChatMessageForm.tsx
@@ -27,6 +27,13 @@ type CourseChatMessageFormProps = {
   wrapperClassName?: string;
   textareaClassName?: string;
   autoFocus?: boolean;
+  testIds?: {
+    form?: string;
+    input?: string;
+    sendButton?: string;
+    mentionList?: string;
+    mentionOption?: (userId: string) => string;
+  };
 };
 
 export function CourseChatMessageForm({
@@ -38,6 +45,7 @@ export function CourseChatMessageForm({
   wrapperClassName,
   textareaClassName,
   autoFocus,
+  testIds,
 }: CourseChatMessageFormProps) {
   const { t } = useTranslation();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -63,7 +71,7 @@ export function CourseChatMessageForm({
   };
 
   return (
-    <form className={formClassName} onSubmit={handleSubmit}>
+    <form className={formClassName} data-testid={testIds?.form} onSubmit={handleSubmit}>
       <div className={wrapperClassName}>
         <Controller
           control={form.control}
@@ -78,6 +86,11 @@ export function CourseChatMessageForm({
               placeholder={placeholder}
               maxLength={5000}
               className={textareaClassName}
+              testIds={{
+                input: testIds?.input,
+                mentionList: testIds?.mentionList,
+                mentionOption: testIds?.mentionOption,
+              }}
             />
           )}
         />
@@ -87,6 +100,7 @@ export function CourseChatMessageForm({
           className="size-8 self-end rounded-lg p-0"
           aria-label={t("studentCourseView.courseChat.send")}
           disabled={!content.trim() || isSubmitting}
+          data-testid={testIds?.sendButton}
         >
           <Send className="size-4" />
         </Button>

--- a/apps/web/app/modules/Courses/CourseView/CourseChat/CourseChatStates.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseChat/CourseChatStates.tsx
@@ -1,8 +1,11 @@
 import { Skeleton } from "~/components/ui/skeleton";
 
-export function EmptyState({ text }: { text: string }) {
+export function EmptyState({ text, testId }: { text: string; testId?: string }) {
   return (
-    <div className="rounded-lg border border-dashed border-neutral-300 bg-background p-6 text-center">
+    <div
+      className="rounded-lg border border-dashed border-neutral-300 bg-background p-6 text-center"
+      data-testid={testId}
+    >
       <p className="body-sm text-neutral-600">{text}</p>
     </div>
   );

--- a/apps/web/app/modules/Courses/CourseView/CourseChat/CourseChatTab.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseChat/CourseChatTab.tsx
@@ -13,6 +13,8 @@ import { Pagination } from "~/components/Pagination/Pagination";
 import { Card, CardContent } from "~/components/ui/card";
 import { useToast } from "~/components/ui/use-toast";
 
+import { COURSE_DISCUSSION_HANDLES } from "../../../../../e2e/data/courses/handles";
+
 import { CourseChatMessageForm } from "./CourseChatMessageForm";
 import { EmptyState, MainFeedSkeleton } from "./CourseChatStates";
 import { getMentionedUserIds } from "./courseChatUtils";
@@ -123,10 +125,18 @@ export function CourseChatTab({
         />
       )),
     )
-    .otherwise(() => <EmptyState text={t("studentCourseView.courseChat.emptyThreads")} />);
+    .otherwise(() => (
+      <EmptyState
+        text={t("studentCourseView.courseChat.emptyThreads")}
+        testId={COURSE_DISCUSSION_HANDLES.EMPTY_STATE}
+      />
+    ));
 
   return (
-    <Card className="overflow-hidden border-neutral-200 shadow-sm">
+    <Card
+      className="overflow-hidden border-neutral-200 shadow-sm"
+      data-testid={COURSE_DISCUSSION_HANDLES.ROOT}
+    >
       <CardContent className="min-h-[560px] bg-neutral-50 p-0">
         <div className="flex min-w-0 flex-col">
           <div className="flex flex-1 flex-col gap-3 overflow-y-auto px-3 py-4 md:px-5">
@@ -152,6 +162,13 @@ export function CourseChatTab({
             formClassName="border-t border-neutral-200 bg-background p-3 md:px-5"
             wrapperClassName="flex flex-col gap-1.5 rounded-lg border border-neutral-200 bg-background p-1.5 shadow-sm transition focus-within:border-primary-300 focus-within:ring-2 focus-within:ring-primary-100"
             textareaClassName="min-h-6 resize-none overflow-hidden border-0 px-1 py-0.5 text-sm leading-5 shadow-none focus-visible:ring-0"
+            testIds={{
+              form: COURSE_DISCUSSION_HANDLES.THREAD_FORM,
+              input: COURSE_DISCUSSION_HANDLES.THREAD_INPUT,
+              sendButton: COURSE_DISCUSSION_HANDLES.THREAD_SEND_BUTTON,
+              mentionList: COURSE_DISCUSSION_HANDLES.THREAD_MENTION_LIST,
+              mentionOption: COURSE_DISCUSSION_HANDLES.threadMentionOption,
+            }}
           />
         </div>
       </CardContent>

--- a/apps/web/app/modules/Courses/CourseView/CourseChat/DeleteCourseChatMessageDialog.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseChat/DeleteCourseChatMessageDialog.tsx
@@ -8,6 +8,8 @@ import {
   DialogTitle,
 } from "~/components/ui/dialog";
 
+import { COURSE_DISCUSSION_HANDLES } from "../../../../../e2e/data/courses/handles";
+
 type DeleteCourseChatMessageDialogProps = {
   open: boolean;
   isDeleting: boolean;
@@ -31,7 +33,7 @@ export function DeleteCourseChatMessageDialog({
 }: DeleteCourseChatMessageDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
+      <DialogContent data-testid={COURSE_DISCUSSION_HANDLES.DELETE_DIALOG}>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription>{description}</DialogDescription>
@@ -42,10 +44,17 @@ export function DeleteCourseChatMessageDialog({
             variant="outline"
             onClick={() => onOpenChange(false)}
             disabled={isDeleting}
+            data-testid={COURSE_DISCUSSION_HANDLES.DELETE_DIALOG_CANCEL_BUTTON}
           >
             {cancelLabel}
           </Button>
-          <Button type="button" variant="destructive" onClick={onConfirm} disabled={isDeleting}>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={onConfirm}
+            disabled={isDeleting}
+            data-testid={COURSE_DISCUSSION_HANDLES.DELETE_DIALOG_CONFIRM_BUTTON}
+          >
             {deleteLabel}
           </Button>
         </DialogFooter>

--- a/apps/web/app/modules/Courses/CourseView/CourseChat/MainThreadMessage.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseChat/MainThreadMessage.tsx
@@ -8,6 +8,8 @@ import { UserAvatar } from "~/components/UserProfile/UserAvatar";
 import { useLanguageStore } from "~/modules/Dashboard/Settings/Language/LanguageStore";
 import { getDateLocale } from "~/utils/getDateLocale";
 
+import { COURSE_DISCUSSION_HANDLES } from "../../../../../e2e/data/courses/handles";
+
 import { ChatMessage } from "./ChatMessage";
 import { CourseChatMessageForm } from "./CourseChatMessageForm";
 import { MessagesSkeleton } from "./CourseChatStates";
@@ -95,7 +97,10 @@ export function MainThreadMessage({
     .otherwise(() => null);
 
   return (
-    <article className="rounded-2xl bg-transparent">
+    <article
+      className="rounded-2xl bg-transparent"
+      data-testid={COURSE_DISCUSSION_HANDLES.thread(message.id)}
+    >
       <ChatMessage
         message={message}
         users={users}
@@ -117,6 +122,7 @@ export function MainThreadMessage({
           variant="ghost"
           size="sm"
           className="h-6 gap-1.5 px-2 text-xs text-neutral-600"
+          data-testid={COURSE_DISCUSSION_HANDLES.repliesToggle(message.id)}
           onClick={onToggle}
         >
           <MessagesSquare className="size-3.5" />
@@ -128,7 +134,10 @@ export function MainThreadMessage({
       </div>
 
       {isOpen && (
-        <div className="mt-1.5 border-l border-primary-100 pl-3 md:ml-10">
+        <div
+          className="mt-1.5 border-l border-primary-100 pl-3 md:ml-10"
+          data-testid={COURSE_DISCUSSION_HANDLES.replies(message.id)}
+        >
           <div className="flex flex-col gap-2.5 pr-2">
             {repliesContent}
 
@@ -154,6 +163,11 @@ export function MainThreadMessage({
                 formClassName="flex flex-col gap-2"
                 wrapperClassName="flex flex-col gap-1.5 rounded-lg border border-neutral-200 bg-background p-1.5 shadow-sm transition focus-within:border-primary-300 focus-within:ring-2 focus-within:ring-primary-100"
                 textareaClassName="min-h-6 resize-none overflow-hidden border-0 px-1 py-0.5 text-sm leading-5 shadow-none focus-visible:ring-0"
+                testIds={{
+                  form: COURSE_DISCUSSION_HANDLES.replyForm(message.id),
+                  input: COURSE_DISCUSSION_HANDLES.replyInput(message.id),
+                  sendButton: COURSE_DISCUSSION_HANDLES.replySendButton(message.id),
+                }}
               />
             )}
           </div>

--- a/apps/web/app/modules/Courses/CourseView/CourseChat/MentionTextarea.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseChat/MentionTextarea.tsx
@@ -17,10 +17,15 @@ type MentionTextareaProps = {
   placeholder: string;
   maxLength: number;
   className?: string;
+  testIds?: {
+    input?: string;
+    mentionList?: string;
+    mentionOption?: (userId: string) => string;
+  };
 };
 
 export const MentionTextarea = forwardRef<HTMLTextAreaElement, MentionTextareaProps>(
-  ({ value, onChange, onKeyDown, users, placeholder, maxLength, className }, ref) => {
+  ({ value, onChange, onKeyDown, users, placeholder, maxLength, className, testIds }, ref) => {
     const textareaRef = useRef<HTMLTextAreaElement | null>(null);
     const [highlightedIndex, setHighlightedIndex] = useState(0);
     const [isPickerDismissed, setIsPickerDismissed] = useState(false);
@@ -112,9 +117,13 @@ export const MentionTextarea = forwardRef<HTMLTextAreaElement, MentionTextareaPr
           maxLength={maxLength}
           rows={1}
           className={className}
+          data-testid={testIds?.input}
         />
         {matchingUsers.length > 0 && (
-          <div className="absolute bottom-full left-0 z-10 mb-2 w-72 rounded-xl border border-neutral-200 bg-background p-2 shadow-lg">
+          <div
+            className="absolute bottom-full left-0 z-10 mb-2 w-72 rounded-xl border border-neutral-200 bg-background p-2 shadow-lg"
+            data-testid={testIds?.mentionList}
+          >
             {matchingUsers.map((user, index) => {
               const userName = getUserDisplayName(user);
 
@@ -126,6 +135,7 @@ export const MentionTextarea = forwardRef<HTMLTextAreaElement, MentionTextareaPr
                     "flex w-full items-center gap-3 rounded-lg p-2 text-left hover:bg-neutral-50",
                     { "bg-neutral-50": index === highlightedIndex },
                   )}
+                  data-testid={testIds?.mentionOption?.(user.id)}
                   onMouseDown={(event) => {
                     event.preventDefault();
                     insertMention(user);

--- a/apps/web/app/modules/Courses/CourseView/CourseChat/ReactionButton.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseChat/ReactionButton.tsx
@@ -8,6 +8,7 @@ type ReactionButtonProps = {
   disabled: boolean;
   tooltip: string;
   compact?: boolean;
+  testId?: string;
   onClick: () => void;
 };
 
@@ -18,6 +19,7 @@ export function ReactionButton({
   disabled,
   tooltip,
   compact = false,
+  testId,
   onClick,
 }: ReactionButtonProps) {
   return (
@@ -36,6 +38,7 @@ export function ReactionButton({
               },
             )}
             disabled={disabled}
+            data-testid={testId}
             onClick={onClick}
           >
             <span aria-hidden className="text-[12px] leading-none">

--- a/apps/web/app/modules/Courses/CourseView/CourseView.page.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseView.page.tsx
@@ -3,6 +3,7 @@ import { ACCESS_GUARD, PERMISSIONS, SUPPORTED_LANGUAGES } from "@repo/shared";
 import { isAxiosError } from "axios";
 import { useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import { match } from "ts-pattern";
 
 import { courseLookupQueryOptions, useCourse, useCurrentUser } from "~/api/queries";
 import { useGlobalSettings } from "~/api/queries/useGlobalSettings";
@@ -21,6 +22,7 @@ import { LearningModeBanner } from "~/modules/Courses/Lesson/LearningModeBanner"
 import { useLanguageStore } from "~/modules/Dashboard/Settings/Language/LanguageStore";
 import { isSupportedLanguage } from "~/utils/browser-language";
 
+import { COURSE_DISCUSSION_HANDLES } from "../../../../e2e/data/courses/handles";
 import { COURSE_STATISTICS_HANDLES } from "../../../../e2e/data/statistics/handles";
 
 import { ChapterListOverview } from "./components/ChapterListOverview";
@@ -36,6 +38,12 @@ const COURSE_VIEW_TAB_QUERY_VALUES = {
   MORE_FROM_AUTHOR: "MoreFromAuthor",
   STATISTICS: "Statistics",
 } as const;
+
+const getCourseViewTabTestId = (tabValue: string) =>
+  match(tabValue)
+    .with("chat", () => COURSE_DISCUSSION_HANDLES.TAB)
+    .with("statistics", () => COURSE_STATISTICS_HANDLES.COURSE_VIEW_STATISTICS_TAB)
+    .otherwise(() => undefined);
 
 const resolvePreferredLanguage = (url: URL): SupportedLanguages => {
   const languageFromQuery = url.searchParams.get("language");
@@ -245,11 +253,7 @@ export default function CourseViewPage() {
                     <TabsTrigger
                       key={tab.value}
                       value={tab.value}
-                      data-testid={
-                        tab.value === "statistics"
-                          ? COURSE_STATISTICS_HANDLES.COURSE_VIEW_STATISTICS_TAB
-                          : undefined
-                      }
+                      data-testid={getCourseViewTabTestId(tab.value)}
                       className="flex h-full rounded-none items-center gap-1.5 data-[state=active]:shadow-none text-neutral-900 data-[state=active]:text-primary-700 data-[state=active]:border-b-2 data-[state=active]:border-b-primary-700"
                     >
                       <span className="body-sm">{tab.title}</span>{" "}

--- a/apps/web/e2e/data/courses/handles.ts
+++ b/apps/web/e2e/data/courses/handles.ts
@@ -141,6 +141,36 @@ export const COURSE_OVERVIEW_HANDLES = {
   START_LEARNING_BUTTON: "course-overview-start-learning-button",
 } as const;
 
+const reactionHandleValue = (reaction: string) => reaction.codePointAt(0)?.toString(16) ?? reaction;
+
+export const COURSE_DISCUSSION_HANDLES = {
+  TAB: "course-discussion-tab",
+  ROOT: "course-discussion-root",
+  EMPTY_STATE: "course-discussion-empty-state",
+  THREAD_FORM: "course-discussion-thread-form",
+  THREAD_INPUT: "course-discussion-thread-input",
+  THREAD_SEND_BUTTON: "course-discussion-thread-send-button",
+  THREAD_MENTION_LIST: "course-discussion-thread-mention-list",
+  threadMentionOption: (userId: string) => `course-discussion-thread-mention-option-${userId}`,
+  thread: (messageId: string) => `course-discussion-thread-${messageId}`,
+  message: (messageId: string) => `course-discussion-message-${messageId}`,
+  messageContent: (messageId: string) => `course-discussion-message-content-${messageId}`,
+  messageReplyAction: (messageId: string) => `course-discussion-message-reply-${messageId}`,
+  messageDeleteAction: (messageId: string) => `course-discussion-message-delete-${messageId}`,
+  messageReactionAction: (messageId: string, reaction: string) =>
+    `course-discussion-message-reaction-action-${messageId}-${reactionHandleValue(reaction)}`,
+  messageReactionSummary: (messageId: string, reaction: string) =>
+    `course-discussion-message-reaction-summary-${messageId}-${reactionHandleValue(reaction)}`,
+  repliesToggle: (messageId: string) => `course-discussion-replies-toggle-${messageId}`,
+  replies: (messageId: string) => `course-discussion-replies-${messageId}`,
+  replyForm: (messageId: string) => `course-discussion-reply-form-${messageId}`,
+  replyInput: (messageId: string) => `course-discussion-reply-input-${messageId}`,
+  replySendButton: (messageId: string) => `course-discussion-reply-send-button-${messageId}`,
+  DELETE_DIALOG: "course-discussion-delete-dialog",
+  DELETE_DIALOG_CANCEL_BUTTON: "course-discussion-delete-dialog-cancel-button",
+  DELETE_DIALOG_CONFIRM_BUTTON: "course-discussion-delete-dialog-confirm-button",
+} as const;
+
 export const COURSE_ENROLLED_HANDLES = {
   ROOT: "course-enrolled-root",
   SEARCH_INPUT: "course-enrolled-search-input",

--- a/apps/web/e2e/flows/courses/delete-course-discussion-message.flow.ts
+++ b/apps/web/e2e/flows/courses/delete-course-discussion-message.flow.ts
@@ -1,0 +1,9 @@
+import { COURSE_DISCUSSION_HANDLES } from "../../data/courses/handles";
+
+import type { Page } from "@playwright/test";
+
+export const deleteCourseDiscussionMessageFlow = async (page: Page, messageId: string) => {
+  await page.getByTestId(COURSE_DISCUSSION_HANDLES.message(messageId)).hover();
+  await page.getByTestId(COURSE_DISCUSSION_HANDLES.messageDeleteAction(messageId)).click();
+  await page.getByTestId(COURSE_DISCUSSION_HANDLES.DELETE_DIALOG_CONFIRM_BUTTON).click();
+};

--- a/apps/web/e2e/flows/courses/open-course-discussion-replies.flow.ts
+++ b/apps/web/e2e/flows/courses/open-course-discussion-replies.flow.ts
@@ -1,0 +1,7 @@
+import { COURSE_DISCUSSION_HANDLES } from "../../data/courses/handles";
+
+import type { Page } from "@playwright/test";
+
+export const openCourseDiscussionRepliesFlow = async (page: Page, messageId: string) => {
+  await page.getByTestId(COURSE_DISCUSSION_HANDLES.repliesToggle(messageId)).click();
+};

--- a/apps/web/e2e/flows/courses/open-course-discussion.flow.ts
+++ b/apps/web/e2e/flows/courses/open-course-discussion.flow.ts
@@ -1,0 +1,9 @@
+import { COURSE_DISCUSSION_HANDLES } from "../../data/courses/handles";
+import { openCourseOverviewFlow } from "../learning/open-course-overview.flow";
+
+import type { Page } from "@playwright/test";
+
+export const openCourseDiscussionFlow = async (page: Page, courseIdOrSlug: string) => {
+  await openCourseOverviewFlow(page, courseIdOrSlug);
+  await page.getByTestId(COURSE_DISCUSSION_HANDLES.TAB).click();
+};

--- a/apps/web/e2e/flows/courses/react-to-course-discussion-message.flow.ts
+++ b/apps/web/e2e/flows/courses/react-to-course-discussion-message.flow.ts
@@ -1,0 +1,14 @@
+import { COURSE_DISCUSSION_HANDLES } from "../../data/courses/handles";
+
+import type { Page } from "@playwright/test";
+
+export const reactToCourseDiscussionMessageFlow = async (
+  page: Page,
+  messageId: string,
+  reaction: string,
+) => {
+  await page.getByTestId(COURSE_DISCUSSION_HANDLES.message(messageId)).hover();
+  await page
+    .getByTestId(COURSE_DISCUSSION_HANDLES.messageReactionAction(messageId, reaction))
+    .click();
+};

--- a/apps/web/e2e/flows/courses/select-course-discussion-mention.flow.ts
+++ b/apps/web/e2e/flows/courses/select-course-discussion-mention.flow.ts
@@ -1,0 +1,12 @@
+import { COURSE_DISCUSSION_HANDLES } from "../../data/courses/handles";
+
+import type { Page } from "@playwright/test";
+
+export const selectCourseDiscussionMentionFlow = async (
+  page: Page,
+  query: string,
+  userId: string,
+) => {
+  await page.getByTestId(COURSE_DISCUSSION_HANDLES.THREAD_INPUT).fill(`@${query}`);
+  await page.getByTestId(COURSE_DISCUSSION_HANDLES.threadMentionOption(userId)).click();
+};

--- a/apps/web/e2e/flows/courses/submit-course-discussion-reply.flow.ts
+++ b/apps/web/e2e/flows/courses/submit-course-discussion-reply.flow.ts
@@ -1,0 +1,12 @@
+import { COURSE_DISCUSSION_HANDLES } from "../../data/courses/handles";
+
+import type { Page } from "@playwright/test";
+
+export const submitCourseDiscussionReplyFlow = async (
+  page: Page,
+  messageId: string,
+  content: string,
+) => {
+  await page.getByTestId(COURSE_DISCUSSION_HANDLES.replyInput(messageId)).fill(content);
+  await page.getByTestId(COURSE_DISCUSSION_HANDLES.replySendButton(messageId)).click();
+};

--- a/apps/web/e2e/flows/courses/submit-course-discussion-thread.flow.ts
+++ b/apps/web/e2e/flows/courses/submit-course-discussion-thread.flow.ts
@@ -1,0 +1,8 @@
+import { COURSE_DISCUSSION_HANDLES } from "../../data/courses/handles";
+
+import type { Page } from "@playwright/test";
+
+export const submitCourseDiscussionThreadFlow = async (page: Page, content: string) => {
+  await page.getByTestId(COURSE_DISCUSSION_HANDLES.THREAD_INPUT).fill(content);
+  await page.getByTestId(COURSE_DISCUSSION_HANDLES.THREAD_SEND_BUTTON).click();
+};

--- a/apps/web/e2e/flows/learning/open-course-overview.flow.ts
+++ b/apps/web/e2e/flows/learning/open-course-overview.flow.ts
@@ -1,5 +1,8 @@
 import type { Page } from "@playwright/test";
 
 export const openCourseOverviewFlow = async (page: Page, courseIdOrSlug: string) => {
-  await page.goto(`/course/${courseIdOrSlug}`);
+  const path = `/course/${courseIdOrSlug}`;
+  const currentUrl = page.url();
+
+  await page.goto(currentUrl === "about:blank" ? path : new URL(path, currentUrl).toString());
 };

--- a/apps/web/e2e/specs/courses/course-discussions.spec.ts
+++ b/apps/web/e2e/specs/courses/course-discussions.spec.ts
@@ -1,0 +1,319 @@
+import { randomUUID } from "node:crypto";
+
+import { USER_ROLE } from "~/config/userRoles";
+
+import { COURSE_DISCUSSION_HANDLES } from "../../data/courses/handles";
+import { expect, test } from "../../fixtures/test.fixture";
+import { deleteCourseDiscussionMessageFlow } from "../../flows/courses/delete-course-discussion-message.flow";
+import { openCourseDiscussionRepliesFlow } from "../../flows/courses/open-course-discussion-replies.flow";
+import { openCourseDiscussionFlow } from "../../flows/courses/open-course-discussion.flow";
+import { reactToCourseDiscussionMessageFlow } from "../../flows/courses/react-to-course-discussion-message.flow";
+import { selectCourseDiscussionMentionFlow } from "../../flows/courses/select-course-discussion-mention.flow";
+import { submitCourseDiscussionReplyFlow } from "../../flows/courses/submit-course-discussion-reply.flow";
+import { submitCourseDiscussionThreadFlow } from "../../flows/courses/submit-course-discussion-thread.flow";
+import { openCourseOverviewFlow } from "../../flows/learning/open-course-overview.flow";
+
+import type { IsolatedWorkspaceHandle, TenantUserHandle } from "../../fixtures/test.fixture";
+import type { FixtureApiClient } from "../../utils/api-client";
+import type {
+  GetMessagesResponse,
+  GetPublicGlobalSettingsResponse,
+  GetRepliesResponse,
+} from "~/api/generated-api";
+
+type GlobalSettings = GetPublicGlobalSettingsResponse["data"];
+type CourseDiscussionThread = GetMessagesResponse["data"][number];
+type CourseDiscussionReply = GetRepliesResponse["data"][number];
+
+type DiscussionCourseSetup = {
+  courseId: string;
+  studentSession: TenantUserHandle;
+};
+
+const DISCUSSION_REACTION = "👍";
+
+const uniqueLabel = (prefix: string) => `${prefix}-${randomUUID().slice(0, 8)}`;
+
+const getGlobalSettings = async (apiClient: FixtureApiClient): Promise<GlobalSettings> => {
+  const response = await apiClient.api.settingsControllerGetPublicGlobalSettings();
+
+  return response.data.data;
+};
+
+const setCourseDiscussionsEnabled = async (apiClient: FixtureApiClient, enabled: boolean) => {
+  const settings = await getGlobalSettings(apiClient);
+
+  if (settings.courseDiscussionsEnabled !== enabled) {
+    await apiClient.api.settingsControllerUpdateCourseDiscussionsEnabled();
+  }
+};
+
+const createDiscussionCourseSetup = async (
+  workspace: IsolatedWorkspaceHandle,
+  enabled: boolean,
+): Promise<DiscussionCourseSetup> => {
+  await setCourseDiscussionsEnabled(workspace.apiClient, enabled);
+
+  const categoryFactory = workspace.factories.createCategoryFactory();
+  const courseFactory = workspace.factories.createCourseFactory();
+  const enrollmentFactory = workspace.factories.createEnrollmentFactory();
+  const category = await categoryFactory.create(uniqueLabel("Discussion Category"));
+  const course = await courseFactory.create({
+    title: uniqueLabel("discussion-course"),
+    categoryId: category.id,
+    status: "published",
+  });
+  const studentSession = await workspace.createTenantUserWithPasswordAndRole({
+    firstName: "Discussion",
+    lastName: "Student",
+    role: USER_ROLE.student,
+  });
+
+  await enrollmentFactory.enrollUsers(course.id, [studentSession.user.id]);
+
+  return {
+    courseId: course.id,
+    studentSession,
+  };
+};
+
+const findThreadByContent = async (
+  apiClient: FixtureApiClient,
+  courseId: string,
+  content: string,
+) => {
+  const response = await apiClient.api.courseChatControllerGetMessages(courseId, {
+    page: 1,
+    perPage: 10,
+  });
+
+  return response.data.data.find((message) => message.content === content) ?? null;
+};
+
+const findThreadById = async (apiClient: FixtureApiClient, courseId: string, messageId: string) => {
+  const response = await apiClient.api.courseChatControllerGetMessages(courseId, {
+    page: 1,
+    perPage: 10,
+  });
+
+  return response.data.data.find((message) => message.id === messageId) ?? null;
+};
+
+const waitForThreadByContent = async (
+  apiClient: FixtureApiClient,
+  courseId: string,
+  content: string,
+): Promise<CourseDiscussionThread> => {
+  let thread: CourseDiscussionThread | null = null;
+
+  await expect
+    .poll(async () => {
+      thread = await findThreadByContent(apiClient, courseId, content);
+
+      return thread?.id ?? null;
+    })
+    .not.toBeNull();
+
+  return thread!;
+};
+
+const waitForReplyByContent = async (
+  apiClient: FixtureApiClient,
+  messageId: string,
+  content: string,
+): Promise<CourseDiscussionReply> => {
+  let reply: CourseDiscussionReply | null = null;
+
+  await expect
+    .poll(async () => {
+      const response = await apiClient.api.courseChatControllerGetReplies(messageId, {
+        page: 1,
+        perPage: 10,
+      });
+      reply = response.data.data.find((message) => message.content === content) ?? null;
+
+      return reply?.id ?? null;
+    })
+    .not.toBeNull();
+
+  return reply!;
+};
+
+test("enrolled student does not see Discussion tab when global discussions are disabled", async ({
+  createIsolatedWorkspace,
+}) => {
+  const workspace = await createIsolatedWorkspace({ role: USER_ROLE.admin });
+  const { courseId, studentSession } = await createDiscussionCourseSetup(workspace, false);
+
+  await openCourseOverviewFlow(studentSession.page, courseId);
+
+  await expect(studentSession.page.getByTestId(COURSE_DISCUSSION_HANDLES.TAB)).toHaveCount(0);
+});
+
+test("enrolled student sees empty discussion state when global discussions are enabled", async ({
+  createIsolatedWorkspace,
+}) => {
+  const workspace = await createIsolatedWorkspace({ role: USER_ROLE.admin });
+  const { courseId, studentSession } = await createDiscussionCourseSetup(workspace, true);
+
+  await openCourseDiscussionFlow(studentSession.page, courseId);
+
+  await expect(studentSession.page.getByTestId(COURSE_DISCUSSION_HANDLES.ROOT)).toBeVisible();
+  await expect(
+    studentSession.page.getByTestId(COURSE_DISCUSSION_HANDLES.EMPTY_STATE),
+  ).toBeVisible();
+});
+
+test("student can create a top-level discussion thread", async ({ createIsolatedWorkspace }) => {
+  const workspace = await createIsolatedWorkspace({ role: USER_ROLE.admin });
+  const { courseId, studentSession } = await createDiscussionCourseSetup(workspace, true);
+  const content = uniqueLabel("discussion-thread");
+
+  await openCourseDiscussionFlow(studentSession.page, courseId);
+  await submitCourseDiscussionThreadFlow(studentSession.page, content);
+
+  const thread = await waitForThreadByContent(studentSession.apiClient, courseId, content);
+  await expect(
+    studentSession.page.getByTestId(COURSE_DISCUSSION_HANDLES.messageContent(thread.id)),
+  ).toContainText(content);
+});
+
+test("student can reply to a discussion thread", async ({ createIsolatedWorkspace }) => {
+  const workspace = await createIsolatedWorkspace({ role: USER_ROLE.admin });
+  const { courseId, studentSession } = await createDiscussionCourseSetup(workspace, true);
+  const threadContent = uniqueLabel("discussion-thread-for-reply");
+  const replyContent = uniqueLabel("discussion-reply");
+  const threadResponse = await studentSession.apiClient.api.courseChatControllerCreateMessage(
+    courseId,
+    { content: threadContent },
+  );
+  const thread = threadResponse.data.data;
+
+  await openCourseDiscussionFlow(studentSession.page, courseId);
+  await expect(
+    studentSession.page.getByTestId(COURSE_DISCUSSION_HANDLES.messageContent(thread.id)),
+  ).toContainText(threadContent);
+
+  await openCourseDiscussionRepliesFlow(studentSession.page, thread.id);
+  await submitCourseDiscussionReplyFlow(studentSession.page, thread.id, replyContent);
+
+  const reply = await waitForReplyByContent(studentSession.apiClient, thread.id, replyContent);
+  await expect(
+    studentSession.page.getByTestId(COURSE_DISCUSSION_HANDLES.messageContent(reply.id)),
+  ).toContainText(replyContent);
+  await expect(
+    studentSession.page.getByTestId(COURSE_DISCUSSION_HANDLES.repliesToggle(thread.id)),
+  ).toContainText("1");
+});
+
+test("student can react to a discussion message and toggle the reaction", async ({
+  createIsolatedWorkspace,
+}) => {
+  const workspace = await createIsolatedWorkspace({ role: USER_ROLE.admin });
+  const { courseId, studentSession } = await createDiscussionCourseSetup(workspace, true);
+  const threadContent = uniqueLabel("discussion-thread-for-reaction");
+  const threadResponse = await studentSession.apiClient.api.courseChatControllerCreateMessage(
+    courseId,
+    { content: threadContent },
+  );
+  const thread = threadResponse.data.data;
+
+  await openCourseDiscussionFlow(studentSession.page, courseId);
+  await reactToCourseDiscussionMessageFlow(studentSession.page, thread.id, DISCUSSION_REACTION);
+
+  await expect
+    .poll(async () => {
+      const message = await findThreadByContent(studentSession.apiClient, courseId, threadContent);
+
+      return message?.reactions.find((reaction) => reaction.reaction === DISCUSSION_REACTION)
+        ?.count;
+    })
+    .toBe(1);
+
+  await expect(
+    studentSession.page.getByTestId(
+      COURSE_DISCUSSION_HANDLES.messageReactionSummary(thread.id, DISCUSSION_REACTION),
+    ),
+  ).toContainText("1");
+
+  await studentSession.page
+    .getByTestId(COURSE_DISCUSSION_HANDLES.messageReactionSummary(thread.id, DISCUSSION_REACTION))
+    .click();
+
+  await expect
+    .poll(async () => {
+      const message = await findThreadByContent(studentSession.apiClient, courseId, threadContent);
+
+      return (
+        message?.reactions.find((reaction) => reaction.reaction === DISCUSSION_REACTION)?.count ?? 0
+      );
+    })
+    .toBe(0);
+});
+
+test("student can delete their own thread and sees the deleted placeholder", async ({
+  createIsolatedWorkspace,
+}) => {
+  const workspace = await createIsolatedWorkspace({ role: USER_ROLE.admin });
+  const { courseId, studentSession } = await createDiscussionCourseSetup(workspace, true);
+  const threadContent = uniqueLabel("discussion-thread-for-delete");
+  const replyContent = uniqueLabel("discussion-reply-before-delete");
+  const threadResponse = await studentSession.apiClient.api.courseChatControllerCreateMessage(
+    courseId,
+    { content: threadContent },
+  );
+  const thread = threadResponse.data.data;
+  await studentSession.apiClient.api.courseChatControllerCreateMessage(courseId, {
+    content: replyContent,
+    parentMessageId: thread.id,
+  });
+
+  await openCourseDiscussionFlow(studentSession.page, courseId);
+  await deleteCourseDiscussionMessageFlow(studentSession.page, thread.id);
+
+  await expect
+    .poll(async () => {
+      const message = await findThreadById(studentSession.apiClient, courseId, thread.id);
+
+      return message?.deletedAt ?? null;
+    })
+    .not.toBeNull();
+
+  await expect(
+    studentSession.page.getByTestId(COURSE_DISCUSSION_HANDLES.messageContent(thread.id)),
+  ).toContainText("This message was deleted");
+});
+
+test("student can select another enrolled user from the mention picker", async ({
+  createIsolatedWorkspace,
+}) => {
+  const workspace = await createIsolatedWorkspace({ role: USER_ROLE.admin });
+  const { courseId, studentSession } = await createDiscussionCourseSetup(workspace, true);
+  const userFactory = workspace.factories.createUserFactory();
+  const enrollmentFactory = workspace.factories.createEnrollmentFactory();
+  const mentionTarget = await userFactory.create({
+    firstName: "Mention",
+    lastName: uniqueLabel("Target"),
+  });
+  const mentionLabel = `@${mentionTarget.firstName} ${mentionTarget.lastName}`;
+  const content = `${mentionLabel} ${uniqueLabel("please-review")}`;
+
+  await enrollmentFactory.enrollUsers(courseId, [mentionTarget.id]);
+
+  await openCourseDiscussionFlow(studentSession.page, courseId);
+  await selectCourseDiscussionMentionFlow(
+    studentSession.page,
+    mentionTarget.firstName,
+    mentionTarget.id,
+  );
+
+  const input = studentSession.page.getByTestId(COURSE_DISCUSSION_HANDLES.THREAD_INPUT);
+  await expect(input).toHaveValue(`${mentionLabel} `);
+  await input.fill(content);
+  await studentSession.page.getByTestId(COURSE_DISCUSSION_HANDLES.THREAD_SEND_BUTTON).click();
+
+  const thread = await waitForThreadByContent(studentSession.apiClient, courseId, content);
+  await expect(
+    studentSession.page.getByTestId(COURSE_DISCUSSION_HANDLES.messageContent(thread.id)),
+  ).toContainText(mentionLabel);
+});


### PR DESCRIPTION
## Issue(s)
- #1580 

## Overview
Adds end-to-end coverage for course discussions from the student course view.

The change introduces stable Playwright handles for the discussion UI, reusable course discussion E2E flows, and a dedicated spec covering the main discussion workflows:

- global discussion visibility when the feature is disabled
- empty discussion state when enabled
- creating top-level discussion threads
- replying to a thread
- adding and toggling reactions
- deleting an owned thread
- selecting enrolled users from the mention picker

It also updates the E2E workflow configuration and refreshes README list formatting.

## Business Value
Course discussions are a learner-facing collaboration feature, so regressions directly affect course engagement and peer communication. This coverage protects the critical student workflows around posting, replying, reacting, deleting, and mentioning users, which makes future changes to the course view safer and easier to validate.