### PR TITLE
chore: add a sample user import file

### DIFF
--- a/apps/web/app/components/FileUploadInput/FileUploadInput.tsx
+++ b/apps/web/app/components/FileUploadInput/FileUploadInput.tsx
@@ -89,7 +89,7 @@ const FileUploadInput = ({
 
   if (!videoPreview && !file) {
     return (
-      <div {...getRootProps()} className="max-w-[440px]">
+      <div {...getRootProps()} className={cn("w-full max-w-[440px]", className)}>
         <EmptyStateUpload className={className} />
         <input {...getInputProps()} className="sr-only" data-testid={inputTestId} />
       </div>

--- a/apps/web/app/locales/cs/translation.json
+++ b/apps/web/app/locales/cs/translation.json
@@ -1439,7 +1439,8 @@
         "role": "Uložit",
         "group": "Uložit",
         "archive": "Archiv",
-        "continue": "Potvrdit"
+        "continue": "Potvrdit",
+        "downloadSample": "Stáhnout ukázkový soubor"
       },
       "description": {
         "delete": "Opravdu chcete tyto účty smazat? Tato akce je nevratná.",
@@ -1458,6 +1459,16 @@
       },
       "note": {
         "import": "Poznámka: Stávající uživatelé budou přeskočeni. Pokud je zadaná skupina a neexistuje, nová skupina se nevytvoří. Jazykové pole je nepovinné; pokud není zadán nebo je neplatný, výchozí jazyk bude nastaven na jazyk správce."
+      },
+      "sampleFile": {
+        "filename": "ukazka-importu-uzivatelu.csv",
+        "row": {
+          "firstName": "Jan",
+          "lastName": "Novák",
+          "email": "jan.novak@example.com",
+          "groupOne": "skupina1",
+          "groupTwo": "skupina2"
+        }
       },
       "tabs": {
         "imported": "Importováno",

--- a/apps/web/app/locales/de/translation.json
+++ b/apps/web/app/locales/de/translation.json
@@ -1433,7 +1433,8 @@
         "role": "Speichern",
         "group": "Speichern",
         "archive": "Archiv",
-        "continue": "Bestätigen"
+        "continue": "Bestätigen",
+        "downloadSample": "Beispieldatei herunterladen"
       },
       "description": {
         "delete": "Sind Sie sicher, dass Sie diese Konten löschen möchten? Diese Aktion ist irreversibel.",
@@ -1452,6 +1453,16 @@
       },
       "note": {
         "import": "Hinweis: Bestehende Benutzer werden übersprungen. Wenn eine Gruppe angegeben ist und nicht existiert, wird keine neue Gruppe erstellt. Das Sprachfeld ist optional; Falls nicht angegeben oder ungültig, wird die Standardsprache auf die Sprache des Administrators eingestellt."
+      },
+      "sampleFile": {
+        "filename": "beispiel-benutzerimport.csv",
+        "row": {
+          "firstName": "Max",
+          "lastName": "Mustermann",
+          "email": "max.mustermann@example.com",
+          "groupOne": "gruppe1",
+          "groupTwo": "gruppe2"
+        }
       },
       "tabs": {
         "imported": "Importiert",

--- a/apps/web/app/locales/en/translation.json
+++ b/apps/web/app/locales/en/translation.json
@@ -1494,7 +1494,8 @@
         "role": "Save",
         "group": "Save",
         "archive": "Archive",
-        "continue": "Confirm"
+        "continue": "Confirm",
+        "downloadSample": "Download sample file"
       },
       "description": {
         "delete": "Are you sure you want to delete these accounts? This action is irreversible.",
@@ -1513,6 +1514,16 @@
       },
       "note": {
         "import": "Note: Existing users will be skipped. If a group is specified and does not exist, a new group will not be created. The language field is optional; if not provided or invalid, the default language will be set to admin's language."
+      },
+      "sampleFile": {
+        "filename": "users-import-sample.csv",
+        "row": {
+          "firstName": "Sample",
+          "lastName": "Student",
+          "email": "sample.student@example.com",
+          "groupOne": "group1",
+          "groupTwo": "group2"
+        }
       },
       "tabs": {
         "imported": "Imported",

--- a/apps/web/app/locales/lt/translation.json
+++ b/apps/web/app/locales/lt/translation.json
@@ -1439,7 +1439,8 @@
         "role": "Išsaugoti",
         "group": "Išsaugoti",
         "archive": "Archyvas",
-        "continue": "Patvirtinti"
+        "continue": "Patvirtinti",
+        "downloadSample": "Atsisiųsti pavyzdinį failą"
       },
       "description": {
         "delete": "Ar tikrai norite ištrinti šias paskyras? Šis veiksmas yra negrįžtamas.",
@@ -1458,6 +1459,16 @@
       },
       "note": {
         "import": "Pastaba: esami vartotojai bus praleisti. Jei grupė nurodyta ir jos nėra, nauja grupė nebus sukurta. Kalbos laukas yra neprivalomas; jei nepateikta arba ji neteisinga, numatytoji kalba bus nustatyta į administratoriaus kalbą."
+      },
+      "sampleFile": {
+        "filename": "vartotoju-importo-pavyzdys.csv",
+        "row": {
+          "firstName": "Jonas",
+          "lastName": "Jonaitis",
+          "email": "jonas.jonaitis@example.com",
+          "groupOne": "grupe1",
+          "groupTwo": "grupe2"
+        }
       },
       "tabs": {
         "imported": "Importuota",

--- a/apps/web/app/locales/pl/translation.json
+++ b/apps/web/app/locales/pl/translation.json
@@ -1713,7 +1713,8 @@
         "role": "Zapisz",
         "group": "Zapisz",
         "archive": "Archiwizuj",
-        "continue": "Zatwierdź"
+        "continue": "Zatwierdź",
+        "downloadSample": "Pobierz plik przykładowy"
       },
       "description": {
         "delete": "Czy na pewno chcesz usunąć te konta? Ta operacja jest nieodwracalna.",
@@ -1736,6 +1737,16 @@
       },
       "note": {
         "import": "Notatka: Istniejący użytkownicy zostaną pominięci. Jeśli podana jest grupa, a nie istnieje, nie zostanie utworzona nowa grupa. Jeśli język nie jest podany, bądź podany będzie nieprawidłowy to domyślnie zostanie ustawiony na język interfejsu administratora."
+      },
+      "sampleFile": {
+        "filename": "przyklad-importu-uzytkownikow.csv",
+        "row": {
+          "firstName": "Jan",
+          "lastName": "Kowalski",
+          "email": "jan.kowalski@example.com",
+          "groupOne": "grupa1",
+          "groupTwo": "grupa2"
+        }
       },
       "tabs": {
         "imported": "Zaimportowani użytkownicy",

--- a/apps/web/app/modules/Admin/Users/components/ImportUsersModal/ImportUsersUpload.constants.ts
+++ b/apps/web/app/modules/Admin/Users/components/ImportUsersModal/ImportUsersUpload.constants.ts
@@ -1,0 +1,10 @@
+export const USERS_IMPORT_SAMPLE_ROLE = "student";
+
+export const USERS_IMPORT_SAMPLE_HEADERS = [
+  "firstName",
+  "lastName",
+  "email",
+  "role",
+  "groups",
+  "language",
+];

--- a/apps/web/app/modules/Admin/Users/components/ImportUsersModal/ImportUsersUpload.test.tsx
+++ b/apps/web/app/modules/Admin/Users/components/ImportUsersModal/ImportUsersUpload.test.tsx
@@ -1,7 +1,10 @@
 import { fireEvent, screen } from "@testing-library/react";
-import { vi } from "vitest";
+import { beforeEach, vi } from "vitest";
 
 import { Dialog } from "~/components/ui/dialog";
+import { useLanguageStore } from "~/modules/Dashboard/Settings/Language/LanguageStore";
+import { triggerBrowserDownload } from "~/utils/downloadFile";
+import i18next from "~/utils/mocks/i18next.mock";
 import { renderWith } from "~/utils/testUtils";
 
 import { USERS_IMPORT_MODAL_HANDLES } from "../../../../../../e2e/data/users/handles";
@@ -12,9 +15,22 @@ vi.mock("~/components/FileUploadInput/FileUploadInput", () => ({
   default: () => <div data-testid="mock-file-upload" />,
 }));
 
+vi.mock("~/utils/downloadFile", () => ({
+  triggerBrowserDownload: vi.fn(),
+}));
+
 const importFile = new File(["firstName,lastName,email"], "users.csv", {
   type: "text/csv",
 });
+
+const readBlobText = (blob: Blob) =>
+  new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+
+    reader.onload = () => resolve(String(reader.result));
+    reader.onerror = () => reject(reader.error);
+    reader.readAsText(blob);
+  });
 
 const renderImportUsersUpload = ({
   file = importFile,
@@ -42,6 +58,12 @@ const renderImportUsersUpload = ({
 };
 
 describe("ImportUsersUpload", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await i18next.changeLanguage("en");
+    useLanguageStore.getState().setLanguage("en");
+  });
+
   it("disables the import button while the import request is pending", () => {
     renderImportUsersUpload({ isImportingUsers: true });
 
@@ -60,5 +82,47 @@ describe("ImportUsersUpload", () => {
     fireEvent.click(screen.getByTestId(USERS_IMPORT_MODAL_HANDLES.SUBMIT));
 
     expect(handleUsersImport).not.toHaveBeenCalled();
+  });
+
+  it("renders a sample file download action", () => {
+    renderImportUsersUpload();
+
+    expect(screen.getByTestId(USERS_IMPORT_MODAL_HANDLES.SAMPLE_DOWNLOAD)).toBeVisible();
+  });
+
+  it("downloads a localized english csv sample file with prepared columns and one example row", async () => {
+    renderImportUsersUpload();
+
+    fireEvent.click(screen.getByTestId(USERS_IMPORT_MODAL_HANDLES.SAMPLE_DOWNLOAD));
+
+    expect(triggerBrowserDownload).toHaveBeenCalledOnce();
+
+    const [blob, filename] = vi.mocked(triggerBrowserDownload).mock.calls[0];
+
+    await expect(readBlobText(blob)).resolves.toBe(
+      [
+        "firstName,lastName,email,role,groups,language",
+        'Sample,Student,sample.student@example.com,student,"group1,group2",en',
+      ].join("\n"),
+    );
+    expect(filename).toBe("users-import-sample.csv");
+  });
+
+  it("downloads a localized polish csv sample file", async () => {
+    await i18next.changeLanguage("pl");
+    useLanguageStore.getState().setLanguage("pl");
+    renderImportUsersUpload();
+
+    fireEvent.click(screen.getByTestId(USERS_IMPORT_MODAL_HANDLES.SAMPLE_DOWNLOAD));
+
+    const [blob, filename] = vi.mocked(triggerBrowserDownload).mock.calls[0];
+
+    await expect(readBlobText(blob)).resolves.toBe(
+      [
+        "firstName,lastName,email,role,groups,language",
+        'Jan,Kowalski,jan.kowalski@example.com,student,"grupa1,grupa2",pl',
+      ].join("\n"),
+    );
+    expect(filename).toBe("przyklad-importu-uzytkownikow.csv");
   });
 });

--- a/apps/web/app/modules/Admin/Users/components/ImportUsersModal/ImportUsersUpload.tsx
+++ b/apps/web/app/modules/Admin/Users/components/ImportUsersModal/ImportUsersUpload.tsx
@@ -1,3 +1,4 @@
+import { Download, FileSpreadsheet, Info } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import FileUploadInput from "~/components/FileUploadInput/FileUploadInput";
@@ -9,8 +10,12 @@ import {
   DialogHeader,
   DialogTitle,
 } from "~/components/ui/dialog";
+import { useLanguageStore } from "~/modules/Dashboard/Settings/Language/LanguageStore";
+import { triggerBrowserDownload } from "~/utils/downloadFile";
 
 import { USERS_IMPORT_MODAL_HANDLES } from "../../../../../../e2e/data/users/handles";
+
+import { buildUsersImportSampleCsv } from "./ImportUsersUpload.utils";
 
 interface ImportUsersUploadProps {
   file: File | null;
@@ -30,18 +35,52 @@ export const ImportUsersUpload = ({
   isImportingUsers,
 }: ImportUsersUploadProps) => {
   const { t } = useTranslation();
-  return (
-    <DialogContent data-testid={USERS_IMPORT_MODAL_HANDLES.ROOT} className="gap-2">
-      <DialogHeader>
-        <DialogTitle>{t("adminUsersView.modal.title.import")}</DialogTitle>
-      </DialogHeader>
-      <DialogDescription>
-        <span className="body-sm block text-muted-foreground">
-          {t("adminUsersView.modal.description.import")}
-        </span>
-      </DialogDescription>
 
-      <div className="py-4">
+  const language = useLanguageStore((state) => state.language);
+
+  const handleSampleDownload = () => {
+    triggerBrowserDownload(
+      new Blob([buildUsersImportSampleCsv(t, language)], {
+        type: "text/csv;charset=utf-8",
+      }),
+      t("adminUsersView.modal.sampleFile.filename"),
+    );
+  };
+
+  return (
+    <DialogContent
+      data-testid={USERS_IMPORT_MODAL_HANDLES.ROOT}
+      className="max-h-[92vh] gap-0 overflow-y-auto p-0 sm:max-w-2xl"
+    >
+      <DialogHeader className="border-b border-neutral-200 bg-primary-50/50 px-6 py-5 pr-12">
+        <DialogTitle>{t("adminUsersView.modal.title.import")}</DialogTitle>
+        <DialogDescription className="body-sm pt-1 leading-6 text-muted-foreground">
+          {t("adminUsersView.modal.description.import")}
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="space-y-4 px-6 py-5">
+        <div className="flex flex-col gap-3 rounded-lg border border-neutral-200 bg-white p-3 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-3">
+            <span className="flex size-10 shrink-0 items-center justify-center rounded-md bg-primary-100 text-primary-800">
+              <FileSpreadsheet className="size-5" aria-hidden="true" />
+            </span>
+            <span className="body-sm-md text-neutral-900">
+              {t("adminUsersView.modal.sampleFile.filename")}
+            </span>
+          </div>
+          <Button
+            data-testid={USERS_IMPORT_MODAL_HANDLES.SAMPLE_DOWNLOAD}
+            type="button"
+            variant="outline"
+            size="sm"
+            className="w-full gap-2 sm:w-auto"
+            onClick={handleSampleDownload}
+          >
+            <Download className="size-4" aria-hidden="true" />
+            {t("adminUsersView.modal.button.downloadSample")}
+          </Button>
+        </div>
         <div data-testid={USERS_IMPORT_MODAL_HANDLES.UPLOAD}>
           <FileUploadInput
             className="max-w-none"
@@ -59,12 +98,13 @@ export const ImportUsersUpload = ({
             url={fileUrl}
           />
         </div>
-        <div className="pt-2 text-sm leading-none text-red-400">
-          {t("adminUsersView.modal.note.import")}
+        <div className="flex gap-2 rounded-md border border-neutral-200 bg-neutral-50 px-3 py-2.5 text-sm leading-5 text-neutral-700">
+          <Info className="mt-0.5 size-4 shrink-0 text-neutral-500" aria-hidden="true" />
+          <span>{t("adminUsersView.modal.note.import")}</span>
         </div>
       </div>
 
-      <DialogFooter>
+      <DialogFooter className="border-t border-neutral-200 bg-neutral-50 px-6 py-4">
         <Button
           data-testid={USERS_IMPORT_MODAL_HANDLES.SUBMIT}
           disabled={!file || isImportingUsers}

--- a/apps/web/app/modules/Admin/Users/components/ImportUsersModal/ImportUsersUpload.utils.ts
+++ b/apps/web/app/modules/Admin/Users/components/ImportUsersModal/ImportUsersUpload.utils.ts
@@ -1,0 +1,34 @@
+import {
+  USERS_IMPORT_SAMPLE_HEADERS,
+  USERS_IMPORT_SAMPLE_ROLE,
+} from "./ImportUsersUpload.constants";
+
+import type { SupportedLanguages } from "@repo/shared";
+import type { TFunction } from "i18next";
+
+export const escapeCsvCell = (value: string) => {
+  if (!/[",\n\r]/.test(value)) {
+    return value;
+  }
+
+  return `"${value.replaceAll('"', '""')}"`;
+};
+
+export const buildCsv = (rows: string[][]) =>
+  rows.map((row) => row.map(escapeCsvCell).join(",")).join("\n");
+
+export const buildUsersImportSampleCsv = (t: TFunction, language: SupportedLanguages) =>
+  buildCsv([
+    USERS_IMPORT_SAMPLE_HEADERS,
+    [
+      t("adminUsersView.modal.sampleFile.row.firstName"),
+      t("adminUsersView.modal.sampleFile.row.lastName"),
+      t("adminUsersView.modal.sampleFile.row.email"),
+      USERS_IMPORT_SAMPLE_ROLE,
+      [
+        t("adminUsersView.modal.sampleFile.row.groupOne"),
+        t("adminUsersView.modal.sampleFile.row.groupTwo"),
+      ].join(","),
+      language,
+    ],
+  ]);

--- a/apps/web/e2e/data/users/handles.ts
+++ b/apps/web/e2e/data/users/handles.ts
@@ -80,6 +80,7 @@ export const USERS_IMPORT_MODAL_HANDLES = {
   ROOT: "users-import-modal-root",
   UPLOAD: "users-import-modal-upload",
   FILE_INPUT: "users-import-modal-file-input",
+  SAMPLE_DOWNLOAD: "users-import-modal-sample-download",
   SUBMIT: "users-import-modal-submit",
   RESULT: "users-import-modal-result",
   RESULT_IMPORTED_TAB: "users-import-modal-result-imported-tab",


### PR DESCRIPTION
## Issue(s)
- #1271 

## Overview
Adds a sample CSV download to the user import modal so admins can start from a correctly structured import file.

The sample file:
- uses the required English import headers: `firstName`, `lastName`, `email`, `role`, `groups`, `language`
- localizes the sample filename and example row values
- uses the current app language from `useLanguageStore`

The import modal was also refined visually with a clearer sample-file action, neutral note styling, and a full-width upload input.

## Business Value
Admins no longer need to manually recreate the import column structure before importing users. This reduces formatting mistakes, speeds up bulk onboarding, and makes the import flow easier to understand across supported UI languages.

## Screenshots / Video

https://github.com/user-attachments/assets/3a6cf26b-3709-42f1-9032-5eb5af3c52fb


