### PR TITLE
chore: add automatic database migrations during application startup

### DIFF
--- a/apps/api/nest-cli.json
+++ b/apps/api/nest-cli.json
@@ -3,6 +3,12 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": true
+    "deleteOutDir": true,
+    "assets": [
+      {
+        "include": "storage/migrations/**/*",
+        "outDir": "dist/src"
+      }
+    ]
   }
 }

--- a/apps/api/src/app-startup.service.spec.ts
+++ b/apps/api/src/app-startup.service.spec.ts
@@ -1,0 +1,81 @@
+import { AppStartupService } from "./app-startup.service";
+
+import type { PermissionsBackfillService } from "./permissions/permissions-backfill.service";
+import type { DatabaseMigrationService } from "./storage/db/database-migration.service";
+
+describe("AppStartupService", () => {
+  const originalJestWorkerId = process.env.JEST_WORKER_ID;
+  const originalBuildVerification = process.env.BUILD_VERIFICATION;
+
+  const databaseMigrationService = {
+    runMigrations: jest.fn(),
+  } as unknown as jest.Mocked<DatabaseMigrationService>;
+
+  const permissionsBackfillService = {
+    backfillMissingPermissionsForAllTenants: jest.fn(),
+  } as unknown as jest.Mocked<PermissionsBackfillService>;
+
+  const service = new AppStartupService(databaseMigrationService, permissionsBackfillService);
+
+  beforeEach(() => {
+    delete process.env.JEST_WORKER_ID;
+    delete process.env.BUILD_VERIFICATION;
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    process.env.JEST_WORKER_ID = originalJestWorkerId;
+    process.env.BUILD_VERIFICATION = originalBuildVerification;
+  });
+
+  it("skips startup maintenance in Jest", async () => {
+    process.env.JEST_WORKER_ID = "1";
+
+    await service.onModuleInit();
+
+    expect(databaseMigrationService.runMigrations).not.toHaveBeenCalled();
+    expect(
+      permissionsBackfillService.backfillMissingPermissionsForAllTenants,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("skips startup maintenance during build verification", async () => {
+    process.env.BUILD_VERIFICATION = "true";
+
+    await service.onModuleInit();
+
+    expect(databaseMigrationService.runMigrations).not.toHaveBeenCalled();
+    expect(
+      permissionsBackfillService.backfillMissingPermissionsForAllTenants,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("runs migrations before permission backfill", async () => {
+    const calls: string[] = [];
+
+    databaseMigrationService.runMigrations.mockImplementation(async () => {
+      calls.push("migrations");
+    });
+    permissionsBackfillService.backfillMissingPermissionsForAllTenants.mockImplementation(
+      async () => {
+        calls.push("backfill");
+        return { insertedCount: 0, tenantCount: 2 };
+      },
+    );
+
+    await service.onModuleInit();
+
+    expect(calls).toEqual(["migrations", "backfill"]);
+  });
+
+  it("does not run permission backfill when migrations fail", async () => {
+    const error = new Error("Migration failed");
+
+    databaseMigrationService.runMigrations.mockRejectedValue(error);
+
+    await expect(service.onModuleInit()).rejects.toThrow(error);
+    expect(
+      permissionsBackfillService.backfillMissingPermissionsForAllTenants,
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/app-startup.service.ts
+++ b/apps/api/src/app-startup.service.ts
@@ -1,0 +1,39 @@
+import { Injectable, Logger, type OnModuleInit } from "@nestjs/common";
+
+import { PermissionsBackfillService } from "src/permissions/permissions-backfill.service";
+import { DatabaseMigrationService } from "src/storage/db/database-migration.service";
+
+@Injectable()
+export class AppStartupService implements OnModuleInit {
+  private readonly logger = new Logger(AppStartupService.name);
+
+  constructor(
+    private readonly databaseMigrationService: DatabaseMigrationService,
+    private readonly permissionsBackfillService: PermissionsBackfillService,
+  ) {}
+
+  async onModuleInit() {
+    if (this.shouldSkipStartupMaintenance()) {
+      this.logger.warn("Skipping startup database maintenance");
+      return;
+    }
+
+    await this.databaseMigrationService.runMigrations();
+
+    const { insertedCount, tenantCount } =
+      await this.permissionsBackfillService.backfillMissingPermissionsForAllTenants();
+
+    if (insertedCount > 0) {
+      this.logger.warn(
+        `Backfilled ${insertedCount} missing permission rows across ${tenantCount} tenants`,
+      );
+      return;
+    }
+
+    this.logger.log(`Permission backfill found no missing rows across ${tenantCount} tenants`);
+  }
+
+  private shouldSkipStartupMaintenance() {
+    return Boolean(process.env.JEST_WORKER_ID) || process.env.BUILD_VERIFICATION === "true";
+  }
+}

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -7,6 +7,7 @@ import { ScheduleModule } from "@nestjs/schedule";
 import { ThrottlerModule } from "@nestjs/throttler";
 
 import { ActivityLogsModule } from "src/activity-logs/activity-logs.module";
+import { AppStartupService } from "src/app-startup.service";
 import { EnvModule } from "src/env/env.module";
 import { LearningPathModule } from "src/learning-path/learning-path.module";
 import { LearningTimeModule } from "src/learning-time";
@@ -216,6 +217,7 @@ import type { RedisClient } from "src/redis";
     },
     GoogleStrategy,
     MicrosoftStrategy,
+    AppStartupService,
     ...(process.env.SLACK_OAUTH_ENABLED === "true" ? [SlackStrategy] : []),
   ],
 })

--- a/apps/api/src/permissions/permissions-backfill.service.ts
+++ b/apps/api/src/permissions/permissions-backfill.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, Logger } from "@nestjs/common";
+import { Inject, Injectable } from "@nestjs/common";
 import { SYSTEM_ROLE_PERMISSIONS, SYSTEM_ROLE_SLUGS, SYSTEM_RULE_SET_SLUGS } from "@repo/shared";
 import { and, eq } from "drizzle-orm";
 
@@ -12,13 +12,11 @@ import {
   permissionRuleSets,
 } from "src/storage/schema";
 
-import type { OnApplicationBootstrap } from "@nestjs/common";
 import type { SystemRoleSlug } from "@repo/shared";
 import type { UUIDType } from "src/common";
 
 @Injectable()
-export class PermissionsBackfillService implements OnApplicationBootstrap {
-  private readonly logger = new Logger(PermissionsBackfillService.name);
+export class PermissionsBackfillService {
   private readonly systemRoleDisplayName: Record<SystemRoleSlug, string> = {
     [SYSTEM_ROLE_SLUGS.ADMIN]: "Admin",
     [SYSTEM_ROLE_SLUGS.CONTENT_CREATOR]: "Content Creator",
@@ -30,21 +28,6 @@ export class PermissionsBackfillService implements OnApplicationBootstrap {
     private readonly tenantDbRunner: TenantDbRunnerService,
     @Inject(DB) private readonly db: DatabasePg,
   ) {}
-
-  async onApplicationBootstrap() {
-    // Skip bootstrap backfill only for build verification, where the app starts without Postgres.
-    if (process.env.JEST_WORKER_ID || process.env.BUILD_VERIFICATION === "true") return;
-
-    const { insertedCount, tenantCount } = await this.backfillMissingPermissionsForAllTenants();
-
-    if (insertedCount > 0) {
-      this.logger.warn(
-        `Backfilled ${insertedCount} missing permission rows across ${tenantCount} tenants`,
-      );
-    } else {
-      this.logger.warn(`Permission backfill found no missing rows across ${tenantCount} tenants`);
-    }
-  }
 
   async backfillMissingPermissionsForAllTenants() {
     let tenantCount = 0;

--- a/apps/api/src/permissions/permissions.module.ts
+++ b/apps/api/src/permissions/permissions.module.ts
@@ -5,6 +5,6 @@ import { PermissionsService } from "./permissions.service";
 
 @Module({
   providers: [PermissionsService, PermissionsBackfillService],
-  exports: [PermissionsService],
+  exports: [PermissionsService, PermissionsBackfillService],
 })
 export class PermissionsModule {}

--- a/apps/api/src/storage/db/database-migration.service.spec.ts
+++ b/apps/api/src/storage/db/database-migration.service.spec.ts
@@ -1,0 +1,31 @@
+import { join } from "node:path";
+
+import { migrate } from "drizzle-orm/postgres-js/migrator";
+
+import { DatabaseMigrationService } from "./database-migration.service";
+
+import type { DatabasePg } from "src/common";
+
+jest.mock("drizzle-orm/postgres-js/migrator", () => ({
+  migrate: jest.fn(),
+}));
+
+describe("DatabaseMigrationService", () => {
+  const dbAdmin = {} as DatabasePg;
+  const service = new DatabaseMigrationService(dbAdmin);
+  const migrateMock = jest.mocked(migrate);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("runs Drizzle migrations from the API migrations folder", async () => {
+    migrateMock.mockResolvedValue();
+
+    await service.runMigrations();
+
+    expect(migrateMock).toHaveBeenCalledWith(dbAdmin, {
+      migrationsFolder: join(__dirname, "../migrations"),
+    });
+  });
+});

--- a/apps/api/src/storage/db/database-migration.service.ts
+++ b/apps/api/src/storage/db/database-migration.service.ts
@@ -1,0 +1,25 @@
+import { join } from "node:path";
+
+import { Inject, Injectable, Logger } from "@nestjs/common";
+import { migrate } from "drizzle-orm/postgres-js/migrator";
+
+import { DatabasePg } from "src/common";
+
+import { DB_ADMIN } from "./db.providers";
+
+const MIGRATIONS_FOLDER = join(__dirname, "../migrations");
+
+@Injectable()
+export class DatabaseMigrationService {
+  private readonly logger = new Logger(DatabaseMigrationService.name);
+
+  constructor(@Inject(DB_ADMIN) private readonly dbAdmin: DatabasePg) {}
+
+  async runMigrations() {
+    this.logger.log("Running database migrations");
+
+    await migrate(this.dbAdmin, { migrationsFolder: MIGRATIONS_FOLDER });
+
+    this.logger.log("Database migrations completed");
+  }
+}

--- a/apps/api/src/storage/db/db.module.ts
+++ b/apps/api/src/storage/db/db.module.ts
@@ -5,6 +5,7 @@ import { ConfigModule, ConfigService } from "@nestjs/config";
 import { TokenService } from "src/auth/token.service";
 import * as schema from "src/storage/schema";
 
+import { DatabaseMigrationService } from "./database-migration.service";
 import { createDbProxy, DB, DB_APP, DB_ADMIN } from "./db.providers";
 import { TenantDbRunnerService } from "./tenant-db-runner.service";
 import { TenantResolverService } from "./tenant-resolver.service";
@@ -51,6 +52,7 @@ import type { DatabasePg } from "src/common";
       inject: [DB_APP],
       useFactory: (dbApp: DatabasePg) => createDbProxy(dbApp),
     },
+    DatabaseMigrationService,
     TenantDbRunnerService,
     TenantResolverService,
     TenantStateService,
@@ -58,6 +60,7 @@ import type { DatabasePg } from "src/common";
   ],
   exports: [
     DB,
+    DatabaseMigrationService,
     TenantDbRunnerService,
     TenantResolverService,
     TenantStateService,


### PR DESCRIPTION
## Issue(s)
- #1683 

## Overview

Adds API startup database maintenance so the application runs pending Drizzle migrations before permission backfill logic executes.

This introduces a dedicated startup coordinator service that:

- runs database migrations through a DB admin connection on app startup
- runs the existing permissions backfill only after migrations complete
- skips startup maintenance during Jest and build verification runs
- fails startup when migrations fail, preventing the app from running against an outdated schema
- includes migration SQL files in the Nest build output so production startup can read them from `dist`

## Business Value

This reduces deployment risk when bumping versions by making schema migrations part of API startup. It prevents the app from booting with missing database changes and keeps permission data synchronized automatically after migrations are applied.
