### PR TITLE
fix: correct hero preview redirection

### DIFF
--- a/apps/web/app/modules/Courses/components/modern/HeroBanner.tsx
+++ b/apps/web/app/modules/Courses/components/modern/HeroBanner.tsx
@@ -8,6 +8,7 @@ import { useEnrollCourse } from "~/api/mutations";
 import {
   availableCoursesQueryOptions,
   courseQueryOptions,
+  useCurrentUser,
   studentCoursesQueryOptions,
   useCourse,
 } from "~/api/queries";
@@ -16,6 +17,7 @@ import { queryClient } from "~/api/queryClient";
 import DefaultPhotoCourse from "~/assets/svgs/default-photo-course.svg";
 import { Button } from "~/components/ui/button";
 import { usePermissions } from "~/hooks/usePermissions";
+import { resolveCourseExperienceState } from "~/modules/Courses/context/CourseAccessProvider";
 import { useLanguageStore } from "~/modules/Dashboard/Settings/Language/LanguageStore";
 
 import { findFirstInProgressLessonId, findFirstNotStartedLessonId } from "../../Lesson/utils";
@@ -47,11 +49,12 @@ const HeroBanner = ({
   const { language } = useLanguageStore();
   const navigate = useNavigate();
 
+  const { data: currentUser } = useCurrentUser();
+  const { hasAccess: canUseLearningMode } = usePermissions({
+    required: PERMISSIONS.LEARNING_MODE_USE,
+  });
   const { hasAccess: canUpdateLearningProgress } = usePermissions({
     required: PERMISSIONS.LEARNING_PROGRESS_UPDATE,
-  });
-  const { hasAccess: canManageCourses } = usePermissions({
-    required: [PERMISSIONS.COURSE_UPDATE, PERMISSIONS.COURSE_UPDATE_OWN],
   });
   const { mutateAsync: enrollCourse } = useEnrollCourse();
 
@@ -70,11 +73,33 @@ const HeroBanner = ({
   const firstInProgressLessonId = heroCourseData
     ? findFirstInProgressLessonId(heroCourseData)
     : null;
+  const courseExperienceState = useMemo(() => {
+    if (!heroCourseData) return null;
+
+    return resolveCourseExperienceState({
+      course: heroCourseData,
+      forcePreviewMode: false,
+      currentUserId: currentUser?.id,
+      canUseLearningMode,
+      canUpdateLearningProgress,
+      activeLearningModeCourseIds: currentUser?.studentModeCourseIds ?? [],
+    });
+  }, [
+    heroCourseData,
+    currentUser?.id,
+    currentUser?.studentModeCourseIds,
+    canUseLearningMode,
+    canUpdateLearningProgress,
+  ]);
+  const isPreviewMode = courseExperienceState?.isPreviewMode ?? canUseLearningMode;
 
   const handleNavigateToLesson = useCallback(async () => {
     if (!heroCourseData) return;
 
-    if (!heroCourseData.enrolled && canUpdateLearningProgress) {
+    const shouldEnrollBeforeNavigation =
+      !isPreviewMode && !heroCourseData.enrolled && canUpdateLearningProgress;
+
+    if (shouldEnrollBeforeNavigation) {
       await enrollCourse(
         { id: heroCourseData.id },
         {
@@ -89,8 +114,10 @@ const HeroBanner = ({
       );
     }
 
-    navigateToNextLesson(heroCourseData, navigate);
-  }, [heroCourseData, navigate, enrollCourse, canUpdateLearningProgress, language]);
+    navigateToNextLesson(heroCourseData, navigate, {
+      openFirstLesson: isPreviewMode || shouldEnrollBeforeNavigation,
+    });
+  }, [heroCourseData, isPreviewMode, navigate, enrollCourse, canUpdateLearningProgress, language]);
 
   return (
     <div className="relative h-[50vh] min-h-[400px] w-full overflow-hidden md:h-[70vh] md:min-h-[500px]">
@@ -149,7 +176,7 @@ const HeroBanner = ({
             <Button onClick={handleNavigateToLesson}>
               <Play className="mr-2 h-4 w-4" fill="currentColor" />
               {t(
-                canManageCourses
+                isPreviewMode
                   ? "adminCourseView.common.preview"
                   : !hasCourseProgress
                     ? "studentCourseView.sideSection.button.startLearning"

--- a/apps/web/app/modules/Courses/context/CourseAccessProvider.tsx
+++ b/apps/web/app/modules/Courses/context/CourseAccessProvider.tsx
@@ -30,7 +30,7 @@ type CourseAccessProviderProps = PropsWithChildren<{
   forcePreviewMode?: boolean;
 }>;
 
-function resolveCourseExperienceState({
+export function resolveCourseExperienceState({
   course,
   forcePreviewMode,
   currentUserId,

--- a/apps/web/app/modules/Courses/context/__tests__/CourseAccessProvider.test.ts
+++ b/apps/web/app/modules/Courses/context/__tests__/CourseAccessProvider.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveCourseExperienceState } from "../CourseAccessProvider";
+
+import type { GetCourseResponse } from "~/api/generated-api";
+
+const createCourse = (
+  overrides: Partial<GetCourseResponse["data"]> = {},
+): GetCourseResponse["data"] =>
+  ({
+    id: "course-1",
+    authorId: "author-1",
+    enrolled: false,
+    ...overrides,
+  }) as GetCourseResponse["data"];
+
+describe("resolveCourseExperienceState", () => {
+  it("uses preview mode for learning-mode users who are not actively learning the course", () => {
+    const state = resolveCourseExperienceState({
+      course: createCourse(),
+      forcePreviewMode: false,
+      currentUserId: "admin-1",
+      canUseLearningMode: true,
+      canUpdateLearningProgress: true,
+      activeLearningModeCourseIds: [],
+    });
+
+    expect(state.isPreviewMode).toBe(true);
+    expect(state.isCourseStudentModeActive).toBe(false);
+  });
+
+  it("uses the student experience when learning mode is active for the course", () => {
+    const state = resolveCourseExperienceState({
+      course: createCourse(),
+      forcePreviewMode: false,
+      currentUserId: "admin-1",
+      canUseLearningMode: true,
+      canUpdateLearningProgress: true,
+      activeLearningModeCourseIds: ["course-1"],
+    });
+
+    expect(state.isPreviewMode).toBe(false);
+    expect(state.isCourseStudentModeActive).toBe(true);
+    expect(state.isEffectiveStudentExperience).toBe(true);
+  });
+
+  it("does not treat authors as enrolled learners", () => {
+    const state = resolveCourseExperienceState({
+      course: createCourse({ enrolled: true }),
+      forcePreviewMode: false,
+      currentUserId: "author-1",
+      canUseLearningMode: true,
+      canUpdateLearningProgress: true,
+      activeLearningModeCourseIds: [],
+    });
+
+    expect(state.isPreviewMode).toBe(true);
+    expect(state.isEffectiveStudentExperience).toBe(false);
+  });
+});

--- a/apps/web/app/modules/Courses/utils/__tests__/navigateToNextLesson.test.ts
+++ b/apps/web/app/modules/Courses/utils/__tests__/navigateToNextLesson.test.ts
@@ -124,4 +124,32 @@ describe("navigateToNextLesson", () => {
       state: { chapterId: "chapter-1" },
     });
   });
+
+  it("navigates to the first lesson when requested after enrollment with stale blocked lesson data", () => {
+    const courseData = {
+      slug: "course-slug",
+      chapters: [
+        {
+          id: "chapter-1",
+          lessons: [
+            {
+              id: "first-paid-lesson",
+              status: "blocked",
+            },
+            {
+              id: "second-paid-lesson",
+              status: "blocked",
+            },
+          ],
+        },
+      ],
+    } as GetCourseResponse["data"];
+    const navigate = vi.fn() as unknown as NavigateFunction;
+
+    navigateToNextLesson(courseData, navigate, { openFirstLesson: true });
+
+    expect(navigate).toHaveBeenCalledWith("/course/course-slug/lesson/first-paid-lesson", {
+      state: { chapterId: "chapter-1" },
+    });
+  });
 });


### PR DESCRIPTION
## Overview

Fixes course hero lesson navigation so the hero action follows the same course experience rules as the course overview:

- admin/learning-mode preview opens the first lesson without enrolling or using student progress
- student mode keeps the student learning experience
- Start learning after enrollment opens the first lesson even when the current hero course payload still has paid lessons marked as blocked

The shared course experience resolver is exported and covered with focused tests so the hero and overview use the same preview/student-mode decision rules.

## Business Value

Users can reliably start a course from the hero, including courses without freemium chapters. Admins and course managers also get a predictable preview flow that opens lesson content without mutating enrollment or progress state.

