### PR TITLE
fix: resolve tenants correctly in LiveKit webhooks based on the host

### DIFF
--- a/apps/api/src/live-training/live-training-sessions/live-training-sessions.service.ts
+++ b/apps/api/src/live-training/live-training-sessions/live-training-sessions.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Inject, Injectable, NotFoundException } from "@nestjs/common";
+import { BadRequestException, Inject, Injectable, Logger, NotFoundException } from "@nestjs/common";
 import {
   LIVE_TRAINING_DELIVERY_TYPES,
   LIVE_TRAINING_PARTICIPANT_ROLES,
@@ -69,6 +69,8 @@ const INVALIDATING_SESSION_STATUSES = new Set<string>([
 
 @Injectable()
 export class LiveTrainingSessionsService {
+  private readonly logger = new Logger(LiveTrainingSessionsService.name);
+
   constructor(
     private readonly liveTrainingSessionsRepository: LiveTrainingSessionsRepository,
     private readonly liveKitService: LiveKitService,
@@ -550,7 +552,7 @@ export class LiveTrainingSessionsService {
   }
 
   async handleLiveKitWebhook(input: HandleLiveKitWebhookInput) {
-    const event = await this.liveKitService.receiveWebhook(input.body, input.authorizationHeader);
+    const event = await this.receiveLiveKitWebhook(input);
     const roomName = this.getWebhookRoomName(event);
 
     if (!roomName) return event;
@@ -560,11 +562,34 @@ export class LiveTrainingSessionsService {
 
     if (!sessionTenant) return event;
 
+    if (input.requestTenantId && sessionTenant.tenantId !== input.requestTenantId) {
+      this.logger.warn(
+        `LiveKit webhook tenant mismatch: ${JSON.stringify({
+          requestTenantId: input.requestTenantId,
+          sessionTenantId: sessionTenant.tenantId,
+          roomName,
+          event: event.event,
+        })}`,
+      );
+
+      return event;
+    }
+
     await this.tenantDbRunner.runWithTenant(sessionTenant.tenantId, async () => {
       await this.processLiveKitWebhookEvent(event, sessionTenant);
     });
 
     return event;
+  }
+
+  private async receiveLiveKitWebhook(input: HandleLiveKitWebhookInput) {
+    if (!input.requestTenantId) {
+      return this.liveKitService.receiveWebhook(input.body, input.authorizationHeader);
+    }
+
+    return this.tenantDbRunner.runWithTenant(input.requestTenantId, () =>
+      this.liveKitService.receiveWebhook(input.body, input.authorizationHeader),
+    );
   }
 
   private async processLiveKitWebhookEvent(

--- a/apps/api/src/live-training/live-training-sessions/live-training-sessions.types.ts
+++ b/apps/api/src/live-training/live-training-sessions/live-training-sessions.types.ts
@@ -6,6 +6,7 @@ import { UUIDSchema, baseResponse } from "src/common";
 export const handleLiveKitWebhookInputSchema = Type.Object({
   body: Type.String(),
   authorizationHeader: Type.Optional(Type.String()),
+  requestTenantId: Type.Optional(UUIDSchema),
 });
 
 export const liveTrainingSessionUserSchema = Type.Object({

--- a/apps/api/src/live-training/livekit/livekit-webhook.controller.ts
+++ b/apps/api/src/live-training/livekit/livekit-webhook.controller.ts
@@ -2,28 +2,30 @@ import { Controller, Headers, Logger, Post, Req } from "@nestjs/common";
 
 import { BaseResponse } from "src/common";
 import { Public } from "src/common/decorators/public.decorator";
+import { TenantResolverService } from "src/storage/db/tenant-resolver.service";
 
 import { LiveTrainingSessionsService } from "../live-training-sessions/live-training-sessions.service";
 
-type RequestWithRawBody = Request & {
-  rawBody?: string | Buffer;
-  body?: unknown;
-};
+import { LiveKitWebhookRequest } from "./livekit.types";
 
 @Public()
 @Controller("live-training/livekit")
 export class LiveKitWebhookController {
   private readonly logger = new Logger(LiveKitWebhookController.name);
 
-  constructor(private readonly liveTrainingSessionsService: LiveTrainingSessionsService) {}
+  constructor(
+    private readonly liveTrainingSessionsService: LiveTrainingSessionsService,
+    private readonly tenantResolverService: TenantResolverService,
+  ) {}
 
   @Post("webhook")
   async handleWebhook(
     @Headers() headers: Record<string, string | string[] | undefined>,
-    @Req() request: RequestWithRawBody,
+    @Req() request: LiveKitWebhookRequest,
   ) {
     const body = this.getRawBody(request);
     const authorizationHeader = this.getAuthorizationHeader(headers);
+    const requestTenantId = await this.tenantResolverService.resolveTenantId(request);
 
     this.logger.debug(
       `LiveKit webhook received: ${JSON.stringify({
@@ -32,12 +34,15 @@ export class LiveKitWebhookController {
         bodyLength: body?.length ?? 0,
         contentType: headers["content-type"],
         userAgent: headers["user-agent"],
+        requestTenantId,
+        requestTarget: this.getRequestTargetDiagnostics(request, headers),
       })}`,
     );
 
     await this.liveTrainingSessionsService.handleLiveKitWebhook({
       body: body ?? "",
       authorizationHeader,
+      requestTenantId: requestTenantId ?? undefined,
     });
 
     return new BaseResponse({ received: true });
@@ -60,7 +65,7 @@ export class LiveKitWebhookController {
     return null;
   }
 
-  private getRawBody(request: RequestWithRawBody) {
+  private getRawBody(request: LiveKitWebhookRequest) {
     if (Buffer.isBuffer(request.body)) {
       return request.body.toString("utf8");
     }
@@ -78,5 +83,23 @@ export class LiveKitWebhookController {
     }
 
     return "";
+  }
+
+  private getRequestTargetDiagnostics(
+    request: LiveKitWebhookRequest,
+    headers: Record<string, string | string[] | undefined>,
+  ) {
+    return {
+      protocol: request.protocol,
+      hostname: request.hostname,
+      host: headers.host,
+      forwardedHost: headers["x-forwarded-host"],
+      forwardedProto: headers["x-forwarded-proto"],
+      forwardedFor: headers["x-forwarded-for"],
+      originalUrl: request.originalUrl,
+      baseUrl: request.baseUrl,
+      path: request.path,
+      url: request.url,
+    };
   }
 }

--- a/apps/api/src/live-training/livekit/livekit.types.ts
+++ b/apps/api/src/live-training/livekit/livekit.types.ts
@@ -3,6 +3,7 @@ import { Type, type Static } from "@sinclair/typebox";
 import { UUIDSchema } from "src/common";
 
 import type { LiveTrainingSettings } from "@repo/shared";
+import type { Request } from "express";
 import type { Room, TrackSource, WebhookEvent } from "livekit-server-sdk";
 
 export const liveKitConfigSchema = Type.Object({
@@ -98,5 +99,10 @@ export type CreateLiveKitRoomResult = Static<typeof createLiveKitRoomResultSchem
 export type LiveKitViewerPermissions = LiveTrainingSettings["viewerPermissions"];
 
 export type LiveKitWebhookResult = WebhookEvent;
+
+export type LiveKitWebhookRequest = Request & {
+  rawBody?: string | Buffer;
+  body?: unknown;
+};
 
 export type LiveKitPublishSource = TrackSource;

--- a/apps/api/src/storage/db/tenant-resolver.service.ts
+++ b/apps/api/src/storage/db/tenant-resolver.service.ts
@@ -114,10 +114,13 @@ export class TenantResolverService {
     const fromHeader = this.safeParseOrigin(req.headers.referer ?? req.headers.origin);
     if (fromHeader) return fromHeader;
 
-    const host = req.headers.host;
+    const host = this.getFirstHeaderValue(req.headers["x-forwarded-host"]) ?? req.headers.host;
     if (!host) return null;
 
-    const protocol = (req.protocol as string | undefined) ?? "http";
+    const protocol =
+      this.getFirstHeaderValue(req.headers["x-forwarded-proto"]) ??
+      (req.protocol as string | undefined) ??
+      "http";
     return `${protocol}://${host}`.replace(/\/$/, "");
   }
 
@@ -133,6 +136,12 @@ export class TenantResolverService {
 
   private getSingleQueryValue(value: unknown): string | undefined {
     return typeof value === "string" ? value : undefined;
+  }
+
+  private getFirstHeaderValue(value: string | string[] | undefined): string | undefined {
+    if (Array.isArray(value)) return value[0]?.split(",")[0]?.trim();
+
+    return value?.split(",")[0]?.trim();
   }
 
   private isInactiveAllowed(req: Request): boolean {


### PR DESCRIPTION
<!--
 1. Make sure you have correct branch name i.e. `ab_prefix_123_task_name`, where `123` is a issue ID, and `ab` is an author
 2. Make sure you have meaningful title related to task with correct prefix: feat/fix/chore/style/docs/refactor
 3. Reference multiple issues in one PR by listing them in the issues section
 4. Make sure all necessary sections are filled, remove obsolete sections
 5. Do a self review first
 6. Check if your PR includes only code related to your task
 7. `Notes` is used for additional info but also to notify if any action is required
-->

## Issue(s)
[1662](https://github.com/Selleo/mentingo/issues/1662)

## Overview

  Fixes LiveKit webhook tenant resolution for tenant-specific LiveKit credentials.

  The webhook controller now resolves the tenant from the request target host, logs request target diagnostics, and passes the resolved tenant into LiveKit webhook handling. Tenant resolution now prefers
  X-Forwarded-Host and X-Forwarded-Proto before falling back to the regular request host/protocol, which supports proxied deployments.

  LiveKit webhook verification now runs inside the resolved tenant context when available, so tenant-scoped LIVEKIT_* secrets are used. The handler also guards against mismatches between the request-
  resolved tenant and the session tenant before saving attendance/progress.

  ## Business Value

  Live training attendance and progress can now be saved correctly in multi-tenant deployments where each tenant has separate LiveKit project credentials. This improves reliability for hosted/proxied
  environments and helps diagnose webhook routing issues through clearer request-target logging.