### PR TITLE
fix: improve hero news image display

### DIFF
--- a/apps/web/app/modules/News/NewsItem.tsx
+++ b/apps/web/app/modules/News/NewsItem.tsx
@@ -31,12 +31,13 @@ function NewsItem({
 
   return (
     <button
+      type="button"
       data-testid={NEWS_PAGE_HANDLES.item(id)}
       className={cn(
-        "relative overflow-hidden rounded-lg py-7 px-6 flex flex-col justify-end min-h-[380px] group",
+        "relative flex w-full flex-col justify-end overflow-hidden rounded-lg px-6 py-7 min-h-[380px] group",
         className,
         {
-          "px-10 py-11 min-h-[550px]": isBig,
+          "px-10 py-11 md:aspect-video md:min-h-0": isBig,
         },
       )}
       onClick={() => navigate(`/news/${id}`)}


### PR DESCRIPTION
## Issue(s)
[1642](https://github.com/Selleo/mentingo/issues/1642)

## Overview
Updated the news list card layout so the featured hero news item keeps a consistent responsive 16:9 ratio on tablet and larger screens. The card now explicitly spans the available width, while regular news cards keep their existing layout.

## Business Value
The news page now presents the highlighted news item consistently across environments, avoiding the narrow/tall hero card layout and improving the visual quality of the news listing for end users.