### PR TITLE
fix: display the correct sentence in fill-in-the-blank exercises

### DIFF
--- a/apps/api/src/global-search/search-index.repository.ts
+++ b/apps/api/src/global-search/search-index.repository.ts
@@ -35,11 +35,22 @@ import type {
   SearchDocumentWeight,
 } from "./global-search.types";
 import type { SupportedLanguages } from "@repo/shared";
+import type { SQL } from "drizzle-orm";
+import type { AnyPgColumn } from "drizzle-orm/pg-core";
 import type { UUIDType } from "src/common";
 
 @Injectable()
 export class SearchIndexRepository {
   constructor(@Inject(DB) private readonly db: DatabasePg) {}
+
+  private asLocalizedJsonbObject(fieldExpression: SQL | AnyPgColumn) {
+    return sql`
+      CASE
+        WHEN jsonb_typeof(${fieldExpression}) = 'object' THEN ${fieldExpression}
+        ELSE '{}'::jsonb
+      END
+    `;
+  }
 
   async replaceEntityDocuments(input: ReplaceSearchDocumentsInput) {
     const db = input.db ?? this.db;
@@ -317,7 +328,9 @@ export class SearchIndexRepository {
       .innerJoin(chapters, eq(chapters.id, lessons.chapterId))
       .innerJoin(courses, eq(courses.id, chapters.courseId))
       .innerJoin(
-        sql`LATERAL jsonb_each_text(${fieldExpression}) AS ${sql.raw(lateralAlias)}(lang, value)`,
+        sql`LATERAL jsonb_each_text(${this.asLocalizedJsonbObject(
+          fieldExpression,
+        )}) AS ${sql.raw(lateralAlias)}(lang, value)`,
         sql`true`,
       )
       .where(
@@ -355,7 +368,9 @@ export class SearchIndexRepository {
       .innerJoin(chapters, eq(chapters.id, lessons.chapterId))
       .innerJoin(courses, eq(courses.id, chapters.courseId))
       .innerJoin(
-        sql`LATERAL jsonb_each_text(${fieldExpression}) AS ${sql.raw(lateralAlias)}(lang, value)`,
+        sql`LATERAL jsonb_each_text(${this.asLocalizedJsonbObject(
+          fieldExpression,
+        )}) AS ${sql.raw(lateralAlias)}(lang, value)`,
         sql`true`,
       )
       .where(
@@ -395,7 +410,9 @@ export class SearchIndexRepository {
       .innerJoin(chapters, eq(chapters.id, lessons.chapterId))
       .innerJoin(courses, eq(courses.id, chapters.courseId))
       .innerJoin(
-        sql`LATERAL jsonb_each_text(${questionAnswerOptions.optionText}) AS option_text(lang, value)`,
+        sql`LATERAL jsonb_each_text(${this.asLocalizedJsonbObject(
+          questionAnswerOptions.optionText,
+        )}) AS option_text(lang, value)`,
         sql`true`,
       )
       .where(

--- a/apps/api/src/seed/e2e-data-seeds.ts
+++ b/apps/api/src/seed/e2e-data-seeds.ts
@@ -139,7 +139,7 @@ export const e2eCourses: NiceCourseData[] = [
               {
                 type: QUESTION_TYPE.FILL_IN_THE_BLANKS_TEXT,
                 title: "Complete the Definition",
-                description: "E2E testing is used to test the [word] of an application.",
+                description: "E2E testing is used to test the <blank-answer-1> of an application.",
                 solutionExplanation:
                   "E2E testing is used to test the <strong>workflow</strong> of an application.",
                 options: [

--- a/apps/api/src/seed/nice-data-seeds.ts
+++ b/apps/api/src/seed/nice-data-seeds.ts
@@ -119,7 +119,7 @@ export const niceCourses: NiceCourseData[] = [
                 type: QUESTION_TYPE.FILL_IN_THE_BLANKS_DND,
                 title: "Fill blanks with the correct word.",
                 description:
-                  "In CSS, [word] is used to style the layout, while [word] is used to change colors.",
+                  "In CSS, <blank-answer-1> is used to style the layout, while <blank-answer-2> is used to change colors.",
                 solutionExplanation:
                   "<p>In CSS, <strong>flexbox</strong> is used to style the layout, while <strong>color properties</strong> are used to change colors.</p>",
                 options: [
@@ -382,7 +382,7 @@ export const niceCourses: NiceCourseData[] = [
                 type: QUESTION_TYPE.FILL_IN_THE_BLANKS_DND,
                 title: "Fill blanks with the correct word.",
                 description:
-                  "CSS is used to style [word], while JavaScript is used to add [word] to web pages.",
+                  "CSS is used to style <blank-answer-1>, while JavaScript is used to add <blank-answer-2> to web pages.",
                 solutionExplanation:
                   "<p>CSS is used to style <strong>HTML</strong>, while JavaScript is used to add <strong>interactivity</strong> to web pages.</p>",
                 options: [
@@ -428,7 +428,7 @@ export const niceCourses: NiceCourseData[] = [
                 type: QUESTION_TYPE.FILL_IN_THE_BLANKS_DND,
                 title: "Fill blanks with the correct word.",
                 description:
-                  "In CSS, [word] is used to style the layout, while [word] is used to change colors.",
+                  "In CSS, <blank-answer-1> is used to style the layout, while <blank-answer-2> is used to change colors.",
                 solutionExplanation:
                   "<p>In CSS, <strong>flexbox</strong> is used to style the layout, while <strong>color properties</strong> are used to change colors.</p>",
                 options: [
@@ -449,7 +449,7 @@ export const niceCourses: NiceCourseData[] = [
                 type: QUESTION_TYPE.FILL_IN_THE_BLANKS_DND,
                 title: "Fill blanks with the correct word.",
                 description:
-                  "In JavaScript, [word] are used to store data, while [word] are used to perform actions.",
+                  "In JavaScript, <blank-answer-1> are used to store data, while <blank-answer-2> are used to perform actions.",
                 solutionExplanation:
                   "<p>In JavaScript, <strong>variables</strong> are used to store data, while <strong>functions</strong> are used to perform actions.</p>",
                 options: [
@@ -543,7 +543,7 @@ export const niceCourses: NiceCourseData[] = [
                 type: QUESTION_TYPE.FILL_IN_THE_BLANKS_DND,
                 title: "Fill blanks with the correct word.",
                 description:
-                  "The CSS [word] property is used for creating flexible box layouts, while [word] is used for creating grid layouts.",
+                  "The CSS <blank-answer-1> property is used for creating flexible box layouts, while <blank-answer-2> is used for creating grid layouts.",
                 solutionExplanation:
                   "<p>The CSS <strong>flexbox</strong> property is used for creating flexible box layouts, while <strong>color properties</strong> are used for creating grid layouts.</p>",
                 options: [
@@ -574,7 +574,7 @@ export const niceCourses: NiceCourseData[] = [
                 type: QUESTION_TYPE.FILL_IN_THE_BLANKS_DND,
                 title: "Fill blanks with the correct word.",
                 description:
-                  "To center an element horizontally, you can use 'margin: [word] [word];'.",
+                  "To center an element horizontally, you can use 'margin: <blank-answer-1> <blank-answer-2>;'.",
                 solutionExplanation:
                   "<p>To center an element horizontally, you can use 'margin: <strong>0 auto</strong>;'.</p>",
                 options: [
@@ -626,7 +626,7 @@ export const niceCourses: NiceCourseData[] = [
                 type: QUESTION_TYPE.FILL_IN_THE_BLANKS_DND,
                 title: "Fill blanks with the correct word.",
                 description:
-                  "In CSS, [word] is used to style the layout, while [word] is used to change colors.",
+                  "In CSS, <blank-answer-1> is used to style the layout, while <blank-answer-2> is used to change colors.",
                 solutionExplanation:
                   "<p>In CSS, <strong>flexbox</strong> is used to style the layout, while <strong>color properties</strong> are used to change colors.</p>",
                 options: [
@@ -657,7 +657,7 @@ export const niceCourses: NiceCourseData[] = [
                 type: QUESTION_TYPE.FILL_IN_THE_BLANKS_DND,
                 title: "Fill blanks with the correct word.",
                 description:
-                  "The [word] property is used to set the spacing between lines of text, and the [word] property is used to set the spacing outside an element.",
+                  "The <blank-answer-1> property is used to set the spacing between lines of text, and the <blank-answer-2> property is used to set the spacing outside an element.",
                 solutionExplanation:
                   "<p>In CSS, the <strong>line-height</strong> property is used to set the spacing between lines of text, while the <strong>margin</strong> property is used to set the spacing outside an element.</p>",
                 options: [
@@ -732,7 +732,7 @@ export const niceCourses: NiceCourseData[] = [
                 type: QUESTION_TYPE.FILL_IN_THE_BLANKS_DND,
                 title: "Fill blanks with the correct word.",
                 description:
-                  "In Java, [word] are used to define the blueprint of objects, while [word] are instances.",
+                  "In Java, <blank-answer-1> are used to define the blueprint of objects, while <blank-answer-2> are instances.",
                 solutionExplanation:
                   "<p>In Java, <strong>classes</strong> are used to define the blueprint of objects, while <strong>objects</strong> are instances of these blueprints.</p>",
                 options: [
@@ -759,7 +759,7 @@ export const niceCourses: NiceCourseData[] = [
                 type: QUESTION_TYPE.FILL_IN_THE_BLANKS_DND,
                 title: "Fill blanks with the correct word.",
                 description:
-                  "In Android dev, [word] are used to define the user interface, while [word] handle user interactions.",
+                  "In Android dev, <blank-answer-1> are used to define the user interface, while <blank-answer-2> handle user interactions.",
                 solutionExplanation:
                   "<p>In Android development, <strong>layouts</strong> are used to define the user interface, while <strong>activities</strong> handle user interactions and app logic.</p>",
                 options: [
@@ -929,7 +929,7 @@ export const niceCourses: NiceCourseData[] = [
                 type: QUESTION_TYPE.FILL_IN_THE_BLANKS_DND,
                 title: "Fill blanks with the correct word.",
                 description:
-                  "In Kotlin, [word] are immutable variables, while [word] are mutable variables.",
+                  "In Kotlin, <blank-answer-1> are immutable variables, while <blank-answer-2> are mutable variables.",
                 solutionExplanation:
                   "<p>In Kotlin, <strong>val</strong> are immutable variables, while <strong>var</strong> are mutable variables.</p>",
                 options: [
@@ -985,7 +985,7 @@ export const niceCourses: NiceCourseData[] = [
                 type: QUESTION_TYPE.FILL_IN_THE_BLANKS_DND,
                 title: "Fill blanks with the correct word.",
                 description:
-                  "In arithmetic, [word] is the result of addition, while [word] is the result of subtraction.",
+                  "In arithmetic, <blank-answer-1> is the result of addition, while <blank-answer-2> is the result of subtraction.",
                 solutionExplanation:
                   "<p>In arithmetic, <strong>sum</strong> is the result of addition, while <strong>difference</strong> is the result of subtraction.</p>",
                 options: [
@@ -1072,7 +1072,7 @@ export const niceCourses: NiceCourseData[] = [
                 type: QUESTION_TYPE.FILL_IN_THE_BLANKS_DND,
                 title: "Fill blanks with the correct word.",
                 description:
-                  "In algebra, [word] represent unknown values, while [word] are mathematical phrases",
+                  "In algebra, <blank-answer-1> represent unknown values, while <blank-answer-2> are mathematical phrases",
                 solutionExplanation:
                   "<p>In algebra, <strong>variables</strong> represent unknown values, while <strong>expressions</strong> are mathematical phrases that combine numbers and variables.</p>",
                 options: [
@@ -1162,7 +1162,7 @@ export const niceCourses: NiceCourseData[] = [
                 type: QUESTION_TYPE.FILL_IN_THE_BLANKS_DND,
                 title: "Fill blanks with the correct word.",
                 description:
-                  "In algebra, [word] are used to represent unknowns, while [word] can be solved to find their values.",
+                  "In algebra, <blank-answer-1> are used to represent unknowns, while <blank-answer-2> can be solved to find their values.",
                 solutionExplanation:
                   "<p>In algebra, <strong>variables</strong> are used to represent unknowns, while <strong>equations</strong> can be solved to find their values.</p>",
                 options: [
@@ -1232,7 +1232,7 @@ export const niceCourses: NiceCourseData[] = [
               {
                 type: QUESTION_TYPE.FILL_IN_THE_BLANKS_DND,
                 title: "Fill blanks with the correct word.",
-                description: "Fill in the blanks: 'She [word] to the store yesterday.'",
+                description: "Fill in the blanks: 'She <blank-answer-1> to the store yesterday.'",
                 solutionExplanation: "<p>She <strong>went</strong> to the store yesterday.</p>",
                 options: [
                   { optionText: "went", isCorrect: true, language: "en" },
@@ -1297,7 +1297,7 @@ export const niceCourses: NiceCourseData[] = [
               {
                 type: QUESTION_TYPE.FILL_IN_THE_BLANKS_TEXT,
                 title: "Fill in the blanks with the correct word.",
-                description: "I [word] to the park every day.",
+                description: "I <blank-answer-1> to the park every day.",
                 solutionExplanation: "I <strong>go</strong> to the park every day.",
                 options: [
                   { optionText: "go", isCorrect: true, language: "en" },
@@ -1355,7 +1355,7 @@ export const niceCourses: NiceCourseData[] = [
               {
                 type: QUESTION_TYPE.FILL_IN_THE_BLANKS_DND,
                 title: "Fill blanks with the correct word.",
-                description: "I love [word] (swimming/swim).",
+                description: "I love <blank-answer-1> (swimming/swim).",
                 solutionExplanation: "I love <strong>swimming</strong> (swimming/swim).",
                 options: [
                   {
@@ -1422,7 +1422,7 @@ export const niceCourses: NiceCourseData[] = [
               {
                 type: QUESTION_TYPE.FILL_IN_THE_BLANKS_DND,
                 title: "Fill blanks with the correct word.",
-                description: "She [word] to the park every day.",
+                description: "She <blank-answer-1> to the park every day.",
                 solutionExplanation: "She <strong>went</strong> to the park every day.",
                 options: [
                   { optionText: "goes", isCorrect: true, language: "en" },
@@ -1616,7 +1616,7 @@ export const niceCourses: NiceCourseData[] = [
                 type: QUESTION_TYPE.FILL_IN_THE_BLANKS_TEXT,
                 title: "Fill blanks with the correct word.",
                 description:
-                  "The book was [word] by the author to explain complex [word] concepts.",
+                  "The book was <blank-answer-1> by the author to explain complex <blank-answer-2> concepts.",
                 solutionExplanation:
                   "The book was <strong>written</strong> by the author to explain complex <strong>grammatical</strong> concepts.",
                 options: [
@@ -1637,7 +1637,7 @@ export const niceCourses: NiceCourseData[] = [
                 type: QUESTION_TYPE.FILL_IN_THE_BLANKS_DND,
                 title: "Fill blanks with the correct word.",
                 description:
-                  "The [word] of the study focused on the effects of [word] in [word] language acquisition.",
+                  "The <blank-answer-1> of the study focused on the effects of <blank-answer-2> in <blank-answer-3> language acquisition.",
                 solutionExplanation:
                   "The <strong>focus</strong> of the study focused on the effects of <strong>context</strong> in <strong>second</strong> language acquisition.",
                 options: [
@@ -1801,7 +1801,7 @@ export const niceCourses: NiceCourseData[] = [
               {
                 type: QUESTION_TYPE.FILL_IN_THE_BLANKS_DND,
                 title: "Fill blanks with the correct word.",
-                description: "The book [word] I borrowed yesterday was fascinating.",
+                description: "The book <blank-answer-1> I borrowed yesterday was fascinating.",
                 solutionExplanation:
                   "The book <strong>that</strong> I borrowed yesterday was fascinating.",
                 options: [
@@ -1868,7 +1868,7 @@ export const niceCourses: NiceCourseData[] = [
               {
                 type: QUESTION_TYPE.FILL_IN_THE_BLANKS_DND,
                 title: "Fill blanks with the correct word.",
-                description: "The results [word] the hypothesis.",
+                description: "The results <blank-answer-1> the hypothesis.",
                 solutionExplanation: "The results <strong>support</strong> the hypothesis.",
                 options: [
                   {
@@ -1973,7 +1973,7 @@ export const niceCourses: NiceCourseData[] = [
                 type: QUESTION_TYPE.FILL_IN_THE_BLANKS_DND,
                 title: "Fill in the blanks with the correct word.",
                 description:
-                  "The break the ice expression is used to [word] a person who is not interested in a conversation.",
+                  "The break the ice expression is used to <blank-answer-1> a person who is not interested in a conversation.",
                 solutionExplanation:
                   "The break the ice expression is used to <strong>make</strong> a person feel better.",
                 options: [
@@ -2009,7 +2009,7 @@ export const niceCourses: NiceCourseData[] = [
               {
                 type: QUESTION_TYPE.FILL_IN_THE_BLANKS_DND,
                 title: "Fill blanks with the correct word.",
-                description: "She was [word] when she heard the good news.",
+                description: "She was <blank-answer-1> when she heard the good news.",
                 solutionExplanation:
                   "She was <strong>over the moon</strong> when she heard the good news.",
                 options: [
@@ -2194,7 +2194,7 @@ export const niceCourses: NiceCourseData[] = [
                 type: QUESTION_TYPE.FILL_IN_THE_BLANKS_DND,
                 title: "Fill blanks with the correct word.",
                 description:
-                  "Complete the blanks: Artificial [word] refers to the ability of machines to mimic [word] intelligence.",
+                  "Complete the blanks: Artificial <blank-answer-1> refers to the ability of machines to mimic <blank-answer-2> intelligence.",
                 solutionExplanation:
                   "Complete the blanks: Artificial <strong>intelligence</strong> refers to the ability of machines to mimic <strong>human</strong> intelligence.",
                 options: [

--- a/apps/api/src/seed/seed-helpers.ts
+++ b/apps/api/src/seed/seed-helpers.ts
@@ -34,8 +34,7 @@ import { StripeService } from "src/stripe/stripe.service";
 import type { DatabasePg, UUIDType } from "../common";
 import type { NiceCourseData } from "../utils/types/test-types";
 
-const BLANK_ANSWER_MARKER_PREFIX = "<blank-answer-";
-const LEGACY_BLANK_MARKER = "[word]";
+const BLANK_ANSWER_MARKER_REGEX = /<blank-answer-([^>]+)>/g;
 
 type SeedQuestionData = NonNullable<
   NonNullable<NiceCourseData["chapters"][number]["lessons"][number]["questions"]>[number]
@@ -47,15 +46,14 @@ const isFillInTheBlanksQuestion = (questionType: SeedQuestionData["type"]) =>
   questionType === QUESTION_TYPE.FILL_IN_THE_BLANKS_DND ||
   questionType === QUESTION_TYPE.FILL_IN_THE_BLANKS_TEXT;
 
-const replaceLegacyBlankMarkers = (description: string | undefined, answerIds: UUIDType[]) => {
-  if (!description || description.includes(BLANK_ANSWER_MARKER_PREFIX)) return description;
+const replaceSeedBlankMarkers = (description: string | undefined, answerIds: UUIDType[]) => {
+  if (!description) return description;
 
-  let answerIndex = 0;
-  return description.replaceAll(LEGACY_BLANK_MARKER, () => {
-    const answerId = answerIds[answerIndex];
-    answerIndex += 1;
+  return description.replace(BLANK_ANSWER_MARKER_REGEX, (marker, markerAnswerId: string) => {
+    if (!/^\d+$/.test(markerAnswerId)) return marker;
 
-    return answerId ? `<blank-answer-${answerId}>` : LEGACY_BLANK_MARKER;
+    const answerId = answerIds[Number(markerAnswerId) - 1];
+    return answerId ? `<blank-answer-${answerId}>` : marker;
   });
 };
 
@@ -235,7 +233,7 @@ export async function createNiceCourses(
               .filter(({ isCorrect }) => isCorrect)
               .map(({ id }) => id);
             const description = isFillInTheBlanksQuestion(questionData.type)
-              ? replaceLegacyBlankMarkers(
+              ? replaceSeedBlankMarkers(
                   normalizeOptionalString(questionData.description),
                   correctFillBlankAnswerIds,
                 )

--- a/apps/web/app/modules/Courses/Lesson/Question/FillInTheBlanks/FillInTheBlanks.test.tsx
+++ b/apps/web/app/modules/Courses/Lesson/Question/FillInTheBlanks/FillInTheBlanks.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen } from "@testing-library/react";
+import { FormProvider, useForm } from "react-hook-form";
+import { I18nextProvider } from "react-i18next";
+import { describe, expect, it, vi } from "vitest";
+
+import { QuizContextProvider } from "~/modules/Courses/components/QuizContextProvider";
+import i18next from "~/utils/mocks/i18next.mock";
+
+import { FillInTheBlanksDnd } from "./dnd/FillInTheBlanksDnd";
+import { FillInTheBlanks } from "./FillInTheBlanks";
+
+import type { QuizQuestion } from "../types";
+import type { PropsWithChildren, ReactNode } from "react";
+import type { QuizForm } from "~/modules/Courses/Lesson/types";
+
+vi.mock("~/components/RichText/Viever", () => ({
+  default: ({ content, className }: { content: string; className?: string }) => (
+    <div className={className} dangerouslySetInnerHTML={{ __html: content }} />
+  ),
+}));
+
+const renderQuestion = (children: ReactNode) => {
+  const Wrapper = ({ children }: PropsWithChildren) => {
+    const form = useForm<QuizForm>({
+      defaultValues: {
+        briefResponses: {},
+        detailedResponses: {},
+        fillInTheBlanksDnd: {},
+        fillInTheBlanksText: {},
+        multiAnswerQuestions: {},
+        photoQuestionMultipleChoice: {},
+        photoQuestionSingleChoice: {},
+        singleAnswerQuestions: {},
+        trueOrFalseQuestions: {},
+      },
+    });
+
+    return (
+      <I18nextProvider i18n={i18next}>
+        <QuizContextProvider isQuizSubmitted={true}>
+          <FormProvider {...form}>{children}</FormProvider>
+        </QuizContextProvider>
+      </I18nextProvider>
+    );
+  };
+
+  return render(<Wrapper>{children}</Wrapper>);
+};
+
+describe("FillInTheBlanks", () => {
+  it("shows a derived correct sentence for completed text blanks without solution explanation", () => {
+    renderQuestion(
+      <FillInTheBlanks
+        isCompleted
+        question={
+          {
+            id: "question-1",
+            type: "fill_in_the_blanks_text",
+            displayOrder: 1,
+            description: "The <blank-answer-answer-1> answer.",
+            solutionExplanation: null,
+            passQuestion: false,
+            options: [
+              {
+                id: "answer-1",
+                optionText: "correct",
+                displayOrder: 1,
+                isCorrect: true,
+                isStudentAnswer: false,
+                studentAnswer: "wrong",
+              },
+            ],
+          } as QuizQuestion
+        }
+      />,
+    );
+
+    expect(screen.getByText("Correct sentence:")).toBeInTheDocument();
+    expect(screen.getByText("correct")).toBeInTheDocument();
+  });
+
+  it("shows a derived correct sentence for completed drag-and-drop blanks without solution explanation", () => {
+    renderQuestion(
+      <FillInTheBlanksDnd
+        isCompleted
+        question={
+          {
+            id: "question-2",
+            type: "fill_in_the_blanks_dnd",
+            displayOrder: 2,
+            description: "Drag the <blank-answer-answer-2> answer.",
+            solutionExplanation: null,
+            passQuestion: false,
+            options: [
+              {
+                id: "answer-2",
+                optionText: "correct",
+                displayOrder: 1,
+                isCorrect: true,
+                isStudentAnswer: false,
+                studentAnswer: "wrong",
+              },
+            ],
+          } as QuizQuestion
+        }
+      />,
+    );
+
+    expect(screen.getByText("Correct sentence:")).toBeInTheDocument();
+    expect(screen.getByText("correct")).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/modules/Courses/Lesson/Question/FillInTheBlanks/FillInTheBlanks.tsx
+++ b/apps/web/app/modules/Courses/Lesson/Question/FillInTheBlanks/FillInTheBlanks.tsx
@@ -4,6 +4,7 @@ import Viewer from "~/components/RichText/Viever";
 import { Card } from "~/components/ui/card";
 import { useQuizContext } from "~/modules/Courses/components/QuizContextProvider";
 
+import { getCorrectSentence } from "./correctSentence";
 import { FillInTheTextBlanks } from "./FillInTheTextBlanks";
 import { TextBlank } from "./TextBlank";
 
@@ -21,9 +22,10 @@ export const FillInTheBlanks = ({ question, isCompleted }: FillInTheBlanksProps)
     ({ isStudentAnswer, studentAnswer }) =>
       Boolean(studentAnswer) || typeof isStudentAnswer === "boolean",
   );
+  const correctSentence = getCorrectSentence(question);
   const showCorrectSentence =
     Boolean(isCompleted || hasSubmittedAnswer) &&
-    Boolean(question.solutionExplanation) &&
+    Boolean(correctSentence) &&
     !question.passQuestion &&
     !isQuizFeedbackRedacted;
 
@@ -60,7 +62,7 @@ export const FillInTheBlanks = ({ question, isCompleted }: FillInTheBlanksProps)
           <span className="body-base-md text-error-700">
             {t("studentLessonView.other.correctSentence")}
           </span>
-          <Viewer content={question.solutionExplanation ?? ""} />
+          <Viewer content={correctSentence ?? ""} />
         </div>
       )}
     </Card>

--- a/apps/web/app/modules/Courses/Lesson/Question/FillInTheBlanks/correctSentence.test.ts
+++ b/apps/web/app/modules/Courses/Lesson/Question/FillInTheBlanks/correctSentence.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import { getCorrectSentence } from "./correctSentence";
+
+import type { QuizQuestion } from "../types";
+
+const buildQuestion = (overrides: Partial<QuizQuestion>): QuizQuestion =>
+  ({
+    id: "question-1",
+    type: "fill_in_the_blanks_text",
+    title: "Question",
+    displayOrder: 1,
+    description: null,
+    solutionExplanation: null,
+    photoS3Key: null,
+    passQuestion: false,
+    options: [],
+    ...overrides,
+  }) as QuizQuestion;
+
+describe("getCorrectSentence", () => {
+  it("uses stored solution explanation when it exists", () => {
+    expect(
+      getCorrectSentence(
+        buildQuestion({
+          solutionExplanation: "<p>Stored sentence</p>",
+        }),
+      ),
+    ).toBe("<p>Stored sentence</p>");
+  });
+
+  it("derives a sentence from blank answer markers", () => {
+    expect(
+      getCorrectSentence(
+        buildQuestion({
+          description: "<p>The <blank-answer-answer-1> answer.</p>",
+          solutionExplanation: null,
+          options: [
+            {
+              id: "answer-1",
+              optionText: "correct",
+              displayOrder: 1,
+              isCorrect: true,
+              isStudentAnswer: false,
+              studentAnswer: "wrong",
+            },
+          ],
+        }),
+      ),
+    ).toBe("The <strong>correct</strong> answer.");
+  });
+
+  it("derives a sentence from legacy word markers by display order", () => {
+    expect(
+      getCorrectSentence(
+        buildQuestion({
+          description: "First [word], then [word].",
+          solutionExplanation: null,
+          options: [
+            {
+              id: "answer-2",
+              optionText: "second",
+              displayOrder: 2,
+              isCorrect: true,
+              isStudentAnswer: false,
+              studentAnswer: "wrong",
+            },
+            {
+              id: "answer-1",
+              optionText: "first",
+              displayOrder: 1,
+              isCorrect: true,
+              isStudentAnswer: true,
+              studentAnswer: "first",
+            },
+          ],
+        }),
+      ),
+    ).toBe("First <strong>first</strong>, then <strong>second</strong>.");
+  });
+
+  it("returns null when there is not enough data to build a sentence", () => {
+    expect(
+      getCorrectSentence(
+        buildQuestion({
+          description: "The <blank-answer-answer-1> answer.",
+          solutionExplanation: null,
+          options: [],
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null when only some blanks can be resolved", () => {
+    expect(
+      getCorrectSentence(
+        buildQuestion({
+          description: "First <blank-answer-answer-1>, then <blank-answer-answer-2>.",
+          solutionExplanation: null,
+          options: [
+            {
+              id: "answer-1",
+              optionText: "first",
+              displayOrder: 1,
+              isCorrect: true,
+              isStudentAnswer: true,
+              studentAnswer: "first",
+            },
+          ],
+        }),
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/web/app/modules/Courses/Lesson/Question/FillInTheBlanks/correctSentence.ts
+++ b/apps/web/app/modules/Courses/Lesson/Question/FillInTheBlanks/correctSentence.ts
@@ -1,17 +1,11 @@
+import { escape } from "lodash-es";
+
 import {
   normalizeBlankAnswerLineBreaks,
   splitByBlankAnswerMarkers,
 } from "~/utils/blankAnswerMarkers";
 
 import type { QuizQuestion, QuizQuestionOption } from "../types";
-
-const escapeHtml = (value: string) =>
-  value
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
 
 const findOptionForBlank = (
   options: QuizQuestionOption[],
@@ -54,7 +48,7 @@ export const getCorrectSentence = (question: QuizQuestion) => {
       if (!option?.optionText) return part.text;
 
       replacedBlankCount += 1;
-      return `${part.text}<strong>${escapeHtml(option.optionText)}</strong>`;
+      return `${part.text}<strong>${escape(option.optionText)}</strong>`;
     })
     .join("");
 

--- a/apps/web/app/modules/Courses/Lesson/Question/FillInTheBlanks/correctSentence.ts
+++ b/apps/web/app/modules/Courses/Lesson/Question/FillInTheBlanks/correctSentence.ts
@@ -1,0 +1,62 @@
+import {
+  normalizeBlankAnswerLineBreaks,
+  splitByBlankAnswerMarkers,
+} from "~/utils/blankAnswerMarkers";
+
+import type { QuizQuestion, QuizQuestionOption } from "../types";
+
+const escapeHtml = (value: string) =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+const findOptionForBlank = (
+  options: QuizQuestionOption[],
+  answerId: string,
+  legacyCorrectOptions: QuizQuestionOption[],
+) => {
+  const optionById = options.find((option) => option.id === answerId);
+  if (optionById?.optionText) return optionById;
+
+  const displayOrder = Number(answerId);
+  if (!Number.isInteger(displayOrder)) return null;
+
+  return (
+    legacyCorrectOptions.find((option) => option.displayOrder === displayOrder) ??
+    legacyCorrectOptions[displayOrder - 1] ??
+    null
+  );
+};
+
+export const getCorrectSentence = (question: QuizQuestion) => {
+  const storedSolutionExplanation = question.solutionExplanation?.trim();
+  if (storedSolutionExplanation) return storedSolutionExplanation;
+
+  if (!question.description || !question.options?.length) return null;
+
+  const options = question.options;
+  const legacyCorrectOptions = options
+    .filter((option) => option.isCorrect)
+    .sort((a, b) => (a.displayOrder ?? 0) - (b.displayOrder ?? 0));
+
+  const parts = splitByBlankAnswerMarkers(normalizeBlankAnswerLineBreaks(question.description));
+  const blankCount = parts.filter((part) => part.answerId).length;
+  let replacedBlankCount = 0;
+
+  const content = parts
+    .map((part) => {
+      if (!part.answerId) return part.text;
+
+      const option = findOptionForBlank(options, part.answerId, legacyCorrectOptions);
+      if (!option?.optionText) return part.text;
+
+      replacedBlankCount += 1;
+      return `${part.text}<strong>${escapeHtml(option.optionText)}</strong>`;
+    })
+    .join("");
+
+  return replacedBlankCount > 0 && replacedBlankCount === blankCount ? content : null;
+};

--- a/apps/web/app/modules/Courses/Lesson/Question/FillInTheBlanks/dnd/FillInTheBlanksDnd.tsx
+++ b/apps/web/app/modules/Courses/Lesson/Question/FillInTheBlanks/dnd/FillInTheBlanksDnd.tsx
@@ -22,6 +22,8 @@ import Viewer from "~/components/RichText/Viever";
 import { useQuizContext } from "~/modules/Courses/components/QuizContextProvider";
 import { getBlankAnswerIds, getBlankCount } from "~/utils/blankAnswerMarkers";
 
+import { getCorrectSentence } from "../correctSentence";
+
 import { DndBlank } from "./DndBlank";
 import { DraggableWord } from "./DraggableWord";
 import { SentenceBuilder } from "./SentenceBuilder";
@@ -157,7 +159,12 @@ export const FillInTheBlanksDnd: FC<FillInTheBlanksDndProps> = ({ question, isCo
   const [previewBlankId, setPreviewBlankId] = useState<string | null>(null);
   const wordsBeforeDragRef = useRef<DndWord[] | null>(null);
 
-  const solutionExplanation = question.solutionExplanation;
+  const correctSentence = getCorrectSentence(question);
+  const showCorrectSentence =
+    Boolean(isCompleted) &&
+    Boolean(correctSentence) &&
+    !question.passQuestion &&
+    !isQuizFeedbackRedacted;
   const blankMinWidth = useMemo(() => {
     const longestAnswerLength = getLongestAnswerLength(question.options);
     const minLength = Math.max(longestAnswerLength, 8);
@@ -437,12 +444,12 @@ export const FillInTheBlanksDnd: FC<FillInTheBlanksDndProps> = ({ question, isCo
           }}
         />
         <WordBank words={renderedWordBankWords} />
-        {solutionExplanation && !question.passQuestion && !isQuizFeedbackRedacted && (
+        {showCorrectSentence && (
           <div className="mt-4">
             <span className="body-base-md text-error-700">
               {t("studentLessonView.other.correctSentence")}
             </span>
-            <Viewer content={solutionExplanation} />
+            <Viewer content={correctSentence ?? ""} />
           </div>
         )}
       </DndContext>

--- a/docs/specs/quiz-assessment-engine-business-spec.md
+++ b/docs/specs/quiz-assessment-engine-business-spec.md
@@ -23,6 +23,7 @@ The core workflow starts in curriculum authoring, where a creator adds a quiz le
 - Configure passing threshold, optional attempt limit, and optional retake cooldown.
 - Require learners to answer every quiz question before submission.
 - Score learner submissions and store question results.
+- Show feedback after submission, including correct-answer context for failed gap-filling questions when feedback is enabled.
 - Mark the lesson complete only when the learner passes the quiz.
 - Let learners retake eligible quizzes and show why retake is unavailable when attempts or cooldown rules block it.
 
@@ -36,6 +37,8 @@ A course author adds a quiz lesson in the curriculum builder, gives it a title, 
 
 A learner opens the quiz lesson, answers every rendered question, and submits the form. Mentingo validates that no expected question is missing, evaluates the answers, calculates the percentage score, and compares the result with the passing threshold. Passing submissions complete the lesson and can unlock course progression; failed submissions keep progression rules in place.
 
+After submission, learners can review which answers were accepted when quiz feedback is enabled for the course. Fill-in-the-blanks questions show the correct completed sentence for failed answers, so learners can understand the intended wording instead of seeing only the words they chose.
+
 When a learner retakes a quiz, Mentingo first checks the attempt limit and cooldown. If retake is allowed, previous answers are cleared and a new attempt begins. If not, the retake button remains disabled and the interface explains the remaining limit or cooldown.
 
 ## Key Technical Context
@@ -43,9 +46,10 @@ When a learner retakes a quiz, Mentingo first checks the attempt limit and coold
 - Learner quiz delivery lives in `apps/web/app/modules/Courses/Lesson/Quiz.tsx` and the question components under `apps/web/app/modules/Courses/Lesson/Question`.
 - Quiz authoring lives in `apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/QuizLessonForm`.
 - Quiz evaluation and retake behavior are implemented in `apps/api/src/lesson/services/lesson.service.ts`; question scoring lives in `apps/api/src/questions/question.service.ts`.
+- Gap-filling result feedback uses stored solution text when present and can derive the correct sentence from localized blank markers plus correct answer options for legacy or imported quiz data.
 - Passing quiz completion publishes a `QuizCompletedEvent` through the outbox and updates student lesson progress.
 - Match-words and scale question types exist in code paths but are not exposed in the current question selector; brief and detailed responses currently evaluate as passing when a single answer is submitted.
 
 ## Test Evidence
 
-Frontend E2E coverage verifies quiz authoring for choice, text, fill-in-the-blanks, and photo questions; confirms unavailable question types in the builder; verifies learner submission with every rendered question type; covers quiz retake, final-quiz retake after certificate completion, and blocked progression after failing a required quiz. Source evidence covers backend validation for missing answers, duplicate completed submissions, threshold scoring, answer storage, retake attempts, cooldown checks, and quiz completion events.
+Frontend E2E coverage verifies quiz authoring for choice, text, fill-in-the-blanks, and photo questions; confirms unavailable question types in the builder; verifies learner submission with every rendered question type; covers quiz retake, final-quiz retake after certificate completion, and blocked progression after failing a required quiz. Unit coverage verifies the fallback correct-sentence rendering for completed fill-in-the-blanks questions. Source evidence covers backend validation for missing answers, duplicate completed submissions, threshold scoring, answer storage, retake attempts, cooldown checks, and quiz completion events.


### PR DESCRIPTION
## Issue(s)
- #1678 

## Overview
Fixes missing correct-sentence feedback for failed fill-in-the-blanks quiz questions.

The learner result view now uses the stored solution explanation when available and falls back to deriving the correct sentence from the question description plus correct answer options. This applies to both text-entry and drag-and-drop fill-in-the-blanks questions.

This also updates seed gap-filling descriptions to use the current blank-answer marker format and hardens global search indexing so lesson save does not fail when a localized JSONB field is not an object.

## Business Value
Learners who answer a gap-filling question incorrectly can see the intended completed sentence after submission, making feedback actionable instead of only showing selected or typed words.

For L&D teams, this improves quiz review quality and keeps existing or imported quiz content usable even when stored solution text is missing.

## Screenshots / Video

https://github.com/user-attachments/assets/11f722a0-d70f-4285-a235-29d5684e8de9
