### PR TITLE
feat: add keyboard shortcuts for easier video playback control

### DIFF
--- a/apps/web/app/components/VideoPlayer/Video.tsx
+++ b/apps/web/app/components/VideoPlayer/Video.tsx
@@ -88,6 +88,7 @@ export function Video({ src, url, provider, index = null, onEnded, coverageTrack
               provider={resolvedProvider ?? VIDEO_EMBED_PROVIDERS.UNKNOWN}
               url={resolvedUrl}
               autoPlay
+              focusOnMount
               onAspectRatioChange={setAspectRatio}
               onEnded={handleEnded}
               coverageTracking={coverageTracking}

--- a/apps/web/app/components/VideoPlayer/VideoPlayer.tsx
+++ b/apps/web/app/components/VideoPlayer/VideoPlayer.tsx
@@ -32,12 +32,14 @@ import { useVideoCoverageTracker } from "./useVideoCoverageTracker";
 
 import type { VideoAspectRatio } from "./aspectRatio";
 import type { VideoCoverageTrackingOptions } from "./videoCoverage.types";
+import type { KeyboardEvent } from "react";
 
 interface VideoPlayerProps {
   url: string;
   onAspectRatioChange?: (aspectRatio: VideoAspectRatio) => void;
   onEnded?: () => void;
   autoPlay?: boolean;
+  focusOnMount?: boolean;
   fill?: boolean;
   className?: string;
   provider: VideoProvider;
@@ -48,10 +50,76 @@ type VideoJSType = ReturnType<typeof videojs>;
 type VideoJsPlayerWithQualityLevels = VideoJSType & {
   qualityLevels?: () => HlsQualityLevelList;
 };
+type VideoJsPlayerWithFullscreenSetter = VideoJSType & {
+  isFullscreen: {
+    (): boolean;
+    (isFullscreen: boolean): void;
+  };
+};
+type VideoJsPlayerWithUserActivity = VideoJSType & {
+  userActive?: (isActive: boolean) => void;
+};
 
 const PLAYBACK_RATES = [0.5, 0.75, 1, 1.25, 1.5, 2];
 const HLS_MIME_TYPE = "application/vnd.apple.mpegurl";
 const MP4_MIME_TYPE = "video/mp4";
+const KEYBOARD_SEEK_SECONDS = 5;
+const KEYBOARD_VOLUME_STEP = 0.1;
+const KEYBOARD_SHORTCUT_IGNORED_TARGET_SELECTOR = [
+  "a",
+  "button",
+  "input",
+  "select",
+  "textarea",
+  "[contenteditable='true']",
+  "[role='button']",
+  "[role='menu']",
+  "[role='menuitem']",
+  "[role='option']",
+  "[tabindex]:not([data-video-player-shortcuts])",
+  ".vjs-control",
+  ".vjs-menu",
+  ".mentingo-vjs-quality-selector",
+].join(",");
+const PLAYER_CONTROLS_TARGET_SELECTOR = [
+  ".vjs-control-bar",
+  ".vjs-control",
+  ".vjs-menu",
+  ".mentingo-vjs-quality-selector",
+].join(",");
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const isKeyboardShortcutIgnoredTarget = (
+  target: EventTarget | null,
+  currentTarget: HTMLElement,
+) => {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target === currentTarget) return false;
+
+  return Boolean(target.closest(KEYBOARD_SHORTCUT_IGNORED_TARGET_SELECTOR));
+};
+
+const isPlayerControlsTarget = (target: EventTarget | null) =>
+  target instanceof HTMLElement && Boolean(target.closest(PLAYER_CONTROLS_TARGET_SELECTOR));
+
+const getFiniteNumber = (value: number | undefined) =>
+  typeof value === "number" && Number.isFinite(value) ? value : null;
+
+const syncVideoJsFullscreenState = (player: VideoJSType, isFullscreen: boolean) => {
+  (player as VideoJsPlayerWithFullscreenSetter).isFullscreen(isFullscreen);
+};
+
+const setVideoJsUserActive = (player: VideoJSType | null, isActive: boolean) => {
+  (player as VideoJsPlayerWithUserActivity | null)?.userActive?.(isActive);
+};
+
+const eventPathIncludesElement = (event: Event, element: Element | null | undefined) => {
+  if (!element) return false;
+
+  const path = event.composedPath();
+  return path.includes(element);
+};
 
 const enableCustomControls = (player: VideoJSType) => {
   player.controls(true);
@@ -96,6 +164,7 @@ export const VideoPlayer = ({
   onAspectRatioChange,
   onEnded,
   autoPlay = false,
+  focusOnMount = false,
   fill = true,
   className,
   coverageTracking,
@@ -116,6 +185,7 @@ export const VideoPlayer = ({
   const onAspectRatioChangeRef = useRef(onAspectRatioChange);
   const onEndedRef = useRef(onEnded);
   const controlsVisibilityTimeoutRef = useRef<number | null>(null);
+  const controlsInteractionActiveRef = useRef(false);
   const coverage = useVideoCoverageTracker(
     player,
     coverageTracking ?? {
@@ -139,12 +209,14 @@ export const VideoPlayer = ({
   }, []);
 
   const showControls = useCallback(() => {
+    setVideoJsUserActive(playerRef.current, true);
     setControlsVisible(true);
     clearControlsVisibilityTimer();
   }, [clearControlsVisibilityTimer]);
 
   const hideControls = useCallback(() => {
     clearControlsVisibilityTimer();
+    setVideoJsUserActive(playerRef.current, false);
     setControlsVisible(false);
   }, [clearControlsVisibilityTimer]);
 
@@ -188,9 +260,154 @@ export const VideoPlayer = ({
     [setHlsSelection],
   );
 
+  const togglePlay = useCallback((player: VideoJSType) => {
+    if (player.paused()) {
+      void player.play()?.catch(() => undefined);
+      return;
+    }
+
+    player.pause();
+  }, []);
+
+  const seekBy = useCallback((player: VideoJSType, secondsDelta: number) => {
+    const currentTime = getFiniteNumber(player.currentTime()) ?? 0;
+    const duration = getFiniteNumber(player.duration());
+    const maxTime = duration ?? Number.MAX_SAFE_INTEGER;
+
+    player.currentTime(clamp(currentTime + secondsDelta, 0, maxTime));
+  }, []);
+
+  const setVolumeBy = useCallback((player: VideoJSType, volumeDelta: number) => {
+    const currentVolume = getFiniteNumber(player.volume()) ?? 0;
+    const nextVolume = clamp(currentVolume + volumeDelta, 0, 1);
+
+    player.volume(nextVolume);
+
+    if (nextVolume > 0 && player.muted()) {
+      player.muted(false);
+    }
+  }, []);
+
+  const toggleFullscreen = useCallback((player: VideoJSType) => {
+    const container = containerRef.current;
+    const playerElement = player.el();
+    const fullscreenElement = document.fullscreenElement;
+    const isFullscreen =
+      fullscreenElement === container ||
+      fullscreenElement === playerElement ||
+      player.isFullscreen();
+
+    if (isFullscreen) {
+      if (document.fullscreenElement && document.exitFullscreen) {
+        void document.exitFullscreen().catch(() => {
+          void player.exitFullscreen()?.catch(() => undefined);
+        });
+        return;
+      }
+
+      void player.exitFullscreen()?.catch(() => undefined);
+      return;
+    }
+
+    if (container?.requestFullscreen) {
+      void container.requestFullscreen().catch(() => {
+        void player.requestFullscreen()?.catch(() => undefined);
+      });
+      return;
+    }
+
+    void player.requestFullscreen()?.catch(() => undefined);
+  }, []);
+
+  const runKeyboardShortcut = useCallback(
+    (
+      event: Pick<
+        KeyboardEvent<HTMLDivElement> | globalThis.KeyboardEvent,
+        "key" | "target" | "preventDefault" | "stopPropagation"
+      >,
+      currentTarget: HTMLElement,
+    ) => {
+      if (isPlayerControlsTarget(event.target)) {
+        showControls();
+      }
+
+      if (isKeyboardShortcutIgnoredTarget(event.target, currentTarget)) return;
+
+      const currentPlayer = playerRef.current;
+      if (!currentPlayer || currentPlayer.isDisposed()) return;
+
+      if (
+        event.key !== " " &&
+        event.key !== "Enter" &&
+        event.key !== "ArrowLeft" &&
+        event.key !== "ArrowRight" &&
+        event.key !== "ArrowUp" &&
+        event.key !== "ArrowDown" &&
+        event.key.toLowerCase() !== "m" &&
+        event.key.toLowerCase() !== "f" &&
+        event.key !== "0"
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      showControls();
+
+      switch (event.key) {
+        case " ":
+        case "Enter":
+          togglePlay(currentPlayer);
+          return;
+        case "ArrowLeft":
+          seekBy(currentPlayer, -KEYBOARD_SEEK_SECONDS);
+          return;
+        case "ArrowRight":
+          seekBy(currentPlayer, KEYBOARD_SEEK_SECONDS);
+          return;
+        case "ArrowUp":
+          setVolumeBy(currentPlayer, KEYBOARD_VOLUME_STEP);
+          return;
+        case "ArrowDown":
+          setVolumeBy(currentPlayer, -KEYBOARD_VOLUME_STEP);
+          return;
+        case "0":
+          currentPlayer.currentTime(0);
+          return;
+        default:
+          break;
+      }
+
+      if (event.key.toLowerCase() === "m") {
+        currentPlayer.muted(!currentPlayer.muted());
+        return;
+      }
+
+      if (event.key.toLowerCase() === "f") {
+        toggleFullscreen(currentPlayer);
+      }
+    },
+    [seekBy, setVolumeBy, showControls, toggleFullscreen, togglePlay],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      runKeyboardShortcut(event, event.currentTarget);
+    },
+    [runKeyboardShortcut],
+  );
+
   useEffect(() => {
     qualityControlHost?.classList.toggle("vjs-hidden", hlsQualityOptions.length === 0);
   }, [hlsQualityOptions.length, qualityControlHost]);
+
+  useEffect(() => {
+    if (!focusOnMount) return;
+
+    window.requestAnimationFrame(() => {
+      containerRef.current?.focus({ preventScroll: true });
+    });
+  }, [focusOnMount, url]);
 
   const resolvedProvider = useMemo(
     () => (provider === VIDEO_EMBED_PROVIDERS.UNKNOWN ? detectVideoProviderFromUrl(url) : provider),
@@ -225,6 +442,8 @@ export const VideoPlayer = ({
 
     const videoElement = document.createElement("video-js");
     videoElement.classList.add("mentingo-video-js");
+    videoElement.setAttribute("data-video-player-shortcuts", "");
+    videoElement.setAttribute("tabindex", "0");
     videoRef.current?.appendChild(videoElement);
 
     const player = (playerRef.current = videojs(videoElement, options));
@@ -363,24 +582,148 @@ export const VideoPlayer = ({
     if (!container) return;
 
     const handleShowControls = () => showControls();
-    const handleHideControls = () => hideControls();
+    const handleHideControls = () => {
+      if (controlsInteractionActiveRef.current) {
+        showControls();
+        return;
+      }
 
-    container.addEventListener("mouseenter", handleShowControls);
-    container.addEventListener("mousemove", handleShowControls);
-    container.addEventListener("pointerdown", handleShowControls);
-    container.addEventListener("pointerleave", handleHideControls);
-    container.addEventListener("touchstart", handleShowControls, { passive: true });
-    container.addEventListener("mouseleave", handleHideControls);
+      hideControls();
+    };
+    const handleControlsInteractionStart = (event: Event) => {
+      if (!isPlayerControlsTarget(event.target)) return;
+
+      controlsInteractionActiveRef.current = true;
+      showControls();
+    };
+    const handleControlsInteraction = (event: Event) => {
+      if (!isPlayerControlsTarget(event.target)) return;
+
+      showControls();
+    };
+    const handleControlsInteractionEnd = () => {
+      controlsInteractionActiveRef.current = false;
+    };
+    const targets = new Set<HTMLElement>([container]);
+    const playerElement = player?.el() as HTMLElement | undefined;
+
+    if (playerElement) {
+      targets.add(playerElement);
+    }
+
+    targets.forEach((target) => {
+      target.addEventListener("mouseenter", handleShowControls);
+      target.addEventListener("mousemove", handleShowControls);
+      target.addEventListener("pointerdown", handleShowControls);
+      target.addEventListener("pointerdown", handleControlsInteractionStart, true);
+      target.addEventListener("pointermove", handleControlsInteraction, true);
+      target.addEventListener("click", handleControlsInteraction, true);
+      target.addEventListener("focusin", handleControlsInteraction, true);
+      target.addEventListener("keydown", handleControlsInteraction, true);
+      target.addEventListener("pointerleave", handleHideControls);
+      target.addEventListener("touchstart", handleShowControls, { passive: true });
+      target.addEventListener("mouseleave", handleHideControls);
+    });
+    document.addEventListener("pointerup", handleControlsInteractionEnd);
+    document.addEventListener("pointercancel", handleControlsInteractionEnd);
 
     return () => {
-      container.removeEventListener("mouseenter", handleShowControls);
-      container.removeEventListener("mousemove", handleShowControls);
-      container.removeEventListener("pointerdown", handleShowControls);
-      container.removeEventListener("pointerleave", handleHideControls);
-      container.removeEventListener("touchstart", handleShowControls);
-      container.removeEventListener("mouseleave", handleHideControls);
+      targets.forEach((target) => {
+        target.removeEventListener("mouseenter", handleShowControls);
+        target.removeEventListener("mousemove", handleShowControls);
+        target.removeEventListener("pointerdown", handleShowControls);
+        target.removeEventListener("pointerdown", handleControlsInteractionStart, true);
+        target.removeEventListener("pointermove", handleControlsInteraction, true);
+        target.removeEventListener("click", handleControlsInteraction, true);
+        target.removeEventListener("focusin", handleControlsInteraction, true);
+        target.removeEventListener("keydown", handleControlsInteraction, true);
+        target.removeEventListener("pointerleave", handleHideControls);
+        target.removeEventListener("touchstart", handleShowControls);
+        target.removeEventListener("mouseleave", handleHideControls);
+      });
+      document.removeEventListener("pointerup", handleControlsInteractionEnd);
+      document.removeEventListener("pointercancel", handleControlsInteractionEnd);
     };
-  }, [hideControls, showControls]);
+  }, [hideControls, player, showControls]);
+
+  useEffect(() => {
+    if (!player) return;
+
+    const playerElement = player.el() as HTMLElement;
+    const handlePlayerKeyDown = (event: Event) => {
+      runKeyboardShortcut(event as globalThis.KeyboardEvent, playerElement);
+    };
+
+    playerElement.setAttribute("data-video-player-shortcuts", "");
+    playerElement.setAttribute("tabindex", "0");
+    playerElement.addEventListener("keydown", handlePlayerKeyDown);
+
+    return () => {
+      playerElement.removeEventListener("keydown", handlePlayerKeyDown);
+    };
+  }, [player, runKeyboardShortcut]);
+
+  useEffect(() => {
+    if (!player) return;
+
+    const getEventScope = (event: Event) => {
+      const container = containerRef.current;
+      const playerElement = player.el();
+
+      if (eventPathIncludesElement(event, container)) return "container";
+      if (eventPathIncludesElement(event, playerElement)) return "player";
+
+      return null;
+    };
+    const handleDocumentPlayerInteraction = (event: Event) => {
+      const scope = getEventScope(event);
+
+      if (!scope) return;
+
+      showControls();
+    };
+
+    document.addEventListener("pointermove", handleDocumentPlayerInteraction, true);
+    document.addEventListener("pointerdown", handleDocumentPlayerInteraction, true);
+    document.addEventListener("click", handleDocumentPlayerInteraction, true);
+    document.addEventListener("keydown", handleDocumentPlayerInteraction, true);
+
+    return () => {
+      document.removeEventListener("pointermove", handleDocumentPlayerInteraction, true);
+      document.removeEventListener("pointerdown", handleDocumentPlayerInteraction, true);
+      document.removeEventListener("click", handleDocumentPlayerInteraction, true);
+      document.removeEventListener("keydown", handleDocumentPlayerInteraction, true);
+    };
+  }, [player, showControls]);
+
+  useEffect(() => {
+    if (!player) return;
+
+    const syncFullscreenState = () => {
+      window.requestAnimationFrame(() => {
+        const container = containerRef.current;
+        const fullscreenElement = document.fullscreenElement;
+        const isFullscreen =
+          fullscreenElement === container ||
+          (!!fullscreenElement && fullscreenElement === player.el());
+
+        syncVideoJsFullscreenState(player, isFullscreen);
+
+        if (!isFullscreen) return;
+
+        showControls();
+        if (fullscreenElement instanceof HTMLElement) {
+          fullscreenElement.focus({ preventScroll: true });
+        }
+      });
+    };
+
+    document.addEventListener("fullscreenchange", syncFullscreenState);
+
+    return () => {
+      document.removeEventListener("fullscreenchange", syncFullscreenState);
+    };
+  }, [player, showControls]);
 
   useEffect(() => {
     return () => {
@@ -437,6 +780,11 @@ export const VideoPlayer = ({
     <div
       ref={containerRef}
       data-vjs-player
+      data-video-player-shortcuts
+      role="button"
+      aria-label="Video player"
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
       className={cn(
         "relative w-full overflow-hidden bg-black",
         !controlsVisible && "mentingo-video-player--controls-hidden",

--- a/apps/web/app/components/VideoPlayer/VideoPlayer.tsx
+++ b/apps/web/app/components/VideoPlayer/VideoPlayer.tsx
@@ -5,6 +5,7 @@ import {
   type VideoProvider,
   VIDEO_EMBED_PROVIDERS,
 } from "@repo/shared";
+import { clamp } from "lodash-es";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { match } from "ts-pattern";
@@ -65,6 +66,17 @@ const HLS_MIME_TYPE = "application/vnd.apple.mpegurl";
 const MP4_MIME_TYPE = "video/mp4";
 const KEYBOARD_SEEK_SECONDS = 5;
 const KEYBOARD_VOLUME_STEP = 0.1;
+const KEYBOARD_SHORTCUT_KEYS = [
+  " ",
+  "enter",
+  "arrowleft",
+  "arrowright",
+  "arrowup",
+  "arrowdown",
+  "m",
+  "f",
+  "0",
+];
 const KEYBOARD_SHORTCUT_IGNORED_TARGET_SELECTOR = [
   "a",
   "button",
@@ -87,8 +99,6 @@ const PLAYER_CONTROLS_TARGET_SELECTOR = [
   ".vjs-menu",
   ".mentingo-vjs-quality-selector",
 ].join(",");
-
-const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
 
 const isKeyboardShortcutIgnoredTarget = (
   target: EventTarget | null,
@@ -336,55 +346,39 @@ export const VideoPlayer = ({
       const currentPlayer = playerRef.current;
       if (!currentPlayer || currentPlayer.isDisposed()) return;
 
-      if (
-        event.key !== " " &&
-        event.key !== "Enter" &&
-        event.key !== "ArrowLeft" &&
-        event.key !== "ArrowRight" &&
-        event.key !== "ArrowUp" &&
-        event.key !== "ArrowDown" &&
-        event.key.toLowerCase() !== "m" &&
-        event.key.toLowerCase() !== "f" &&
-        event.key !== "0"
-      ) {
-        return;
-      }
+      const keyboardShortcutKey = event.key.toLowerCase();
+
+      if (!KEYBOARD_SHORTCUT_KEYS.includes(keyboardShortcutKey)) return;
 
       event.preventDefault();
       event.stopPropagation();
       showControls();
 
-      switch (event.key) {
+      switch (keyboardShortcutKey) {
         case " ":
-        case "Enter":
+        case "enter":
           togglePlay(currentPlayer);
           return;
-        case "ArrowLeft":
+        case "arrowleft":
           seekBy(currentPlayer, -KEYBOARD_SEEK_SECONDS);
           return;
-        case "ArrowRight":
+        case "arrowright":
           seekBy(currentPlayer, KEYBOARD_SEEK_SECONDS);
           return;
-        case "ArrowUp":
+        case "arrowup":
           setVolumeBy(currentPlayer, KEYBOARD_VOLUME_STEP);
           return;
-        case "ArrowDown":
+        case "arrowdown":
           setVolumeBy(currentPlayer, -KEYBOARD_VOLUME_STEP);
           return;
         case "0":
           currentPlayer.currentTime(0);
           return;
-        default:
-          break;
-      }
-
-      if (event.key.toLowerCase() === "m") {
-        currentPlayer.muted(!currentPlayer.muted());
-        return;
-      }
-
-      if (event.key.toLowerCase() === "f") {
-        toggleFullscreen(currentPlayer);
+        case "m":
+          currentPlayer.muted(!currentPlayer.muted());
+          return;
+        case "f":
+          toggleFullscreen(currentPlayer);
       }
     },
     [seekBy, setVolumeBy, showControls, toggleFullscreen, togglePlay],

--- a/apps/web/app/components/VideoPlayer/__tests__/VideoPlayer.test.tsx
+++ b/apps/web/app/components/VideoPlayer/__tests__/VideoPlayer.test.tsx
@@ -1,0 +1,254 @@
+import { VIDEO_EMBED_PROVIDERS } from "@repo/shared";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWith } from "~/utils/testUtils";
+
+import { VideoPlayer } from "../VideoPlayer";
+
+type PlayerListener = () => void;
+
+class FakeVideoJsPlayer {
+  readonly element = document.createElement("div");
+
+  private listeners = new Map<string, Set<PlayerListener>>();
+  private videoTime = 20;
+  private durationValue = 100;
+  private volumeValue = 0.5;
+  private mutedValue = false;
+  private pausedValue = true;
+  private fullscreenValue = false;
+  private disposedValue = false;
+
+  controls = vi.fn();
+  removeClass = vi.fn();
+  addClass = vi.fn();
+  userActive = vi.fn();
+  src = vi.fn();
+  load = vi.fn();
+  error = vi.fn(() => null);
+  videoWidth = vi.fn(() => 1920);
+  videoHeight = vi.fn(() => 1080);
+  readyState = vi.fn(() => 1);
+  el = vi.fn(() => this.element);
+  dispose = vi.fn(() => {
+    this.disposedValue = true;
+  });
+
+  ready(listener: PlayerListener) {
+    listener();
+  }
+
+  on(eventName: string, listener: PlayerListener) {
+    const listeners = this.listeners.get(eventName) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(eventName, listeners);
+
+    return this;
+  }
+
+  off(eventName: string, listener: PlayerListener) {
+    this.listeners.get(eventName)?.delete(listener);
+
+    return this;
+  }
+
+  one(eventName: string, listener: PlayerListener) {
+    const wrappedListener = () => {
+      this.off(eventName, wrappedListener);
+      listener();
+    };
+
+    return this.on(eventName, wrappedListener);
+  }
+
+  currentTime(value?: number) {
+    if (value !== undefined) {
+      this.videoTime = value;
+    }
+
+    return this.videoTime;
+  }
+
+  duration() {
+    return this.durationValue;
+  }
+
+  volume(value?: number) {
+    if (value !== undefined) {
+      this.volumeValue = value;
+    }
+
+    return this.volumeValue;
+  }
+
+  muted(value?: boolean) {
+    if (value !== undefined) {
+      this.mutedValue = value;
+    }
+
+    return this.mutedValue;
+  }
+
+  paused() {
+    return this.pausedValue;
+  }
+
+  play = vi.fn(() => {
+    this.pausedValue = false;
+
+    return Promise.resolve();
+  });
+
+  pause = vi.fn(() => {
+    this.pausedValue = true;
+  });
+
+  isFullscreen(value?: boolean) {
+    if (value !== undefined) {
+      this.fullscreenValue = value;
+    }
+
+    return this.fullscreenValue;
+  }
+
+  requestFullscreen = vi.fn(() => {
+    this.fullscreenValue = true;
+  });
+
+  exitFullscreen = vi.fn(() => {
+    this.fullscreenValue = false;
+  });
+
+  isDisposed() {
+    return this.disposedValue;
+  }
+}
+
+const addHlsQualityControlComponent = vi.fn(() => document.createElement("div"));
+let player: FakeVideoJsPlayer;
+
+vi.mock("videojs-youtube", () => ({}));
+vi.mock("../videojs-vimeo-tech", () => ({}));
+vi.mock("../hlsQualityControlComponent", () => ({
+  addHlsQualityControlComponent: () => addHlsQualityControlComponent(),
+}));
+vi.mock("video.js", () => ({
+  default: vi.fn(() => player),
+}));
+
+const renderPlayer = async () => {
+  const view = renderWith({ withQuery: true }).render(
+    <VideoPlayer provider={VIDEO_EMBED_PROVIDERS.SELF} url="https://example.com/video.mp4" />,
+  );
+  await waitFor(() =>
+    expect(view.container.querySelector("[data-vjs-player]")).toBeInTheDocument(),
+  );
+
+  return {
+    ...view,
+    playerContainer: view.container.querySelector("[data-vjs-player]") as HTMLElement,
+  };
+};
+
+describe("VideoPlayer keyboard shortcuts", () => {
+  beforeEach(() => {
+    player = new FakeVideoJsPlayer();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("toggles playback with space", async () => {
+    const { playerContainer } = await renderPlayer();
+
+    fireEvent.keyDown(playerContainer, { key: " " });
+    expect(player.play).toHaveBeenCalledTimes(1);
+
+    fireEvent.keyDown(playerContainer, { key: " " });
+    expect(player.pause).toHaveBeenCalledTimes(1);
+  });
+
+  it("seeks backward and forward by five seconds", async () => {
+    const { playerContainer } = await renderPlayer();
+
+    fireEvent.keyDown(playerContainer, { key: "ArrowRight" });
+    expect(player.currentTime()).toBe(25);
+
+    fireEvent.keyDown(playerContainer, { key: "ArrowLeft" });
+    expect(player.currentTime()).toBe(20);
+  });
+
+  it("clamps seek shortcuts to the video duration", async () => {
+    const { playerContainer } = await renderPlayer();
+
+    player.currentTime(98);
+    fireEvent.keyDown(playerContainer, { key: "ArrowRight" });
+    expect(player.currentTime()).toBe(100);
+
+    player.currentTime(2);
+    fireEvent.keyDown(playerContainer, { key: "ArrowLeft" });
+    expect(player.currentTime()).toBe(0);
+  });
+
+  it("adjusts volume with arrow up and down", async () => {
+    const { playerContainer } = await renderPlayer();
+
+    fireEvent.keyDown(playerContainer, { key: "ArrowUp" });
+    expect(player.volume()).toBeCloseTo(0.6);
+
+    fireEvent.keyDown(playerContainer, { key: "ArrowDown" });
+    expect(player.volume()).toBeCloseTo(0.5);
+  });
+
+  it("toggles mute, restarts, and toggles fullscreen", async () => {
+    const { playerContainer } = await renderPlayer();
+
+    fireEvent.keyDown(playerContainer, { key: "m" });
+    expect(player.muted()).toBe(true);
+
+    fireEvent.keyDown(playerContainer, { key: "0" });
+    expect(player.currentTime()).toBe(0);
+
+    fireEvent.keyDown(playerContainer, { key: "f" });
+    expect(player.requestFullscreen).toHaveBeenCalledTimes(1);
+
+    fireEvent.keyDown(playerContainer, { key: "f" });
+    expect(player.exitFullscreen).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps shortcuts working on the inner player element after fullscreen", async () => {
+    await renderPlayer();
+
+    fireEvent.keyDown(player.element, { key: " " });
+
+    expect(player.play).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the bottom bar when keyboard events come from player controls", async () => {
+    const { playerContainer } = await renderPlayer();
+    const controlButton = document.createElement("button");
+    controlButton.className = "vjs-control";
+    controlButton.textContent = "Play";
+    playerContainer.appendChild(controlButton);
+
+    fireEvent.mouseLeave(playerContainer);
+    expect(playerContainer).toHaveClass("mentingo-video-player--controls-hidden");
+
+    fireEvent.keyDown(controlButton, { key: " " });
+    expect(playerContainer).not.toHaveClass("mentingo-video-player--controls-hidden");
+  });
+
+  it("ignores shortcuts from interactive descendants", async () => {
+    const { playerContainer } = await renderPlayer();
+    const button = document.createElement("button");
+    button.textContent = "Control";
+    playerContainer.appendChild(button);
+
+    fireEvent.keyDown(screen.getByRole("button", { name: "Control" }), { key: " " });
+
+    expect(player.play).not.toHaveBeenCalled();
+    expect(player.pause).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/components/VideoPlayer/videoPlayer.css
+++ b/apps/web/app/components/VideoPlayer/videoPlayer.css
@@ -66,7 +66,29 @@
 
 .mentingo-video-player--controls-hidden .mentingo-video-js .vjs-control-bar {
   opacity: 0 !important;
-  pointer-events: none;
+  visibility: visible !important;
+  pointer-events: auto !important;
+}
+
+.mentingo-video-player--controls-hidden .mentingo-video-js.vjs-user-active .vjs-control-bar,
+.mentingo-video-player--controls-hidden .mentingo-video-js.vjs-scrubbing .vjs-control-bar,
+.mentingo-video-player--controls-hidden .mentingo-video-js:focus-within .vjs-control-bar,
+.mentingo-video-player--controls-hidden
+  .mentingo-video-js:has(.vjs-control-bar:hover)
+  .vjs-control-bar,
+.mentingo-video-player--controls-hidden .mentingo-video-js:has(.vjs-slider-active) .vjs-control-bar,
+.mentingo-video-player--controls-hidden
+  .mentingo-video-js:has(.vjs-menu-button.vjs-hover)
+  .vjs-control-bar,
+.mentingo-video-player--controls-hidden
+  .mentingo-video-js:has(.vjs-menu.vjs-lock-showing)
+  .vjs-control-bar,
+.mentingo-video-player--controls-hidden
+  .mentingo-video-js:has(.mentingo-vjs-quality-selector__menu)
+  .vjs-control-bar {
+  visibility: visible !important;
+  opacity: 1 !important;
+  pointer-events: auto !important;
 }
 
 .mentingo-video-js .vjs-control-bar,

--- a/apps/web/app/modules/LiveTraining/components/LiveTrainingMeeting/LiveTrainingParticipantGrid.tsx
+++ b/apps/web/app/modules/LiveTraining/components/LiveTrainingMeeting/LiveTrainingParticipantGrid.tsx
@@ -235,6 +235,7 @@ export function LiveTrainingParticipantGrid({
     : [];
   const participantGridStyle = {
     "--participant-grid-columns": getDesiredGridColumns(participantEntries.length),
+    "--participant-grid-mobile-columns": Math.min(2, Math.max(1, participantEntries.length)),
   } as CSSProperties;
 
   useEffect(() => {
@@ -345,7 +346,7 @@ export function LiveTrainingParticipantGrid({
     <div className="flex size-full min-h-0 min-w-0 overflow-x-hidden overflow-y-auto">
       <motion.div
         layout
-        className="flex min-h-full w-full min-w-0 flex-wrap items-center justify-center gap-3 [align-content:safe_center]"
+        className="grid min-h-full w-full min-w-0 items-center justify-center gap-3 [align-content:safe_center] [grid-template-columns:repeat(var(--participant-grid-mobile-columns),minmax(0,1fr))] lg:[grid-template-columns:repeat(var(--participant-grid-columns),minmax(0,1fr))]"
         style={participantGridStyle}
       >
         {participantEntries.map((entry) => (
@@ -353,12 +354,9 @@ export function LiveTrainingParticipantGrid({
             layout
             layoutId={getTrackEntryLayoutId(entry.key)}
             key={entry.key}
-            className={cn(
-              "aspect-[16/10] min-h-[11rem] min-w-0 flex-none basis-full min-[520px]:basis-[calc((100%_-_12px)_/_2)] lg:basis-[calc((100%_-_12px_*_(var(--participant-grid-columns)_-_1))_/_var(--participant-grid-columns))]",
-              {
-                "max-w-[min(100%,calc(160dvh_-_19.2rem))]": participantEntries.length === 1,
-              },
-            )}
+            className={cn("aspect-[16/10] min-h-0 w-full min-w-0 justify-self-center", {
+              "max-w-[min(100%,calc(160dvh_-_19.2rem))]": participantEntries.length === 1,
+            })}
             transition={layoutTransition}
           >
             <LiveTrainingParticipantTile

--- a/apps/web/app/modules/LiveTraining/components/LiveTrainingMeeting/LiveTrainingParticipantGrid.tsx
+++ b/apps/web/app/modules/LiveTraining/components/LiveTrainingMeeting/LiveTrainingParticipantGrid.tsx
@@ -233,9 +233,21 @@ export function LiveTrainingParticipantGrid({
         ...participantEntries,
       ]
     : [];
+  const participantGridColumns = getDesiredGridColumns(participantEntries.length);
+  const participantGridRows = Math.max(
+    1,
+    Math.ceil(participantEntries.length / participantGridColumns),
+  );
+  const participantGridMobileColumns = 1;
+  const participantGridMobileRows = Math.max(
+    1,
+    Math.ceil(participantEntries.length / participantGridMobileColumns),
+  );
   const participantGridStyle = {
-    "--participant-grid-columns": getDesiredGridColumns(participantEntries.length),
-    "--participant-grid-mobile-columns": Math.min(2, Math.max(1, participantEntries.length)),
+    "--participant-grid-columns": participantGridColumns,
+    "--participant-grid-mobile-columns": participantGridMobileColumns,
+    "--participant-card-width": `min(calc((100cqw - 12px * (${participantGridMobileColumns} - 1)) / ${participantGridMobileColumns}), calc(((100cqh - 12px * (${participantGridMobileRows} - 1)) / ${participantGridMobileRows}) * 1.6))`,
+    "--participant-card-width-desktop": `min(calc((100cqw - 12px * (${participantGridColumns} - 1)) / ${participantGridColumns}), calc(((100cqh - 12px * (${participantGridRows} - 1)) / ${participantGridRows}) * 1.6))`,
   } as CSSProperties;
 
   useEffect(() => {
@@ -343,10 +355,10 @@ export function LiveTrainingParticipantGrid({
   }
 
   return (
-    <div className="flex size-full min-h-0 min-w-0 overflow-x-hidden overflow-y-auto">
+    <div className="flex size-full min-h-0 min-w-0 items-center justify-center overflow-hidden [container-type:size]">
       <motion.div
         layout
-        className="grid min-h-full w-full min-w-0 items-center justify-center gap-3 [align-content:safe_center] [grid-template-columns:repeat(var(--participant-grid-mobile-columns),minmax(0,1fr))] lg:[grid-template-columns:repeat(var(--participant-grid-columns),minmax(0,1fr))]"
+        className="grid max-h-full w-fit max-w-full min-w-0 items-center justify-center gap-3 [grid-template-columns:repeat(var(--participant-grid-mobile-columns),var(--participant-card-width))] min-[520px]:[grid-template-columns:repeat(var(--participant-grid-columns),var(--participant-card-width-desktop))]"
         style={participantGridStyle}
       >
         {participantEntries.map((entry) => (
@@ -354,9 +366,12 @@ export function LiveTrainingParticipantGrid({
             layout
             layoutId={getTrackEntryLayoutId(entry.key)}
             key={entry.key}
-            className={cn("aspect-[16/10] min-h-0 w-full min-w-0 justify-self-center", {
-              "max-w-[min(100%,calc(160dvh_-_19.2rem))]": participantEntries.length === 1,
-            })}
+            className={cn(
+              "aspect-[16/10] w-[var(--participant-card-width)] max-w-full self-center justify-self-center min-[520px]:w-[var(--participant-card-width-desktop)]",
+              {
+                "max-w-[min(100%,calc(160dvh_-_19.2rem))]": participantEntries.length === 1,
+              },
+            )}
             transition={layoutTransition}
           >
             <LiveTrainingParticipantTile

--- a/docs/specs/lesson-delivery-learning-mode-business-spec.md
+++ b/docs/specs/lesson-delivery-learning-mode-business-spec.md
@@ -19,6 +19,7 @@ The main workflow starts when a learner opens a course and chooses to start or c
 
 - Start or continue a course from the course overview.
 - Render content, quiz, AI mentor, embed, SCORM, and live training lessons.
+- Control lesson videos with focused keyboard shortcuts for play, seeking, volume, mute, restart, and fullscreen.
 - Navigate to previous and next lessons from the learner lesson page.
 - Enforce lesson sequencing when ordered completion is enabled.
 - Keep later lessons locked after unmet requirements, such as a failed required quiz.
@@ -38,6 +39,8 @@ The lesson page loads the selected course and lesson in the active content langu
 
 Each lesson type has its own completion behavior. Content and embed lessons can complete when opened or when required video content finishes. Quiz lessons depend on quiz submission and passing rules. AI mentor, SCORM, and live training lessons use their own lesson-specific state. When sequence mode is enabled, Mentingo blocks access to later lessons until earlier lessons are complete.
 
+For content videos, opening the video focuses the player so learners can use familiar playback shortcuts while the player is active, without those shortcuts taking over the rest of the lesson page.
+
 While the learner studies, the page also runs the learning-time tracker. Completion events update lesson, chapter, and course progress and can trigger downstream completion behavior such as certificates or reporting updates.
 
 ## Key Technical Context
@@ -45,6 +48,7 @@ While the learner studies, the page also runs the learning-time tracker. Complet
 - Learner lesson UI lives in `apps/web/app/modules/Courses/Lesson`.
 - The route is `/course/:courseId/lesson/:lessonId`.
 - Lesson rendering is centralized in `LessonContentRenderer`.
+- Rich-text lesson videos use the shared `VideoPlayer` component for playback controls and focused keyboard shortcuts.
 - Lesson access and progress updates use `PERMISSIONS.LEARNING_PROGRESS_UPDATE` and `PERMISSIONS.LEARNING_MODE_USE`.
 - Progress updates are handled through `apps/api/src/studentLessonProgress`.
 - Learning-time tracking uses `apps/web/app/hooks/useLearningTimeTracker.ts` and `apps/api/src/learning-time`.

--- a/docs/specs/live-training-business-spec.md
+++ b/docs/specs/live-training-business-spec.md
@@ -20,6 +20,7 @@ Administrators create sessions from the Live Training or Calendar workflow, trai
 - Create, edit, and delete standalone or course-linked live training events.
 - Configure delivery type, date, time, location, hosts, maximum participants, and viewer permissions.
 - Start, join, and end live training sessions through permission-controlled actions.
+- Keep online room participants arranged in a stable responsive grid, including balanced 2x2 layout for four participants.
 - Attach before-session and after-session materials.
 - Link sessions to course lessons so session completion can contribute to learning progress.
 - Restrict learner material visibility based on the session lifecycle.
@@ -38,6 +39,8 @@ Administrators create a live training item with title, schedule, delivery type, 
 
 When LiveKit is configured, online sessions expose join-room behavior. When it is not configured, online delivery is not selectable and offline sessions remain available. Hosts can start and end sessions. For course-linked offline sessions, ending the session can complete the linked lesson for enrolled learners.
 
+In online rooms, participant tiles adapt to the available stage size so small group sessions remain easy to scan, including a balanced two-by-two arrangement when four camera tiles are visible.
+
 Materials are separated into before-session and after-session resources. Privileged users can manage and preview materials, while learners see resources according to their access and the session lifecycle. Live session state changes are pushed to open pages so learners and hosts see the current session state.
 
 ## Key Technical Context
@@ -47,6 +50,7 @@ Materials are separated into before-session and after-session resources. Privile
 - API endpoints live under `apps/api/src/live-training`.
 - Access is guarded by the Live Training feature flag plus permissions such as `PERMISSIONS.LIVE_TRAINING_READ`, create/update/delete, join, start, end, and statistics.
 - Live Training integrates with Calendar, course lessons, resource uploads, announcements/email, realtime session updates, and LiveKit online rooms.
+- Online room participant layout is handled by the LiveKit-based meeting components in `apps/web/app/modules/LiveTraining/components/LiveTrainingMeeting`.
 
 ## Test Evidence
 


### PR DESCRIPTION
## Issue(s)
- #1641 

## Overview
Adds focused keyboard shortcuts to the shared lesson video player:

- `Space` / `Enter` toggles play and pause.
- Left and right arrows seek backward or forward by 5 seconds.
- Up and down arrows adjust volume.
- `M` toggles mute.
- `0` restarts the video from the beginning.
- `F` toggles fullscreen.

The video player now focuses itself after thumbnail activation so learners can use shortcuts immediately, while shortcut handling stays scoped to the player and avoids inputs, menus, and native player controls.

This also improves player control visibility in fullscreen and while interacting with the control bar, and updates the live training participant grid so four visible participant tiles render as a stable 2x2 layout.

## Business Value
Learners get a smoother video lesson experience with familiar playback shortcuts and more reliable fullscreen controls. This reduces friction during self-paced training, especially for longer video lessons where seeking, muting, and fullscreen playback are common actions.

Live training rooms are easier to scan in small group sessions because the four-participant layout is balanced instead of wrapping unpredictably.

## Screenshots / Video

