### PR TITLE
chore: improve video playback quality with resolution controls

### DIFF
--- a/apps/api/src/common/utils/__tests__/injectResourcesIntoContent.spec.ts
+++ b/apps/api/src/common/utils/__tests__/injectResourcesIntoContent.spec.ts
@@ -1,4 +1,4 @@
-import { VIDEO_AUTOPLAY } from "@repo/shared";
+import { VIDEO_AUTOPLAY, VIDEO_EMBED_PROVIDERS } from "@repo/shared";
 import { load as loadHtml } from "cheerio";
 
 import { createLessonResourceIdRegex } from "src/lesson/lesson-resource-references";
@@ -7,6 +7,7 @@ import { injectResourcesIntoContent } from "../injectResourcesIntoContent";
 
 const resourceA = "11111111-1111-1111-1111-111111111111";
 const resourceB = "22222222-2222-2222-2222-222222222222";
+const resourceEntityA = "33333333-3333-3333-3333-333333333333";
 
 const getVideoAutoplayActions = (html: string) => {
   const $ = loadHtml(html);
@@ -85,5 +86,28 @@ describe("injectResourcesIntoContent", () => {
       `http://localhost:5173/api/lesson/lesson-resource/${resourceA}`,
       `http://localhost:5173/api/lesson/lesson-resource/${resourceB}`,
     ]);
+  });
+
+  it("injects video provider metadata over stale saved provider", () => {
+    const content = `<div data-node-type="video" data-source-type="internal" data-provider="unknown" data-src="http://localhost:5173/api/lesson/lesson-resource/${resourceEntityA}"></div>`;
+
+    const result = injectResourcesIntoContent(
+      content,
+      [
+        {
+          id: resourceA,
+          resourceEntityId: resourceEntityA,
+          fileUrl: "http://localhost:5173/api/lesson/lesson-resource/resourceA",
+          contentType: "video/mp4",
+          provider: VIDEO_EMBED_PROVIDERS.BUNNY,
+        },
+      ],
+      {
+        resourceIdRegex: createLessonResourceIdRegex(),
+        trackNodeTypes: ["video"],
+      },
+    );
+
+    expect(result.html).toContain('data-provider="bunny"');
   });
 });

--- a/apps/api/src/common/utils/injectResourcesIntoContent.ts
+++ b/apps/api/src/common/utils/injectResourcesIntoContent.ts
@@ -1,4 +1,4 @@
-import { VIDEO_AUTOPLAY } from "@repo/shared";
+import { VIDEO_AUTOPLAY, type VideoProvider } from "@repo/shared";
 import { load as loadHtml } from "cheerio";
 
 import { annotateVideoAutoplayAndBlockIndexesInContent } from "./annotateVideoAutoplayAndBlockIndexesInContent";
@@ -14,6 +14,7 @@ export type ContentResource = {
   title?: string;
   description?: string;
   fileName?: string;
+  provider?: VideoProvider;
   videoProgress?: {
     coveragePercent: number;
     isWatched: boolean;
@@ -51,7 +52,13 @@ export const injectResourcesIntoContent = <T extends ContentResource>(
 
   const normalizedContent = annotateVideoAutoplayAndBlockIndexesInContent(content) ?? content;
   const $ = loadHtml(normalizedContent);
-  const resourceMap = new Map(resources.map((resource) => [resource.id, resource]));
+  const resourceMap = new Map<UUIDType, T>();
+  resources.forEach((resource) => {
+    resourceMap.set(resource.id, resource);
+    if (resource.resourceEntityId) {
+      resourceMap.set(resource.resourceEntityId, resource);
+    }
+  });
   const trackNodeTypes = new Set(options.trackNodeTypes ?? []);
   const convertImageAnchors = options.convertImageAnchors ?? true;
 
@@ -99,6 +106,9 @@ export const injectResourcesIntoContent = <T extends ContentResource>(
 
       if (resource?.resourceEntityId && resource.contentType?.startsWith("video/")) {
         $(element).attr("data-source-type", "internal");
+        if (resource.provider) {
+          $(element).attr("data-provider", resource.provider);
+        }
         $(element).attr("data-resource-entity-id", resource.resourceEntityId);
         $(element).attr(
           "data-video-coverage-percent",

--- a/apps/api/src/file/__tests__/thumbnail.service.spec.ts
+++ b/apps/api/src/file/__tests__/thumbnail.service.spec.ts
@@ -1,0 +1,49 @@
+import { VIDEO_EMBED_PROVIDERS } from "@repo/shared";
+
+import { ThumbnailService } from "../thumbnail.service";
+
+describe("ThumbnailService", () => {
+  const resourceId = "11111111-1111-1111-1111-111111111111";
+  const bunnyVideoId = "22222222-2222-2222-2222-222222222222";
+
+  const createService = () => {
+    const where = jest.fn().mockResolvedValue([
+      {
+        id: resourceId,
+        reference: `bunny-${bunnyVideoId}`,
+        tenantId: "33333333-3333-3333-3333-333333333333",
+        entityType: "unknown",
+        entityId: "44444444-4444-4444-4444-444444444444",
+      },
+    ]);
+    const innerJoin = jest.fn(() => ({ where }));
+    const from = jest.fn(() => ({ innerJoin }));
+    const select = jest.fn(() => ({ from }));
+    const bunnyStreamService = {
+      getThumbnailUrl: jest.fn().mockResolvedValue("https://bunny.example/thumbnail.jpg"),
+    };
+
+    const service = new ThumbnailService(
+      {} as ConstructorParameters<typeof ThumbnailService>[0],
+      bunnyStreamService as unknown as ConstructorParameters<typeof ThumbnailService>[1],
+      { select } as unknown as ConstructorParameters<typeof ThumbnailService>[2],
+    );
+
+    return { service, bunnyStreamService, select };
+  };
+
+  it("resolves internal Bunny resource URLs before using the provider", async () => {
+    const { service, bunnyStreamService, select } = createService();
+
+    await expect(
+      service.getThumbnail(
+        `https://tenant.lms.localhost/api/lesson/lesson-resource/${resourceId}`,
+        VIDEO_EMBED_PROVIDERS.BUNNY,
+        null,
+      ),
+    ).resolves.toBe("https://bunny.example/thumbnail.jpg");
+
+    expect(select).toHaveBeenCalled();
+    expect(bunnyStreamService.getThumbnailUrl).toHaveBeenCalledWith(bunnyVideoId);
+  });
+});

--- a/apps/api/src/file/thumbnail.service.ts
+++ b/apps/api/src/file/thumbnail.service.ts
@@ -56,6 +56,10 @@ export class ThumbnailService {
   ) {
     if (!sourceUrl) throw new BadRequestException("Missing sourceUrl");
 
+    if (extractResourceIdFromSourceUrl(sourceUrl)) {
+      return this.getInternalThumbnail(sourceUrl, currentUser);
+    }
+
     const resolvedProvider =
       provider === VIDEO_EMBED_PROVIDERS.UNKNOWN ? detectVideoProviderFromUrl(sourceUrl) : provider;
 

--- a/apps/api/src/file/utils/videoProvider.ts
+++ b/apps/api/src/file/utils/videoProvider.ts
@@ -1,0 +1,13 @@
+import {
+  VIDEO_EMBED_PROVIDERS,
+  detectVideoProviderFromUrl,
+  type VideoProvider,
+} from "@repo/shared";
+
+export const getVideoProviderFromReference = (reference: string): VideoProvider => {
+  const detectedProvider = detectVideoProviderFromUrl(reference);
+
+  return detectedProvider === VIDEO_EMBED_PROVIDERS.UNKNOWN
+    ? VIDEO_EMBED_PROVIDERS.SELF
+    : detectedProvider;
+};

--- a/apps/api/src/lesson/services/lesson.service.ts
+++ b/apps/api/src/lesson/services/lesson.service.ts
@@ -31,6 +31,7 @@ import { RESOURCE_RELATIONSHIP_TYPES } from "src/file/file.constants";
 import { FileService } from "src/file/file.service";
 import { FILE_DELIVERY_TYPE } from "src/file/types/file-delivery.type";
 import { streamFileToResponse } from "src/file/utils/streamFileToResponse";
+import { getVideoProviderFromReference } from "src/file/utils/videoProvider";
 import { LessonVideoProgressService } from "src/lesson-video-progress/lesson-video-progress.service";
 import { LiveTrainingService } from "src/live-training/live-training.service";
 import { LocalizationService } from "src/localization/localization.service";
@@ -158,6 +159,9 @@ export class LessonService {
         contentType: resource.contentType,
         title: typeof resource.title === "string" ? resource.title : undefined,
         description: typeof resource.description === "string" ? resource.description : undefined,
+        provider: resource.contentType?.startsWith("video/")
+          ? getVideoProviderFromReference(resource.reference)
+          : undefined,
         videoProgress: resource.resourceEntityId
           ? videoProgressByResourceEntityId.get(resource.resourceEntityId)
           : undefined,

--- a/apps/api/src/resource-library/__tests__/resource-library.controller.e2e-spec.ts
+++ b/apps/api/src/resource-library/__tests__/resource-library.controller.e2e-spec.ts
@@ -1,6 +1,11 @@
 import { join } from "node:path";
 
-import { ENTITY_TYPES, RESOURCE_LIBRARY_ASSET_TYPE, SYSTEM_ROLE_SLUGS } from "@repo/shared";
+import {
+  ENTITY_TYPES,
+  RESOURCE_LIBRARY_ASSET_TYPE,
+  SYSTEM_ROLE_SLUGS,
+  VIDEO_EMBED_PROVIDERS,
+} from "@repo/shared";
 import { eq } from "drizzle-orm";
 import request from "supertest";
 
@@ -205,6 +210,34 @@ describe("ResourceLibraryController (e2e)", () => {
         uploadedBy: admin.id,
         usageCount: 1,
       });
+    });
+
+    it("returns derived Bunny provider for video assets from their stored reference", async () => {
+      const admin = await createAdmin();
+      const bunnyAsset = await createResource({
+        title: buildJsonbField("en", "Bunny video"),
+        reference: "bunny-11111111-1111-1111-1111-111111111111",
+        contentType: "video/mp4",
+      });
+
+      const response = await request(app.getHttpServer())
+        .get("/api/resource-library/assets")
+        .query({
+          language: "en",
+          page: 1,
+          perPage: 10,
+          search: "Bunny",
+        })
+        .set("Cookie", await cookieFor(admin, app))
+        .expect(200);
+
+      expect(response.body.data).toEqual([
+        expect.objectContaining({
+          id: bunnyAsset.id,
+          type: RESOURCE_LIBRARY_ASSET_TYPE.VIDEO,
+          videoProvider: VIDEO_EMBED_PROVIDERS.BUNNY,
+        }),
+      ]);
     });
   });
 

--- a/apps/api/src/resource-library/resource-library.service.ts
+++ b/apps/api/src/resource-library/resource-library.service.ts
@@ -1,10 +1,11 @@
 import { BadRequestException, Inject, Injectable, NotFoundException } from "@nestjs/common";
-import { ENTITY_TYPES, type SupportedLanguages } from "@repo/shared";
+import { ENTITY_TYPES, VIDEO_EMBED_PROVIDERS, type SupportedLanguages } from "@repo/shared";
 
 import { DatabasePg } from "src/common";
 import { parsePagination } from "src/common/pagination";
 import { RESOURCE_CATEGORIES, RESOURCE_RELATIONSHIP_TYPES } from "src/file/file.constants";
 import { FileService } from "src/file/file.service";
+import { getVideoProviderFromReference } from "src/file/utils/videoProvider";
 import { ResourceLibraryRepository } from "src/resource-library/resource-library.repository";
 import { DB } from "src/storage/db/db.providers";
 
@@ -55,7 +56,17 @@ export class ResourceLibraryService {
     });
 
     return {
-      data: rows,
+      data: rows.map((asset) => {
+        const videoProvider = getVideoProviderFromReference(asset.reference);
+
+        return {
+          ...asset,
+          videoProvider:
+            asset.type === "video" || videoProvider === VIDEO_EMBED_PROVIDERS.BUNNY
+              ? videoProvider
+              : undefined,
+        };
+      }),
       pagination: { totalItems, page, perPage },
       appliedFilters: {
         search: params.search,

--- a/apps/api/src/resource-library/schemas/resource-library.schema.ts
+++ b/apps/api/src/resource-library/schemas/resource-library.schema.ts
@@ -1,4 +1,4 @@
-import { ENTITY_TYPES, RESOURCE_LIBRARY_ASSET_TYPE } from "@repo/shared";
+import { ENTITY_TYPES, RESOURCE_LIBRARY_ASSET_TYPE, VIDEO_EMBED_PROVIDERS } from "@repo/shared";
 import { Type } from "@sinclair/typebox";
 
 import { UUIDSchema } from "src/common";
@@ -23,6 +23,7 @@ export const assetLibraryAssetSchema = Type.Object({
   size: Type.Union([Type.Number(), Type.Null()]),
   originalFilename: Type.Union([Type.String(), Type.Null()]),
   reference: Type.String(),
+  videoProvider: Type.Optional(Type.Enum(VIDEO_EMBED_PROVIDERS)),
   uploadedBy: Type.Union([UUIDSchema, Type.Null()]),
   createdAt: Type.String({ format: "date-time" }),
   usageCount: Type.Number(),

--- a/apps/api/src/swagger/api-schema.json
+++ b/apps/api/src/swagger/api-schema.json
@@ -34441,6 +34441,30 @@
                 "reference": {
                   "type": "string"
                 },
+                "videoProvider": {
+                  "anyOf": [
+                    {
+                      "const": "self",
+                      "type": "string"
+                    },
+                    {
+                      "const": "youtube",
+                      "type": "string"
+                    },
+                    {
+                      "const": "vimeo",
+                      "type": "string"
+                    },
+                    {
+                      "const": "bunny",
+                      "type": "string"
+                    },
+                    {
+                      "const": "unknown",
+                      "type": "string"
+                    }
+                  ]
+                },
                 "uploadedBy": {
                   "anyOf": [
                     {

--- a/apps/web/app/api/generated-api.ts
+++ b/apps/web/app/api/generated-api.ts
@@ -3948,6 +3948,7 @@ export interface GetAssetsResponse {
     size: number | null;
     originalFilename: string | null;
     reference: string;
+    videoProvider?: "self" | "youtube" | "vimeo" | "bunny" | "unknown";
     uploadedBy: string | null;
     /** @format date-time */
     createdAt: string;

--- a/apps/web/app/components/RichText/components/AssetLibraryDialog.tsx
+++ b/apps/web/app/components/RichText/components/AssetLibraryDialog.tsx
@@ -204,6 +204,7 @@ export const AssetLibraryDialog = ({
       file: { name: displayName },
       resourceType,
       displayMode,
+      videoProvider: asset.videoProvider,
     });
 
     resetDialog(false);

--- a/apps/web/app/components/RichText/extensions/utils/__tests__/video.test.ts
+++ b/apps/web/app/components/RichText/extensions/utils/__tests__/video.test.ts
@@ -1,0 +1,36 @@
+import { VIDEO_EMBED_PROVIDERS } from "@repo/shared";
+import { describe, expect, it } from "vitest";
+
+import { normalizeVideoEmbedAttributes } from "../video";
+
+describe("normalizeVideoEmbedAttributes", () => {
+  it("detects external provider when provider is unknown", () => {
+    expect(
+      normalizeVideoEmbedAttributes({
+        src: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        sourceType: "external",
+        provider: VIDEO_EMBED_PROVIDERS.UNKNOWN,
+      }).provider,
+    ).toBe(VIDEO_EMBED_PROVIDERS.YOUTUBE);
+  });
+
+  it("keeps explicit resolved provider", () => {
+    expect(
+      normalizeVideoEmbedAttributes({
+        src: "/api/lesson/lesson-resource/11111111-1111-1111-1111-111111111111",
+        sourceType: "internal",
+        provider: VIDEO_EMBED_PROVIDERS.BUNNY,
+      }).provider,
+    ).toBe(VIDEO_EMBED_PROVIDERS.BUNNY);
+  });
+
+  it("defaults internal resources with unknown provider to self", () => {
+    expect(
+      normalizeVideoEmbedAttributes({
+        src: "/api/lesson/lesson-resource/11111111-1111-1111-1111-111111111111",
+        sourceType: "internal",
+        provider: VIDEO_EMBED_PROVIDERS.UNKNOWN,
+      }).provider,
+    ).toBe(VIDEO_EMBED_PROVIDERS.SELF);
+  });
+});

--- a/apps/web/app/components/RichText/extensions/utils/video.ts
+++ b/apps/web/app/components/RichText/extensions/utils/video.ts
@@ -45,6 +45,9 @@ const isVideoProvider = (value: string | null | undefined): value is VideoProvid
   typeof value === "string" &&
   (Object.values(VIDEO_EMBED_PROVIDERS) as VideoProvider[]).includes(value as VideoProvider);
 
+const isResolvedVideoProvider = (value: string | null | undefined): value is VideoProvider =>
+  isVideoProvider(value) && value !== VIDEO_EMBED_PROVIDERS.UNKNOWN;
+
 export const extractUrlFromClipboard = (e: ClipboardEvent): string | null => {
   const text = e.clipboardData?.getData("text/plain")?.trim();
   if (text) return text;
@@ -108,7 +111,7 @@ export const normalizeVideoEmbedAttributes = (attrs: VideoEmbedAttrsInput): Vide
     sourceType === "internal" ? VIDEO_EMBED_PROVIDERS.SELF : detectVideoProviderFromUrl(src || "");
 
   const provider = match(attrs.provider)
-    .when(isVideoProvider, (value) => value)
+    .when(isResolvedVideoProvider, (value) => value)
     .otherwise(() => detectedProvider);
 
   const finalSrc = sourceType === "external" && src ? canonicalizeExternalUrl(src, provider) : src;

--- a/apps/web/app/components/RichText/utils/insertResourceIntoEditor.ts
+++ b/apps/web/app/components/RichText/utils/insertResourceIntoEditor.ts
@@ -20,6 +20,7 @@ export const insertResourceIntoEditor = ({
   file,
   resourceType = RICH_TEXT_RESOURCE_TYPE.OTHER,
   displayMode = RICH_TEXT_RESOURCE_DISPLAY_MODE.PREVIEW,
+  videoProvider,
 }: InsertResourceArgs) => {
   const resourceUrl = buildEntityResourceUrl(resourceId, entityType);
 
@@ -37,7 +38,7 @@ export const insertResourceIntoEditor = ({
     .with(RICH_TEXT_RESOURCE_TYPE.VIDEO, () =>
       insertContentIntoEditor(editor, {
         type: RICH_TEXT_RESOURCE_TYPE.VIDEO,
-        attrs: { src: resourceUrl, sourceType: "internal" },
+        attrs: { src: resourceUrl, sourceType: "internal", provider: videoProvider },
       }),
     )
     .with(RICH_TEXT_RESOURCE_TYPE.PRESENTATION, () =>

--- a/apps/web/app/components/RichText/utils/richTextResource.types.ts
+++ b/apps/web/app/components/RichText/utils/richTextResource.types.ts
@@ -1,4 +1,4 @@
-import type { EntityType, SupportedLanguages } from "@repo/shared";
+import type { EntityType, SupportedLanguages, VideoProvider } from "@repo/shared";
 import type { Editor as TiptapEditor } from "@tiptap/react";
 
 export type UploadResourceArgs = {
@@ -38,4 +38,5 @@ export type InsertResourceArgs = {
   file: Pick<File, "name">;
   resourceType?: RichTextResourceType;
   displayMode?: RichTextResourceDisplayMode;
+  videoProvider?: VideoProvider;
 };

--- a/apps/web/app/components/VideoPlayer/HlsQualitySelector.tsx
+++ b/apps/web/app/components/VideoPlayer/HlsQualitySelector.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useRef, useState } from "react";
+
+import { getHlsQualityLabel, type HlsQualityOption, type HlsQualitySelection } from "./hlsQuality";
+
+type HlsQualitySelectorProps = {
+  options: HlsQualityOption[];
+  selection: HlsQualitySelection;
+  onSelect: (selection: HlsQualitySelection) => void;
+};
+
+export const HlsQualitySelector = ({ options, selection, onSelect }: HlsQualitySelectorProps) => {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const closeOnOutsidePointerDown = (event: PointerEvent) => {
+      if (rootRef.current?.contains(event.target as Node)) return;
+      setOpen(false);
+    };
+
+    window.addEventListener("pointerdown", closeOnOutsidePointerDown);
+
+    return () => {
+      window.removeEventListener("pointerdown", closeOnOutsidePointerDown);
+    };
+  }, [open]);
+
+  if (!options.length) return null;
+
+  return (
+    <div ref={rootRef} className="mentingo-vjs-quality-selector">
+      <button
+        type="button"
+        className="mentingo-vjs-quality-selector__button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label="Video quality"
+        onClick={() => setOpen((currentOpen) => !currentOpen)}
+      >
+        {getHlsQualityLabel(selection, options)}
+      </button>
+      {open && (
+        <div className="mentingo-vjs-quality-selector__menu" role="menu">
+          {options.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              role="menuitemradio"
+              aria-checked={selection === option.value}
+              className="mentingo-vjs-quality-selector__item"
+              data-selected={selection === option.value}
+              onClick={() => {
+                onSelect(option.value);
+                setOpen(false);
+              }}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/web/app/components/VideoPlayer/VideoPlayer.tsx
+++ b/apps/web/app/components/VideoPlayer/VideoPlayer.tsx
@@ -6,6 +6,7 @@ import {
   VIDEO_EMBED_PROVIDERS,
 } from "@repo/shared";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { match } from "ts-pattern";
 import videojs from "video.js";
 
@@ -14,6 +15,17 @@ import "videojs-youtube";
 import { cn } from "~/lib/utils";
 
 import { getVideoAspectRatio } from "./aspectRatio";
+import {
+  applyHlsQualitySelection,
+  getHlsQualityLevels,
+  getHlsQualityOptions,
+  HLS_AUTO_HD_VALUE,
+  type HlsQualityLevelList,
+  type HlsQualityOption,
+  type HlsQualitySelection,
+} from "./hlsQuality";
+import { addHlsQualityControlComponent } from "./hlsQualityControlComponent";
+import { HlsQualitySelector } from "./HlsQualitySelector";
 import "./videojs-vimeo-tech";
 import "./videoPlayer.css";
 import { useVideoCoverageTracker } from "./useVideoCoverageTracker";
@@ -33,8 +45,13 @@ interface VideoPlayerProps {
 }
 
 type VideoJSType = ReturnType<typeof videojs>;
+type VideoJsPlayerWithQualityLevels = VideoJSType & {
+  qualityLevels?: () => HlsQualityLevelList;
+};
 
 const PLAYBACK_RATES = [0.5, 0.75, 1, 1.25, 1.5, 2];
+const HLS_MIME_TYPE = "application/vnd.apple.mpegurl";
+const MP4_MIME_TYPE = "video/mp4";
 
 const enableCustomControls = (player: VideoJSType) => {
   player.controls(true);
@@ -47,16 +64,21 @@ const getTypeByProvider = (provider: VideoProvider) =>
   match(provider)
     .with(VIDEO_EMBED_PROVIDERS.YOUTUBE, () => "video/youtube")
     .with(VIDEO_EMBED_PROVIDERS.VIMEO, () => "video/vimeo")
-    .with(VIDEO_EMBED_PROVIDERS.BUNNY, () => "application/vnd.apple.mpegurl")
-    .with(VIDEO_EMBED_PROVIDERS.SELF, () => "video/mp4")
+    .with(VIDEO_EMBED_PROVIDERS.BUNNY, () => HLS_MIME_TYPE)
+    .with(VIDEO_EMBED_PROVIDERS.SELF, () => MP4_MIME_TYPE)
     .otherwise(() => "");
 
-const getSourceTypes = (url: string, type: string) => {
+const getSourceTypes = (url: string, type: string, provider: VideoProvider) => {
   const isInternalLessonResource = /\/api\/lesson\/lesson-resource\//i.test(url);
+
+  if (!isInternalLessonResource) return [type].filter(Boolean);
 
   return Array.from(
     new Set(
-      isInternalLessonResource ? [type, "application/vnd.apple.mpegurl", "video/mp4"] : [type],
+      match(provider)
+        .with(VIDEO_EMBED_PROVIDERS.BUNNY, () => [HLS_MIME_TYPE])
+        .with(VIDEO_EMBED_PROVIDERS.SELF, () => [MP4_MIME_TYPE])
+        .otherwise(() => [HLS_MIME_TYPE, type, MP4_MIME_TYPE]),
     ),
   ).filter(Boolean) as string[];
 };
@@ -80,9 +102,15 @@ export const VideoPlayer = ({
 }: VideoPlayerProps) => {
   const [controlsVisible, setControlsVisible] = useState(true);
   const [player, setPlayer] = useState<VideoJSType | null>(null);
+  const [qualityControlHost, setQualityControlHost] = useState<HTMLDivElement | null>(null);
+  const [hlsQualityOptions, setHlsQualityOptions] = useState<HlsQualityOption[]>([]);
+  const [hlsQualitySelection, setHlsQualitySelection] =
+    useState<HlsQualitySelection>(HLS_AUTO_HD_VALUE);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const videoRef = useRef<HTMLDivElement | null>(null);
   const playerRef = useRef<VideoJSType | null>(null);
+  const userSelectedHlsQualityRef = useRef(false);
+  const hlsQualitySelectionRef = useRef<HlsQualitySelection>(HLS_AUTO_HD_VALUE);
   const lastSourceRef = useRef<string | null>(null);
   const resumeAppliedSourceRef = useRef<string | null>(null);
   const onAspectRatioChangeRef = useRef(onAspectRatioChange);
@@ -119,6 +147,50 @@ export const VideoPlayer = ({
     clearControlsVisibilityTimer();
     setControlsVisible(false);
   }, [clearControlsVisibilityTimer]);
+
+  const setHlsSelection = useCallback((selection: HlsQualitySelection) => {
+    hlsQualitySelectionRef.current = selection;
+    setHlsQualitySelection(selection);
+  }, []);
+
+  const syncHlsQuality = useCallback(
+    (player: VideoJSType) => {
+      const qualityLevelsList = (player as VideoJsPlayerWithQualityLevels).qualityLevels?.();
+      const qualityLevels = getHlsQualityLevels(qualityLevelsList);
+      const options = getHlsQualityOptions(qualityLevels);
+      const currentSelection = hlsQualitySelectionRef.current;
+      const selectionExists = options.some((option) => option.value === currentSelection);
+      const nextSelection =
+        selectionExists && userSelectedHlsQualityRef.current ? currentSelection : HLS_AUTO_HD_VALUE;
+
+      setHlsQualityOptions(options);
+      setHlsSelection(nextSelection);
+
+      if (options.length) {
+        applyHlsQualitySelection(qualityLevels, nextSelection);
+      }
+    },
+    [setHlsSelection],
+  );
+
+  const selectHlsQuality = useCallback(
+    (selection: HlsQualitySelection) => {
+      const currentPlayer = playerRef.current;
+      if (!currentPlayer) return;
+
+      const qualityLevelsList = (currentPlayer as VideoJsPlayerWithQualityLevels).qualityLevels?.();
+      const qualityLevels = getHlsQualityLevels(qualityLevelsList);
+
+      userSelectedHlsQualityRef.current = true;
+      setHlsSelection(selection);
+      applyHlsQualitySelection(qualityLevels, selection);
+    },
+    [setHlsSelection],
+  );
+
+  useEffect(() => {
+    qualityControlHost?.classList.toggle("vjs-hidden", hlsQualityOptions.length === 0);
+  }, [hlsQualityOptions.length, qualityControlHost]);
 
   const resolvedProvider = useMemo(
     () => (provider === VIDEO_EMBED_PROVIDERS.UNKNOWN ? detectVideoProviderFromUrl(url) : provider),
@@ -157,26 +229,47 @@ export const VideoPlayer = ({
 
     const player = (playerRef.current = videojs(videoElement, options));
     setPlayer(player);
+    const qualityLevels = (player as VideoJsPlayerWithQualityLevels).qualityLevels?.();
 
     player.ready(() => {
       enableCustomControls(player);
+      setQualityControlHost(addHlsQualityControlComponent(player));
     });
+
+    const handleHlsQualitySync = () => syncHlsQuality(player);
 
     player.on("loadedmetadata", () => {
       const aspectRatio = getPlayerAspectRatio(player);
       if (aspectRatio) onAspectRatioChangeRef.current?.(aspectRatio);
+      handleHlsQualitySync();
     });
 
     player.on("ended", () => {
       onEndedRef.current?.();
     });
-  }, [options]);
+
+    player.on("loadedplaylist", handleHlsQualitySync);
+    player.on("loadeddata", handleHlsQualitySync);
+    player.on("canplay", handleHlsQualitySync);
+    player.on("playing", handleHlsQualitySync);
+    qualityLevels?.on("addqualitylevel", handleHlsQualitySync);
+    qualityLevels?.on("change", handleHlsQualitySync);
+
+    return () => {
+      player.off("loadedplaylist", handleHlsQualitySync);
+      player.off("loadeddata", handleHlsQualitySync);
+      player.off("canplay", handleHlsQualitySync);
+      player.off("playing", handleHlsQualitySync);
+      qualityLevels?.off("addqualitylevel", handleHlsQualitySync);
+      qualityLevels?.off("change", handleHlsQualitySync);
+    };
+  }, [options, syncHlsQuality]);
 
   useEffect(() => {
     const player = playerRef.current;
     if (!player || !url) return;
 
-    const sourceTypes = getSourceTypes(url, type);
+    const sourceTypes = getSourceTypes(url, type, resolvedProvider);
     const sourceKey = `${url}::${coverageTracking?.resourceEntityId ?? ""}::${sourceTypes.join("|")}`;
 
     if (lastSourceRef.current === sourceKey) {
@@ -195,9 +288,13 @@ export const VideoPlayer = ({
       player.error(undefined);
       player.removeClass?.("vjs-error");
       enableCustomControls(player);
+      userSelectedHlsQualityRef.current = false;
+      setHlsQualityOptions([]);
+      setHlsSelection(HLS_AUTO_HD_VALUE);
 
       player.src(source);
       player.load();
+      syncHlsQuality(player);
       if (autoPlay) {
         void player.play()?.catch(() => undefined);
       }
@@ -219,7 +316,15 @@ export const VideoPlayer = ({
     return () => {
       player.off("error", onError);
     };
-  }, [autoPlay, coverageTracking?.resourceEntityId, url, type]);
+  }, [
+    autoPlay,
+    coverageTracking?.resourceEntityId,
+    resolvedProvider,
+    setHlsSelection,
+    syncHlsQuality,
+    url,
+    type,
+  ]);
 
   useEffect(() => {
     const sourceKey = lastSourceRef.current;
@@ -281,6 +386,7 @@ export const VideoPlayer = ({
     return () => {
       lastSourceRef.current = null;
       clearControlsVisibilityTimer();
+      setQualityControlHost(null);
 
       if (playerRef.current && !playerRef.current.isDisposed()) {
         playerRef.current.dispose();
@@ -339,6 +445,15 @@ export const VideoPlayer = ({
       )}
     >
       <div ref={videoRef} className="size-full" />
+      {qualityControlHost &&
+        createPortal(
+          <HlsQualitySelector
+            options={hlsQualityOptions}
+            selection={hlsQualitySelection}
+            onSelect={selectHlsQuality}
+          />,
+          qualityControlHost,
+        )}
     </div>
   );
 };

--- a/apps/web/app/components/VideoPlayer/__tests__/hlsQuality.test.ts
+++ b/apps/web/app/components/VideoPlayer/__tests__/hlsQuality.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyHlsQualitySelection,
+  getHlsQualityOptions,
+  HLS_AUTO_HD_VALUE,
+  type HlsQualityLevel,
+} from "../hlsQuality";
+
+const createQualityLevel = (height: number): HlsQualityLevel => ({
+  height,
+  width: Math.round((height / 9) * 16),
+  bitrate: height * 1000,
+  enabled: true,
+});
+
+describe("hlsQuality", () => {
+  it("builds auto and fixed quality options from available representation heights", () => {
+    const options = getHlsQualityOptions([
+      createQualityLevel(360),
+      createQualityLevel(720),
+      createQualityLevel(1080),
+      createQualityLevel(720),
+    ]);
+
+    expect(options).toEqual([
+      { value: HLS_AUTO_HD_VALUE, label: "Auto" },
+      { value: "fixed:1080", label: "1080p", height: 1080 },
+      { value: "fixed:720", label: "720p", height: 720 },
+      { value: "fixed:360", label: "360p", height: 360 },
+    ]);
+  });
+
+  it("hides quality options when only one representation height exists", () => {
+    expect(getHlsQualityOptions([createQualityLevel(720), createQualityLevel(720)])).toEqual([]);
+  });
+
+  it("auto hd enables only 720p to 1080p representations when available", () => {
+    const representations = [
+      createQualityLevel(360),
+      createQualityLevel(720),
+      createQualityLevel(1080),
+      createQualityLevel(1440),
+    ];
+
+    applyHlsQualitySelection(representations, HLS_AUTO_HD_VALUE);
+
+    expect(representations.map((representation) => representation.enabled)).toEqual([
+      false,
+      true,
+      true,
+      false,
+    ]);
+  });
+
+  it("auto hd falls back to the best lower representation when no hd representation exists", () => {
+    const representations = [
+      createQualityLevel(240),
+      createQualityLevel(360),
+      createQualityLevel(480),
+    ];
+
+    applyHlsQualitySelection(representations, HLS_AUTO_HD_VALUE);
+
+    expect(representations.map((representation) => representation.enabled)).toEqual([
+      false,
+      false,
+      true,
+    ]);
+  });
+
+  it("fixed quality enables only matching representation heights", () => {
+    const representations = [
+      createQualityLevel(360),
+      createQualityLevel(720),
+      createQualityLevel(1080),
+    ];
+
+    applyHlsQualitySelection(representations, "fixed:720");
+
+    expect(representations.map((representation) => representation.enabled)).toEqual([
+      false,
+      true,
+      false,
+    ]);
+  });
+});

--- a/apps/web/app/components/VideoPlayer/hlsQuality.ts
+++ b/apps/web/app/components/VideoPlayer/hlsQuality.ts
@@ -1,0 +1,122 @@
+export const HLS_AUTO_HD_VALUE = "auto-hd";
+export const HLS_AUTO_HD_LABEL = "Auto";
+
+const MIN_HLS_RENDITION_HEIGHT = 720;
+const MAX_HLS_RENDITION_HEIGHT = 1080;
+
+export type HlsQualitySelection = typeof HLS_AUTO_HD_VALUE | `fixed:${number}`;
+
+export type HlsQualityLevel = {
+  id?: string;
+  height?: number;
+  width?: number;
+  bitrate?: number;
+  enabled: boolean;
+};
+
+export type HlsQualityLevelList = {
+  readonly length: number;
+  readonly selectedIndex: number;
+  [index: number]: HlsQualityLevel | undefined;
+  on: (type: string, listener: () => void) => void;
+  off: (type: string, listener: () => void) => void;
+};
+
+export type HlsQualityOption = {
+  value: HlsQualitySelection;
+  label: string;
+  height?: number;
+};
+
+export const getHlsQualityLevels = (qualityLevels: HlsQualityLevelList | null | undefined) => {
+  if (!qualityLevels) return [];
+
+  return Array.from({ length: qualityLevels.length }, (_, index) => qualityLevels[index]).filter(
+    (qualityLevel): qualityLevel is HlsQualityLevel => Boolean(qualityLevel),
+  );
+};
+
+export const getQualityLevelHeight = (qualityLevel: HlsQualityLevel) => {
+  const { height } = qualityLevel;
+  return typeof height === "number" && Number.isFinite(height) ? height : null;
+};
+
+export const getHlsQualityOptions = (qualityLevels: HlsQualityLevel[]): HlsQualityOption[] => {
+  const heights = Array.from(
+    new Set(
+      qualityLevels
+        .map(getQualityLevelHeight)
+        .filter((height): height is number => height !== null),
+    ),
+  ).sort((a, b) => b - a);
+
+  if (heights.length < 2) return [];
+
+  return [
+    { value: HLS_AUTO_HD_VALUE, label: HLS_AUTO_HD_LABEL },
+    ...heights.map((height) => ({
+      value: `fixed:${height}` as const,
+      label: `${height}p`,
+      height,
+    })),
+  ];
+};
+
+const getAutoHdFallback = (qualityLevels: HlsQualityLevel[]) =>
+  qualityLevels
+    .filter((qualityLevel) => {
+      const height = getQualityLevelHeight(qualityLevel);
+      return height !== null && height < MIN_HLS_RENDITION_HEIGHT;
+    })
+    .sort((a, b) => (getQualityLevelHeight(b) ?? 0) - (getQualityLevelHeight(a) ?? 0))[0];
+
+export const applyHlsQualitySelection = (
+  qualityLevels: HlsQualityLevel[],
+  selection: HlsQualitySelection,
+) => {
+  if (!qualityLevels.length) return;
+
+  if (selection === HLS_AUTO_HD_VALUE) {
+    const hasTargetRangeQuality = qualityLevels.some((qualityLevel) => {
+      const height = getQualityLevelHeight(qualityLevel);
+      return (
+        height !== null && height >= MIN_HLS_RENDITION_HEIGHT && height <= MAX_HLS_RENDITION_HEIGHT
+      );
+    });
+    const fallbackQuality = getAutoHdFallback(qualityLevels);
+
+    if (!hasTargetRangeQuality && !fallbackQuality) {
+      qualityLevels.forEach((qualityLevel) => {
+        qualityLevel.enabled = true;
+      });
+      return;
+    }
+
+    qualityLevels.forEach((qualityLevel) => {
+      const height = getQualityLevelHeight(qualityLevel);
+      const isInTargetRange =
+        height !== null && height >= MIN_HLS_RENDITION_HEIGHT && height <= MAX_HLS_RENDITION_HEIGHT;
+
+      qualityLevel.enabled = hasTargetRangeQuality
+        ? isInTargetRange
+        : qualityLevel === fallbackQuality;
+    });
+    return;
+  }
+
+  const fixedHeight = Number(selection.replace("fixed:", ""));
+
+  if (!Number.isFinite(fixedHeight)) {
+    qualityLevels.forEach((qualityLevel) => {
+      qualityLevel.enabled = true;
+    });
+    return;
+  }
+
+  qualityLevels.forEach((qualityLevel) => {
+    qualityLevel.enabled = getQualityLevelHeight(qualityLevel) === fixedHeight;
+  });
+};
+
+export const getHlsQualityLabel = (selection: HlsQualitySelection, options: HlsQualityOption[]) =>
+  options.find((option) => option.value === selection)?.label ?? HLS_AUTO_HD_LABEL;

--- a/apps/web/app/components/VideoPlayer/hlsQualityControlComponent.ts
+++ b/apps/web/app/components/VideoPlayer/hlsQualityControlComponent.ts
@@ -1,0 +1,39 @@
+import videojs from "video.js";
+
+type VideoJSType = ReturnType<typeof videojs>;
+
+const HLS_QUALITY_CONTROL_NAME = "MentingoHlsQualityControl";
+const HLS_QUALITY_CONTROL_INDEX = 13;
+
+let registered = false;
+
+export const registerHlsQualityControlComponent = () => {
+  if (registered) return;
+
+  const Component = videojs.getComponent("Component");
+
+  class HlsQualityControlComponent extends Component {
+    createEl() {
+      return videojs.dom.createEl("div", {
+        className: "mentingo-vjs-quality-selector-host vjs-hidden",
+      });
+    }
+  }
+
+  videojs.registerComponent(HLS_QUALITY_CONTROL_NAME, HlsQualityControlComponent);
+  registered = true;
+};
+
+export const addHlsQualityControlComponent = (player: VideoJSType) => {
+  registerHlsQualityControlComponent();
+
+  const controlBar = player.getChild("controlBar");
+  if (!controlBar) return null;
+
+  const existingControl = controlBar.getChild(HLS_QUALITY_CONTROL_NAME);
+  if (existingControl) return existingControl.el() as HTMLDivElement;
+
+  const control = controlBar.addChild(HLS_QUALITY_CONTROL_NAME, {}, HLS_QUALITY_CONTROL_INDEX);
+
+  return control.el() as HTMLDivElement;
+};

--- a/apps/web/app/components/VideoPlayer/videoPlayer.css
+++ b/apps/web/app/components/VideoPlayer/videoPlayer.css
@@ -307,6 +307,79 @@
   transform: translateX(-50%);
 }
 
+.mentingo-video-js .mentingo-vjs-quality-selector-host {
+  position: relative;
+  width: 4.25rem;
+  min-width: 4.25rem;
+  height: 2.25rem;
+  flex-shrink: 0;
+  color: var(--vjs-theme-contrast) !important;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.mentingo-video-js .mentingo-vjs-quality-selector {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.mentingo-video-js .mentingo-vjs-quality-selector__button {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 0.375rem;
+  color: var(--vjs-theme-contrast) !important;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: "Open Sans", sans-serif;
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: 1;
+  text-align: center;
+}
+
+.mentingo-video-js .mentingo-vjs-quality-selector__button:hover,
+.mentingo-video-js .mentingo-vjs-quality-selector__button:active {
+  background: color-mix(in srgb, var(--vjs-theme-contrast) 10%, transparent);
+}
+
+.mentingo-video-js .mentingo-vjs-quality-selector__menu {
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 0.5rem);
+  z-index: 3;
+  display: grid;
+  min-width: 5rem;
+  padding: 0.25rem 0;
+  transform: translateX(-50%);
+  background: var(--vjs-surface);
+  border: 1px solid var(--vjs-border);
+  border-radius: 0.5rem;
+}
+
+.mentingo-video-js .mentingo-vjs-quality-selector__item {
+  padding: 0.375rem 0.625rem;
+  color: var(--vjs-theme-contrast) !important;
+  font-family: "Open Sans", sans-serif;
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.mentingo-video-js .mentingo-vjs-quality-selector__item:hover,
+.mentingo-video-js .mentingo-vjs-quality-selector__item:focus,
+.mentingo-video-js .mentingo-vjs-quality-selector__item[data-selected="true"] {
+  background: color-mix(in srgb, var(--vjs-theme-contrast) 10%, transparent);
+  outline: none;
+}
+
 .mentingo-video-js .vjs-menu .vjs-menu-content {
   background: var(--vjs-surface);
   border: 1px solid var(--vjs-border);
@@ -378,6 +451,13 @@
   .mentingo-video-js .vjs-playback-rate {
     width: 2.75rem;
     min-width: 2.75rem;
+    height: 2rem;
+    font-size: 0.625rem;
+  }
+
+  .mentingo-video-js .mentingo-vjs-quality-selector-host {
+    width: 3.75rem;
+    min-width: 3.75rem;
     height: 2rem;
     font-size: 0.625rem;
   }

--- a/apps/web/app/hooks/buildRichTextFileUploadHandler.ts
+++ b/apps/web/app/hooks/buildRichTextFileUploadHandler.ts
@@ -115,7 +115,7 @@ const handleVideoUpload = async ({
       if (insertOnUpload && session.resourceId) {
         updateVideoUploadNodeById(editor, uploadId, {
           src: buildEntityResourceUrl(session.resourceId, entityType),
-          sourceType: session.provider === "s3" ? "external" : "internal",
+          sourceType: "internal",
           provider: session.provider,
           hasError: false,
           uploadStatus: null,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -144,6 +144,7 @@
     "tus-js-client": "4.1.0",
     "vaul": "1.1.2",
     "video.js": "8.23.6",
+    "videojs-contrib-quality-levels": "4.1.0",
     "videojs-youtube": "3.0.1",
     "vite-plugin-cjs-interop": "2.1.4",
     "vite-plugin-svgr": "4.2.0",

--- a/packages/shared/src/utils/videoUrls.ts
+++ b/packages/shared/src/utils/videoUrls.ts
@@ -65,6 +65,8 @@ const extractBunnyId = (sourceUrl: string, url: URL | null): string | null => {
 };
 
 export const detectVideoProviderFromUrl = (sourceUrl: string): VideoProvider => {
+  if (sourceUrl.startsWith("bunny-")) return VIDEO_EMBED_PROVIDERS.BUNNY;
+
   const url = tryParseUrl(sourceUrl);
   if (!url) return VIDEO_EMBED_PROVIDERS.UNKNOWN;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -872,6 +872,9 @@ importers:
       video.js:
         specifier: 8.23.6
         version: 8.23.6
+      videojs-contrib-quality-levels:
+        specifier: 4.1.0
+        version: 4.1.0(video.js@8.23.6)
       videojs-youtube:
         specifier: 3.0.1
         version: 3.0.1(video.js@8.23.6)


### PR DESCRIPTION
<!--
 1. Make sure you have correct branch name i.e. `ab_prefix_123_task_name`, where `123` is a issue ID, and `ab` is an author
 2. Make sure you have meaningful title related to task with correct prefix: feat/fix/chore/style/docs/refactor
 3. Reference multiple issues in one PR by listing them in the issues section
 4. Make sure all necessary sections are filled, remove obsolete sections
 5. Do a self review first
 6. Check if your PR includes only code related to your task
 7. `Notes` is used for additional info but also to notify if any action is required
-->

## Issue(s)
[1638](https://github.com/Selleo/mentingo/issues/1638)

  ## Overview
  <!--
  General description what it does
  -->

  Fixes Bunny Stream playback and provider handling for rich-text lesson videos.

  - Derives video provider from stored resource references, including bunny-* references.
  - Injects backend-derived data-provider into lesson video content so stale or missing unknown providers do not force internal Bunny videos to MP4.
  - Returns videoProvider from resource-library assets and uses it when inserting videos from the asset library.
  - Keeps uploaded rich-text videos as internal resources while allowing the provider metadata to decide Bunny HLS vs self-hosted MP4 playback.
  - Adds HLS quality selection for Bunny videos using Video.js quality levels.
  - Fixes Bunny thumbnails for internal resource URLs by resolving the stored resource reference before calling Bunny.
  - Updates API schema and generated web client for the resource-library videoProvider field.
  - Adds focused coverage for provider injection, resource-library Bunny provider derivation, thumbnail routing, video normalization, and HLS quality selection.

  ## Business Value
  <!--
  Why are we doing this from a business perspective? What value does this bring to the project from end-users perspective?
  -->

  Bunny-hosted lesson videos now play through the intended HLS flow with quality selection instead of being treated as plain MP4 files. Content creators can insert Bunny videos from the asset library
  without losing provider metadata, and learners get correct playback and thumbnails for Bunny videos in lesson content.
  
  ## Screenshots / Video

https://github.com/user-attachments/assets/5f655c1c-7e99-4dfd-8165-6a209aa7435a


  
  