### PR TITLE
fix: reset quiz questions properly when retaking a quiz

### DIFF
--- a/apps/api/src/lesson/services/lesson.service.ts
+++ b/apps/api/src/lesson/services/lesson.service.ts
@@ -95,7 +95,7 @@ export class LessonService {
 
     const hasLessonAccess = await this.lessonRepository.getHasLessonAccess(id, userId, isStudent);
 
-    if (!hasLessonAccess) throw new UnauthorizedException("You don't have access to this lesson");
+    if (!hasLessonAccess) throw new UnauthorizedException("common.toast.lessonAccessDenied");
 
     const { language: actualLanguage } = await this.localizationService.getBaseLanguage(
       ENTITY_TYPE.LESSON,
@@ -110,10 +110,10 @@ export class LessonService {
 
     const lesson = await this.lessonRepository.getLessonDetails(id, userId, actualLanguage);
 
-    if (!lesson) throw new NotFoundException("Lesson not found");
+    if (!lesson) throw new NotFoundException("common.toast.notFound");
 
     if (isStudent && !lesson.isFreemium && !lesson.isEnrolled)
-      throw new UnauthorizedException("You don't have access");
+      throw new UnauthorizedException("common.toast.lessonAccessDenied");
 
     if (
       lesson.type === LESSON_TYPES.QUIZ ||
@@ -314,12 +314,16 @@ export class LessonService {
       userId,
     );
 
+    if (!accessCourseLessonWithDetails) {
+      throw new NotFoundException("common.toast.notFound");
+    }
+
     if (accessCourseLessonWithDetails.lessonIsCompleted) {
-      throw new ConflictException("You have already answered this quiz");
+      throw new ConflictException("studentLessonView.validation.quizAlreadyAnswered");
     }
 
     if (!accessCourseLessonWithDetails.isAssigned && !accessCourseLessonWithDetails.isFreemium)
-      throw new UnauthorizedException("You don't have assignment to this lesson");
+      throw new UnauthorizedException("studentLessonView.validation.lessonAssignmentRequired");
 
     const quizSettings = await this.lessonRepository.getLessonSettings(studentQuizAnswers.lessonId);
 
@@ -434,12 +438,7 @@ export class LessonService {
           score: quizScore,
         };
       } catch (error) {
-        throw new ConflictException(
-          "Quiz evaluation failed, problem with question: " +
-            error?.message +
-            " problem is: " +
-            error?.response?.error,
-        );
+        throw new ConflictException("studentLessonView.validation.quizEvaluationFailed");
       }
     });
   }
@@ -454,12 +453,16 @@ export class LessonService {
       userId,
     );
 
+    if (!accessCourseLessonWithDetails) {
+      throw new NotFoundException("common.toast.notFound");
+    }
+
     if (!accessCourseLessonWithDetails.lessonIsCompleted) {
-      throw new ConflictException("You have not answered this quiz yet");
+      throw new ConflictException("studentLessonView.validation.quizNotAnsweredYet");
     }
 
     if (!accessCourseLessonWithDetails.isAssigned) {
-      throw new ConflictException("You are not enrolled to this course");
+      throw new ConflictException("studentLessonView.validation.courseEnrollmentRequired");
     }
 
     const quizSettings = await this.lessonRepository.getLessonSettings(lessonId);
@@ -474,9 +477,7 @@ export class LessonService {
         quizSettings?.quizCooldownInHours,
       )
     ) {
-      throw new ConflictException(
-        "Quiz answers cannot be deleted due to attempts limit or cooldown",
-      );
+      throw new ConflictException("studentLessonView.validation.quizRetakeUnavailable");
     }
 
     attempts += 1;
@@ -504,7 +505,7 @@ export class LessonService {
           null,
         );
       } catch (error) {
-        throw new ConflictException(`Failed to delete student quiz answers: ${error.message}`);
+        throw new ConflictException("studentLessonView.validation.quizResetFailed");
       }
     });
   }

--- a/apps/api/src/swagger/api-schema.json
+++ b/apps/api/src/swagger/api-schema.json
@@ -5887,218 +5887,9 @@
         }
       }
     },
-    "/api/ingestion/ingest": {
-      "post": {
-        "operationId": "IngestionController_ingest",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "lessonId": {
-                    "type": "string",
-                    "format": "uuid"
-                  },
-                  "files": {
-                    "type": "array",
-                    "items": {
-                      "type": "string",
-                      "format": "binary"
-                    }
-                  }
-                },
-                "required": [
-                  "lessonId",
-                  "files"
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        }
-      }
-    },
-    "/api/ingestion/{lessonId}": {
+    "/api/chapter": {
       "get": {
-        "operationId": "IngestionController_getAllAssignedDocumentsForLesson",
-        "parameters": [
-          {
-            "name": "lessonId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetAllAssignedDocumentsForLessonResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/ingestion/{documentLinkId}": {
-      "delete": {
-        "operationId": "IngestionController_deleteDocumentLink",
-        "parameters": [
-          {
-            "name": "documentLinkId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        }
-      }
-    },
-    "/api/ai/thread": {
-      "get": {
-        "operationId": "AiController_getThread",
-        "parameters": [
-          {
-            "name": "thread",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetThreadResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/ai/thread/messages": {
-      "get": {
-        "operationId": "AiController_getThreadMessages",
-        "parameters": [
-          {
-            "name": "thread",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetThreadMessagesResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/ai/chat": {
-      "post": {
-        "operationId": "AiController_streamChat",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/StreamChatBody"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        }
-      }
-    },
-    "/api/ai/judge/{threadId}": {
-      "post": {
-        "operationId": "AiController_judgeThread",
-        "parameters": [
-          {
-            "name": "threadId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JudgeThreadResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/ai/retake/{lessonId}": {
-      "post": {
-        "operationId": "AiController_retakeLesson",
-        "parameters": [
-          {
-            "name": "lessonId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        }
-      }
-    },
-    "/api/studentLessonProgress": {
-      "post": {
-        "operationId": "StudentLessonProgressController_markLessonAsCompleted",
+        "operationId": "ChapterController_getChapterWithLesson",
         "parameters": [
           {
             "name": "id",
@@ -6145,79 +5936,57 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/MarkLessonAsCompletedResponse"
+                  "$ref": "#/components/schemas/GetChapterWithLessonResponse"
                 }
               }
             }
           }
         }
-      }
-    },
-    "/api/certificates/all": {
-      "get": {
-        "operationId": "CertificatesController_getAllCertificates",
+      },
+      "patch": {
+        "operationId": "ChapterController_updateChapter",
         "parameters": [
           {
-            "name": "userId",
+            "name": "id",
             "required": false,
             "in": "query",
             "schema": {
               "format": "uuid",
               "type": "string"
             }
-          },
-          {
-            "name": "language",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "default": "en",
-              "anyOf": [
-                {
-                  "const": "en",
-                  "type": "string"
-                },
-                {
-                  "const": "pl",
-                  "type": "string"
-                },
-                {
-                  "const": "de",
-                  "type": "string"
-                },
-                {
-                  "const": "lt",
-                  "type": "string"
-                },
-                {
-                  "const": "cs",
-                  "type": "string"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateChapterBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateChapterResponse"
                 }
-              ]
+              }
             }
-          },
+          }
+        }
+      },
+      "delete": {
+        "operationId": "ChapterController_removeChapter",
+        "parameters": [
           {
-            "name": "page",
-            "required": false,
+            "name": "chapterId",
+            "required": true,
             "in": "query",
             "schema": {
-              "minimum": 1,
-              "type": "number"
-            }
-          },
-          {
-            "name": "perPage",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "type": "number"
-            }
-          },
-          {
-            "name": "sort",
-            "required": false,
-            "in": "query",
-            "schema": {
+              "format": "uuid",
               "type": "string"
             }
           }
@@ -6227,7 +5996,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GetAllCertificatesResponse"
+                  "$ref": "#/components/schemas/RemoveChapterResponse"
                 }
               }
             }
@@ -6235,103 +6004,43 @@
         }
       }
     },
-    "/api/certificates/certificate": {
-      "get": {
-        "operationId": "CertificatesController_getCertificate",
-        "parameters": [
-          {
-            "name": "userId",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          },
-          {
-            "name": "courseId",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          },
-          {
-            "name": "language",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "default": "en",
-              "anyOf": [
-                {
-                  "const": "en",
-                  "type": "string"
-                },
-                {
-                  "const": "pl",
-                  "type": "string"
-                },
-                {
-                  "const": "de",
-                  "type": "string"
-                },
-                {
-                  "const": "lt",
-                  "type": "string"
-                },
-                {
-                  "const": "cs",
-                  "type": "string"
-                }
-              ]
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetCertificateResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/certificates/download": {
+    "/api/chapter/beta-create-chapter": {
       "post": {
-        "operationId": "CertificatesController_downloadCertificate",
+        "operationId": "ChapterController_betaCreateChapter",
         "parameters": [],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/DownloadCertificateBody"
+                "$ref": "#/components/schemas/BetaCreateChapterBody"
               }
             }
           }
         },
         "responses": {
-          "201": {
-            "description": ""
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaCreateChapterResponse"
+                }
+              }
+            }
           }
         }
       }
     },
-    "/api/certificates/share-link": {
-      "post": {
-        "operationId": "CertificatesController_createCertificateShareLink",
+    "/api/chapter/chapter-display-order": {
+      "patch": {
+        "operationId": "ChapterController_updateChapterDisplayOrder",
         "parameters": [],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateCertificateShareLinkBody"
+                "$ref": "#/components/schemas/UpdateChapterDisplayOrderBody"
               }
             }
           }
@@ -6341,7 +6050,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CreateCertificateShareLinkResponse"
+                  "$ref": "#/components/schemas/UpdateChapterDisplayOrderResponse"
                 }
               }
             }
@@ -6349,14 +6058,14 @@
         }
       }
     },
-    "/api/certificates/course/{courseId}/validity-impact": {
-      "post": {
-        "operationId": "CertificatesController_getCertificateValidityImpact",
+    "/api/chapter/freemium-status": {
+      "patch": {
+        "operationId": "ChapterController_updateFreemiumStatus",
         "parameters": [
           {
-            "name": "courseId",
-            "required": true,
-            "in": "path",
+            "name": "chapterId",
+            "required": false,
+            "in": "query",
             "schema": {
               "format": "uuid",
               "type": "string"
@@ -6368,7 +6077,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/GetCertificateValidityImpactBody"
+                "$ref": "#/components/schemas/UpdateFreemiumStatusBody"
               }
             }
           }
@@ -6378,243 +6087,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GetCertificateValidityImpactResponse"
+                  "$ref": "#/components/schemas/UpdateFreemiumStatusResponse"
                 }
               }
             }
-          }
-        }
-      }
-    },
-    "/api/certificates/course/{courseId}/reset-options": {
-      "get": {
-        "operationId": "CertificatesController_getCertificateResetOptions",
-        "parameters": [
-          {
-            "name": "courseId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          },
-          {
-            "name": "language",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "default": "en",
-              "anyOf": [
-                {
-                  "const": "en",
-                  "type": "string"
-                },
-                {
-                  "const": "pl",
-                  "type": "string"
-                },
-                {
-                  "const": "de",
-                  "type": "string"
-                },
-                {
-                  "const": "lt",
-                  "type": "string"
-                },
-                {
-                  "const": "cs",
-                  "type": "string"
-                }
-              ]
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetCertificateResetOptionsResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/certificates/course/{courseId}/reset-users": {
-      "get": {
-        "operationId": "CertificatesController_getCertificateResetUsers",
-        "parameters": [
-          {
-            "name": "courseId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          },
-          {
-            "name": "page",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "minimum": 1,
-              "type": "number"
-            }
-          },
-          {
-            "name": "perPage",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "minimum": 1,
-              "type": "number"
-            }
-          },
-          {
-            "name": "search",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "language",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "default": "en",
-              "anyOf": [
-                {
-                  "const": "en",
-                  "type": "string"
-                },
-                {
-                  "const": "pl",
-                  "type": "string"
-                },
-                {
-                  "const": "de",
-                  "type": "string"
-                },
-                {
-                  "const": "lt",
-                  "type": "string"
-                },
-                {
-                  "const": "cs",
-                  "type": "string"
-                }
-              ]
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetCertificateResetUsersResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/certificates/course/{courseId}/reset": {
-      "post": {
-        "operationId": "CertificatesController_resetCourseCertificates",
-        "parameters": [
-          {
-            "name": "courseId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ResetCourseCertificatesBody"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ResetCourseCertificatesResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/certificates/share": {
-      "get": {
-        "operationId": "CertificatesController_getCertificateSharePage",
-        "parameters": [
-          {
-            "name": "certificateId",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "lang",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        }
-      }
-    },
-    "/api/certificates/share-image": {
-      "get": {
-        "operationId": "CertificatesController_getCertificateShareImage",
-        "parameters": [
-          {
-            "name": "certificateId",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "lang",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
           }
         }
       }
@@ -7395,6 +6871,738 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/api/studentLessonProgress": {
+      "post": {
+        "operationId": "StudentLessonProgressController_markLessonAsCompleted",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "language",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": "en",
+              "anyOf": [
+                {
+                  "const": "en",
+                  "type": "string"
+                },
+                {
+                  "const": "pl",
+                  "type": "string"
+                },
+                {
+                  "const": "de",
+                  "type": "string"
+                },
+                {
+                  "const": "lt",
+                  "type": "string"
+                },
+                {
+                  "const": "cs",
+                  "type": "string"
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MarkLessonAsCompletedResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/certificates/all": {
+      "get": {
+        "operationId": "CertificatesController_getAllCertificates",
+        "parameters": [
+          {
+            "name": "userId",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "language",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": "en",
+              "anyOf": [
+                {
+                  "const": "en",
+                  "type": "string"
+                },
+                {
+                  "const": "pl",
+                  "type": "string"
+                },
+                {
+                  "const": "de",
+                  "type": "string"
+                },
+                {
+                  "const": "lt",
+                  "type": "string"
+                },
+                {
+                  "const": "cs",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "minimum": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "perPage",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetAllCertificatesResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/certificates/certificate": {
+      "get": {
+        "operationId": "CertificatesController_getCertificate",
+        "parameters": [
+          {
+            "name": "userId",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "courseId",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "language",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": "en",
+              "anyOf": [
+                {
+                  "const": "en",
+                  "type": "string"
+                },
+                {
+                  "const": "pl",
+                  "type": "string"
+                },
+                {
+                  "const": "de",
+                  "type": "string"
+                },
+                {
+                  "const": "lt",
+                  "type": "string"
+                },
+                {
+                  "const": "cs",
+                  "type": "string"
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetCertificateResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/certificates/download": {
+      "post": {
+        "operationId": "CertificatesController_downloadCertificate",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DownloadCertificateBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/api/certificates/share-link": {
+      "post": {
+        "operationId": "CertificatesController_createCertificateShareLink",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCertificateShareLinkBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateCertificateShareLinkResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/certificates/course/{courseId}/validity-impact": {
+      "post": {
+        "operationId": "CertificatesController_getCertificateValidityImpact",
+        "parameters": [
+          {
+            "name": "courseId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GetCertificateValidityImpactBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetCertificateValidityImpactResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/certificates/course/{courseId}/reset-options": {
+      "get": {
+        "operationId": "CertificatesController_getCertificateResetOptions",
+        "parameters": [
+          {
+            "name": "courseId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "language",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": "en",
+              "anyOf": [
+                {
+                  "const": "en",
+                  "type": "string"
+                },
+                {
+                  "const": "pl",
+                  "type": "string"
+                },
+                {
+                  "const": "de",
+                  "type": "string"
+                },
+                {
+                  "const": "lt",
+                  "type": "string"
+                },
+                {
+                  "const": "cs",
+                  "type": "string"
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetCertificateResetOptionsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/certificates/course/{courseId}/reset-users": {
+      "get": {
+        "operationId": "CertificatesController_getCertificateResetUsers",
+        "parameters": [
+          {
+            "name": "courseId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "minimum": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "perPage",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "minimum": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "search",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "language",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": "en",
+              "anyOf": [
+                {
+                  "const": "en",
+                  "type": "string"
+                },
+                {
+                  "const": "pl",
+                  "type": "string"
+                },
+                {
+                  "const": "de",
+                  "type": "string"
+                },
+                {
+                  "const": "lt",
+                  "type": "string"
+                },
+                {
+                  "const": "cs",
+                  "type": "string"
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetCertificateResetUsersResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/certificates/course/{courseId}/reset": {
+      "post": {
+        "operationId": "CertificatesController_resetCourseCertificates",
+        "parameters": [
+          {
+            "name": "courseId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResetCourseCertificatesBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResetCourseCertificatesResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/certificates/share": {
+      "get": {
+        "operationId": "CertificatesController_getCertificateSharePage",
+        "parameters": [
+          {
+            "name": "certificateId",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "lang",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/api/certificates/share-image": {
+      "get": {
+        "operationId": "CertificatesController_getCertificateShareImage",
+        "parameters": [
+          {
+            "name": "certificateId",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "lang",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/api/ai/thread": {
+      "get": {
+        "operationId": "AiController_getThread",
+        "parameters": [
+          {
+            "name": "thread",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetThreadResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ai/thread/messages": {
+      "get": {
+        "operationId": "AiController_getThreadMessages",
+        "parameters": [
+          {
+            "name": "thread",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetThreadMessagesResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ai/chat": {
+      "post": {
+        "operationId": "AiController_streamChat",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StreamChatBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/api/ai/judge/{threadId}": {
+      "post": {
+        "operationId": "AiController_judgeThread",
+        "parameters": [
+          {
+            "name": "threadId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JudgeThreadResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ai/retake/{lessonId}": {
+      "post": {
+        "operationId": "AiController_retakeLesson",
+        "parameters": [
+          {
+            "name": "lessonId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/api/ingestion/ingest": {
+      "post": {
+        "operationId": "IngestionController_ingest",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "lessonId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "files": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "binary"
+                    }
+                  }
+                },
+                "required": [
+                  "lessonId",
+                  "files"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/api/ingestion/{lessonId}": {
+      "get": {
+        "operationId": "IngestionController_getAllAssignedDocumentsForLesson",
+        "parameters": [
+          {
+            "name": "lessonId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetAllAssignedDocumentsForLessonResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ingestion/{documentLinkId}": {
+      "delete": {
+        "operationId": "IngestionController_deleteDocumentLink",
+        "parameters": [
+          {
+            "name": "documentLinkId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
           }
         }
       }
@@ -9028,214 +9236,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/GetEnvKeyResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/chapter": {
-      "get": {
-        "operationId": "ChapterController_getChapterWithLesson",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          },
-          {
-            "name": "language",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "default": "en",
-              "anyOf": [
-                {
-                  "const": "en",
-                  "type": "string"
-                },
-                {
-                  "const": "pl",
-                  "type": "string"
-                },
-                {
-                  "const": "de",
-                  "type": "string"
-                },
-                {
-                  "const": "lt",
-                  "type": "string"
-                },
-                {
-                  "const": "cs",
-                  "type": "string"
-                }
-              ]
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetChapterWithLessonResponse"
-                }
-              }
-            }
-          }
-        }
-      },
-      "patch": {
-        "operationId": "ChapterController_updateChapter",
-        "parameters": [
-          {
-            "name": "id",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateChapterBody"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UpdateChapterResponse"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "operationId": "ChapterController_removeChapter",
-        "parameters": [
-          {
-            "name": "chapterId",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RemoveChapterResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/chapter/beta-create-chapter": {
-      "post": {
-        "operationId": "ChapterController_betaCreateChapter",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BetaCreateChapterBody"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BetaCreateChapterResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/chapter/chapter-display-order": {
-      "patch": {
-        "operationId": "ChapterController_updateChapterDisplayOrder",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateChapterDisplayOrderBody"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UpdateChapterDisplayOrderResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/chapter/freemium-status": {
-      "patch": {
-        "operationId": "ChapterController_updateFreemiumStatus",
-        "parameters": [
-          {
-            "name": "chapterId",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateFreemiumStatusBody"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UpdateFreemiumStatusResponse"
                 }
               }
             }
@@ -27397,42 +27397,7 @@
           ]
         }
       },
-      "GetAllAssignedDocumentsForLessonResponse": {
-        "type": "object",
-        "properties": {
-          "data": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "format": "uuid",
-                  "type": "string"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "type": {
-                  "type": "string"
-                },
-                "size": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "id",
-                "name",
-                "type",
-                "size"
-              ]
-            }
-          }
-        },
-        "required": [
-          "data"
-        ]
-      },
-      "GetThreadResponse": {
+      "GetChapterWithLessonResponse": {
         "type": "object",
         "properties": {
           "data": {
@@ -27442,15 +27407,1163 @@
                 "format": "uuid",
                 "type": "string"
               },
-              "aiMentorLessonId": {
+              "title": {
+                "type": "string"
+              },
+              "lessonCount": {
+                "type": "number"
+              },
+              "lessons": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "anyOf": [
+                        {
+                          "const": "content",
+                          "type": "string"
+                        },
+                        {
+                          "const": "quiz",
+                          "type": "string"
+                        },
+                        {
+                          "const": "ai_mentor",
+                          "type": "string"
+                        },
+                        {
+                          "const": "embed",
+                          "type": "string"
+                        },
+                        {
+                          "const": "scorm",
+                          "type": "string"
+                        },
+                        {
+                          "const": "live_training",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "displayOrder": {
+                      "type": "number"
+                    },
+                    "status": {
+                      "anyOf": [
+                        {
+                          "const": "not_started",
+                          "type": "string"
+                        },
+                        {
+                          "const": "in_progress",
+                          "type": "string"
+                        },
+                        {
+                          "const": "completed",
+                          "type": "string"
+                        },
+                        {
+                          "const": "blocked",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "quizQuestionCount": {
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "isExternal": {
+                      "type": "boolean"
+                    },
+                    "lessonResources": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "format": "uuid",
+                            "type": "string"
+                          },
+                          "fileUrl": {
+                            "type": "string"
+                          },
+                          "contentType": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "fileName": {
+                            "type": "string"
+                          },
+                          "allowFullscreen": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "fileUrl",
+                          "contentType"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "title",
+                    "type",
+                    "displayOrder",
+                    "status",
+                    "quizQuestionCount"
+                  ]
+                }
+              },
+              "completedLessonCount": {
+                "type": "number"
+              },
+              "chapterProgress": {
+                "anyOf": [
+                  {
+                    "const": "not_started",
+                    "type": "string"
+                  },
+                  {
+                    "const": "in_progress",
+                    "type": "string"
+                  },
+                  {
+                    "const": "completed",
+                    "type": "string"
+                  },
+                  {
+                    "const": "blocked",
+                    "type": "string"
+                  }
+                ]
+              },
+              "isFreemium": {
+                "type": "boolean"
+              },
+              "enrolled": {
+                "type": "boolean"
+              },
+              "isSubmitted": {
+                "type": "boolean"
+              },
+              "createdAt": {
+                "type": "string"
+              },
+              "updatedAt": {
+                "type": "string"
+              },
+              "quizCount": {
+                "type": "number"
+              },
+              "displayOrder": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "id",
+              "title",
+              "lessonCount",
+              "lessons",
+              "displayOrder"
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "BetaCreateChapterBody": {
+        "type": "object",
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "lessons": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "anyOf": [
+                        {
+                          "const": "content",
+                          "type": "string"
+                        },
+                        {
+                          "const": "quiz",
+                          "type": "string"
+                        },
+                        {
+                          "const": "ai_mentor",
+                          "type": "string"
+                        },
+                        {
+                          "const": "embed",
+                          "type": "string"
+                        },
+                        {
+                          "const": "scorm",
+                          "type": "string"
+                        },
+                        {
+                          "const": "live_training",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "description": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "displayOrder": {
+                      "type": "number"
+                    },
+                    "fileS3Key": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "avatarReferenceUrl": {
+                      "type": "string"
+                    },
+                    "fileType": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "questions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "format": "uuid",
+                            "type": "string"
+                          },
+                          "type": {
+                            "anyOf": [
+                              {
+                                "const": "brief_response",
+                                "type": "string"
+                              },
+                              {
+                                "const": "detailed_response",
+                                "type": "string"
+                              },
+                              {
+                                "const": "match_words",
+                                "type": "string"
+                              },
+                              {
+                                "const": "scale_1_5",
+                                "type": "string"
+                              },
+                              {
+                                "const": "single_choice",
+                                "type": "string"
+                              },
+                              {
+                                "const": "multiple_choice",
+                                "type": "string"
+                              },
+                              {
+                                "const": "true_or_false",
+                                "type": "string"
+                              },
+                              {
+                                "const": "photo_question_single_choice",
+                                "type": "string"
+                              },
+                              {
+                                "const": "photo_question_multiple_choice",
+                                "type": "string"
+                              },
+                              {
+                                "const": "fill_in_the_blanks_text",
+                                "type": "string"
+                              },
+                              {
+                                "const": "fill_in_the_blanks_dnd",
+                                "type": "string"
+                              }
+                            ]
+                          },
+                          "description": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "displayOrder": {
+                            "type": "number"
+                          },
+                          "solutionExplanation": {
+                            "type": "string"
+                          },
+                          "photoS3Key": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "options": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "format": "uuid",
+                                  "type": "string"
+                                },
+                                "optionText": {
+                                  "maxLength": 250,
+                                  "type": "string"
+                                },
+                                "displayOrder": {
+                                  "anyOf": [
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "isStudentAnswer": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "isCorrect": {
+                                  "type": "boolean"
+                                },
+                                "questionId": {
+                                  "format": "uuid",
+                                  "type": "string"
+                                },
+                                "matchedWord": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "scaleAnswer": {
+                                  "anyOf": [
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "language": {
+                                  "default": "en",
+                                  "anyOf": [
+                                    {
+                                      "const": "en",
+                                      "type": "string"
+                                    },
+                                    {
+                                      "const": "pl",
+                                      "type": "string"
+                                    },
+                                    {
+                                      "const": "de",
+                                      "type": "string"
+                                    },
+                                    {
+                                      "const": "lt",
+                                      "type": "string"
+                                    },
+                                    {
+                                      "const": "cs",
+                                      "type": "string"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "optionText",
+                                "displayOrder",
+                                "isCorrect"
+                              ]
+                            }
+                          },
+                          "language": {
+                            "default": "en",
+                            "anyOf": [
+                              {
+                                "const": "en",
+                                "type": "string"
+                              },
+                              {
+                                "const": "pl",
+                                "type": "string"
+                              },
+                              {
+                                "const": "de",
+                                "type": "string"
+                              },
+                              {
+                                "const": "lt",
+                                "type": "string"
+                              },
+                              {
+                                "const": "cs",
+                                "type": "string"
+                              }
+                            ]
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "title"
+                        ]
+                      }
+                    },
+                    "aiMentor": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "format": "uuid",
+                              "type": "string"
+                            },
+                            "lessonId": {
+                              "format": "uuid",
+                              "type": "string"
+                            },
+                            "aiMentorInstructions": {
+                              "type": "string"
+                            },
+                            "completionConditions": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "anyOf": [
+                                {
+                                  "const": "mentor",
+                                  "type": "string"
+                                },
+                                {
+                                  "const": "teacher",
+                                  "type": "string"
+                                },
+                                {
+                                  "const": "roleplay",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "avatarReference": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "voiceMode": {
+                              "anyOf": [
+                                {
+                                  "const": "preset",
+                                  "type": "string"
+                                },
+                                {
+                                  "const": "custom",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "ttsPreset": {
+                              "anyOf": [
+                                {
+                                  "const": "male",
+                                  "type": "string"
+                                },
+                                {
+                                  "const": "female",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "customTtsReference": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "lessonId",
+                            "aiMentorInstructions",
+                            "completionConditions",
+                            "type",
+                            "avatarReference",
+                            "voiceMode",
+                            "ttsPreset",
+                            "customTtsReference"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "liveTrainingId": {
+                      "anyOf": [
+                        {
+                          "format": "uuid",
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "title",
+                    "type",
+                    "displayOrder"
+                  ]
+                }
+              },
+              "chapterProgress": {
+                "anyOf": [
+                  {
+                    "const": "not_started",
+                    "type": "string"
+                  },
+                  {
+                    "const": "in_progress",
+                    "type": "string"
+                  },
+                  {
+                    "const": "completed",
+                    "type": "string"
+                  },
+                  {
+                    "const": "blocked",
+                    "type": "string"
+                  }
+                ]
+              },
+              "isFreemium": {
+                "type": "boolean"
+              },
+              "enrolled": {
+                "type": "boolean"
+              },
+              "isSubmitted": {
+                "type": "boolean"
+              },
+              "createdAt": {
+                "type": "string"
+              },
+              "updatedAt": {
+                "type": "string"
+              },
+              "quizCount": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "title"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "courseId": {
+                "format": "uuid",
+                "type": "string"
+              }
+            },
+            "required": [
+              "courseId"
+            ]
+          }
+        ]
+      },
+      "BetaCreateChapterResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "id": {
                 "format": "uuid",
                 "type": "string"
               },
-              "userId": {
-                "format": "uuid",
+              "message": {
                 "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "message"
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "UpdateChapterBody": {
+        "allOf": [
+          {
+            "type": "object",
+            "allOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string"
+                  },
+                  "lessons": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "format": "uuid",
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "anyOf": [
+                            {
+                              "const": "content",
+                              "type": "string"
+                            },
+                            {
+                              "const": "quiz",
+                              "type": "string"
+                            },
+                            {
+                              "const": "ai_mentor",
+                              "type": "string"
+                            },
+                            {
+                              "const": "embed",
+                              "type": "string"
+                            },
+                            {
+                              "const": "scorm",
+                              "type": "string"
+                            },
+                            {
+                              "const": "live_training",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "description": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "displayOrder": {
+                          "type": "number"
+                        },
+                        "fileS3Key": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "avatarReferenceUrl": {
+                          "type": "string"
+                        },
+                        "fileType": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "questions": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "format": "uuid",
+                                "type": "string"
+                              },
+                              "type": {
+                                "anyOf": [
+                                  {
+                                    "const": "brief_response",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "const": "detailed_response",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "const": "match_words",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "const": "scale_1_5",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "const": "single_choice",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "const": "multiple_choice",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "const": "true_or_false",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "const": "photo_question_single_choice",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "const": "photo_question_multiple_choice",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "const": "fill_in_the_blanks_text",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "const": "fill_in_the_blanks_dnd",
+                                    "type": "string"
+                                  }
+                                ]
+                              },
+                              "description": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "title": {
+                                "type": "string"
+                              },
+                              "displayOrder": {
+                                "type": "number"
+                              },
+                              "solutionExplanation": {
+                                "type": "string"
+                              },
+                              "photoS3Key": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "options": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "format": "uuid",
+                                      "type": "string"
+                                    },
+                                    "optionText": {
+                                      "maxLength": 250,
+                                      "type": "string"
+                                    },
+                                    "displayOrder": {
+                                      "anyOf": [
+                                        {
+                                          "type": "number"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "isStudentAnswer": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "isCorrect": {
+                                      "type": "boolean"
+                                    },
+                                    "questionId": {
+                                      "format": "uuid",
+                                      "type": "string"
+                                    },
+                                    "matchedWord": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "scaleAnswer": {
+                                      "anyOf": [
+                                        {
+                                          "type": "number"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "language": {
+                                      "default": "en",
+                                      "anyOf": [
+                                        {
+                                          "const": "en",
+                                          "type": "string"
+                                        },
+                                        {
+                                          "const": "pl",
+                                          "type": "string"
+                                        },
+                                        {
+                                          "const": "de",
+                                          "type": "string"
+                                        },
+                                        {
+                                          "const": "lt",
+                                          "type": "string"
+                                        },
+                                        {
+                                          "const": "cs",
+                                          "type": "string"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "optionText",
+                                    "displayOrder",
+                                    "isCorrect"
+                                  ]
+                                }
+                              },
+                              "language": {
+                                "default": "en",
+                                "anyOf": [
+                                  {
+                                    "const": "en",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "const": "pl",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "const": "de",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "const": "lt",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "const": "cs",
+                                    "type": "string"
+                                  }
+                                ]
+                              }
+                            },
+                            "required": [
+                              "type",
+                              "title"
+                            ]
+                          }
+                        },
+                        "aiMentor": {
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "format": "uuid",
+                                  "type": "string"
+                                },
+                                "lessonId": {
+                                  "format": "uuid",
+                                  "type": "string"
+                                },
+                                "aiMentorInstructions": {
+                                  "type": "string"
+                                },
+                                "completionConditions": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "anyOf": [
+                                    {
+                                      "const": "mentor",
+                                      "type": "string"
+                                    },
+                                    {
+                                      "const": "teacher",
+                                      "type": "string"
+                                    },
+                                    {
+                                      "const": "roleplay",
+                                      "type": "string"
+                                    }
+                                  ]
+                                },
+                                "avatarReference": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "voiceMode": {
+                                  "anyOf": [
+                                    {
+                                      "const": "preset",
+                                      "type": "string"
+                                    },
+                                    {
+                                      "const": "custom",
+                                      "type": "string"
+                                    }
+                                  ]
+                                },
+                                "ttsPreset": {
+                                  "anyOf": [
+                                    {
+                                      "const": "male",
+                                      "type": "string"
+                                    },
+                                    {
+                                      "const": "female",
+                                      "type": "string"
+                                    }
+                                  ]
+                                },
+                                "customTtsReference": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "id",
+                                "lessonId",
+                                "aiMentorInstructions",
+                                "completionConditions",
+                                "type",
+                                "avatarReference",
+                                "voiceMode",
+                                "ttsPreset",
+                                "customTtsReference"
+                              ]
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "liveTrainingId": {
+                          "anyOf": [
+                            {
+                              "format": "uuid",
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "updatedAt": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "title",
+                        "type",
+                        "displayOrder"
+                      ]
+                    }
+                  },
+                  "chapterProgress": {
+                    "anyOf": [
+                      {
+                        "const": "not_started",
+                        "type": "string"
+                      },
+                      {
+                        "const": "in_progress",
+                        "type": "string"
+                      },
+                      {
+                        "const": "completed",
+                        "type": "string"
+                      },
+                      {
+                        "const": "blocked",
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "isFreemium": {
+                    "type": "boolean"
+                  },
+                  "enrolled": {
+                    "type": "boolean"
+                  },
+                  "isSubmitted": {
+                    "type": "boolean"
+                  },
+                  "createdAt": {
+                    "type": "string"
+                  },
+                  "updatedAt": {
+                    "type": "string"
+                  },
+                  "quizCount": {
+                    "type": "number"
+                  }
+                }
               },
-              "userLanguage": {
+              {
+                "type": "object",
+                "properties": {
+                  "courseId": {
+                    "format": "uuid",
+                    "type": "string"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "language": {
+                "default": "en",
                 "anyOf": [
                   {
                     "const": "en",
@@ -27473,177 +28586,15 @@
                     "type": "string"
                   }
                 ]
-              },
-              "createdAt": {
-                "type": "string"
-              },
-              "updatedAt": {
-                "type": "string"
-              },
-              "status": {
-                "anyOf": [
-                  {
-                    "const": "active",
-                    "type": "string"
-                  },
-                  {
-                    "const": "completed",
-                    "type": "string"
-                  },
-                  {
-                    "const": "archived",
-                    "type": "string"
-                  }
-                ]
               }
             },
             "required": [
-              "id",
-              "aiMentorLessonId",
-              "userId",
-              "userLanguage",
-              "createdAt",
-              "updatedAt",
-              "status"
+              "language"
             ]
           }
-        },
-        "required": [
-          "data"
         ]
       },
-      "GetThreadMessagesResponse": {
-        "type": "object",
-        "properties": {
-          "data": {
-            "type": "array",
-            "items": {
-              "allOf": [
-                {
-                  "type": "object",
-                  "allOf": [
-                    {
-                      "type": "object",
-                      "properties": {
-                        "content": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "content"
-                      ]
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "role": {
-                          "anyOf": [
-                            {
-                              "const": "system",
-                              "type": "string"
-                            },
-                            {
-                              "const": "user",
-                              "type": "string"
-                            },
-                            {
-                              "const": "assistant",
-                              "type": "string"
-                            },
-                            {
-                              "const": "tool",
-                              "type": "string"
-                            },
-                            {
-                              "const": "summary",
-                              "type": "string"
-                            }
-                          ]
-                        },
-                        "isJudge": {
-                          "type": "boolean"
-                        },
-                        "userName": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        }
-                      },
-                      "required": [
-                        "role"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "id"
-                  ]
-                }
-              ]
-            }
-          }
-        },
-        "required": [
-          "data"
-        ]
-      },
-      "StreamChatBody": {
-        "type": "object",
-        "properties": {
-          "threadId": {
-            "format": "uuid",
-            "type": "string"
-          },
-          "content": {
-            "minLength": 1,
-            "type": "string"
-          },
-          "id": {
-            "format": "uuid",
-            "type": "string"
-          }
-        },
-        "required": [
-          "threadId",
-          "content"
-        ]
-      },
-      "JudgeThreadResponse": {
-        "type": "object",
-        "properties": {
-          "data": {
-            "type": "object",
-            "properties": {
-              "summary": {
-                "type": "string"
-              },
-              "passed": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "summary",
-              "passed"
-            ]
-          }
-        },
-        "required": [
-          "data"
-        ]
-      },
-      "MarkLessonAsCompletedResponse": {
+      "UpdateChapterResponse": {
         "type": "object",
         "properties": {
           "data": {
@@ -27662,520 +28613,88 @@
           "data"
         ]
       },
-      "GetAllCertificatesResponse": {
+      "UpdateChapterDisplayOrderBody": {
         "type": "object",
         "properties": {
-          "data": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "format": "uuid",
-                  "type": "string"
-                },
-                "userId": {
-                  "format": "uuid",
-                  "type": "string"
-                },
-                "courseId": {
-                  "format": "uuid",
-                  "type": "string"
-                },
-                "courseTitle": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "completionDate": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "fullName": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "certificateSignatureUrl": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "certificateFontColor": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "issuedAt": {
-                  "type": "string"
-                },
-                "expiresAt": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "createdAt": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "id",
-                "userId",
-                "courseId",
-                "issuedAt",
-                "createdAt"
-              ]
-            }
-          },
-          "pagination": {
-            "type": "object",
-            "properties": {
-              "totalItems": {
-                "type": "number"
-              },
-              "page": {
-                "type": "number"
-              },
-              "perPage": {
-                "type": "number"
-              }
-            },
-            "required": [
-              "totalItems",
-              "page",
-              "perPage"
-            ]
-          },
-          "appliedFilters": {
-            "type": "object",
-            "patternProperties": {
-              "^(.*)$": {}
-            }
-          }
-        },
-        "required": [
-          "data",
-          "pagination"
-        ]
-      },
-      "GetCertificateResponse": {
-        "anyOf": [
-          {
-            "type": "object",
-            "properties": {
-              "id": {
-                "format": "uuid",
-                "type": "string"
-              },
-              "userId": {
-                "format": "uuid",
-                "type": "string"
-              },
-              "learningPathId": {
-                "format": "uuid",
-                "type": "string"
-              },
-              "courseTitle": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "completionDate": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "fullName": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "certificateSignatureUrl": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "certificateFontColor": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "createdAt": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "id",
-              "userId",
-              "learningPathId",
-              "createdAt"
-            ]
-          },
-          {
-            "type": "null"
-          }
-        ]
-      },
-      "DownloadCertificateBody": {
-        "type": "object",
-        "properties": {
-          "certificateId": {
+          "chapterId": {
             "format": "uuid",
             "type": "string"
           },
-          "language": {
-            "anyOf": [
-              {
-                "const": "en",
-                "type": "string"
-              },
-              {
-                "const": "pl",
-                "type": "string"
-              },
-              {
-                "const": "de",
-                "type": "string"
-              },
-              {
-                "const": "lt",
-                "type": "string"
-              },
-              {
-                "const": "cs",
-                "type": "string"
-              }
-            ]
-          }
-        },
-        "required": [
-          "certificateId",
-          "language"
-        ]
-      },
-      "CreateCertificateShareLinkBody": {
-        "type": "object",
-        "properties": {
-          "certificateId": {
-            "format": "uuid",
-            "type": "string"
-          },
-          "language": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "certificateId"
-        ]
-      },
-      "CreateCertificateShareLinkResponse": {
-        "type": "object",
-        "properties": {
-          "shareUrl": {
-            "type": "string"
-          },
-          "linkedinShareUrl": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "shareUrl",
-          "linkedinShareUrl"
-        ]
-      },
-      "GetCertificateValidityImpactBody": {
-        "type": "object",
-        "properties": {
-          "certificateValidity": {
-            "anyOf": [
-              {
-                "anyOf": [
-                  {
-                    "additionalProperties": false,
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "const": "period",
-                        "type": "string"
-                      },
-                      "value": {
-                        "minimum": 1,
-                        "type": "number"
-                      },
-                      "unit": {
-                        "anyOf": [
-                          {
-                            "const": "days",
-                            "type": "string"
-                          },
-                          {
-                            "const": "months",
-                            "type": "string"
-                          },
-                          {
-                            "const": "years",
-                            "type": "string"
-                          }
-                        ]
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "value",
-                      "unit"
-                    ]
-                  },
-                  {
-                    "additionalProperties": false,
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "const": "fixedDate",
-                        "type": "string"
-                      },
-                      "date": {
-                        "format": "date",
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "date"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "required": [
-          "certificateValidity"
-        ]
-      },
-      "GetCertificateValidityImpactResponse": {
-        "type": "object",
-        "properties": {
-          "activeCertificateCount": {
-            "type": "number"
-          },
-          "immediatelyExpiringCertificateCount": {
+          "displayOrder": {
             "type": "number"
           }
         },
         "required": [
-          "activeCertificateCount",
-          "immediatelyExpiringCertificateCount"
+          "chapterId",
+          "displayOrder"
         ]
       },
-      "GetCertificateResetOptionsResponse": {
-        "type": "object",
-        "properties": {
-          "groups": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "format": "uuid",
-                  "type": "string"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "activeCertificateCount": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "id",
-                "name",
-                "activeCertificateCount"
-              ]
-            }
-          },
-          "activeCertificateUserCount": {
-            "type": "number"
-          }
-        },
-        "required": [
-          "groups",
-          "activeCertificateUserCount"
-        ]
-      },
-      "GetCertificateResetUsersResponse": {
+      "UpdateChapterDisplayOrderResponse": {
         "type": "object",
         "properties": {
           "data": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "format": "uuid",
-                  "type": "string"
-                },
-                "firstName": {
-                  "type": "string"
-                },
-                "lastName": {
-                  "type": "string"
-                },
-                "email": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "id",
-                "firstName",
-                "lastName",
-                "email"
-              ]
-            }
-          },
-          "pagination": {
             "type": "object",
             "properties": {
-              "totalItems": {
-                "type": "number"
-              },
-              "page": {
-                "type": "number"
-              },
-              "perPage": {
-                "type": "number"
+              "message": {
+                "type": "string"
               }
             },
             "required": [
-              "totalItems",
-              "page",
-              "perPage"
+              "message"
             ]
-          },
-          "appliedFilters": {
-            "type": "object",
-            "patternProperties": {
-              "^(.*)$": {}
-            }
           }
         },
         "required": [
-          "data",
-          "pagination"
+          "data"
         ]
       },
-      "ResetCourseCertificatesBody": {
+      "RemoveChapterResponse": {
         "type": "object",
         "properties": {
-          "scope": {
-            "anyOf": [
-              {
-                "const": "all",
-                "type": "string"
-              },
-              {
-                "const": "groups",
-                "type": "string"
-              },
-              {
-                "const": "users",
+          "data": {
+            "type": "object",
+            "properties": {
+              "message": {
                 "type": "string"
               }
+            },
+            "required": [
+              "message"
             ]
-          },
-          "groupIds": {
-            "type": "array",
-            "items": {
-              "format": "uuid",
-              "type": "string"
-            }
-          },
-          "userIds": {
-            "type": "array",
-            "items": {
-              "format": "uuid",
-              "type": "string"
-            }
-          },
-          "sendEmail": {
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "UpdateFreemiumStatusBody": {
+        "type": "object",
+        "properties": {
+          "isFreemium": {
             "type": "boolean"
           }
         },
         "required": [
-          "scope"
+          "isFreemium"
         ]
       },
-      "ResetCourseCertificatesResponse": {
+      "UpdateFreemiumStatusResponse": {
         "type": "object",
         "properties": {
-          "affectedCertificateCount": {
-            "type": "number"
-          },
-          "affectedUserCount": {
-            "type": "number"
+          "data": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "message"
+            ]
           }
         },
         "required": [
-          "affectedCertificateCount",
-          "affectedUserCount"
+          "data"
         ]
       },
       "GetLessonsResponse": {
@@ -32838,6 +33357,787 @@
           "data"
         ]
       },
+      "MarkLessonAsCompletedResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "message"
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "GetAllCertificatesResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "userId": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "courseId": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "courseTitle": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "completionDate": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "fullName": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "certificateSignatureUrl": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "certificateFontColor": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "issuedAt": {
+                  "type": "string"
+                },
+                "expiresAt": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "createdAt": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "userId",
+                "courseId",
+                "issuedAt",
+                "createdAt"
+              ]
+            }
+          },
+          "pagination": {
+            "type": "object",
+            "properties": {
+              "totalItems": {
+                "type": "number"
+              },
+              "page": {
+                "type": "number"
+              },
+              "perPage": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "totalItems",
+              "page",
+              "perPage"
+            ]
+          },
+          "appliedFilters": {
+            "type": "object",
+            "patternProperties": {
+              "^(.*)$": {}
+            }
+          }
+        },
+        "required": [
+          "data",
+          "pagination"
+        ]
+      },
+      "GetCertificateResponse": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "format": "uuid",
+                "type": "string"
+              },
+              "userId": {
+                "format": "uuid",
+                "type": "string"
+              },
+              "learningPathId": {
+                "format": "uuid",
+                "type": "string"
+              },
+              "courseTitle": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "completionDate": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "fullName": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "certificateSignatureUrl": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "certificateFontColor": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "createdAt": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "userId",
+              "learningPathId",
+              "createdAt"
+            ]
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "DownloadCertificateBody": {
+        "type": "object",
+        "properties": {
+          "certificateId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "language": {
+            "anyOf": [
+              {
+                "const": "en",
+                "type": "string"
+              },
+              {
+                "const": "pl",
+                "type": "string"
+              },
+              {
+                "const": "de",
+                "type": "string"
+              },
+              {
+                "const": "lt",
+                "type": "string"
+              },
+              {
+                "const": "cs",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "required": [
+          "certificateId",
+          "language"
+        ]
+      },
+      "CreateCertificateShareLinkBody": {
+        "type": "object",
+        "properties": {
+          "certificateId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "language": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "certificateId"
+        ]
+      },
+      "CreateCertificateShareLinkResponse": {
+        "type": "object",
+        "properties": {
+          "shareUrl": {
+            "type": "string"
+          },
+          "linkedinShareUrl": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "shareUrl",
+          "linkedinShareUrl"
+        ]
+      },
+      "GetCertificateValidityImpactBody": {
+        "type": "object",
+        "properties": {
+          "certificateValidity": {
+            "anyOf": [
+              {
+                "anyOf": [
+                  {
+                    "additionalProperties": false,
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "const": "period",
+                        "type": "string"
+                      },
+                      "value": {
+                        "minimum": 1,
+                        "type": "number"
+                      },
+                      "unit": {
+                        "anyOf": [
+                          {
+                            "const": "days",
+                            "type": "string"
+                          },
+                          {
+                            "const": "months",
+                            "type": "string"
+                          },
+                          {
+                            "const": "years",
+                            "type": "string"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "type",
+                      "value",
+                      "unit"
+                    ]
+                  },
+                  {
+                    "additionalProperties": false,
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "const": "fixedDate",
+                        "type": "string"
+                      },
+                      "date": {
+                        "format": "date",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "type",
+                      "date"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "certificateValidity"
+        ]
+      },
+      "GetCertificateValidityImpactResponse": {
+        "type": "object",
+        "properties": {
+          "activeCertificateCount": {
+            "type": "number"
+          },
+          "immediatelyExpiringCertificateCount": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "activeCertificateCount",
+          "immediatelyExpiringCertificateCount"
+        ]
+      },
+      "GetCertificateResetOptionsResponse": {
+        "type": "object",
+        "properties": {
+          "groups": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "activeCertificateCount": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "name",
+                "activeCertificateCount"
+              ]
+            }
+          },
+          "activeCertificateUserCount": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "groups",
+          "activeCertificateUserCount"
+        ]
+      },
+      "GetCertificateResetUsersResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "firstName": {
+                  "type": "string"
+                },
+                "lastName": {
+                  "type": "string"
+                },
+                "email": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "firstName",
+                "lastName",
+                "email"
+              ]
+            }
+          },
+          "pagination": {
+            "type": "object",
+            "properties": {
+              "totalItems": {
+                "type": "number"
+              },
+              "page": {
+                "type": "number"
+              },
+              "perPage": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "totalItems",
+              "page",
+              "perPage"
+            ]
+          },
+          "appliedFilters": {
+            "type": "object",
+            "patternProperties": {
+              "^(.*)$": {}
+            }
+          }
+        },
+        "required": [
+          "data",
+          "pagination"
+        ]
+      },
+      "ResetCourseCertificatesBody": {
+        "type": "object",
+        "properties": {
+          "scope": {
+            "anyOf": [
+              {
+                "const": "all",
+                "type": "string"
+              },
+              {
+                "const": "groups",
+                "type": "string"
+              },
+              {
+                "const": "users",
+                "type": "string"
+              }
+            ]
+          },
+          "groupIds": {
+            "type": "array",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          "userIds": {
+            "type": "array",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          "sendEmail": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "scope"
+        ]
+      },
+      "ResetCourseCertificatesResponse": {
+        "type": "object",
+        "properties": {
+          "affectedCertificateCount": {
+            "type": "number"
+          },
+          "affectedUserCount": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "affectedCertificateCount",
+          "affectedUserCount"
+        ]
+      },
+      "GetThreadResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "format": "uuid",
+                "type": "string"
+              },
+              "aiMentorLessonId": {
+                "format": "uuid",
+                "type": "string"
+              },
+              "userId": {
+                "format": "uuid",
+                "type": "string"
+              },
+              "userLanguage": {
+                "anyOf": [
+                  {
+                    "const": "en",
+                    "type": "string"
+                  },
+                  {
+                    "const": "pl",
+                    "type": "string"
+                  },
+                  {
+                    "const": "de",
+                    "type": "string"
+                  },
+                  {
+                    "const": "lt",
+                    "type": "string"
+                  },
+                  {
+                    "const": "cs",
+                    "type": "string"
+                  }
+                ]
+              },
+              "createdAt": {
+                "type": "string"
+              },
+              "updatedAt": {
+                "type": "string"
+              },
+              "status": {
+                "anyOf": [
+                  {
+                    "const": "active",
+                    "type": "string"
+                  },
+                  {
+                    "const": "completed",
+                    "type": "string"
+                  },
+                  {
+                    "const": "archived",
+                    "type": "string"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "id",
+              "aiMentorLessonId",
+              "userId",
+              "userLanguage",
+              "createdAt",
+              "updatedAt",
+              "status"
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "GetThreadMessagesResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "allOf": [
+                {
+                  "type": "object",
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "content": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "content"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "anyOf": [
+                            {
+                              "const": "system",
+                              "type": "string"
+                            },
+                            {
+                              "const": "user",
+                              "type": "string"
+                            },
+                            {
+                              "const": "assistant",
+                              "type": "string"
+                            },
+                            {
+                              "const": "tool",
+                              "type": "string"
+                            },
+                            {
+                              "const": "summary",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "isJudge": {
+                          "type": "boolean"
+                        },
+                        "userName": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "role"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "StreamChatBody": {
+        "type": "object",
+        "properties": {
+          "threadId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "content": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "threadId",
+          "content"
+        ]
+      },
+      "JudgeThreadResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "summary": {
+                "type": "string"
+              },
+              "passed": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "summary",
+              "passed"
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "GetAllAssignedDocumentsForLessonResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "size": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "name",
+                "type",
+                "size"
+              ]
+            }
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
       "GetAssetsResponse": {
         "type": "object",
         "properties": {
@@ -37258,1306 +38558,6 @@
             "required": [
               "name",
               "value"
-            ]
-          }
-        },
-        "required": [
-          "data"
-        ]
-      },
-      "GetChapterWithLessonResponse": {
-        "type": "object",
-        "properties": {
-          "data": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "format": "uuid",
-                "type": "string"
-              },
-              "title": {
-                "type": "string"
-              },
-              "lessonCount": {
-                "type": "number"
-              },
-              "lessons": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "format": "uuid",
-                      "type": "string"
-                    },
-                    "title": {
-                      "type": "string"
-                    },
-                    "type": {
-                      "anyOf": [
-                        {
-                          "const": "content",
-                          "type": "string"
-                        },
-                        {
-                          "const": "quiz",
-                          "type": "string"
-                        },
-                        {
-                          "const": "ai_mentor",
-                          "type": "string"
-                        },
-                        {
-                          "const": "embed",
-                          "type": "string"
-                        },
-                        {
-                          "const": "scorm",
-                          "type": "string"
-                        },
-                        {
-                          "const": "live_training",
-                          "type": "string"
-                        }
-                      ]
-                    },
-                    "displayOrder": {
-                      "type": "number"
-                    },
-                    "status": {
-                      "anyOf": [
-                        {
-                          "const": "not_started",
-                          "type": "string"
-                        },
-                        {
-                          "const": "in_progress",
-                          "type": "string"
-                        },
-                        {
-                          "const": "completed",
-                          "type": "string"
-                        },
-                        {
-                          "const": "blocked",
-                          "type": "string"
-                        }
-                      ]
-                    },
-                    "quizQuestionCount": {
-                      "anyOf": [
-                        {
-                          "type": "number"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "isExternal": {
-                      "type": "boolean"
-                    },
-                    "lessonResources": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "format": "uuid",
-                            "type": "string"
-                          },
-                          "fileUrl": {
-                            "type": "string"
-                          },
-                          "contentType": {
-                            "type": "string"
-                          },
-                          "title": {
-                            "type": "string"
-                          },
-                          "description": {
-                            "type": "string"
-                          },
-                          "fileName": {
-                            "type": "string"
-                          },
-                          "allowFullscreen": {
-                            "type": "boolean"
-                          }
-                        },
-                        "required": [
-                          "id",
-                          "fileUrl",
-                          "contentType"
-                        ]
-                      }
-                    }
-                  },
-                  "required": [
-                    "id",
-                    "title",
-                    "type",
-                    "displayOrder",
-                    "status",
-                    "quizQuestionCount"
-                  ]
-                }
-              },
-              "completedLessonCount": {
-                "type": "number"
-              },
-              "chapterProgress": {
-                "anyOf": [
-                  {
-                    "const": "not_started",
-                    "type": "string"
-                  },
-                  {
-                    "const": "in_progress",
-                    "type": "string"
-                  },
-                  {
-                    "const": "completed",
-                    "type": "string"
-                  },
-                  {
-                    "const": "blocked",
-                    "type": "string"
-                  }
-                ]
-              },
-              "isFreemium": {
-                "type": "boolean"
-              },
-              "enrolled": {
-                "type": "boolean"
-              },
-              "isSubmitted": {
-                "type": "boolean"
-              },
-              "createdAt": {
-                "type": "string"
-              },
-              "updatedAt": {
-                "type": "string"
-              },
-              "quizCount": {
-                "type": "number"
-              },
-              "displayOrder": {
-                "type": "number"
-              }
-            },
-            "required": [
-              "id",
-              "title",
-              "lessonCount",
-              "lessons",
-              "displayOrder"
-            ]
-          }
-        },
-        "required": [
-          "data"
-        ]
-      },
-      "BetaCreateChapterBody": {
-        "type": "object",
-        "allOf": [
-          {
-            "type": "object",
-            "properties": {
-              "title": {
-                "type": "string"
-              },
-              "lessons": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "format": "uuid",
-                      "type": "string"
-                    },
-                    "title": {
-                      "type": "string"
-                    },
-                    "type": {
-                      "anyOf": [
-                        {
-                          "const": "content",
-                          "type": "string"
-                        },
-                        {
-                          "const": "quiz",
-                          "type": "string"
-                        },
-                        {
-                          "const": "ai_mentor",
-                          "type": "string"
-                        },
-                        {
-                          "const": "embed",
-                          "type": "string"
-                        },
-                        {
-                          "const": "scorm",
-                          "type": "string"
-                        },
-                        {
-                          "const": "live_training",
-                          "type": "string"
-                        }
-                      ]
-                    },
-                    "description": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "displayOrder": {
-                      "type": "number"
-                    },
-                    "fileS3Key": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "avatarReferenceUrl": {
-                      "type": "string"
-                    },
-                    "fileType": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "questions": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "format": "uuid",
-                            "type": "string"
-                          },
-                          "type": {
-                            "anyOf": [
-                              {
-                                "const": "brief_response",
-                                "type": "string"
-                              },
-                              {
-                                "const": "detailed_response",
-                                "type": "string"
-                              },
-                              {
-                                "const": "match_words",
-                                "type": "string"
-                              },
-                              {
-                                "const": "scale_1_5",
-                                "type": "string"
-                              },
-                              {
-                                "const": "single_choice",
-                                "type": "string"
-                              },
-                              {
-                                "const": "multiple_choice",
-                                "type": "string"
-                              },
-                              {
-                                "const": "true_or_false",
-                                "type": "string"
-                              },
-                              {
-                                "const": "photo_question_single_choice",
-                                "type": "string"
-                              },
-                              {
-                                "const": "photo_question_multiple_choice",
-                                "type": "string"
-                              },
-                              {
-                                "const": "fill_in_the_blanks_text",
-                                "type": "string"
-                              },
-                              {
-                                "const": "fill_in_the_blanks_dnd",
-                                "type": "string"
-                              }
-                            ]
-                          },
-                          "description": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "title": {
-                            "type": "string"
-                          },
-                          "displayOrder": {
-                            "type": "number"
-                          },
-                          "solutionExplanation": {
-                            "type": "string"
-                          },
-                          "photoS3Key": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "options": {
-                            "type": "array",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "format": "uuid",
-                                  "type": "string"
-                                },
-                                "optionText": {
-                                  "maxLength": 250,
-                                  "type": "string"
-                                },
-                                "displayOrder": {
-                                  "anyOf": [
-                                    {
-                                      "type": "number"
-                                    },
-                                    {
-                                      "type": "null"
-                                    }
-                                  ]
-                                },
-                                "isStudentAnswer": {
-                                  "anyOf": [
-                                    {
-                                      "type": "boolean"
-                                    },
-                                    {
-                                      "type": "null"
-                                    }
-                                  ]
-                                },
-                                "isCorrect": {
-                                  "type": "boolean"
-                                },
-                                "questionId": {
-                                  "format": "uuid",
-                                  "type": "string"
-                                },
-                                "matchedWord": {
-                                  "anyOf": [
-                                    {
-                                      "type": "string"
-                                    },
-                                    {
-                                      "type": "null"
-                                    }
-                                  ]
-                                },
-                                "scaleAnswer": {
-                                  "anyOf": [
-                                    {
-                                      "type": "number"
-                                    },
-                                    {
-                                      "type": "null"
-                                    }
-                                  ]
-                                },
-                                "language": {
-                                  "default": "en",
-                                  "anyOf": [
-                                    {
-                                      "const": "en",
-                                      "type": "string"
-                                    },
-                                    {
-                                      "const": "pl",
-                                      "type": "string"
-                                    },
-                                    {
-                                      "const": "de",
-                                      "type": "string"
-                                    },
-                                    {
-                                      "const": "lt",
-                                      "type": "string"
-                                    },
-                                    {
-                                      "const": "cs",
-                                      "type": "string"
-                                    }
-                                  ]
-                                }
-                              },
-                              "required": [
-                                "optionText",
-                                "displayOrder",
-                                "isCorrect"
-                              ]
-                            }
-                          },
-                          "language": {
-                            "default": "en",
-                            "anyOf": [
-                              {
-                                "const": "en",
-                                "type": "string"
-                              },
-                              {
-                                "const": "pl",
-                                "type": "string"
-                              },
-                              {
-                                "const": "de",
-                                "type": "string"
-                              },
-                              {
-                                "const": "lt",
-                                "type": "string"
-                              },
-                              {
-                                "const": "cs",
-                                "type": "string"
-                              }
-                            ]
-                          }
-                        },
-                        "required": [
-                          "type",
-                          "title"
-                        ]
-                      }
-                    },
-                    "aiMentor": {
-                      "anyOf": [
-                        {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "format": "uuid",
-                              "type": "string"
-                            },
-                            "lessonId": {
-                              "format": "uuid",
-                              "type": "string"
-                            },
-                            "aiMentorInstructions": {
-                              "type": "string"
-                            },
-                            "completionConditions": {
-                              "type": "string"
-                            },
-                            "type": {
-                              "anyOf": [
-                                {
-                                  "const": "mentor",
-                                  "type": "string"
-                                },
-                                {
-                                  "const": "teacher",
-                                  "type": "string"
-                                },
-                                {
-                                  "const": "roleplay",
-                                  "type": "string"
-                                }
-                              ]
-                            },
-                            "avatarReference": {
-                              "anyOf": [
-                                {
-                                  "type": "string"
-                                },
-                                {
-                                  "type": "null"
-                                }
-                              ]
-                            },
-                            "voiceMode": {
-                              "anyOf": [
-                                {
-                                  "const": "preset",
-                                  "type": "string"
-                                },
-                                {
-                                  "const": "custom",
-                                  "type": "string"
-                                }
-                              ]
-                            },
-                            "ttsPreset": {
-                              "anyOf": [
-                                {
-                                  "const": "male",
-                                  "type": "string"
-                                },
-                                {
-                                  "const": "female",
-                                  "type": "string"
-                                }
-                              ]
-                            },
-                            "customTtsReference": {
-                              "anyOf": [
-                                {
-                                  "type": "string"
-                                },
-                                {
-                                  "type": "null"
-                                }
-                              ]
-                            }
-                          },
-                          "required": [
-                            "id",
-                            "lessonId",
-                            "aiMentorInstructions",
-                            "completionConditions",
-                            "type",
-                            "avatarReference",
-                            "voiceMode",
-                            "ttsPreset",
-                            "customTtsReference"
-                          ]
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "liveTrainingId": {
-                      "anyOf": [
-                        {
-                          "format": "uuid",
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "updatedAt": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "id",
-                    "title",
-                    "type",
-                    "displayOrder"
-                  ]
-                }
-              },
-              "chapterProgress": {
-                "anyOf": [
-                  {
-                    "const": "not_started",
-                    "type": "string"
-                  },
-                  {
-                    "const": "in_progress",
-                    "type": "string"
-                  },
-                  {
-                    "const": "completed",
-                    "type": "string"
-                  },
-                  {
-                    "const": "blocked",
-                    "type": "string"
-                  }
-                ]
-              },
-              "isFreemium": {
-                "type": "boolean"
-              },
-              "enrolled": {
-                "type": "boolean"
-              },
-              "isSubmitted": {
-                "type": "boolean"
-              },
-              "createdAt": {
-                "type": "string"
-              },
-              "updatedAt": {
-                "type": "string"
-              },
-              "quizCount": {
-                "type": "number"
-              }
-            },
-            "required": [
-              "title"
-            ]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "courseId": {
-                "format": "uuid",
-                "type": "string"
-              }
-            },
-            "required": [
-              "courseId"
-            ]
-          }
-        ]
-      },
-      "BetaCreateChapterResponse": {
-        "type": "object",
-        "properties": {
-          "data": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "format": "uuid",
-                "type": "string"
-              },
-              "message": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "id",
-              "message"
-            ]
-          }
-        },
-        "required": [
-          "data"
-        ]
-      },
-      "UpdateChapterBody": {
-        "allOf": [
-          {
-            "type": "object",
-            "allOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "title": {
-                    "type": "string"
-                  },
-                  "lessons": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "format": "uuid",
-                          "type": "string"
-                        },
-                        "title": {
-                          "type": "string"
-                        },
-                        "type": {
-                          "anyOf": [
-                            {
-                              "const": "content",
-                              "type": "string"
-                            },
-                            {
-                              "const": "quiz",
-                              "type": "string"
-                            },
-                            {
-                              "const": "ai_mentor",
-                              "type": "string"
-                            },
-                            {
-                              "const": "embed",
-                              "type": "string"
-                            },
-                            {
-                              "const": "scorm",
-                              "type": "string"
-                            },
-                            {
-                              "const": "live_training",
-                              "type": "string"
-                            }
-                          ]
-                        },
-                        "description": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        },
-                        "displayOrder": {
-                          "type": "number"
-                        },
-                        "fileS3Key": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        },
-                        "avatarReferenceUrl": {
-                          "type": "string"
-                        },
-                        "fileType": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        },
-                        "questions": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "id": {
-                                "format": "uuid",
-                                "type": "string"
-                              },
-                              "type": {
-                                "anyOf": [
-                                  {
-                                    "const": "brief_response",
-                                    "type": "string"
-                                  },
-                                  {
-                                    "const": "detailed_response",
-                                    "type": "string"
-                                  },
-                                  {
-                                    "const": "match_words",
-                                    "type": "string"
-                                  },
-                                  {
-                                    "const": "scale_1_5",
-                                    "type": "string"
-                                  },
-                                  {
-                                    "const": "single_choice",
-                                    "type": "string"
-                                  },
-                                  {
-                                    "const": "multiple_choice",
-                                    "type": "string"
-                                  },
-                                  {
-                                    "const": "true_or_false",
-                                    "type": "string"
-                                  },
-                                  {
-                                    "const": "photo_question_single_choice",
-                                    "type": "string"
-                                  },
-                                  {
-                                    "const": "photo_question_multiple_choice",
-                                    "type": "string"
-                                  },
-                                  {
-                                    "const": "fill_in_the_blanks_text",
-                                    "type": "string"
-                                  },
-                                  {
-                                    "const": "fill_in_the_blanks_dnd",
-                                    "type": "string"
-                                  }
-                                ]
-                              },
-                              "description": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
-                                ]
-                              },
-                              "title": {
-                                "type": "string"
-                              },
-                              "displayOrder": {
-                                "type": "number"
-                              },
-                              "solutionExplanation": {
-                                "type": "string"
-                              },
-                              "photoS3Key": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
-                                ]
-                              },
-                              "options": {
-                                "type": "array",
-                                "items": {
-                                  "type": "object",
-                                  "properties": {
-                                    "id": {
-                                      "format": "uuid",
-                                      "type": "string"
-                                    },
-                                    "optionText": {
-                                      "maxLength": 250,
-                                      "type": "string"
-                                    },
-                                    "displayOrder": {
-                                      "anyOf": [
-                                        {
-                                          "type": "number"
-                                        },
-                                        {
-                                          "type": "null"
-                                        }
-                                      ]
-                                    },
-                                    "isStudentAnswer": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "null"
-                                        }
-                                      ]
-                                    },
-                                    "isCorrect": {
-                                      "type": "boolean"
-                                    },
-                                    "questionId": {
-                                      "format": "uuid",
-                                      "type": "string"
-                                    },
-                                    "matchedWord": {
-                                      "anyOf": [
-                                        {
-                                          "type": "string"
-                                        },
-                                        {
-                                          "type": "null"
-                                        }
-                                      ]
-                                    },
-                                    "scaleAnswer": {
-                                      "anyOf": [
-                                        {
-                                          "type": "number"
-                                        },
-                                        {
-                                          "type": "null"
-                                        }
-                                      ]
-                                    },
-                                    "language": {
-                                      "default": "en",
-                                      "anyOf": [
-                                        {
-                                          "const": "en",
-                                          "type": "string"
-                                        },
-                                        {
-                                          "const": "pl",
-                                          "type": "string"
-                                        },
-                                        {
-                                          "const": "de",
-                                          "type": "string"
-                                        },
-                                        {
-                                          "const": "lt",
-                                          "type": "string"
-                                        },
-                                        {
-                                          "const": "cs",
-                                          "type": "string"
-                                        }
-                                      ]
-                                    }
-                                  },
-                                  "required": [
-                                    "optionText",
-                                    "displayOrder",
-                                    "isCorrect"
-                                  ]
-                                }
-                              },
-                              "language": {
-                                "default": "en",
-                                "anyOf": [
-                                  {
-                                    "const": "en",
-                                    "type": "string"
-                                  },
-                                  {
-                                    "const": "pl",
-                                    "type": "string"
-                                  },
-                                  {
-                                    "const": "de",
-                                    "type": "string"
-                                  },
-                                  {
-                                    "const": "lt",
-                                    "type": "string"
-                                  },
-                                  {
-                                    "const": "cs",
-                                    "type": "string"
-                                  }
-                                ]
-                              }
-                            },
-                            "required": [
-                              "type",
-                              "title"
-                            ]
-                          }
-                        },
-                        "aiMentor": {
-                          "anyOf": [
-                            {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "format": "uuid",
-                                  "type": "string"
-                                },
-                                "lessonId": {
-                                  "format": "uuid",
-                                  "type": "string"
-                                },
-                                "aiMentorInstructions": {
-                                  "type": "string"
-                                },
-                                "completionConditions": {
-                                  "type": "string"
-                                },
-                                "type": {
-                                  "anyOf": [
-                                    {
-                                      "const": "mentor",
-                                      "type": "string"
-                                    },
-                                    {
-                                      "const": "teacher",
-                                      "type": "string"
-                                    },
-                                    {
-                                      "const": "roleplay",
-                                      "type": "string"
-                                    }
-                                  ]
-                                },
-                                "avatarReference": {
-                                  "anyOf": [
-                                    {
-                                      "type": "string"
-                                    },
-                                    {
-                                      "type": "null"
-                                    }
-                                  ]
-                                },
-                                "voiceMode": {
-                                  "anyOf": [
-                                    {
-                                      "const": "preset",
-                                      "type": "string"
-                                    },
-                                    {
-                                      "const": "custom",
-                                      "type": "string"
-                                    }
-                                  ]
-                                },
-                                "ttsPreset": {
-                                  "anyOf": [
-                                    {
-                                      "const": "male",
-                                      "type": "string"
-                                    },
-                                    {
-                                      "const": "female",
-                                      "type": "string"
-                                    }
-                                  ]
-                                },
-                                "customTtsReference": {
-                                  "anyOf": [
-                                    {
-                                      "type": "string"
-                                    },
-                                    {
-                                      "type": "null"
-                                    }
-                                  ]
-                                }
-                              },
-                              "required": [
-                                "id",
-                                "lessonId",
-                                "aiMentorInstructions",
-                                "completionConditions",
-                                "type",
-                                "avatarReference",
-                                "voiceMode",
-                                "ttsPreset",
-                                "customTtsReference"
-                              ]
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        },
-                        "liveTrainingId": {
-                          "anyOf": [
-                            {
-                              "format": "uuid",
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        },
-                        "updatedAt": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "id",
-                        "title",
-                        "type",
-                        "displayOrder"
-                      ]
-                    }
-                  },
-                  "chapterProgress": {
-                    "anyOf": [
-                      {
-                        "const": "not_started",
-                        "type": "string"
-                      },
-                      {
-                        "const": "in_progress",
-                        "type": "string"
-                      },
-                      {
-                        "const": "completed",
-                        "type": "string"
-                      },
-                      {
-                        "const": "blocked",
-                        "type": "string"
-                      }
-                    ]
-                  },
-                  "isFreemium": {
-                    "type": "boolean"
-                  },
-                  "enrolled": {
-                    "type": "boolean"
-                  },
-                  "isSubmitted": {
-                    "type": "boolean"
-                  },
-                  "createdAt": {
-                    "type": "string"
-                  },
-                  "updatedAt": {
-                    "type": "string"
-                  },
-                  "quizCount": {
-                    "type": "number"
-                  }
-                }
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "courseId": {
-                    "format": "uuid",
-                    "type": "string"
-                  }
-                }
-              }
-            ]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "language": {
-                "default": "en",
-                "anyOf": [
-                  {
-                    "const": "en",
-                    "type": "string"
-                  },
-                  {
-                    "const": "pl",
-                    "type": "string"
-                  },
-                  {
-                    "const": "de",
-                    "type": "string"
-                  },
-                  {
-                    "const": "lt",
-                    "type": "string"
-                  },
-                  {
-                    "const": "cs",
-                    "type": "string"
-                  }
-                ]
-              }
-            },
-            "required": [
-              "language"
-            ]
-          }
-        ]
-      },
-      "UpdateChapterResponse": {
-        "type": "object",
-        "properties": {
-          "data": {
-            "type": "object",
-            "properties": {
-              "message": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "message"
-            ]
-          }
-        },
-        "required": [
-          "data"
-        ]
-      },
-      "UpdateChapterDisplayOrderBody": {
-        "type": "object",
-        "properties": {
-          "chapterId": {
-            "format": "uuid",
-            "type": "string"
-          },
-          "displayOrder": {
-            "type": "number"
-          }
-        },
-        "required": [
-          "chapterId",
-          "displayOrder"
-        ]
-      },
-      "UpdateChapterDisplayOrderResponse": {
-        "type": "object",
-        "properties": {
-          "data": {
-            "type": "object",
-            "properties": {
-              "message": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "message"
-            ]
-          }
-        },
-        "required": [
-          "data"
-        ]
-      },
-      "RemoveChapterResponse": {
-        "type": "object",
-        "properties": {
-          "data": {
-            "type": "object",
-            "properties": {
-              "message": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "message"
-            ]
-          }
-        },
-        "required": [
-          "data"
-        ]
-      },
-      "UpdateFreemiumStatusBody": {
-        "type": "object",
-        "properties": {
-          "isFreemium": {
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "isFreemium"
-        ]
-      },
-      "UpdateFreemiumStatusResponse": {
-        "type": "object",
-        "properties": {
-          "data": {
-            "type": "object",
-            "properties": {
-              "message": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "message"
             ]
           }
         },

--- a/apps/web/app/api/mutations/useRetakeQuiz.ts
+++ b/apps/web/app/api/mutations/useRetakeQuiz.ts
@@ -1,9 +1,10 @@
 import { useMutation } from "@tanstack/react-query";
-import { AxiosError } from "axios";
+import { useTranslation } from "react-i18next";
 
 import { useToast } from "~/components/ui/use-toast";
 
 import { ApiClient } from "../api-client";
+import { getTranslatedApiErrorMessage } from "../utils/getTranslatedApiErrorMessage";
 
 type RetakeQuizProps = {
   lessonId: string;
@@ -12,6 +13,7 @@ type RetakeQuizProps = {
 
 export function useRetakeQuiz({ lessonId, handleOnSuccess }: RetakeQuizProps) {
   const { toast } = useToast();
+  const { t } = useTranslation();
 
   return useMutation({
     mutationFn: async () => {
@@ -22,15 +24,9 @@ export function useRetakeQuiz({ lessonId, handleOnSuccess }: RetakeQuizProps) {
       handleOnSuccess();
     },
     onError: (error) => {
-      if (error instanceof AxiosError) {
-        return toast({
-          variant: "destructive",
-          description: error.response?.data.message,
-        });
-      }
       toast({
         variant: "destructive",
-        description: error.message,
+        description: getTranslatedApiErrorMessage(error, t, t("common.toast.somethingWentWrong")),
       });
     },
   });

--- a/apps/web/app/locales/cs/translation.json
+++ b/apps/web/app/locales/cs/translation.json
@@ -2687,7 +2687,14 @@
       "trueOrFalseRequired": "Vyžaduje se pravdivá nebo nepravdivá odpověď.",
       "photoQuestionMustHaveAnswer": "Na tuto fotografickou otázku je vyžadována odpověď.",
       "unansweredQuestions": "Zdá se, že jste ještě nezkontrolovali všechny odpovědi. Zkontrolujte je a zkuste to znovu!",
-      "unansweredQuestionsWithNames": "Odpovězte na chybějící otázky: {{questionNames}}"
+      "unansweredQuestionsWithNames": "Odpovězte na chybějící otázky: {{questionNames}}",
+      "quizAlreadyAnswered": "Tento kvíz jste již vyplnili.",
+      "lessonAssignmentRequired": "K této lekci nejste přiřazeni.",
+      "quizEvaluationFailed": "Vyhodnocení kvízu se nezdařilo. Zkuste to prosím znovu.",
+      "quizNotAnsweredYet": "Tento kvíz jste ještě nevyplnili.",
+      "courseEnrollmentRequired": "Nejste zapsáni do tohoto kurzu.",
+      "quizRetakeUnavailable": "Odpovědi v kvízu nelze resetovat kvůli limitu pokusů nebo čekací době.",
+      "quizResetFailed": "Odpovědi v kvízu se nepodařilo resetovat. Zkuste to prosím znovu."
     }
   },
   "studentCourseView": {

--- a/apps/web/app/locales/de/translation.json
+++ b/apps/web/app/locales/de/translation.json
@@ -2681,7 +2681,14 @@
       "trueOrFalseRequired": "Es ist eine wahre oder falsche Antwort erforderlich.",
       "photoQuestionMustHaveAnswer": "Für diese Fotofrage ist eine Antwort erforderlich.",
       "unansweredQuestions": "Anscheinend haben Sie noch nicht alle Antworten überprüft. Bitte überprüfen Sie sie und versuchen Sie es erneut!",
-      "unansweredQuestionsWithNames": "Bitte beantworten Sie die fehlenden Fragen: {{questionNames}}"
+      "unansweredQuestionsWithNames": "Bitte beantworten Sie die fehlenden Fragen: {{questionNames}}",
+      "quizAlreadyAnswered": "Sie haben dieses Quiz bereits beantwortet.",
+      "lessonAssignmentRequired": "Sie sind dieser Lektion nicht zugewiesen.",
+      "quizEvaluationFailed": "Die Quizbewertung ist fehlgeschlagen. Bitte versuchen Sie es erneut.",
+      "quizNotAnsweredYet": "Sie haben dieses Quiz noch nicht beantwortet.",
+      "courseEnrollmentRequired": "Sie sind nicht in diesen Kurs eingeschrieben.",
+      "quizRetakeUnavailable": "Die Quizantworten können wegen des Versuchslimits oder der Wartezeit nicht zurückgesetzt werden.",
+      "quizResetFailed": "Die Quizantworten konnten nicht zurückgesetzt werden. Bitte versuchen Sie es erneut."
     }
   },
   "studentCourseView": {

--- a/apps/web/app/locales/en/translation.json
+++ b/apps/web/app/locales/en/translation.json
@@ -2742,7 +2742,14 @@
       "trueOrFalseRequired": "A true or false response is required.",
       "photoQuestionMustHaveAnswer": "An answer is required for this photo question.",
       "unansweredQuestions": "It seems you haven't checked all the answers yet. Please review them and try again!",
-      "unansweredQuestionsWithNames": "Please answer the missing questions: {{questionNames}}"
+      "unansweredQuestionsWithNames": "Please answer the missing questions: {{questionNames}}",
+      "quizAlreadyAnswered": "You have already answered this quiz.",
+      "lessonAssignmentRequired": "You are not assigned to this lesson.",
+      "quizEvaluationFailed": "Quiz evaluation failed. Please try again.",
+      "quizNotAnsweredYet": "You have not answered this quiz yet.",
+      "courseEnrollmentRequired": "You are not enrolled in this course.",
+      "quizRetakeUnavailable": "Quiz answers cannot be reset because of the attempts limit or cooldown.",
+      "quizResetFailed": "Failed to reset quiz answers. Please try again."
     }
   },
   "studentCourseView": {

--- a/apps/web/app/locales/lt/translation.json
+++ b/apps/web/app/locales/lt/translation.json
@@ -2687,7 +2687,14 @@
       "trueOrFalseRequired": "Reikalingas teisingas arba klaidingas atsakymas.",
       "photoQuestionMustHaveAnswer": "Atsakymas reikalingas į šį klausimą su nuotrauka.",
       "unansweredQuestions": "Atrodo, kad dar nepatikrinote visų atsakymų. Peržiūrėkite juos ir bandykite dar kartą!",
-      "unansweredQuestionsWithNames": "Atsakykite į trūkstamus klausimus: {{questionNames}}"
+      "unansweredQuestionsWithNames": "Atsakykite į trūkstamus klausimus: {{questionNames}}",
+      "quizAlreadyAnswered": "Jūs jau atsakėte į šią viktoriną.",
+      "lessonAssignmentRequired": "Jūs nesate priskirti šiai pamokai.",
+      "quizEvaluationFailed": "Nepavyko įvertinti viktorinos. Bandykite dar kartą.",
+      "quizNotAnsweredYet": "Jūs dar neatsakėte į šią viktoriną.",
+      "courseEnrollmentRequired": "Jūs nesate užregistruoti į šį kursą.",
+      "quizRetakeUnavailable": "Viktorinos atsakymų negalima atstatyti dėl bandymų limito arba laukimo laikotarpio.",
+      "quizResetFailed": "Nepavyko atstatyti viktorinos atsakymų. Bandykite dar kartą."
     }
   },
   "studentCourseView": {

--- a/apps/web/app/locales/pl/translation.json
+++ b/apps/web/app/locales/pl/translation.json
@@ -2980,7 +2980,14 @@
       "trueOrFalseRequired": "Wymagana jest odpowiedź prawda lub fałsz.",
       "photoQuestionMustHaveAnswer": "Wymagana jest odpowiedź na pytanie ze zdjęciem.",
       "unansweredQuestions": "Wygląda na to, że nie zaznaczyłaś/zaznaczyłeś wszystkich odpowiedzi. Proszę przejrzyj je i spróbuj ponownie!",
-      "unansweredQuestionsWithNames": "Uzupełnij brakujące pytania: {{questionNames}}"
+      "unansweredQuestionsWithNames": "Uzupełnij brakujące pytania: {{questionNames}}",
+      "quizAlreadyAnswered": "Ten quiz został już rozwiązany.",
+      "lessonAssignmentRequired": "Nie masz przypisania do tej lekcji.",
+      "quizEvaluationFailed": "Nie udało się ocenić quizu. Spróbuj ponownie.",
+      "quizNotAnsweredYet": "Ten quiz nie został jeszcze rozwiązany.",
+      "courseEnrollmentRequired": "Nie jesteś zapisany/a na ten kurs.",
+      "quizRetakeUnavailable": "Nie można zresetować odpowiedzi z powodu limitu podejść lub okresu oczekiwania.",
+      "quizResetFailed": "Nie udało się zresetować odpowiedzi quizu. Spróbuj ponownie."
     }
   },
   "studentCourseView": {

--- a/apps/web/app/modules/Courses/Lesson/Question/FillInTheBlanks/FillInTheBlanks.tsx
+++ b/apps/web/app/modules/Courses/Lesson/Question/FillInTheBlanks/FillInTheBlanks.tsx
@@ -17,6 +17,15 @@ type FillInTheBlanksProps = {
 export const FillInTheBlanks = ({ question, isCompleted }: FillInTheBlanksProps) => {
   const { t } = useTranslation();
   const { isQuizFeedbackRedacted } = useQuizContext();
+  const hasSubmittedAnswer = question.options?.some(
+    ({ isStudentAnswer, studentAnswer }) =>
+      Boolean(studentAnswer) || typeof isStudentAnswer === "boolean",
+  );
+  const showCorrectSentence =
+    Boolean(isCompleted || hasSubmittedAnswer) &&
+    Boolean(question.solutionExplanation) &&
+    !question.passQuestion &&
+    !isQuizFeedbackRedacted;
 
   if (!question.description) return null;
 
@@ -46,17 +55,14 @@ export const FillInTheBlanks = ({ question, isCompleted }: FillInTheBlanksProps)
           );
         }}
       />
-      {isCompleted &&
-        !!question?.solutionExplanation &&
-        !question.passQuestion &&
-        !isQuizFeedbackRedacted && (
-          <div>
-            <span className="body-base-md text-error-700">
-              {t("studentLessonView.other.correctSentence")}
-            </span>
-            <Viewer content={question.solutionExplanation} />
-          </div>
-        )}
+      {showCorrectSentence && (
+        <div>
+          <span className="body-base-md text-error-700">
+            {t("studentLessonView.other.correctSentence")}
+          </span>
+          <Viewer content={question.solutionExplanation ?? ""} />
+        </div>
+      )}
     </Card>
   );
 };

--- a/apps/web/app/modules/Courses/Lesson/Question/TrueOrFalse.tsx
+++ b/apps/web/app/modules/Courses/Lesson/Question/TrueOrFalse.tsx
@@ -54,7 +54,6 @@ export const TrueOrFalse = ({ question, isCompleted }: TrueOrFalseProps) => {
                   className={cn("size-4", {
                     grayscale: isQuizFeedbackRedacted && isQuizSubmitted,
                   })}
-                  {...(studentAnswer === "true" && { checked: true })}
                   type="radio"
                   value="true"
                   {...register(`trueOrFalseQuestions.${question.id}.${id}`)}
@@ -67,7 +66,6 @@ export const TrueOrFalse = ({ question, isCompleted }: TrueOrFalseProps) => {
                   className={cn("size-4", {
                     grayscale: isQuizFeedbackRedacted && isQuizSubmitted,
                   })}
-                  {...(studentAnswer === "false" && { checked: true })}
                   {...register(`trueOrFalseQuestions.${question.id}.${id}`)}
                   name={`trueOrFalseQuestions.${question.id}.${id}`}
                   type="radio"

--- a/apps/web/e2e/specs/learning/quiz-all-question-types.spec.ts
+++ b/apps/web/e2e/specs/learning/quiz-all-question-types.spec.ts
@@ -4,6 +4,7 @@ import { LEARNING_HANDLES } from "../../data/learning/handles";
 import { expect, test } from "../../fixtures/test.fixture";
 import { answerAllRenderedQuizQuestionTypesFlow } from "../../flows/learning/answer-all-rendered-quiz-question-types.flow";
 import { openCourseOverviewFlow } from "../../flows/learning/open-course-overview.flow";
+import { retakeQuizFlow } from "../../flows/learning/retake-quiz.flow";
 import { startLearningFlow } from "../../flows/learning/start-learning.flow";
 import { submitQuizFlow } from "../../flows/learning/submit-quiz.flow";
 import {
@@ -98,6 +99,12 @@ test("student can submit a quiz containing every rendered question type", async 
         });
 
       await waitForUserQuizAttemptCountFlow(apiClient, expectedQuizAttemptCount);
+
+      await retakeQuizFlow(page);
+
+      await expect(page.locator('input[name^="trueOrFalseQuestions."]:checked')).toHaveCount(0);
+      await expect(page.getByTestId("text-blank-1")).toBeEditable();
+      await expect(page.getByTestId("text-blank-1")).toHaveValue("");
     },
     { root: true },
   );


### PR DESCRIPTION
<!--
 1. Make sure you have correct branch name i.e. `ab_prefix_123_task_name`, where `123` is a issue ID, and `ab` is an author
 2. Make sure you have meaningful title related to task with correct prefix: feat/fix/chore/style/docs/refactor
 3. Reference multiple issues in one PR by listing them in the issues section
 4. Make sure all necessary sections are filled, remove obsolete sections
 5. Do a self review first
 6. Check if your PR includes only code related to your task
 7. `Notes` is used for additional info but also to notify if any action is required
-->

## Issue(s)
[1639](https://github.com/Selleo/mentingo/issues/1639)

## Overview

  Fixes quiz retake reset behavior for true/false and fill-in-the-blanks questions.

  - Removes forced checked state from true/false radio inputs so form reset clears selected answers correctly.
  - Keeps the correct sentence feedback available for fill-in-the-blanks questions when submitted answer metadata exists.
  - Adds E2E coverage for retaking a quiz and verifying reset fields are cleared.
  - Hardens lesson quiz evaluation/reset API paths against missing lesson assignment rows.
  - Replaces raw lesson/quiz API error strings with translation keys and updates retake quiz mutation error handling to use translated API messages.
  - Adds matching quiz error translations for supported locales.

  ## Business Value

  Learners can reliably retake quizzes without stale answers being left in the UI, which makes quiz attempts feel predictable and fair. Error messages are also localized and clearer, reducing confusion
  when a quiz cannot be submitted or reset.