### PR TITLE
fix: prevent external HTTP resources from being routed through S3

### DIFF
--- a/apps/api/src/file/__tests__/file.service.image-variants.spec.ts
+++ b/apps/api/src/file/__tests__/file.service.image-variants.spec.ts
@@ -65,6 +65,17 @@ describe("FileService image variant references", () => {
     expect(s3Service.getSignedUrl).toHaveBeenCalledWith("tenant/course/variants/image-1920w.webp");
   });
 
+  it("returns remote URLs without signing them", async () => {
+    await expect(service.getFileUrl("https://cdn.example.com/image.png")).resolves.toBe(
+      "https://cdn.example.com/image.png",
+    );
+    await expect(service.getFileUrl("http://cdn.example.com/image.png")).resolves.toBe(
+      "http://cdn.example.com/image.png",
+    );
+
+    expect(s3Service.getSignedUrl).not.toHaveBeenCalled();
+  });
+
   it("streams the high quality concrete variant", async () => {
     await service.getFileDelivery(variantReference);
 

--- a/apps/api/src/file/file.service.ts
+++ b/apps/api/src/file/file.service.ts
@@ -107,7 +107,7 @@ export class FileService {
 
   async getFileUrl(fileKey: string): Promise<string> {
     if (!fileKey) return "https://app.lms.localhost/app/assets/placeholders/card-placeholder.jpg";
-    if (fileKey.startsWith("https://")) return fileKey;
+    if (fileKey.startsWith("https://") || fileKey.startsWith("http://")) return fileKey;
     if (fileKey.startsWith("bunny-")) {
       const videoId = fileKey.replace("bunny-", "");
 


### PR DESCRIPTION
<!--
 1. Make sure you have correct branch name i.e. `ab_prefix_123_task_name`, where `123` is a issue ID, and `ab` is an author
 2. Make sure you have meaningful title related to task with correct prefix: feat/fix/chore/style/docs/refactor
 3. Reference multiple issues in one PR by listing them in the issues section
 4. Make sure all necessary sections are filled, remove obsolete sections
 5. Do a self review first
 6. Check if your PR includes only code related to your task
 7. `Notes` is used for additional info but also to notify if any action is required
-->

## Issue(s)
[1656](https://github.com/Selleo/mentingo/issues/1657)

  ## Overview

  Fixes remote HTTP image URL handling in FileService.getFileUrl.

  Previously, only https:// references were returned directly. Plain http:// image references fell through to S3 signing, so course thumbnails stored as HTTP URLs were treated as storage keys and failed
  to load. This change returns both http:// and https:// references as-is and adds focused coverage for remote URL references.

  ## Business Value

  Course thumbnails backed by external HTTP image URLs now render correctly instead of falling back to broken images. This preserves compatibility with URL-based course thumbnails and prevents unnecessary
  S3 signing for assets that are already externally hosted.