### PR TITLE
feat: save video progress so learners can resume where they left off

### DIFF
--- a/apps/api/src/lesson-video-progress/lesson-video-progress.service.spec.ts
+++ b/apps/api/src/lesson-video-progress/lesson-video-progress.service.spec.ts
@@ -220,6 +220,34 @@ describe("LessonVideoProgressService", () => {
     });
   });
 
+  it("stores progress without watched or lesson completion side effects when tracking is disabled", async () => {
+    const { service, repository, studentLessonProgressService } = createService();
+    const thresholdProgress = progressRow({
+      watchedRanges: [[0, 90]],
+      coveredBucketCount: 90,
+      coveragePercent: VIDEO_COMPLETION_COVERAGE_THRESHOLD,
+    });
+
+    repository.getLessonVideoContext.mockResolvedValue({
+      ...context,
+      videoCompletionTrackingEnabled: false,
+    });
+    repository.mergeWatchedRanges.mockResolvedValue(thresholdProgress);
+
+    const result = await service.upsertProgress(body({ watchedRanges: [[0, 90]] }), currentUser);
+
+    expect(repository.mergeWatchedRanges).toHaveBeenCalled();
+    expect(repository.markWatched).not.toHaveBeenCalled();
+    expect(repository.getRequiredVideoProgressForLesson).not.toHaveBeenCalled();
+    expect(studentLessonProgressService.markLessonAsCompleted).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      watchedRanges: [[0, 90]],
+      coveragePercent: VIDEO_COMPLETION_COVERAGE_THRESHOLD,
+      isWatched: false,
+      lessonCompleted: false,
+    });
+  });
+
   it("completes the lesson when every required video is watched", async () => {
     const { service, repository, studentLessonProgressService, trx } = createService();
     const watchedProgress = progressRow({

--- a/apps/api/src/lesson-video-progress/lesson-video-progress.service.ts
+++ b/apps/api/src/lesson-video-progress/lesson-video-progress.service.ts
@@ -68,9 +68,6 @@ export class LessonVideoProgressService {
       if (!context.resourceContentType?.startsWith("video/")) {
         throw new BadRequestException(LESSON_VIDEO_PROGRESS_ERROR_KEYS.INVALID_RESOURCE_TYPE);
       }
-      if (!context.videoCompletionTrackingEnabled) {
-        throw new BadRequestException(LESSON_VIDEO_PROGRESS_ERROR_KEYS.TRACKING_DISABLED);
-      }
 
       const lessonProgressAccess = await this.studentLessonProgressService.getLessonProgressAccess(
         body.lessonId,
@@ -141,7 +138,9 @@ export class LessonVideoProgressService {
       }
 
       const watchedProgress =
-        !progress.isWatched && progress.coveragePercent >= VIDEO_COMPLETION_COVERAGE_THRESHOLD
+        context.videoCompletionTrackingEnabled &&
+        !progress.isWatched &&
+        progress.coveragePercent >= VIDEO_COMPLETION_COVERAGE_THRESHOLD
           ? await this.lessonVideoProgressRepository.markWatched(
               {
                 studentId: currentUser.userId,
@@ -152,17 +151,20 @@ export class LessonVideoProgressService {
             )
           : progress;
 
-      const requiredVideos =
-        await this.lessonVideoProgressRepository.getRequiredVideoProgressForLesson(
-          {
-            lessonId: body.lessonId,
-            studentId: currentUser.userId,
-          },
-          trx,
-        );
+      const requiredVideos = context.videoCompletionTrackingEnabled
+        ? await this.lessonVideoProgressRepository.getRequiredVideoProgressForLesson(
+            {
+              lessonId: body.lessonId,
+              studentId: currentUser.userId,
+            },
+            trx,
+          )
+        : [];
 
       const lessonCompleted =
-        requiredVideos.length > 0 && requiredVideos.every((video) => video.isWatched);
+        context.videoCompletionTrackingEnabled &&
+        requiredVideos.length > 0 &&
+        requiredVideos.every((video) => video.isWatched);
 
       if (lessonCompleted && !context.lessonCompleted) {
         await this.studentLessonProgressService.markLessonAsCompleted({

--- a/apps/api/src/lesson/lesson.schema.ts
+++ b/apps/api/src/lesson/lesson.schema.ts
@@ -233,6 +233,7 @@ export const lessonShowSchema = Type.Object({
   hasOnlyVideo: Type.Optional(Type.Boolean()),
   hasVideo: Type.Optional(Type.Boolean()),
   hasTrackedVideo: Type.Optional(Type.Boolean()),
+  videoCompletionTrackingEnabled: Type.Optional(Type.Boolean()),
   hasAutoplayTrigger: Type.Optional(Type.Boolean()),
   videos: Type.Optional(Type.Array(Type.String())),
   isQuizFeedbackRedacted: Type.Optional(Type.Boolean()),

--- a/apps/api/src/lesson/services/lesson.service.ts
+++ b/apps/api/src/lesson/services/lesson.service.ts
@@ -181,8 +181,7 @@ export class LessonService {
         description: updatedDescription ?? lesson.description,
         hasOnlyVideo: hasVideo,
         hasVideo: contentCount.video > 0,
-        hasTrackedVideo:
-          Boolean(lesson.videoCompletionTrackingEnabled) && videoResourceEntityIds.length > 0,
+        hasTrackedVideo: videoResourceEntityIds.length > 0,
         hasAutoplayTrigger,
         videos,
       };

--- a/apps/api/src/swagger/api-schema.json
+++ b/apps/api/src/swagger/api-schema.json
@@ -29490,6 +29490,9 @@
               "hasTrackedVideo": {
                 "type": "boolean"
               },
+              "videoCompletionTrackingEnabled": {
+                "type": "boolean"
+              },
               "hasAutoplayTrigger": {
                 "type": "boolean"
               },

--- a/apps/web/app/api/generated-api.ts
+++ b/apps/web/app/api/generated-api.ts
@@ -2990,6 +2990,7 @@ export interface GetLessonByIdResponse {
     hasOnlyVideo?: boolean;
     hasVideo?: boolean;
     hasTrackedVideo?: boolean;
+    videoCompletionTrackingEnabled?: boolean;
     hasAutoplayTrigger?: boolean;
     videos?: string[];
     isQuizFeedbackRedacted?: boolean;

--- a/apps/web/app/components/RichText/Viever.tsx
+++ b/apps/web/app/components/RichText/Viever.tsx
@@ -22,6 +22,7 @@ type ViewerProps = {
   onVideoEnded?: (index: number | null) => void;
   videoCoverageTracking?: {
     enabled: boolean;
+    showCoverageMarkers?: boolean;
     lessonId?: string;
     language?: SupportedLanguages;
   };

--- a/apps/web/app/components/RichText/extensions/video.tsx
+++ b/apps/web/app/components/RichText/extensions/video.tsx
@@ -30,6 +30,7 @@ type VideoViewerOptions = {
   onVideoEnded?: (index: number | null) => void;
   videoCoverageTracking?: {
     enabled: boolean;
+    showCoverageMarkers?: boolean;
     lessonId?: string;
     language?: SupportedLanguages;
   };
@@ -237,7 +238,7 @@ const VideoViewerView = ({ node, extension }: NodeViewProps) => {
   );
 
   return (
-    <NodeViewWrapper className="video-node">
+    <NodeViewWrapper className="video-node not-prose">
       <Video
         src={attrs.src}
         provider={attrs.provider}
@@ -245,6 +246,7 @@ const VideoViewerView = ({ node, extension }: NodeViewProps) => {
         onEnded={onVideoEnded}
         coverageTracking={{
           enabled: trackingEnabled,
+          showCoverageMarkers: trackingEnabled && videoCoverageTracking?.showCoverageMarkers,
           lessonId: videoCoverageTracking?.lessonId,
           resourceEntityId: attrs.resourceEntityId,
           language: videoCoverageTracking?.language,

--- a/apps/web/app/components/VideoPlayer/VideoPlayer.tsx
+++ b/apps/web/app/components/VideoPlayer/VideoPlayer.tsx
@@ -84,6 +84,7 @@ export const VideoPlayer = ({
   const videoRef = useRef<HTMLDivElement | null>(null);
   const playerRef = useRef<VideoJSType | null>(null);
   const lastSourceRef = useRef<string | null>(null);
+  const resumeAppliedSourceRef = useRef<string | null>(null);
   const onAspectRatioChangeRef = useRef(onAspectRatioChange);
   const onEndedRef = useRef(onEnded);
   const controlsVisibilityTimeoutRef = useRef<number | null>(null);
@@ -176,13 +177,14 @@ export const VideoPlayer = ({
     if (!player || !url) return;
 
     const sourceTypes = getSourceTypes(url, type);
-    const sourceKey = `${url}::${sourceTypes.join("|")}`;
+    const sourceKey = `${url}::${coverageTracking?.resourceEntityId ?? ""}::${sourceTypes.join("|")}`;
 
     if (lastSourceRef.current === sourceKey) {
       return;
     }
 
     lastSourceRef.current = sourceKey;
+    resumeAppliedSourceRef.current = null;
 
     let attemptIndex = 0;
 
@@ -217,7 +219,39 @@ export const VideoPlayer = ({
     return () => {
       player.off("error", onError);
     };
-  }, [autoPlay, url, type]);
+  }, [autoPlay, coverageTracking?.resourceEntityId, url, type]);
+
+  useEffect(() => {
+    const sourceKey = lastSourceRef.current;
+    if (!player || !coverageTracking?.enabled || !sourceKey) return;
+
+    if (resumeAppliedSourceRef.current === sourceKey) return;
+
+    const applyResumeTime = () => {
+      const duration = player.duration();
+      const resumeTimeSeconds =
+        typeof duration === "number" && Number.isFinite(duration) && duration > 0
+          ? Math.min(coverage.resumeTimeSeconds, Math.max(0, duration - 0.5))
+          : coverage.resumeTimeSeconds;
+
+      if (resumeTimeSeconds > 0) {
+        player.currentTime(resumeTimeSeconds);
+      }
+
+      resumeAppliedSourceRef.current = sourceKey;
+    };
+
+    if (player.readyState() >= 1) {
+      applyResumeTime();
+      return;
+    }
+
+    player.one("loadedmetadata", applyResumeTime);
+
+    return () => {
+      player.off("loadedmetadata", applyResumeTime);
+    };
+  }, [coverage.resumeTimeSeconds, coverageTracking?.enabled, player]);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -257,7 +291,7 @@ export const VideoPlayer = ({
   }, [clearControlsVisibilityTimer]);
 
   useEffect(() => {
-    if (!player || !coverageTracking?.enabled) return;
+    if (!player || !coverageTracking?.showCoverageMarkers) return;
 
     const holder = player.el()?.querySelector(".vjs-progress-holder") as HTMLElement | null;
     if (!holder) return;
@@ -289,7 +323,7 @@ export const VideoPlayer = ({
   }, [
     coverage.snapshot.durationSeconds,
     coverage.snapshot.watchedRanges,
-    coverageTracking?.enabled,
+    coverageTracking?.showCoverageMarkers,
     player,
   ]);
 

--- a/apps/web/app/components/VideoPlayer/__tests__/useVideoCoverageTracker.test.tsx
+++ b/apps/web/app/components/VideoPlayer/__tests__/useVideoCoverageTracker.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { syncLessonVideoCompletionQueries, useLessonVideoProgress } from "~/api/mutations";
 
-import { useVideoCoverageTracker } from "../useVideoCoverageTracker";
+import { getVideoResumeTimeSeconds, useVideoCoverageTracker } from "../useVideoCoverageTracker";
 
 import type { VideoCoverageRange } from "../videoCoverage.types";
 import type videojs from "video.js";
@@ -238,5 +238,50 @@ describe("useVideoCoverageTracker", () => {
     });
 
     await waitFor(() => expect(syncLessonCompletionQueries).toHaveBeenCalledWith("lesson-id"));
+  });
+});
+
+describe("getVideoResumeTimeSeconds", () => {
+  it("returns the end of the first watched range when the video has an unwatched gap", () => {
+    expect(
+      getVideoResumeTimeSeconds({
+        watchedRanges: [
+          [0, 50],
+          [60, 100],
+        ],
+        durationSeconds: 100,
+        isWatched: false,
+      }),
+    ).toBe(50);
+  });
+
+  it("starts from the beginning when the first watched range reaches the end", () => {
+    expect(
+      getVideoResumeTimeSeconds({
+        watchedRanges: [[0, 100]],
+        durationSeconds: 100,
+        isWatched: false,
+      }),
+    ).toBe(0);
+  });
+
+  it("starts from the beginning when the video is already watched", () => {
+    expect(
+      getVideoResumeTimeSeconds({
+        watchedRanges: [[0, 50]],
+        durationSeconds: 100,
+        isWatched: true,
+      }),
+    ).toBe(0);
+  });
+
+  it("starts from the beginning when there are no watched ranges", () => {
+    expect(
+      getVideoResumeTimeSeconds({
+        watchedRanges: [],
+        durationSeconds: 100,
+        isWatched: false,
+      }),
+    ).toBe(0);
   });
 });

--- a/apps/web/app/components/VideoPlayer/useVideoCoverageTracker.ts
+++ b/apps/web/app/components/VideoPlayer/useVideoCoverageTracker.ts
@@ -19,6 +19,7 @@ type VideoJSType = ReturnType<typeof videojs>;
 const DEFAULT_BUCKET_SIZE_SECONDS = 1;
 const DEFAULT_FLUSH_INTERVAL_MS = 15_000;
 const MEDIA_DELTA_TOLERANCE_SECONDS = 1.5;
+const VIDEO_RESUME_END_TOLERANCE_SECONDS = 1;
 
 type FlushOptions = {
   syncCompletionQueries?: boolean;
@@ -47,6 +48,29 @@ const getInitialSnapshot = ({
   durationSeconds: initialDurationSeconds ?? null,
   bucketSizeSeconds: initialBucketSizeSeconds ?? DEFAULT_BUCKET_SIZE_SECONDS,
 });
+
+export const getVideoResumeTimeSeconds = ({
+  watchedRanges,
+  durationSeconds,
+  isWatched,
+}: Pick<VideoCoverageSnapshot, "watchedRanges" | "durationSeconds" | "isWatched">) => {
+  if (isWatched) return 0;
+
+  const [firstRange] = mergeVideoCoverageRanges(watchedRanges);
+  if (!firstRange) return 0;
+
+  const [, resumeTimeSeconds] = firstRange;
+
+  if (
+    typeof durationSeconds === "number" &&
+    Number.isFinite(durationSeconds) &&
+    resumeTimeSeconds >= Math.max(0, durationSeconds - VIDEO_RESUME_END_TOLERANCE_SECONDS)
+  ) {
+    return 0;
+  }
+
+  return Math.max(0, resumeTimeSeconds);
+};
 
 export const useVideoCoverageTracker = (
   player: VideoJSType | null,
@@ -318,10 +342,12 @@ export const useVideoCoverageTracker = (
     () => Math.round(snapshot.coveragePercent * 100),
     [snapshot.coveragePercent],
   );
+  const resumeTimeSeconds = useMemo(() => getVideoResumeTimeSeconds(snapshot), [snapshot]);
 
   return {
     snapshot,
     coveragePercentLabel,
+    resumeTimeSeconds,
     flush,
   };
 };

--- a/apps/web/app/components/VideoPlayer/videoCoverage.types.ts
+++ b/apps/web/app/components/VideoPlayer/videoCoverage.types.ts
@@ -4,6 +4,7 @@ export type { VideoCoverageRange };
 
 export type VideoCoverageTrackingOptions = {
   enabled: boolean;
+  showCoverageMarkers?: boolean;
   lessonId?: string;
   resourceEntityId?: string | null;
   language?: SupportedLanguages;

--- a/apps/web/app/modules/Courses/Lesson/LessonContent.tsx
+++ b/apps/web/app/modules/Courses/Lesson/LessonContent.tsx
@@ -59,16 +59,18 @@ export const LessonContent = ({
   const { data: user } = useCurrentUser();
   const { mutate: markLessonAsCompleted } = useMarkLessonAsCompleted(user?.id || "");
   const { sequenceEnabled } = useLessonsSequence(course.id);
-  const videoCoverageTrackingEnabled = Boolean(
+  const videoProgressPersistenceEnabled = Boolean(
     lesson.hasTrackedVideo && isEffectiveStudentExperience && !isPreviewMode,
   );
+  const videoCompletionTrackingEnabled = Boolean(lesson.videoCompletionTrackingEnabled);
   const videoCoverageTracking = useMemo(
     () => ({
-      enabled: videoCoverageTrackingEnabled,
+      enabled: videoProgressPersistenceEnabled,
+      showCoverageMarkers: videoProgressPersistenceEnabled && videoCompletionTrackingEnabled,
       lessonId: lesson.id,
       language,
     }),
-    [language, lesson.id, videoCoverageTrackingEnabled],
+    [language, lesson.id, videoCompletionTrackingEnabled, videoProgressPersistenceEnabled],
   );
 
   const currentChapterIndex = course.chapters.findIndex((chapter) =>

--- a/apps/web/app/modules/Courses/Lesson/LessonContentRenderer.tsx
+++ b/apps/web/app/modules/Courses/Lesson/LessonContentRenderer.tsx
@@ -23,6 +23,7 @@ type LessonContentRendererProps = {
   onVideoEnded?: (index: number | null) => void;
   videoCoverageTracking?: {
     enabled: boolean;
+    showCoverageMarkers?: boolean;
     lessonId: string;
     language: SupportedLanguages;
   };


### PR DESCRIPTION
<!--
 1. Make sure you have correct branch name i.e. `ab_prefix_123_task_name`, where `123` is a issue ID, and `ab` is an author
 2. Make sure you have meaningful title related to task with correct prefix: feat/fix/chore/style/docs/refactor
 3. Reference multiple issues in one PR by listing them in the issues section
 4. Make sure all necessary sections are filled, remove obsolete sections
 5. Do a self review first
 6. Check if your PR includes only code related to your task
 7. `Notes` is used for additional info but also to notify if any action is required
-->

## Issue(s)
[998](https://github.com/Selleo/mentingo/issues/998)

  ## Overview
  <!--
  General description what it does
  -->

  Adds persistent resume support for internal video lessons by saving video watched ranges even when course video completion tracking is disabled.

  Updates the lesson video progress flow so disabled completion tracking no longer rejects progress writes, but still avoids marking videos as watched or completing lessons through coverage thresholds.
  The lesson response now exposes videoCompletionTrackingEnabled to the web client and keeps internal videos eligible for progress persistence.

  On the frontend, video progress persistence is separated from completion marker display. Video players now resume from the end of the first watched range, while progress markers remain visible only when
  video completion tracking is enabled. Rich-text video nodes also opt out of prose image styling to avoid thumbnail layout issues.

  ## Business Value
  <!--
  Why are we doing this from a business perspective? What value does this bring to the project from end-users perspective?
  -->

  Learners can leave and reopen video lessons without losing their playback position, regardless of whether strict video completion tracking is enabled for the course.

  This improves the learning experience for longer video lessons while preserving existing course settings around whether watched coverage should count toward lesson completion.

## Screenshots / Video


https://github.com/user-attachments/assets/8bed60bc-f5cf-43c1-8bc5-a2a5add10496

