### PR TITLE
fix: show course preview cards correctly during AI course generation

### DIFF
--- a/apps/api/src/luma/luma.controller.ts
+++ b/apps/api/src/luma/luma.controller.ts
@@ -72,18 +72,37 @@ export class LumaController {
 
     const response = await this.lumaService.chatWithCourseAgent(data, currentUser);
     let syncEnqueued = false;
+    let pendingCourseGeneratedFrame = "";
 
     try {
       for await (const chunk of response.data as AsyncIterable<Buffer>) {
         res.write(chunk);
 
-        if (!syncEnqueued && this.lumaService.hasCourseGeneratedEvent(chunk)) {
+        const courseGeneratedDetection = this.lumaService.hasCourseGeneratedEvent(
+          chunk,
+          pendingCourseGeneratedFrame,
+        );
+        pendingCourseGeneratedFrame = courseGeneratedDetection.pendingFrame;
+
+        if (!syncEnqueued && courseGeneratedDetection.hasCourseGeneratedEvent) {
           syncEnqueued = true;
           await this.lumaCourseGenerationSyncService.enqueueGeneratedCourseBundleSync(
             data.integrationId,
             currentUser,
           );
         }
+      }
+
+      const finalCourseGeneratedDetection = this.lumaService.hasCourseGeneratedEvent(
+        Buffer.from("\n"),
+        pendingCourseGeneratedFrame,
+      );
+
+      if (!syncEnqueued && finalCourseGeneratedDetection.hasCourseGeneratedEvent) {
+        await this.lumaCourseGenerationSyncService.enqueueGeneratedCourseBundleSync(
+          data.integrationId,
+          currentUser,
+        );
       }
 
       res.end();

--- a/apps/api/src/luma/luma.service.ts
+++ b/apps/api/src/luma/luma.service.ts
@@ -1,4 +1,4 @@
-import { createLumaClient } from "@japro/luma-sdk";
+import { createLumaClient, isLumaCourseGeneratedEvent } from "@japro/luma-sdk";
 import {
   BadRequestException,
   ConflictException,
@@ -8,7 +8,7 @@ import {
   ServiceUnavailableException,
   UnauthorizedException,
 } from "@nestjs/common";
-import { COURSE_GENERATION_STREAM_EVENT_TYPE, COURSE_GENERATION_SYNC_STATUS } from "@repo/shared";
+import { COURSE_GENERATION_SYNC_STATUS } from "@repo/shared";
 import { isAxiosError } from "axios";
 
 import { EnvService } from "src/env/services/env.service";
@@ -150,19 +150,26 @@ export class LumaService {
     return this.withLumaErrorHandling(() => luma.getDraftFiles(data));
   }
 
-  hasCourseGeneratedEvent(chunk: Buffer) {
-    const chunkString = chunk.toString();
-    const frames = chunkString.replace(/\r\n/g, "\n").split("\n");
+  hasCourseGeneratedEvent(chunk: Buffer, pendingFrame = "") {
+    const chunkString = `${pendingFrame}${chunk.toString()}`.replace(/\r\n/g, "\n");
+    const hasTrailingNewline = chunkString.endsWith("\n");
+    const frames = chunkString.split("\n");
+    const nextPendingFrame = hasTrailingNewline ? "" : (frames.pop() ?? "");
+    let hasCourseGeneratedEvent = false;
 
     for (const frame of frames) {
       if (!frame.trim()) continue;
       if (!frame.startsWith("2:")) continue;
       if (this.parseDataChunk(frame).some((payload) => this.isCourseGeneratedPayload(payload))) {
-        return true;
+        hasCourseGeneratedEvent = true;
+        break;
       }
     }
 
-    return false;
+    return {
+      hasCourseGeneratedEvent,
+      pendingFrame: nextPendingFrame,
+    };
   }
 
   private parseDataChunk(chunkString: string): unknown[] {
@@ -178,12 +185,7 @@ export class LumaService {
   }
 
   private isCourseGeneratedPayload(payload: unknown) {
-    return (
-      !!payload &&
-      typeof payload === "object" &&
-      "type" in payload &&
-      payload.type === COURSE_GENERATION_STREAM_EVENT_TYPE.COURSE_GENERATED
-    );
+    return isLumaCourseGeneratedEvent(payload);
   }
 
   private async withCoreSyncStatus<

--- a/apps/web/app/modules/Admin/EditCourse/components/course-generation/utils/__tests__/courseGenerationCourseCache.utils.test.ts
+++ b/apps/web/app/modules/Admin/EditCourse/components/course-generation/utils/__tests__/courseGenerationCourseCache.utils.test.ts
@@ -1,0 +1,76 @@
+import { COURSE_GENERATION_STREAM_EVENT_TYPE } from "@repo/shared";
+import { describe, expect, it } from "vitest";
+
+import { LessonType } from "~/modules/Admin/EditCourse/EditCourse.types";
+
+import {
+  getCourseGenerationPreviewChapters,
+  hasCourseGenerationPreviewEvents,
+} from "../courseGenerationCourseCache.utils";
+
+describe("course generation preview cache utilities", () => {
+  it("maps camelCase Luma SDK preview events into temporary course chapters", () => {
+    const streamData = [
+      [
+        {
+          type: COURSE_GENERATION_STREAM_EVENT_TYPE.DESIGNER_CHAPTER_GENERATED,
+          generation: {
+            title: "Vectors, Matrices, and Core Operations",
+            targetLessonCount: 3,
+          },
+        },
+      ],
+      [
+        {
+          type: COURSE_GENERATION_STREAM_EVENT_TYPE.ARCHITECT_LESSON_GENERATED,
+          chapterIndex: 0,
+          lessonIndex: 0,
+          generation: {
+            lessonType: "CONTENT",
+            title: "Representing Data as Vectors",
+          },
+        },
+      ],
+    ];
+
+    expect(hasCourseGenerationPreviewEvents(streamData)).toBe(true);
+
+    expect(getCourseGenerationPreviewChapters(streamData)).toEqual([
+      expect.objectContaining({
+        id: "luma-preview-chapter-0-vectors-matrices-and-core-operations",
+        title: "Vectors, Matrices, and Core Operations",
+        displayOrder: 1,
+        lessonCount: 1,
+        lessons: [
+          expect.objectContaining({
+            id: "luma-preview-lesson-0-representing-data-as-vectors",
+            title: "Representing Data as Vectors",
+            type: LessonType.CONTENT,
+            displayOrder: 1,
+          }),
+        ],
+      }),
+    ]);
+  });
+
+  it("uses explicit camelCase chapter indexes when Luma sends them", () => {
+    const streamData = [
+      {
+        type: COURSE_GENERATION_STREAM_EVENT_TYPE.DESIGNER_CHAPTER_GENERATED,
+        chapterIndex: 2,
+        generation: {
+          title: "Final Applications",
+          targetLessonCount: 2,
+        },
+      },
+    ];
+
+    expect(getCourseGenerationPreviewChapters(streamData)).toEqual([
+      expect.objectContaining({
+        id: "luma-preview-chapter-2-final-applications",
+        displayOrder: 3,
+        lessonCount: 2,
+      }),
+    ]);
+  });
+});

--- a/apps/web/app/modules/Admin/EditCourse/components/course-generation/utils/courseGenerationCourseCache.utils.ts
+++ b/apps/web/app/modules/Admin/EditCourse/components/course-generation/utils/courseGenerationCourseCache.utils.ts
@@ -14,6 +14,23 @@ type StreamEvents = {
   lessons: Array<Lesson & { chapterId: string }>;
 };
 
+type PreviewChapterGeneratedEvent = CourseGenerationChapterGeneratedEvent & {
+  chapterIndex?: number;
+  generation: {
+    title: string;
+    targetLessonCount?: number;
+  };
+};
+
+type PreviewLessonGeneratedEvent = CourseGenerationLessonGeneratedEvent & {
+  chapterIndex: number;
+  lessonIndex: number;
+  generation: {
+    lessonType: "AI_MENTOR" | "CONTENT" | "QUIZ";
+    title: string;
+  };
+};
+
 const LUMA_PREVIEW_LESSON_TYPES = {
   AI_MENTOR: "AI_MENTOR",
   CONTENT: "CONTENT",
@@ -28,33 +45,27 @@ function toObject(value: unknown): Record<string, unknown> | null {
   return isPlainObject(value) ? (value as Record<string, unknown>) : null;
 }
 
-function isPreviewChapterGeneratedEvent(
-  value: unknown,
-): value is CourseGenerationChapterGeneratedEvent {
+function isPreviewChapterGeneratedEvent(value: unknown): value is PreviewChapterGeneratedEvent {
   const event = toObject(value);
   const generation = toObject(event?.generation);
 
   return (
     event?.type === COURSE_GENERATION_STREAM_EVENT_TYPE.DESIGNER_CHAPTER_GENERATED &&
     generation !== null &&
-    typeof generation.chapter_index === "number" &&
-    typeof generation.title === "string" &&
-    typeof generation.target_lesson_count === "number"
+    typeof generation.title === "string"
   );
 }
 
-function isPreviewLessonGeneratedEvent(
-  value: unknown,
-): value is CourseGenerationLessonGeneratedEvent {
+function isPreviewLessonGeneratedEvent(value: unknown): value is PreviewLessonGeneratedEvent {
   const event = toObject(value);
   const generation = toObject(event?.generation);
 
   return (
     event?.type === COURSE_GENERATION_STREAM_EVENT_TYPE.ARCHITECT_LESSON_GENERATED &&
-    typeof event.chapter_index === "number" &&
-    typeof event.lesson_index === "number" &&
+    typeof event.chapterIndex === "number" &&
+    typeof event.lessonIndex === "number" &&
     generation !== null &&
-    typeof generation.lesson_type === "string" &&
+    typeof generation.lessonType === "string" &&
     typeof generation.title === "string"
   );
 }
@@ -70,7 +81,7 @@ function getTempId(prefix: string, index: number, title: string | null) {
 }
 
 function normalizeLessonType(
-  value: CourseGenerationLessonGeneratedEvent["generation"]["lesson_type"],
+  value: PreviewLessonGeneratedEvent["generation"]["lessonType"],
 ): LessonType {
   if (value === LUMA_PREVIEW_LESSON_TYPES.AI_MENTOR) {
     return LessonType.AI_MENTOR;
@@ -83,12 +94,18 @@ function normalizeLessonType(
   return LessonType.CONTENT;
 }
 
-function mapPreviewChapter(event: CourseGenerationChapterGeneratedEvent): {
+function mapPreviewChapter(
+  event: PreviewChapterGeneratedEvent,
+  fallbackPreviewIndex: number,
+): {
   chapter: Chapter;
   previewIndex: number;
 } {
-  const { generation } = event;
-  const previewIndex = generation.chapter_index;
+  const generation = event.generation;
+  const previewIndex =
+    typeof event.chapterIndex === "number" ? event.chapterIndex : fallbackPreviewIndex;
+  const targetLessonCount =
+    typeof generation.targetLessonCount === "number" ? generation.targetLessonCount : 0;
   const id = getTempId("chapter", previewIndex, generation.title);
 
   return {
@@ -98,7 +115,7 @@ function mapPreviewChapter(event: CourseGenerationChapterGeneratedEvent): {
       updatedAt: new Date(0).toISOString(),
       displayOrder: previewIndex + 1,
       isFree: false,
-      lessonCount: generation.target_lesson_count,
+      lessonCount: targetLessonCount,
       lessons: [],
     },
     previewIndex,
@@ -106,16 +123,17 @@ function mapPreviewChapter(event: CourseGenerationChapterGeneratedEvent): {
 }
 
 function mapPreviewLesson(
-  event: CourseGenerationLessonGeneratedEvent,
+  event: PreviewLessonGeneratedEvent,
   chapterIdsByPreviewIndex: Map<number, string>,
 ): (Lesson & { chapterId: string }) | null {
   const { generation } = event;
-  const chapterId = chapterIdsByPreviewIndex.get(event.chapter_index);
+
+  const chapterId = chapterIdsByPreviewIndex.get(event.chapterIndex);
 
   if (!chapterId) return null;
 
-  const type = normalizeLessonType(generation.lesson_type);
-  const id = getTempId("lesson", event.lesson_index, generation.title);
+  const type = normalizeLessonType(generation.lessonType);
+  const id = getTempId("lesson", event.lessonIndex, generation.title);
 
   return {
     id,
@@ -124,7 +142,7 @@ function mapPreviewLesson(
     chapterId,
     description: "",
     updatedAt: new Date(0).toISOString(),
-    displayOrder: event.lesson_index + 1,
+    displayOrder: event.lessonIndex + 1,
   };
 }
 
@@ -135,7 +153,7 @@ function extractPreviewEvents(streamData: unknown): StreamEvents {
 
   for (const item of flatten(streamData)) {
     if (isPreviewChapterGeneratedEvent(item)) {
-      const previewChapter = mapPreviewChapter(item);
+      const previewChapter = mapPreviewChapter(item, chapters.length);
       chapters.push(previewChapter.chapter);
       chapterIdsByPreviewIndex.set(previewChapter.previewIndex, previewChapter.chapter.id);
       continue;

--- a/apps/web/app/modules/News/NewsItem.tsx
+++ b/apps/web/app/modules/News/NewsItem.tsx
@@ -31,12 +31,13 @@ function NewsItem({
 
   return (
     <button
+      type="button"
       data-testid={NEWS_PAGE_HANDLES.item(id)}
       className={cn(
-        "relative overflow-hidden rounded-lg py-7 px-6 flex flex-col justify-end min-h-[380px] group",
+        "relative flex w-full flex-col justify-end overflow-hidden rounded-lg px-6 py-7 min-h-[380px] group",
         className,
         {
-          "px-10 py-11 min-h-[550px]": isBig,
+          "px-10 py-11 md:aspect-video md:min-h-0": isBig,
         },
       )}
       onClick={() => navigate(`/news/${id}`)}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -18,5 +18,8 @@
     "glob": "^11.0.3",
     "tsup": "^8.0.2",
     "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@japro/luma-sdk": "0.2.12"
   }
 }

--- a/packages/shared/src/constants/lumaCourseGeneration.ts
+++ b/packages/shared/src/constants/lumaCourseGeneration.ts
@@ -1,3 +1,11 @@
+import type {
+  LumaAssetRequestedEvent,
+  LumaChapterGeneratedEvent,
+  LumaCourseGeneratedEvent,
+  LumaCourseGenerationStreamEvent as SdkLumaCourseGenerationStreamEvent,
+  LumaLessonGeneratedEvent,
+} from "@japro/luma-sdk";
+
 export const COURSE_GENERATION_SYNC_SOCKET_EVENT = "luma-course-generation:sync-status-changed";
 
 export const COURSE_GENERATION_SYNC_STATUS = {
@@ -51,45 +59,15 @@ export type CourseGenerationCourseGeneratedFlagEvent = {
   course_generated: true;
 };
 
-export type CourseGenerationCourseGeneratedEvent = {
-  type: (typeof COURSE_GENERATION_STREAM_EVENT_TYPE)["COURSE_GENERATED"];
-  draftId: string;
-};
+export type CourseGenerationCourseGeneratedEvent = LumaCourseGeneratedEvent;
 
-export type CourseGenerationChapterGeneratedEvent = {
-  type: (typeof COURSE_GENERATION_STREAM_EVENT_TYPE)["DESIGNER_CHAPTER_GENERATED"];
-  generation: {
-    chapter_index: number;
-    title: string;
-    target_lesson_count: number;
-  };
-};
+export type CourseGenerationChapterGeneratedEvent = LumaChapterGeneratedEvent;
 
-export type CourseGenerationLessonGeneratedEvent = {
-  type: (typeof COURSE_GENERATION_STREAM_EVENT_TYPE)["ARCHITECT_LESSON_GENERATED"];
-  chapter_index: number;
-  lesson_index: number;
-  generation: {
-    lesson_type: "AI_MENTOR" | "CONTENT" | "QUIZ";
-    title: string;
-  };
-  relevant_context: string | null;
-};
+export type CourseGenerationLessonGeneratedEvent = LumaLessonGeneratedEvent;
 
-export type CourseGenerationAssetRequestedEvent = {
-  type: (typeof COURSE_GENERATION_STREAM_EVENT_TYPE)["ASSET_REQUESTED"];
-  draftId: string;
-  assetId: string;
-  chapterIndex?: number;
-  lessonIndex?: number;
-  provider?: string;
-  status?: string;
-};
+export type CourseGenerationAssetRequestedEvent = LumaAssetRequestedEvent;
 
 export type CourseGenerationStreamEvent =
   | CourseGenerationMessageKeyEvent
   | CourseGenerationCourseGeneratedFlagEvent
-  | CourseGenerationCourseGeneratedEvent
-  | CourseGenerationChapterGeneratedEvent
-  | CourseGenerationLessonGeneratedEvent
-  | CourseGenerationAssetRequestedEvent;
+  | SdkLumaCourseGenerationStreamEvent;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1162,6 +1162,10 @@ importers:
         version: 5.9.3
 
   packages/shared:
+    dependencies:
+      '@japro/luma-sdk':
+        specifier: 0.2.12
+        version: 0.2.12
     devDependencies:
       glob:
         specifier: ^11.0.3


### PR DESCRIPTION
## Issue(s)
[](https://github.com/Selleo/mentingo/issues/1643)

## Overview
Updates Luma course generation live preview handling so generated chapter and lesson cards appear while the course is still being created.

- Maps the camelCase Luma stream events used by the deployed backend.
- Keeps the Luma stream event contract aligned with `@japro/luma-sdk` through shared types.
- Makes backend course completion detection resilient when stream frames arrive split across chunks.
- Adds a regression test for the deployed live-preview event shape.

## Business Value
Users can see course structure appearing live during generation instead of waiting with an empty preview area. This makes course generation feel responsive and reliable, especially in deployed environments where stream chunks can arrive differently than local development.