### PR TITLE
fix: improve group selector search in the user edit view

### DIFF
--- a/apps/web/app/hooks/useGroupsOptions.ts
+++ b/apps/web/app/hooks/useGroupsOptions.ts
@@ -7,13 +7,13 @@ export const useGroupsOptions = (groups?: Array<{ id: string; name: string }>) =
 
   const filterGroups = useMemo(
     () => (value: string, search: string) =>
-      selectedGroups
-        .find((g) => g.value === value)
-        ?.label.toLowerCase()
+      groups
+        ?.find((group) => group.id === value)
+        ?.name.toLowerCase()
         .includes(search.toLowerCase())
         ? 1
         : 0,
-    [selectedGroups],
+    [groups],
   );
 
   const options = useMemo(


### PR DESCRIPTION
<!--
 1. Make sure you have correct branch name i.e. `ab_prefix_123_task_name`, where `123` is a issue ID, and `ab` is an author
 2. Make sure you have meaningful title related to task with correct prefix: feat/fix/chore/style/docs/refactor
 3. Reference multiple issues in one PR by listing them in the issues section
 4. Make sure all necessary sections are filled, remove obsolete sections
 5. Do a self review first
 6. Check if your PR includes only code related to your task
 7. `Notes` is used for additional info but also to notify if any action is required
-->

## Issue(s)
[1647](https://github.com/Selleo/mentingo/issues/1647)

 ## Overview

  Fixes group search in the user edit view by updating the shared group selector
  filter to search against all available groups instead of only already selected
  groups.

  This restores expected behavior when assigning a user to a new group from the user
  details page, and also improves the shared bulk user group selector that uses the
  same hook. The API schema artifact was updated as part of the branch state.

  ## Business Value

  Admins can reliably find and assign users to groups from the user edit flow. This
  removes a blocker where only existing user groups were searchable, making user
  management faster and less error-prone.