### PR TITLE
chore: hide AI mentor results when AI services are not configured

### DIFF
--- a/apps/web/app/api/queries/admin/useCourseStudentsAiMentorResults.tsx
+++ b/apps/web/app/api/queries/admin/useCourseStudentsAiMentorResults.tsx
@@ -7,22 +7,9 @@ export const COURSE_STUDENTS_AI_MENTOR_RESULTS_QUERY_KEY = [
   "admin",
 ];
 
-export type CourseStudentsAiMentorResultsQueryParams = {
-  page?: number;
-  perPage?: number;
-  lessonId?: string;
-  groupId?: string;
-  search?: string;
-  sort?:
-    | "studentName"
-    | "lessonName"
-    | "score"
-    | "lastSession"
-    | "-studentName"
-    | "-lessonName"
-    | "-score"
-    | "-lastSession";
-};
+export type CourseStudentsAiMentorResultsQueryParams = NonNullable<
+  Parameters<typeof ApiClient.api.courseControllerGetCourseStudentsAiMentorResults>[1]
+>;
 
 interface CourseStudentsAiMentorResultsOptions {
   id: string;

--- a/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/CourseAdminStatistics.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/CourseAdminStatistics.tsx
@@ -1,12 +1,14 @@
 import { TabsList } from "@radix-ui/react-tabs";
 import { PERMISSIONS } from "@repo/shared";
-import { useMemo, useState, useTransition } from "react";
+import { useEffect, useMemo, useState, useTransition } from "react";
 import { useTranslation } from "react-i18next";
 import { match } from "ts-pattern";
 
 import { useCourseAverageScorePerQuiz } from "~/api/queries/admin/useCourseAverageScorePerQuiz";
 import { useCourseStatisticsFilter } from "~/api/queries/admin/useCourseLearningTimeStatisticsFilterOptions";
 import { useCourseStatistics } from "~/api/queries/admin/useCourseStatistics";
+import { useCourseStudentsAiMentorResults } from "~/api/queries/admin/useCourseStudentsAiMentorResults";
+import { useAIConfigured } from "~/api/queries/useAIConfigured";
 import { Card, CardContent, CardHeader } from "~/components/ui/card";
 import {
   Select,
@@ -37,22 +39,18 @@ import {
   CourseStudentsQuizResultsTable,
 } from "./components";
 import { CourseStudentsAiMentorResultsTable } from "./components/CourseStudentsAiMentorResults";
+import {
+  CourseAdminStatisticsTabs,
+  getVisibleCourseStatisticsTabs,
+} from "./utils/courseAdminStatisticsTabs";
 
+import type { CourseAdminStatisticsTab } from "./utils/courseAdminStatisticsTabs";
 import type { GetCourseResponse } from "~/api/generated-api";
 import type { CourseLearningTimeFilterQuery } from "~/api/queries/admin/useCourseLearningTimeStatistics";
 import type { CourseStatisticsParams } from "~/api/queries/admin/useCourseStatistics";
 import type { CourseStudentsAiMentorResultsQueryParams } from "~/api/queries/admin/useCourseStudentsAiMentorResults";
 import type { CourseStudentsProgressQueryParams } from "~/api/queries/admin/useCourseStudentsProgress";
 import type { CourseStudentsQuizResultsQueryParams } from "~/api/queries/admin/useCourseStudentsQuizResults";
-
-const StatisticsTabs = {
-  progress: "progress",
-  quizResults: "quizResults",
-  aiMentorResults: "aiMentorResults",
-  learningTime: "learningTime",
-} as const;
-
-type AdminCourseStatisticsTab = (typeof StatisticsTabs)[keyof typeof StatisticsTabs];
 
 interface CourseAdminStatisticsProps {
   course?: GetCourseResponse["data"];
@@ -85,7 +83,9 @@ export function CourseAdminStatistics({ course }: CourseAdminStatisticsProps) {
 
   const [courseStatisticsParams, setCourseStatisticsParams] = useState<CourseStatisticsParams>({});
 
-  const [activeTab, setActiveTab] = useState<AdminCourseStatisticsTab>("progress");
+  const [activeTab, setActiveTab] = useState<CourseAdminStatisticsTab>(
+    CourseAdminStatisticsTabs.progress,
+  );
 
   const [progressSearchParams, setProgressSearchParams] =
     useState<CourseStudentsProgressQueryParams>({});
@@ -142,6 +142,32 @@ export function CourseAdminStatistics({ course }: CourseAdminStatisticsProps) {
     enabled: canManageCourses,
     query: courseStatisticsParams,
   });
+  const { data: aiConfigured } = useAIConfigured();
+
+  const isAIConfigured = aiConfigured?.enabled === true;
+
+  const { data: aiMentorResultsPreview } = useCourseStudentsAiMentorResults({
+    id: courseId,
+    enabled: canManageCourses && Boolean(courseId),
+    query: {
+      page: 1,
+      perPage: 1,
+      language,
+    },
+  });
+
+  const hasAiMentorResults = (aiMentorResultsPreview?.pagination.totalItems ?? 0) > 0;
+
+  const visibleStatisticsTabs = useMemo(
+    () => getVisibleCourseStatisticsTabs({ hasAiMentorResults, isAIConfigured }),
+    [hasAiMentorResults, isAIConfigured],
+  );
+
+  useEffect(() => {
+    if (!visibleStatisticsTabs.includes(activeTab)) {
+      setActiveTab(CourseAdminStatisticsTabs.progress);
+    }
+  }, [activeTab, visibleStatisticsTabs]);
 
   const filterConfig: FilterConfig[] = [
     {
@@ -403,7 +429,7 @@ export function CourseAdminStatistics({ course }: CourseAdminStatisticsProps) {
                     .otherwise(() => null)}
                 </div>
                 <TabsList className="h-[42px] rounded-sm p-1 bg-primary-50 flex items-center">
-                  {Object.values(StatisticsTabs).map((tab) => (
+                  {visibleStatisticsTabs.map((tab) => (
                     <TabsTrigger
                       key={tab}
                       data-testid={
@@ -424,7 +450,7 @@ export function CourseAdminStatistics({ course }: CourseAdminStatisticsProps) {
                 </TabsList>
               </div>
             </div>
-            <TabsContent value="progress">
+            <TabsContent value={CourseAdminStatisticsTabs.progress}>
               <CourseStudentsProgressTable
                 courseId={courseId}
                 lessonCount={lessonCount}
@@ -432,7 +458,7 @@ export function CourseAdminStatistics({ course }: CourseAdminStatisticsProps) {
                 onFilterChange={handleProgressFilterChange}
               />
             </TabsContent>
-            <TabsContent value="quizResults">
+            <TabsContent value={CourseAdminStatisticsTabs.quizResults}>
               <CourseStudentsQuizResultsTable
                 courseId={courseId}
                 course={course}
@@ -440,15 +466,17 @@ export function CourseAdminStatistics({ course }: CourseAdminStatisticsProps) {
                 onFilterChange={handleQuizFilterChange}
               />
             </TabsContent>
-            <TabsContent value="aiMentorResults">
-              <CourseStudentsAiMentorResultsTable
-                courseId={courseId}
-                course={course}
-                searchParams={aiMentorSearchParams}
-                onFilterChange={handleAiMentorFilterChange}
-              />
-            </TabsContent>
-            <TabsContent value="learningTime">
+            {visibleStatisticsTabs.includes(CourseAdminStatisticsTabs.aiMentorResults) && (
+              <TabsContent value={CourseAdminStatisticsTabs.aiMentorResults}>
+                <CourseStudentsAiMentorResultsTable
+                  courseId={courseId}
+                  course={course}
+                  searchParams={aiMentorSearchParams}
+                  onFilterChange={handleAiMentorFilterChange}
+                />
+              </TabsContent>
+            )}
+            <TabsContent value={CourseAdminStatisticsTabs.learningTime}>
               <CourseStudentsLearningTimeTable
                 courseId={courseId}
                 searchParams={learningTimeParams}

--- a/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/utils/courseAdminStatisticsTabs.test.ts
+++ b/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/utils/courseAdminStatisticsTabs.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CourseAdminStatisticsTabs,
+  getVisibleCourseStatisticsTabs,
+} from "./courseAdminStatisticsTabs";
+
+describe("getVisibleCourseStatisticsTabs", () => {
+  it("hides AI mentor results when AI is not configured and no AI mentor results exist", () => {
+    expect(
+      getVisibleCourseStatisticsTabs({
+        hasAiMentorResults: false,
+        isAIConfigured: false,
+      }),
+    ).not.toContain(CourseAdminStatisticsTabs.aiMentorResults);
+  });
+
+  it("includes AI mentor results when AI is not configured but AI mentor results exist", () => {
+    expect(
+      getVisibleCourseStatisticsTabs({
+        hasAiMentorResults: true,
+        isAIConfigured: false,
+      }),
+    ).toContain(CourseAdminStatisticsTabs.aiMentorResults);
+  });
+
+  it("includes AI mentor results when AI is configured", () => {
+    expect(
+      getVisibleCourseStatisticsTabs({
+        hasAiMentorResults: false,
+        isAIConfigured: true,
+      }),
+    ).toContain(CourseAdminStatisticsTabs.aiMentorResults);
+  });
+});

--- a/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/utils/courseAdminStatisticsTabs.ts
+++ b/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/utils/courseAdminStatisticsTabs.ts
@@ -1,0 +1,27 @@
+export const CourseAdminStatisticsTabs = {
+  progress: "progress",
+  quizResults: "quizResults",
+  aiMentorResults: "aiMentorResults",
+  learningTime: "learningTime",
+} as const;
+
+export type CourseAdminStatisticsTab =
+  (typeof CourseAdminStatisticsTabs)[keyof typeof CourseAdminStatisticsTabs];
+
+interface GetVisibleCourseStatisticsTabsOptions {
+  hasAiMentorResults: boolean;
+  isAIConfigured: boolean;
+}
+
+export const getVisibleCourseStatisticsTabs = ({
+  hasAiMentorResults,
+  isAIConfigured,
+}: GetVisibleCourseStatisticsTabsOptions): CourseAdminStatisticsTab[] => {
+  const tabs = Object.values(CourseAdminStatisticsTabs);
+
+  if (!isAIConfigured && !hasAiMentorResults) {
+    return tabs.filter((tab) => tab !== CourseAdminStatisticsTabs.aiMentorResults);
+  }
+
+  return tabs;
+};


### PR DESCRIPTION
## Overview

Hides the AI Mentor results tab in course admin statistics when OpenAI/AI is not configured and there are no existing AI Mentor results to show.

This change keeps historical AI Mentor results accessible when they already exist, even if AI is currently disabled. It also keeps the tab available when AI is configured, so admins can access newly generated results normally.

Implementation details:

- Adds a shared `CourseAdminStatisticsTabs` helper for deciding which statistics tabs should be visible.
- Checks AI configuration through `useAIConfigured`.
- Loads a lightweight one-item AI Mentor results preview to determine whether historical results exist.
- Resets the active statistics tab back to progress if the current tab becomes hidden.
- Derives AI Mentor results query params from the generated API client method signature instead of maintaining a duplicated manual type.

## Business Value

Course admins should not see an AI Mentor results tab when the feature cannot produce or display anything useful. Removing the empty tab reduces confusion in tenants where AI is not configured, while preserving access to existing AI Mentor results for tenants that previously used the feature.
