### PR TITLE
chore: add a native time input option to calendar date and time fields

### DIFF
--- a/apps/web/app/modules/Calendar/components/CalendarDateTimeField.tsx
+++ b/apps/web/app/modules/Calendar/components/CalendarDateTimeField.tsx
@@ -10,7 +10,10 @@ import { cn } from "~/lib/utils";
 import { useLanguageStore } from "~/modules/Dashboard/Settings/Language/LanguageStore";
 
 import { CalendarFormFieldLabel } from "./CalendarFormFieldLabel";
+import { CalendarTimeInput } from "./CalendarTimeInput";
 import { CalendarTimeSelect } from "./CalendarTimeSelect";
+
+type CalendarDateTimeFieldTimeInputVariant = "select" | "native";
 
 type CalendarDateTimeFieldProps = {
   label: string;
@@ -20,6 +23,7 @@ type CalendarDateTimeFieldProps = {
   portalledDatePicker?: boolean;
   hideTime?: boolean;
   timeStepMinutes?: number;
+  timeInputVariant?: CalendarDateTimeFieldTimeInputVariant;
   dateButtonTestId?: string;
   timeSelectTestId?: string;
   onDateChange: (date: string) => void;
@@ -41,6 +45,7 @@ export function CalendarDateTimeField({
   portalledDatePicker = true,
   hideTime = false,
   timeStepMinutes,
+  timeInputVariant = "select",
   dateButtonTestId,
   timeSelectTestId,
   onDateChange,
@@ -56,7 +61,8 @@ export function CalendarDateTimeField({
       <CalendarFormFieldLabel label={label} tooltip={tooltip} />
       <div
         className={cn("grid gap-2", {
-          "grid-cols-[1fr_8.5rem]": !hideTime,
+          "grid-cols-[1fr_8.5rem]": !hideTime && timeInputVariant === "select",
+          "grid-cols-[1fr_12rem]": !hideTime && timeInputVariant === "native",
         })}
       >
         <Popover>
@@ -99,14 +105,23 @@ export function CalendarDateTimeField({
             />
           </PopoverContent>
         </Popover>
-        {!hideTime && (
-          <CalendarTimeSelect
-            value={time}
-            stepMinutes={timeStepMinutes}
-            testId={timeSelectTestId}
-            onChange={onTimeChange}
-          />
-        )}
+        {!hideTime &&
+          (timeInputVariant === "native" ? (
+            <CalendarTimeInput
+              value={time}
+              stepMinutes={timeStepMinutes}
+              testId={timeSelectTestId}
+              onChange={onTimeChange}
+              disabled={!selectedDate}
+            />
+          ) : (
+            <CalendarTimeSelect
+              value={time}
+              stepMinutes={timeStepMinutes}
+              testId={timeSelectTestId}
+              onChange={onTimeChange}
+            />
+          ))}
       </div>
     </div>
   );

--- a/apps/web/app/modules/Calendar/components/CalendarTimeInput.tsx
+++ b/apps/web/app/modules/Calendar/components/CalendarTimeInput.tsx
@@ -1,0 +1,54 @@
+import { Clock } from "lucide-react";
+
+import { Input } from "~/components/ui/input";
+import { cn } from "~/lib/utils";
+
+import { DEFAULT_TIME_STEP_MINUTES } from "./calendarTimeSelect.utils";
+
+type CalendarTimeInputProps = {
+  value: string;
+  stepMinutes?: number;
+  testId?: string;
+  disabled?: boolean;
+  onChange: (time: string) => void;
+};
+
+const normalizeTimeValue = (value: string) => {
+  if (!value) return "";
+
+  const match = /^(\d{2}):(\d{2})/.exec(value.trim());
+  if (!match) return "";
+
+  return `${match[1]}:${match[2]}`;
+};
+
+export function CalendarTimeInput({
+  value,
+  stepMinutes = DEFAULT_TIME_STEP_MINUTES,
+  testId,
+  disabled = false,
+  onChange,
+}: CalendarTimeInputProps) {
+  return (
+    <div className="relative">
+      <Clock
+        className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-neutral-500"
+        aria-hidden="true"
+      />
+      <Input
+        type="time"
+        data-testid={testId}
+        value={normalizeTimeValue(value)}
+        step={stepMinutes * 60}
+        disabled={disabled}
+        onChange={(event) => onChange(event.target.value)}
+        className={cn(
+          "block w-full min-w-[10.5rem] appearance-none pl-9 pr-3 tabular-nums",
+          "[&::-webkit-calendar-picker-indicator]:hidden",
+          "[&::-webkit-datetime-edit]:m-0 [&::-webkit-datetime-edit]:p-0",
+          "[&::-webkit-datetime-edit-fields-wrapper]:p-0",
+        )}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
<!--
 1. Make sure you have correct branch name i.e. `ab_prefix_123_task_name`, where `123` is a issue ID, and `ab` is an author
 2. Make sure you have meaningful title related to task with correct prefix: feat/fix/chore/style/docs/refactor
 3. Reference multiple issues in one PR by listing them in the issues section
 4. Make sure all necessary sections are filled, remove obsolete sections
 5. Do a self review first
 6. Check if your PR includes only code related to your task
 7. `Notes` is used for additional info but also to notify if any action is required
-->

## Issue(s)
[](https://github.com/Selleo/mentingo/issues/)

## Overview 
Add native time input variant to CalendarDateTimeField component

## Business Value
Speeds up time selection by users.

## Screenshots / Video
<img width="1552" height="185" alt="image" src="https://github.com/user-attachments/assets/25ea1ac7-c1dd-4f1a-b379-d2b0698b36e0" />

<!-- ## Testing prerequisites

## Testing scenarios

- [ ] A
- [ ] B
- [ ] C 

# Video showing the complete working flow of the feature / enhancement / bug-fix included in this code change.
-->

### Notes 

- [ ] Fired up e2e tests and got a positive result
