### PR TITLE
refactor: improve resource library structure for easier maintenance

### DIFF
--- a/apps/api/src/articles/services/articles.service.ts
+++ b/apps/api/src/articles/services/articles.service.ts
@@ -29,7 +29,7 @@ import { FILE_DELIVERY_TYPE } from "src/file/types/file-delivery.type";
 import { streamFileToResponse } from "src/file/utils/streamFileToResponse";
 import { LocalizationService } from "src/localization/localization.service";
 import { OutboxPublisher } from "src/outbox/outbox.publisher";
-import { ResourceLibraryRepository } from "src/resource-library/resource-library.repository";
+import { ResourceLibraryService } from "src/resource-library/resource-library.service";
 import { SettingsService } from "src/settings/settings.service";
 import { articles, articleSections } from "src/storage/schema";
 
@@ -54,10 +54,10 @@ import type {
 import type { UUIDType } from "src/common";
 import type { CurrentUserType } from "src/common/types/current-user.type";
 import type { FilePreviewFormat, FilePreviewOptions } from "src/file/types/file-preview.type";
+import type { ResourceMetadata } from "src/file/types/resource-metadata.type";
 import type { ResourceWithUrlError } from "src/lesson/lesson-resource.types";
 
 type StoredArticleResource = Awaited<ReturnType<FileService["getResourcesForEntity"]>>[number];
-type ResourceMetadata = StoredArticleResource["metadata"] & { originalFilename?: unknown };
 
 @Injectable()
 export class ArticlesService {
@@ -67,7 +67,7 @@ export class ArticlesService {
     private readonly articlesRepository: ArticlesRepository,
     private readonly outboxPublisher: OutboxPublisher,
     private readonly settingsService: SettingsService,
-    private readonly resourceLibraryRepository: ResourceLibraryRepository,
+    private readonly resourceLibraryService: ResourceLibraryService,
     @Inject("DB") private readonly db: DatabasePg,
   ) {}
 
@@ -346,7 +346,7 @@ export class ArticlesService {
     if (!updatedArticle) throw new BadRequestException("adminArticleView.toast.updateError");
 
     if ("content" in updateArticleData && updateArticleData.content !== undefined) {
-      await this.resourceLibraryRepository.syncArticleAssetRelations(articleId);
+      await this.resourceLibraryService.syncArticleAssetRelations(articleId);
     }
 
     const updatedSnapshot = await this.buildArticleActivitySnapshot(articleId, language);
@@ -531,7 +531,7 @@ export class ArticlesService {
     const resource = await this.articlesRepository.getResource(resourceId);
 
     if (!resource) {
-      throw new NotFoundException("Article resource not found");
+      throw new NotFoundException("articlesView.resourceNotFound");
     }
 
     const isAdminLike = hasAnyPermission(currentUser?.permissions, [
@@ -547,7 +547,7 @@ export class ArticlesService {
         });
       }
 
-      throw new NotFoundException("Article resource not found");
+      throw new NotFoundException("articlesView.resourceNotFound");
     }
 
     const [article] = await this.articlesRepository.getArticleById(resource.entityId);
@@ -562,7 +562,7 @@ export class ArticlesService {
     const isPublic = Boolean(article.isPublic && article.publishedAt !== null);
 
     if (!isAdminLike && !isAuthor && !isPublic) {
-      throw new NotFoundException("Article resource not found");
+      throw new NotFoundException("articlesView.resourceNotFound");
     }
 
     return this.streamArticleResource(req, res, resource.reference, {
@@ -897,7 +897,7 @@ export class ArticlesService {
   private extractOriginalFilename(metadata: StoredArticleResource["metadata"]) {
     if (!metadata || typeof metadata !== "object") return undefined;
 
-    const { originalFilename } = metadata as ResourceMetadata;
+    const { originalFilename } = metadata as StoredArticleResource["metadata"] & ResourceMetadata;
 
     return typeof originalFilename === "string" ? originalFilename : undefined;
   }

--- a/apps/api/src/courses/master-course.service.ts
+++ b/apps/api/src/courses/master-course.service.ts
@@ -83,6 +83,7 @@ import type {
   MasterCourseResourceGroupKey,
   ResolveTargetResourceReferenceParams,
   SourceSnapshot,
+  SyncAiMentorsParams,
   SyncChaptersParams,
   SyncFillInTheBlanksQuestionReferencesParams,
   SyncLessonResourceReferencesParams,
@@ -479,7 +480,11 @@ export class MasterCourseService {
         questionMap,
       });
 
-      const aiMentorMap = await this.syncAiMentors(sourceSnapshot, lessonMap, resourceCollection);
+      const aiMentorMap = await this.syncAiMentors({
+        sourceSnapshot,
+        lessonMap,
+        resourceCollection,
+      });
       await this.syncAiMentorContexts(sourceSnapshot, aiMentorMap, exportLink.targetTenantId);
       await this.syncScormPackages({
         exportId: exportLink.id,
@@ -868,11 +873,9 @@ export class MasterCourseService {
     return optionMap;
   }
 
-  private async syncAiMentors(
-    sourceSnapshot: SourceSnapshot,
-    lessonMap: Map<UUIDType, UUIDType>,
-    resourceCollection: MasterCourseResourceCollection,
-  ) {
+  private async syncAiMentors(params: SyncAiMentorsParams) {
+    const { lessonMap, sourceSnapshot, resourceCollection } = params;
+
     const aiMentorMap = new Map<UUIDType, UUIDType>();
 
     for (const sourceAiMentor of sourceSnapshot.aiMentors) {

--- a/apps/api/src/courses/types/master-course.types.ts
+++ b/apps/api/src/courses/types/master-course.types.ts
@@ -281,6 +281,12 @@ export type SyncOptionsParams = {
   questionMap: Map<UUIDType, UUIDType>;
 };
 
+export type SyncAiMentorsParams = {
+  sourceSnapshot: SourceSnapshot;
+  lessonMap: Map<UUIDType, UUIDType>;
+  resourceCollection: MasterCourseResourceCollection;
+};
+
 export type SyncScormPackagesParams = {
   exportId: UUIDType;
   sourceSnapshot: SourceSnapshot;

--- a/apps/api/src/file/types/resource-metadata.type.ts
+++ b/apps/api/src/file/types/resource-metadata.type.ts
@@ -1,0 +1,6 @@
+export type ResourceMetadata = {
+  allowFullscreen?: boolean;
+  originalFilename?: string;
+  size?: number | string;
+  [key: string]: unknown;
+};

--- a/apps/api/src/lesson/services/adminLesson.service.ts
+++ b/apps/api/src/lesson/services/adminLesson.service.ts
@@ -36,7 +36,7 @@ import { LiveTrainingService } from "src/live-training/live-training.service";
 import { LocalizationService } from "src/localization/localization.service";
 import { ENTITY_TYPE } from "src/localization/localization.types";
 import { OutboxPublisher } from "src/outbox/outbox.publisher";
-import { ResourceLibraryRepository } from "src/resource-library/resource-library.repository";
+import { ResourceLibraryService } from "src/resource-library/resource-library.service";
 import { questionAnswerOptions, questions } from "src/storage/schema";
 import { StudentLessonProgressService } from "src/studentLessonProgress/studentLessonProgress.service";
 import { isRichTextEmpty } from "src/utils/isRichTextEmpty";
@@ -86,7 +86,7 @@ export class AdminLessonService {
     private readonly studentLessonProgressService: StudentLessonProgressService,
     private readonly masterCourseService: MasterCourseService,
     private readonly courseFeaturePolicyService: CourseFeaturePolicyService,
-    private readonly resourceLibraryRepository: ResourceLibraryRepository,
+    private readonly resourceLibraryService: ResourceLibraryService,
     private readonly liveTrainingService: LiveTrainingService,
     @Inject("CACHE_MANAGER") private readonly cache: CacheManagerStore,
   ) {}
@@ -683,7 +683,7 @@ export class AdminLessonService {
     const updatedLesson = await this.adminLessonRepository.updateLesson(id, data);
 
     if (data.description !== undefined) {
-      await this.resourceLibraryRepository.syncLessonAssetRelations(id);
+      await this.resourceLibraryService.syncLessonAssetRelations(id);
     }
 
     const updatedLessonSnapshot = await this.buildLessonActivitySnapshot(id, data.language);

--- a/apps/api/src/news/news.service.ts
+++ b/apps/api/src/news/news.service.ts
@@ -17,7 +17,7 @@ import { FILE_DELIVERY_TYPE } from "src/file/types/file-delivery.type";
 import { streamFileToResponse } from "src/file/utils/streamFileToResponse";
 import { LocalizationService } from "src/localization/localization.service";
 import { OutboxPublisher } from "src/outbox/outbox.publisher";
-import { ResourceLibraryRepository } from "src/resource-library/resource-library.repository";
+import { ResourceLibraryService } from "src/resource-library/resource-library.service";
 import { SettingsService } from "src/settings/settings.service";
 import { news, resourceEntity, resources, users } from "src/storage/schema";
 
@@ -32,13 +32,13 @@ import type { NewsActivityLogSnapshot } from "src/activity-logs/types";
 import type { UUIDType } from "src/common";
 import type { CurrentUserType } from "src/common/types/current-user.type";
 import type { FilePreviewFormat, FilePreviewOptions } from "src/file/types/file-preview.type";
+import type { ResourceMetadata } from "src/file/types/resource-metadata.type";
 
 // News uses a custom pagination: first page shows up to 7 items, following pages up to 9.
 const FIRST_PAGE_SIZE = 7;
 const SUBSEQUENT_PAGE_SIZE = 9;
 
 type StoredNewsResource = Awaited<ReturnType<FileService["getResourcesForEntity"]>>[number];
-type ResourceMetadata = StoredNewsResource["metadata"] & { originalFilename?: unknown };
 
 @Injectable()
 export class NewsService {
@@ -48,7 +48,7 @@ export class NewsService {
     private readonly fileService: FileService,
     private readonly outboxPublisher: OutboxPublisher,
     private readonly settingsService: SettingsService,
-    private readonly resourceLibraryRepository: ResourceLibraryRepository,
+    private readonly resourceLibraryService: ResourceLibraryService,
   ) {}
 
   async createNews(createNewsBody: CreateNews, currentUser: CurrentUserType) {
@@ -132,7 +132,7 @@ export class NewsService {
     if (!updatedNews) throw new BadRequestException("adminNewsView.toast.updateError");
 
     if ("content" in updateNewsData && updateNewsData.content !== undefined) {
-      await this.resourceLibraryRepository.syncNewsAssetRelations(newsId);
+      await this.resourceLibraryService.syncNewsAssetRelations(newsId);
     }
 
     const updatedSnapshot = await this.buildNewsActivitySnapshot(newsId, language);
@@ -457,7 +457,7 @@ export class NewsService {
       .where(and(eq(resources.id, resourceId), ne(resources.archived, true)));
 
     if (!resource) {
-      throw new NotFoundException("News resource not found");
+      throw new NotFoundException("newsView.resourceNotFound");
     }
 
     const isAdminLike = hasAnyPermission(currentUser?.permissions, [
@@ -473,7 +473,7 @@ export class NewsService {
         });
       }
 
-      throw new NotFoundException("News resource not found");
+      throw new NotFoundException("newsView.resourceNotFound");
     }
 
     const [existingNews] = await this.db
@@ -494,7 +494,7 @@ export class NewsService {
     const isPublic = Boolean(existingNews.isPublic && existingNews.publishedAt !== null);
 
     if (!isAdminLike && !isAuthor && !isPublic) {
-      throw new NotFoundException("News resource not found");
+      throw new NotFoundException("newsView.resourceNotFound");
     }
 
     return this.streamNewsResource(req, res, resource.reference, {
@@ -866,7 +866,7 @@ export class NewsService {
   private extractOriginalFilename(metadata: StoredNewsResource["metadata"]) {
     if (!metadata || typeof metadata !== "object") return undefined;
 
-    const { originalFilename } = metadata as ResourceMetadata;
+    const { originalFilename } = metadata as StoredNewsResource["metadata"] & ResourceMetadata;
 
     return typeof originalFilename === "string" ? originalFilename : undefined;
   }

--- a/apps/api/src/resource-library/resource-library.module.ts
+++ b/apps/api/src/resource-library/resource-library.module.ts
@@ -11,6 +11,6 @@ import { ResourceLibraryService } from "./resource-library.service";
   imports: [FileModule, LocalizationModule],
   controllers: [ResourceLibraryController],
   providers: [ResourceLibraryService, ResourceLibraryRepository],
-  exports: [ResourceLibraryRepository],
+  exports: [ResourceLibraryService, ResourceLibraryRepository],
 })
 export class ResourceLibraryModule {}

--- a/apps/api/src/resource-library/resource-library.repository.ts
+++ b/apps/api/src/resource-library/resource-library.repository.ts
@@ -29,21 +29,13 @@ import {
   RICH_TEXT_ENTITY_TYPES,
   RICH_TEXT_RELATIONSHIP_TYPES,
 } from "./resource-library.constants";
-import {
-  getAssetDisplayFileName,
-  getLocalizedRichTextEntries,
-  getMetadataTextValue,
-  extractResourceIdsFromRichText,
-  removeResourceReferencesFromRichText,
-} from "./resource-library.utils";
+import { getAssetDisplayFileName, getMetadataTextValue } from "./resource-library.utils";
 
 import type {
   ResourceLibraryAssetType,
   RichTextAssetEntityType,
 } from "./schemas/resource-library.schema";
 import type { AnyPgColumn } from "drizzle-orm/pg-core";
-import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
-import type * as schema from "src/storage/schema";
 
 @Injectable()
 export class ResourceLibraryRepository {
@@ -83,20 +75,7 @@ export class ResourceLibraryRepository {
     });
   }
 
-  async getAssetUsages(resourceId: UUIDType, language?: SupportedLanguages) {
-    const relationUsages = await this.getRelationUsages(resourceId, language);
-    const contentUsages = await this.getContentReferenceUsages(resourceId, language);
-
-    const usageByEntity = new Map<string, (typeof relationUsages)[number]>();
-
-    [...contentUsages, ...relationUsages].forEach((usage) => {
-      usageByEntity.set(`${usage.entityType}:${usage.entityId}`, usage);
-    });
-
-    return Array.from(usageByEntity.values());
-  }
-
-  private async getRelationUsages(resourceId: UUIDType, language?: SupportedLanguages) {
+  async getAssetRelationUsages(resourceId: UUIDType, language?: SupportedLanguages) {
     const lessonUsages = await this.db
       .select({
         id: resourceEntity.id,
@@ -154,7 +133,7 @@ export class ResourceLibraryRepository {
     return [...lessonUsages, ...articleUsages, ...newsUsages];
   }
 
-  private async getContentReferenceUsages(resourceId: UUIDType, language?: SupportedLanguages) {
+  async getAssetContentReferenceUsages(resourceId: UUIDType, language?: SupportedLanguages) {
     const pattern = this.getResourceIdSearchPattern(resourceId);
 
     const lessonUsages = await this.db
@@ -274,46 +253,34 @@ export class ResourceLibraryRepository {
       .onConflictDoNothing();
   }
 
-  async syncLessonAssetRelations(lessonId: UUIDType) {
+  async getLessonContent(lessonId: UUIDType) {
     const [lesson] = await this.db
       .select({ description: lessons.description })
       .from(lessons)
       .where(eq(lessons.id, lessonId))
       .limit(1);
 
-    await this.syncEntityAssetRelations({
-      entityId: lessonId,
-      entityType: ENTITY_TYPES.LESSON,
-      contents: getLocalizedRichTextEntries(lesson?.description).map(([, content]) => content),
-    });
+    return lesson?.description;
   }
 
-  async syncArticleAssetRelations(articleId: UUIDType) {
+  async getArticleContent(articleId: UUIDType) {
     const [article] = await this.db
       .select({ content: articles.content })
       .from(articles)
       .where(eq(articles.id, articleId))
       .limit(1);
 
-    await this.syncEntityAssetRelations({
-      entityId: articleId,
-      entityType: ENTITY_TYPES.ARTICLES,
-      contents: getLocalizedRichTextEntries(article?.content).map(([, content]) => content),
-    });
+    return article?.content;
   }
 
-  async syncNewsAssetRelations(newsId: UUIDType) {
+  async getNewsContent(newsId: UUIDType) {
     const [newsItem] = await this.db
       .select({ content: news.content })
       .from(news)
       .where(eq(news.id, newsId))
       .limit(1);
 
-    await this.syncEntityAssetRelations({
-      entityId: newsId,
-      entityType: ENTITY_TYPES.NEWS,
-      contents: getLocalizedRichTextEntries(newsItem?.content).map(([, content]) => content),
-    });
+    return newsItem?.content;
   }
 
   async deleteAssetRelation(params: {
@@ -340,71 +307,68 @@ export class ResourceLibraryRepository {
     return deletedRelations.length;
   }
 
-  private async syncEntityAssetRelations(params: {
-    entityId: UUIDType;
-    entityType: RichTextAssetEntityType;
-    contents: string[];
-  }) {
-    const resourceIds = [
-      ...new Set(params.contents.flatMap((content) => extractResourceIdsFromRichText(content))),
-    ] as UUIDType[];
-
-    await this.db.transaction(async (trx) => {
-      await trx
-        .delete(resourceEntity)
-        .where(
-          and(
-            eq(resourceEntity.entityId, params.entityId),
-            eq(resourceEntity.entityType, params.entityType),
-            eq(resourceEntity.relationshipType, RESOURCE_RELATIONSHIP_TYPES.ATTACHMENT),
-          ),
-        );
-
-      if (!resourceIds.length) return;
-
-      const existingResources = await trx
-        .select({ id: resources.id })
-        .from(resources)
-        .where(and(inArray(resources.id, resourceIds), eq(resources.archived, false)));
-
-      if (!existingResources.length) return;
-
-      await trx
-        .insert(resourceEntity)
-        .values(
-          existingResources.map((resource) => ({
-            resourceId: resource.id,
-            entityId: params.entityId,
-            entityType: params.entityType,
-            relationshipType: RESOURCE_RELATIONSHIP_TYPES.ATTACHMENT,
-          })),
-        )
-        .onConflictDoNothing();
-    });
-  }
-
-  async archiveAssetAndDeleteRelations(resourceId: UUIDType) {
-    return this.db.transaction(async (trx) => {
-      const [{ deletedUsages }] = await trx
-        .select({ deletedUsages: countDistinct(resourceEntity.id) })
-        .from(resourceEntity)
-        .where(eq(resourceEntity.resourceId, resourceId));
-
-      await this.removeAssetReferencesFromContent(resourceId, trx);
-      await trx.delete(resourceEntity).where(eq(resourceEntity.resourceId, resourceId));
-      await trx.update(resources).set({ archived: true }).where(eq(resources.id, resourceId));
-
-      return deletedUsages;
-    });
-  }
-
-  private async removeAssetReferencesFromContent(
-    resourceId: UUIDType,
-    dbInstance: PostgresJsDatabase<typeof schema>,
+  async deleteEntityAttachmentRelations(
+    params: {
+      entityId: UUIDType;
+      entityType: RichTextAssetEntityType;
+    },
+    dbInstance: DatabasePg = this.db,
   ) {
+    await dbInstance
+      .delete(resourceEntity)
+      .where(
+        and(
+          eq(resourceEntity.entityId, params.entityId),
+          eq(resourceEntity.entityType, params.entityType),
+          eq(resourceEntity.relationshipType, RESOURCE_RELATIONSHIP_TYPES.ATTACHMENT),
+        ),
+      );
+  }
+
+  async getExistingAssetIds(resourceIds: UUIDType[], dbInstance: DatabasePg = this.db) {
+    if (!resourceIds.length) return [];
+
+    return dbInstance
+      .select({ id: resources.id })
+      .from(resources)
+      .where(and(inArray(resources.id, resourceIds), eq(resources.archived, false)));
+  }
+
+  async createAssetRelations(
+    params: {
+      resourceId: UUIDType;
+      entityId: UUIDType;
+      entityType: RichTextAssetEntityType;
+      relationshipType: string;
+    }[],
+    dbInstance: DatabasePg = this.db,
+  ) {
+    if (!params.length) return;
+
+    await dbInstance.insert(resourceEntity).values(params).onConflictDoNothing();
+  }
+
+  async countAssetRelations(resourceId: UUIDType, dbInstance: DatabasePg = this.db) {
+    const [{ deletedUsages }] = await dbInstance
+      .select({ deletedUsages: countDistinct(resourceEntity.id) })
+      .from(resourceEntity)
+      .where(eq(resourceEntity.resourceId, resourceId));
+
+    return deletedUsages;
+  }
+
+  async deleteAssetRelations(resourceId: UUIDType, dbInstance: DatabasePg = this.db) {
+    await dbInstance.delete(resourceEntity).where(eq(resourceEntity.resourceId, resourceId));
+  }
+
+  async archiveAsset(resourceId: UUIDType, dbInstance: DatabasePg = this.db) {
+    await dbInstance.update(resources).set({ archived: true }).where(eq(resources.id, resourceId));
+  }
+
+  async getLessonRowsReferencingAsset(resourceId: UUIDType, dbInstance: DatabasePg = this.db) {
     const pattern = this.getResourceIdSearchPattern(resourceId);
 
-    const lessonRows = await dbInstance
+    return dbInstance
       .select({
         id: lessons.id,
         description: lessons.description,
@@ -413,66 +377,99 @@ export class ResourceLibraryRepository {
       .where(
         this.localizationService.getLocalizedFieldSearchCondition(lessons.description, pattern),
       );
+  }
 
-    for (const { id, description } of lessonRows) {
-      for (const [language, localizedContent] of getLocalizedRichTextEntries(description)) {
-        const { content, hasChanged } = removeResourceReferencesFromRichText(
-          localizedContent,
-          resourceId,
-        );
+  async getArticleRowsReferencingAsset(resourceId: UUIDType, dbInstance: DatabasePg = this.db) {
+    const pattern = this.getResourceIdSearchPattern(resourceId);
 
-        if (hasChanged) {
-          await dbInstance
-            .update(lessons)
-            .set({
-              description: setJsonbField(lessons.description, language, content, true, true),
-            })
-            .where(eq(lessons.id, id));
-        }
-      }
-    }
-
-    const articleRows = await dbInstance
+    return dbInstance
       .select({ id: articles.id, content: articles.content })
       .from(articles)
       .where(this.localizationService.getLocalizedFieldSearchCondition(articles.content, pattern));
+  }
 
-    for (const { id, content } of articleRows) {
-      for (const [language, localizedContent] of getLocalizedRichTextEntries(content)) {
-        const { content: cleanedContent, hasChanged } = removeResourceReferencesFromRichText(
-          localizedContent,
-          resourceId,
-        );
+  async getNewsRowsReferencingAsset(resourceId: UUIDType, dbInstance: DatabasePg = this.db) {
+    const pattern = this.getResourceIdSearchPattern(resourceId);
 
-        if (hasChanged) {
-          await dbInstance
-            .update(articles)
-            .set({ content: setJsonbField(articles.content, language, cleanedContent, true, true) })
-            .where(eq(articles.id, id));
-        }
-      }
-    }
-
-    const newsRows = await dbInstance
+    return dbInstance
       .select({ id: news.id, content: news.content })
       .from(news)
       .where(this.localizationService.getLocalizedFieldSearchCondition(news.content, pattern));
+  }
 
-    for (const { id, content } of newsRows) {
-      for (const [language, localizedContent] of getLocalizedRichTextEntries(content)) {
-        const { content: cleanedContent, hasChanged } = removeResourceReferencesFromRichText(
-          localizedContent,
-          resourceId,
-        );
+  async updateLessonDescription(
+    params: {
+      lessonId: UUIDType;
+      language: string;
+      content: string;
+    },
+    dbInstance: DatabasePg = this.db,
+  ) {
+    await dbInstance
+      .update(lessons)
+      .set({
+        description: setJsonbField(
+          lessons.description,
+          params.language,
+          params.content,
+          true,
+          true,
+        ),
+      })
+      .where(eq(lessons.id, params.lessonId));
+  }
 
-        if (hasChanged) {
-          await dbInstance
-            .update(news)
-            .set({ content: setJsonbField(news.content, language, cleanedContent, true, true) })
-            .where(eq(news.id, id));
-        }
-      }
-    }
+  async updateArticleContent(
+    params: {
+      articleId: UUIDType;
+      language: string;
+      content: string;
+    },
+    dbInstance: DatabasePg = this.db,
+  ) {
+    await dbInstance
+      .update(articles)
+      .set({
+        content: setJsonbField(articles.content, params.language, params.content, true, true),
+      })
+      .where(eq(articles.id, params.articleId));
+  }
+
+  async updateNewsContent(
+    params: {
+      newsId: UUIDType;
+      language: string;
+      content: string;
+    },
+    dbInstance: DatabasePg = this.db,
+  ) {
+    await dbInstance
+      .update(news)
+      .set({ content: setJsonbField(news.content, params.language, params.content, true, true) })
+      .where(eq(news.id, params.newsId));
+  }
+
+  async replaceEntityAttachmentRelations(
+    params: {
+      entityId: UUIDType;
+      entityType: RichTextAssetEntityType;
+      resourceIds: UUIDType[];
+    },
+    dbInstance: DatabasePg = this.db,
+  ) {
+    await this.deleteEntityAttachmentRelations(params, dbInstance);
+
+    const existingResources = await this.getExistingAssetIds(params.resourceIds, dbInstance);
+
+    await this.createAssetRelations(
+      existingResources.map((resource) => ({
+        resourceId: resource.id,
+        entityId: params.entityId,
+        entityType: params.entityType,
+        relationshipType: RESOURCE_RELATIONSHIP_TYPES.ATTACHMENT,
+      })),
+      dbInstance,
+    );
   }
 
   private getAssetConditions(search?: string, type?: ResourceLibraryAssetType): SQL[] {

--- a/apps/api/src/resource-library/resource-library.service.ts
+++ b/apps/api/src/resource-library/resource-library.service.ts
@@ -1,10 +1,18 @@
-import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
+import { BadRequestException, Inject, Injectable, NotFoundException } from "@nestjs/common";
 import { ENTITY_TYPES, type SupportedLanguages } from "@repo/shared";
 
+import { DatabasePg } from "src/common";
 import { parsePagination } from "src/common/pagination";
 import { RESOURCE_CATEGORIES, RESOURCE_RELATIONSHIP_TYPES } from "src/file/file.constants";
 import { FileService } from "src/file/file.service";
 import { ResourceLibraryRepository } from "src/resource-library/resource-library.repository";
+import { DB } from "src/storage/db/db.providers";
+
+import {
+  extractResourceIdsFromRichText,
+  getLocalizedRichTextEntries,
+  removeResourceReferencesFromRichText,
+} from "./resource-library.utils";
 
 import type {
   AssetLibraryAsset,
@@ -22,6 +30,7 @@ export class ResourceLibraryService {
   constructor(
     private readonly fileService: FileService,
     private readonly resourceLibraryRepository: ResourceLibraryRepository,
+    @Inject(DB) private readonly db: DatabasePg,
   ) {}
 
   async getAssets(params: {
@@ -57,7 +66,22 @@ export class ResourceLibraryService {
 
   async getAssetUsages(resourceId: UUIDType, language?: SupportedLanguages) {
     await this.assertAssetExists(resourceId);
-    return this.resourceLibraryRepository.getAssetUsages(resourceId, language);
+
+    const relationUsages = await this.resourceLibraryRepository.getAssetRelationUsages(
+      resourceId,
+      language,
+    );
+    const contentUsages = await this.resourceLibraryRepository.getAssetContentReferenceUsages(
+      resourceId,
+      language,
+    );
+    const usageByEntity = new Map<string, (typeof relationUsages)[number]>();
+
+    [...contentUsages, ...relationUsages].forEach((usage) => {
+      usageByEntity.set(`${usage.entityType}:${usage.entityId}`, usage);
+    });
+
+    return Array.from(usageByEntity.values());
   }
 
   async linkAsset(resourceId: UUIDType, body: LinkAssetBody) {
@@ -128,13 +152,57 @@ export class ResourceLibraryService {
   async deleteAsset(resourceId: UUIDType) {
     await this.assertAssetExists(resourceId);
 
-    const deletedUsages =
-      await this.resourceLibraryRepository.archiveAssetAndDeleteRelations(resourceId);
+    const deletedUsages = await this.db.transaction(async (trx) => {
+      const relationCount = await this.resourceLibraryRepository.countAssetRelations(
+        resourceId,
+        trx,
+      );
+
+      await this.removeAssetReferencesFromContent(resourceId, trx);
+      await this.resourceLibraryRepository.deleteAssetRelations(resourceId, trx);
+      await this.resourceLibraryRepository.archiveAsset(resourceId, trx);
+
+      return relationCount;
+    });
 
     return {
       message: "resourceLibrary.toast.assetDeletedSuccessfully",
       deletedUsages,
     };
+  }
+
+  async syncLessonAssetRelations(lessonId: UUIDType) {
+    const description = await this.resourceLibraryRepository.getLessonContent(lessonId);
+
+    await this.syncEntityAssetRelations({
+      entityId: lessonId,
+      entityType: ENTITY_TYPES.LESSON,
+      contents: getLocalizedRichTextEntries(description).map(([, content]) => content),
+    });
+  }
+
+  async syncArticleAssetRelations(articleId: UUIDType) {
+    const content = await this.resourceLibraryRepository.getArticleContent(articleId);
+
+    await this.syncEntityAssetRelations({
+      entityId: articleId,
+      entityType: ENTITY_TYPES.ARTICLES,
+      contents: getLocalizedRichTextEntries(content).map(
+        ([, localizedContent]) => localizedContent,
+      ),
+    });
+  }
+
+  async syncNewsAssetRelations(newsId: UUIDType) {
+    const content = await this.resourceLibraryRepository.getNewsContent(newsId);
+
+    await this.syncEntityAssetRelations({
+      entityId: newsId,
+      entityType: ENTITY_TYPES.NEWS,
+      contents: getLocalizedRichTextEntries(content).map(
+        ([, localizedContent]) => localizedContent,
+      ),
+    });
   }
 
   private async assertAssetExists(resourceId: UUIDType) {
@@ -170,6 +238,92 @@ export class ResourceLibraryService {
       case ENTITY_TYPES.LESSON:
       default:
         return RESOURCE_CATEGORIES.LESSON;
+    }
+  }
+
+  private async syncEntityAssetRelations(params: {
+    entityId: UUIDType;
+    entityType: RichTextAssetEntityType;
+    contents: string[];
+  }) {
+    const resourceIds = [
+      ...new Set(params.contents.flatMap((content) => extractResourceIdsFromRichText(content))),
+    ] as UUIDType[];
+
+    await this.db.transaction(async (trx) =>
+      this.resourceLibraryRepository.replaceEntityAttachmentRelations(
+        {
+          entityId: params.entityId,
+          entityType: params.entityType,
+          resourceIds,
+        },
+        trx,
+      ),
+    );
+  }
+
+  private async removeAssetReferencesFromContent(resourceId: UUIDType, dbInstance: DatabasePg) {
+    const lessonRows = await this.resourceLibraryRepository.getLessonRowsReferencingAsset(
+      resourceId,
+      dbInstance,
+    );
+
+    for (const { id, description } of lessonRows) {
+      for (const [language, localizedContent] of getLocalizedRichTextEntries(description)) {
+        const { content, hasChanged } = removeResourceReferencesFromRichText(
+          localizedContent,
+          resourceId,
+        );
+
+        if (hasChanged) {
+          await this.resourceLibraryRepository.updateLessonDescription(
+            { lessonId: id, language, content },
+            dbInstance,
+          );
+        }
+      }
+    }
+
+    const articleRows = await this.resourceLibraryRepository.getArticleRowsReferencingAsset(
+      resourceId,
+      dbInstance,
+    );
+
+    for (const { id, content } of articleRows) {
+      for (const [language, localizedContent] of getLocalizedRichTextEntries(content)) {
+        const { content: cleanedContent, hasChanged } = removeResourceReferencesFromRichText(
+          localizedContent,
+          resourceId,
+        );
+
+        if (hasChanged) {
+          await this.resourceLibraryRepository.updateArticleContent(
+            { articleId: id, language, content: cleanedContent },
+            dbInstance,
+          );
+        }
+      }
+    }
+
+    const newsRows = await this.resourceLibraryRepository.getNewsRowsReferencingAsset(
+      resourceId,
+      dbInstance,
+    );
+
+    for (const { id, content } of newsRows) {
+      for (const [language, localizedContent] of getLocalizedRichTextEntries(content)) {
+        const { content: cleanedContent, hasChanged } = removeResourceReferencesFromRichText(
+          localizedContent,
+          resourceId,
+        );
+
+        if (hasChanged) {
+          await this.resourceLibraryRepository.updateNewsContent(
+            { newsId: id, language, content: cleanedContent },
+            dbInstance,
+          );
+        }
+      }
     }
   }
 }

--- a/apps/api/src/storage/schema/index.ts
+++ b/apps/api/src/storage/schema/index.ts
@@ -104,6 +104,7 @@ import type {
 } from "@repo/shared";
 import type { ActivityLogMetadata } from "src/activity-logs/types";
 import type { ActivityHistory, AllSettings } from "src/common/types";
+import type { ResourceMetadata } from "src/file/types/resource-metadata.type";
 
 export const users = pgTable(
   "users",
@@ -1806,7 +1807,7 @@ export const resources = pgTable(
     description: jsonb("description").notNull().default({}),
     reference: varchar("reference", { length: 500 }).notNull(),
     contentType: varchar("content_type", { length: 100 }).notNull(),
-    metadata: jsonb("metadata").default({}),
+    metadata: jsonb("metadata").$type<ResourceMetadata>().default({}),
     uploadedBy: uuid("uploaded_by_id").references(() => users.id, { onDelete: "set null" }),
     archived,
     tenantId,

--- a/apps/web/app/locales/cs/translation.json
+++ b/apps/web/app/locales/cs/translation.json
@@ -677,6 +677,7 @@
   "newsView": {
     "header": "Zprávy",
     "notFound": "Novinky nenalezeny.",
+    "resourceNotFound": "Zdroj novinky nebyl nalezen.",
     "previousNews": "Předchozí novinky",
     "nextNews": "Další novinky",
     "prompt": {
@@ -4079,6 +4080,7 @@
   },
   "articlesView": {
     "notFound": "Záznam znalostní báze nebyl nalezen",
+    "resourceNotFound": "Zdroj znalostní báze nebyl nalezen",
     "previousArticle": "Předchozí záznam znalostní báze",
     "nextArticle": "Další záznam znalostní báze",
     "deleteModal": {

--- a/apps/web/app/locales/de/translation.json
+++ b/apps/web/app/locales/de/translation.json
@@ -671,6 +671,7 @@
   "newsView": {
     "header": "Nachricht",
     "notFound": "Nachrichten nicht gefunden.",
+    "resourceNotFound": "News-Ressource nicht gefunden.",
     "previousNews": "Vorherige Nachrichten",
     "nextNews": "Nächste Neuigkeiten",
     "prompt": {
@@ -4071,6 +4072,7 @@
   },
   "articlesView": {
     "notFound": "Wissensdatenbankeintrag nicht gefunden",
+    "resourceNotFound": "Wissensdatenbank-Ressource nicht gefunden",
     "previousArticle": "Vorheriger Wissensdatenbankeintrag",
     "nextArticle": "Nächster Wissensdatenbankeintrag",
     "deleteModal": {

--- a/apps/web/app/locales/en/translation.json
+++ b/apps/web/app/locales/en/translation.json
@@ -672,6 +672,7 @@
   "newsView": {
     "header": "News",
     "notFound": "News not found.",
+    "resourceNotFound": "News resource not found.",
     "previousNews": "Previous news",
     "nextNews": "Next news",
     "prompt": {
@@ -4041,6 +4042,7 @@
   },
   "articlesView": {
     "notFound": "Knowledge base entry not found",
+    "resourceNotFound": "Knowledge base resource not found",
     "previousArticle": "Previous knowledge base entry",
     "nextArticle": "Next knowledge base entry",
     "deleteModal": {

--- a/apps/web/app/locales/lt/translation.json
+++ b/apps/web/app/locales/lt/translation.json
@@ -677,6 +677,7 @@
   "newsView": {
     "header": "Naujienos",
     "notFound": "Naujienos nerasta.",
+    "resourceNotFound": "Naujienos išteklius nerastas.",
     "previousNews": "Ankstesnės naujienos",
     "nextNews": "Kitos naujienos",
     "prompt": {
@@ -4080,6 +4081,7 @@
   },
   "articlesView": {
     "notFound": "Žinių bazės įrašas nerastas",
+    "resourceNotFound": "Žinių bazės išteklius nerastas",
     "previousArticle": "Ankstesnis žinių bazės įrašas",
     "nextArticle": "Kitas žinių bazės įrašas",
     "deleteModal": {

--- a/apps/web/app/locales/pl/translation.json
+++ b/apps/web/app/locales/pl/translation.json
@@ -909,6 +909,7 @@
   "newsView": {
     "header": "Aktualności",
     "notFound": "Nie znaleziono aktualności.",
+    "resourceNotFound": "Nie znaleziono zasobu aktualności.",
     "previousNews": "Poprzednia aktualność",
     "nextNews": "Następna aktualność",
     "previousArticle": "Poprzedni wpis do bazy wiedzy",
@@ -4080,6 +4081,7 @@
   },
   "articlesView": {
     "notFound": "Nie znaleziono wpisu do bazy wiedzy",
+    "resourceNotFound": "Nie znaleziono zasobu bazy wiedzy",
     "previousArticle": "Poprzedni wpis do bazy wiedzy",
     "nextArticle": "Następny wpis do bazy wiedzy",
     "deleteModal": {


### PR DESCRIPTION
## Issue(s)
- #1517 

## Overview

Applies backend review feedback from #1503 around resource-library asset handling.

- Moves rich-text asset relation synchronization and deletion cleanup orchestration into `ResourceLibraryService`.
- Keeps `ResourceLibraryRepository` focused on data access helpers for usages, relations, content lookup, and localized content updates.
- Synchronizes embedded asset relations for lessons, news, and knowledge-base articles after rich-text content updates.
- Deletes resource-library assets transactionally by removing embedded rich-text references, deleting resource relations, and archiving the resource.
- Adds a shared `ResourceMetadata` type for resource metadata access.
- Returns localized missing-resource error keys for news and article resources, with translations added for all supported locales.
- Refactors AI mentor sync parameters into a typed params object.

## Business Value

Resource-library assets stay consistent with the content where they are embedded. When editors update or delete assets used in lessons, news, or knowledge-base articles, the backend now has a clearer and more reliable path for keeping usage tracking and rich-text content clean.

This reduces broken embedded media for learners and gives users localized error messages when a news or knowledge-base resource is unavailable.
