### PR TITLE
chore: add a direct link to the changelog from the login page version number

### DIFF
--- a/apps/web/app/modules/Auth/Login.page.tsx
+++ b/apps/web/app/modules/Auth/Login.page.tsx
@@ -34,6 +34,8 @@ import type { LoginBody } from "~/api/generated-api";
 
 export const meta: MetaFunction = ({ matches }) => setPageTitle(matches, "pages.login");
 
+const CHANGELOG_URL = "https://github.com/Selleo/mentingo/blob/main/CHANGELOG.md";
+
 const loginSchema = (t: (key: string) => string) =>
   z.object({
     email: z.string().email({ message: t("loginView.validation.email") }),
@@ -261,7 +263,15 @@ export default function LoginPage() {
           )}
 
           <p className="bottom-4 mt-4 text-center text-sm text-neutral-300">
-            {t("common.other.appVersion", { version })}
+            <a
+              href={`${CHANGELOG_URL}#${version}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              data-testid={LOGIN_PAGE_HANDLES.VERSION_CHANGELOG_LINK}
+              className="underline-offset-2 hover:underline"
+            >
+              {t("common.other.appVersion", { version })}
+            </a>
           </p>
         </CardContent>
       </Card>

--- a/apps/web/e2e/data/auth/handles.ts
+++ b/apps/web/e2e/data/auth/handles.ts
@@ -6,6 +6,7 @@ export const LOGIN_PAGE_HANDLES = {
   FORGOT_PASSWORD_LINK: "login-page-forgot-password-link",
   MAGIC_LINK_LINK: "login-page-magic-link-link",
   REGISTER_LINK: "login-page-register-link",
+  VERSION_CHANGELOG_LINK: "login-page-version-changelog-link",
 } as const;
 
 export const REGISTER_PAGE_HANDLES = {

--- a/apps/web/e2e/specs/auth/login.spec.ts
+++ b/apps/web/e2e/specs/auth/login.spec.ts
@@ -1,5 +1,6 @@
 import { USER_ROLE } from "~/config/userRoles";
 
+import versionJson from "../../../version.json" with { type: "json" };
 import {
   LOGIN_PAGE_HANDLES,
   MAGIC_LINK_PAGE_HANDLES,
@@ -14,6 +15,8 @@ import { fillLoginFormFlow } from "../../flows/auth/fill-login-form.flow";
 import { openLoginPageFlow } from "../../flows/auth/open-login-page.flow";
 import { submitLoginFormFlow } from "../../flows/auth/submit-login-form.flow";
 import { assertToastVisible } from "../../utils/assert-toast-visible";
+
+const { version } = versionJson;
 
 test("admin can sign in and sign out", async ({ apiClient, withReadonlyPage }) => {
   await withReadonlyPage(USER_ROLE.admin, async ({ page }) => {
@@ -56,6 +59,21 @@ test("visitor can navigate between auth pages", async ({ withReadonlyPage }) => 
 
     await page.getByTestId(REGISTER_PAGE_HANDLES.SIGN_IN_LINK).click();
     await expect(page).toHaveURL("/auth/login");
+  });
+});
+
+test("visitor can open changelog for the current app version", async ({ withReadonlyPage }) => {
+  await withReadonlyPage(USER_ROLE.admin, async ({ page }) => {
+    await openLoginPageFlow(page);
+
+    const changelogLink = page.getByTestId(LOGIN_PAGE_HANDLES.VERSION_CHANGELOG_LINK);
+
+    await expect(changelogLink).toBeVisible();
+    await expect(changelogLink).toHaveAttribute(
+      "href",
+      `https://github.com/Selleo/mentingo/blob/main/CHANGELOG.md#${version}`,
+    );
+    await expect(changelogLink).toHaveAttribute("target", "_blank");
   });
 });
 


### PR DESCRIPTION
## Issue(s)
- #1554 

## Overview

Adds a changelog link to the app version displayed on the login page.

The version text now opens the repository changelog for the currently rendered app version in a new tab. The change also adds a stable E2E selector for the version link and covers the behavior in the auth login Playwright spec.

## Business Value

Users and stakeholders can quickly inspect what changed in the currently deployed app version directly from the login page, making release changes easier to discover without requiring access to the authenticated application.

## Screenshots / Video

https://github.com/user-attachments/assets/0ac01e5b-200d-4bd0-acc9-83e856040c02

