### PR TITLE
chore: extend integration API with tenant creation and deactivation endpoints

### DIFF
--- a/apps/api/src/integration/__tests__/integration.controller.e2e-spec.ts
+++ b/apps/api/src/integration/__tests__/integration.controller.e2e-spec.ts
@@ -1,6 +1,11 @@
 import { randomUUID } from "node:crypto";
 
-import { COURSE_ENROLLMENT, SUPPORTED_LANGUAGES, SYSTEM_ROLE_SLUGS } from "@repo/shared";
+import {
+  COURSE_ENROLLMENT,
+  SUPPORTED_LANGUAGES,
+  SYSTEM_ROLE_SLUGS,
+  TENANT_STATUSES,
+} from "@repo/shared";
 import { and, eq, isNull } from "drizzle-orm";
 import request from "supertest";
 
@@ -18,6 +23,7 @@ import {
   studentCourses,
   studentLessonProgress,
   tenants,
+  users,
 } from "src/storage/schema";
 
 import { createE2ETest } from "../../../test/create-e2e-test";
@@ -403,6 +409,124 @@ describe("IntegrationController (e2e)", () => {
         .set("X-API-Key", apiKey)
         .set("X-Tenant-Id", otherTenantId)
         .expect(200);
+    });
+  });
+
+  describe("integration tenant lifecycle endpoints", () => {
+    const createApiKey = async ({ isManaging }: { isManaging: boolean }) => {
+      const admin = await userFactory
+        .withCredentials({ password })
+        .withAdminSettings(db)
+        .create({ role: SYSTEM_ROLE_SLUGS.ADMIN });
+      const cookies = await cookieFor(admin, app);
+
+      await dbAdmin.update(tenants).set({ isManaging }).where(eq(tenants.id, admin.tenantId));
+
+      const rotateResponse = await request(app.getHttpServer())
+        .post("/api/integration/key")
+        .set("Cookie", cookies)
+        .expect(201);
+
+      return {
+        admin,
+        apiKey: rotateResponse.body.data.key as string,
+      };
+    };
+
+    it("allows managing tenant integration key to create tenant", async () => {
+      const { apiKey } = await createApiKey({ isManaging: true });
+      const host = uniqueTenantHost("integration-created-tenant");
+      const adminEmail = `integration-created-${randomUUID()}@example.com`;
+
+      const response = await request(app.getHttpServer())
+        .post("/api/integration/tenants")
+        .set("X-API-Key", apiKey)
+        .send({
+          name: "Integration Created Tenant",
+          host,
+          adminEmail,
+          adminFirstName: "Integration",
+          adminLastName: "Admin",
+          adminLanguage: SUPPORTED_LANGUAGES.EN,
+        })
+        .expect(201);
+
+      expect(response.body.data).toEqual(
+        expect.objectContaining({
+          id: expect.any(String),
+          name: "Integration Created Tenant",
+          host,
+          status: TENANT_STATUSES.ACTIVE,
+          isManaging: false,
+        }),
+      );
+
+      const [createdAdmin] = await dbAdmin
+        .select({ id: users.id, tenantId: users.tenantId, email: users.email })
+        .from(users)
+        .where(
+          and(eq(users.tenantId, response.body.data.id as string), eq(users.email, adminEmail)),
+        )
+        .limit(1);
+
+      expect(createdAdmin).toEqual(
+        expect.objectContaining({
+          tenantId: response.body.data.id,
+          email: adminEmail,
+        }),
+      );
+    });
+
+    it("allows managing tenant integration key to deactivate tenant", async () => {
+      const { apiKey } = await createApiKey({ isManaging: true });
+
+      const [{ id: tenantId }] = await dbAdmin
+        .insert(tenants)
+        .values({
+          name: "Integration Deactivated Tenant",
+          host: uniqueTenantHost("integration-deactivated-tenant"),
+          status: TENANT_STATUSES.ACTIVE,
+        })
+        .returning({ id: tenants.id });
+
+      const response = await request(app.getHttpServer())
+        .post(`/api/integration/tenants/${tenantId}/deactivate`)
+        .set("X-API-Key", apiKey)
+        .expect(201);
+
+      expect(response.body.data).toEqual(
+        expect.objectContaining({
+          id: tenantId,
+          status: TENANT_STATUSES.INACTIVE,
+        }),
+      );
+
+      const [tenant] = await dbAdmin
+        .select({ status: tenants.status })
+        .from(tenants)
+        .where(eq(tenants.id, tenantId))
+        .limit(1);
+
+      expect(tenant.status).toBe(TENANT_STATUSES.INACTIVE);
+    });
+
+    it("rejects tenant creation for non-managing tenant integration key", async () => {
+      const { apiKey } = await createApiKey({ isManaging: false });
+
+      const response = await request(app.getHttpServer())
+        .post("/api/integration/tenants")
+        .set("X-API-Key", apiKey)
+        .send({
+          name: "Rejected Integration Tenant",
+          host: uniqueTenantHost("rejected-integration-tenant"),
+          adminEmail: `rejected-integration-${randomUUID()}@example.com`,
+          adminFirstName: "Rejected",
+          adminLastName: "Admin",
+          adminLanguage: SUPPORTED_LANGUAGES.EN,
+        })
+        .expect(403);
+
+      expect(response.body.message).toBe("superAdminTenants.error.managingTenantRequired");
     });
   });
 

--- a/apps/api/src/integration/decorators/integration-key-tenant.decorator.ts
+++ b/apps/api/src/integration/decorators/integration-key-tenant.decorator.ts
@@ -1,0 +1,25 @@
+import {
+  createParamDecorator,
+  InternalServerErrorException,
+  type ExecutionContext,
+} from "@nestjs/common";
+
+import type {
+  IntegrationKeyTenantContext,
+  IntegrationRequest,
+} from "src/integration/integration.types";
+
+export const IntegrationKeyTenant = createParamDecorator(
+  (_data: unknown, ctx: ExecutionContext): IntegrationKeyTenantContext => {
+    const request = ctx.switchToHttp().getRequest<IntegrationRequest>();
+
+    if (!request.integrationKeyTenantId || request.integrationKeyTenantIsManaging === undefined) {
+      throw new InternalServerErrorException("integrationApiKey.errors.missingKeyTenantContext");
+    }
+
+    return {
+      tenantId: request.integrationKeyTenantId,
+      isManaging: request.integrationKeyTenantIsManaging,
+    };
+  },
+);

--- a/apps/api/src/integration/guards/integration-api-key.guard.ts
+++ b/apps/api/src/integration/guards/integration-api-key.guard.ts
@@ -55,6 +55,8 @@ export class IntegrationApiKeyGuard implements CanActivate {
     req.user = user;
     req.integrationTenantValidated = true;
     req.integrationApiKeyId = keyId;
+    req.integrationKeyTenantId = keyTenantId;
+    req.integrationKeyTenantIsManaging = keyTenantIsManaging;
 
     await this.integrationService.markKeyAsUsed(keyId);
 

--- a/apps/api/src/integration/integration.controller.ts
+++ b/apps/api/src/integration/integration.controller.ts
@@ -40,15 +40,21 @@ import {
 } from "src/group/group.schema";
 import { GroupService } from "src/group/group.service";
 import { GroupSortFieldsOptions, GroupsFilterSchema } from "src/group/group.types";
+import { IntegrationKeyTenant } from "src/integration/decorators/integration-key-tenant.decorator";
 import { IntegrationTenantOptional } from "src/integration/decorators/tenant-optional.decorator";
 import { IntegrationApiKeyGuard } from "src/integration/guards/integration-api-key.guard";
 import { IntegrationService } from "src/integration/integration.service";
+import { IntegrationKeyTenantContext } from "src/integration/integration.types";
 import {
+  integrationCreateTenantSchema,
   integrationDeleteUserResponseSchema,
   integrationMessageResponseSchema,
+  integrationTenantLifecycleResponseSchema,
   integrationTenantsSchema,
   integrationTrainingResultsSchema,
   integrationTrainingResultsScopeSchema,
+  type IntegrationCreateTenantBody,
+  type IntegrationTenantLifecycleResponse,
   setUserGroupsSchema,
   unenrollGroupsPayloadSchema,
   type IntegrationTrainingResult,
@@ -122,6 +128,68 @@ export class IntegrationController {
     @CurrentUser() currentUser: CurrentUserType,
   ): Promise<BaseResponse<IntegrationTenant[]>> {
     return new BaseResponse(await this.integrationService.getTenantsForActor(currentUser));
+  }
+
+  @Post("tenants")
+  @RequirePermission(PERMISSIONS.INTEGRATION_API_USE)
+  @IntegrationTenantOptional()
+  @ApiEndpointDocs({
+    summary: "Create tenant via integration API",
+    description:
+      "Creates a new tenant and invites its initial admin user.\n\nOnly integration API keys owned by a managing tenant with tenant management permission can use this endpoint.",
+    headers: [
+      {
+        ...API_HEADERS.X_TENANT_ID,
+        required: false,
+        description: "Tenant ID is not required because the integration API key owner is used.",
+      },
+    ],
+  })
+  @Validate({
+    request: [{ type: "body", schema: integrationCreateTenantSchema }],
+    response: baseResponse(integrationTenantLifecycleResponseSchema),
+  })
+  async createTenant(
+    @Body() body: IntegrationCreateTenantBody,
+    @CurrentUser() currentUser: CurrentUserType,
+    @IntegrationKeyTenant() keyTenant: IntegrationKeyTenantContext,
+  ): Promise<BaseResponse<IntegrationTenantLifecycleResponse>> {
+    return new BaseResponse(
+      await this.integrationService.createTenantForIntegration(body, currentUser, keyTenant),
+    );
+  }
+
+  @Post("tenants/:tenantId/deactivate")
+  @RequirePermission(PERMISSIONS.INTEGRATION_API_USE)
+  @IntegrationTenantOptional()
+  @ApiEndpointDocs({
+    summary: "Deactivate tenant via integration API",
+    description:
+      "Marks the target tenant as inactive.\n\nOnly integration API keys owned by a managing tenant with tenant management permission can use this endpoint.",
+    headers: [
+      {
+        ...API_HEADERS.X_TENANT_ID,
+        required: false,
+        description: "Tenant ID is not required because the target tenant is in the path.",
+      },
+    ],
+  })
+  @Validate({
+    request: [{ type: "param", name: "tenantId", schema: UUIDSchema }],
+    response: baseResponse(integrationTenantLifecycleResponseSchema),
+  })
+  async deactivateTenant(
+    @Param("tenantId") tenantId: UUIDType,
+    @CurrentUser() currentUser: CurrentUserType,
+    @IntegrationKeyTenant() keyTenant: IntegrationKeyTenantContext,
+  ): Promise<BaseResponse<IntegrationTenantLifecycleResponse>> {
+    return new BaseResponse(
+      await this.integrationService.deactivateTenantForIntegration(
+        tenantId,
+        currentUser,
+        keyTenant,
+      ),
+    );
   }
 
   @Get("users")

--- a/apps/api/src/integration/integration.module.ts
+++ b/apps/api/src/integration/integration.module.ts
@@ -4,6 +4,7 @@ import { CourseModule } from "src/courses/course.module";
 import { GroupModule } from "src/group/group.module";
 import { LocalizationModule } from "src/localization/localization.module";
 import { PermissionsModule } from "src/permissions/permissions.module";
+import { TenantsModule } from "src/super-admin/tenants.module";
 import { UserModule } from "src/user/user.module";
 
 import { IntegrationApiKeyGuard } from "./guards/integration-api-key.guard";
@@ -13,7 +14,14 @@ import { IntegrationRepository } from "./integration.repository";
 import { IntegrationService } from "./integration.service";
 
 @Module({
-  imports: [UserModule, GroupModule, CourseModule, PermissionsModule, LocalizationModule],
+  imports: [
+    UserModule,
+    GroupModule,
+    CourseModule,
+    PermissionsModule,
+    LocalizationModule,
+    TenantsModule,
+  ],
   controllers: [IntegrationController, IntegrationAdminController],
   providers: [IntegrationService, IntegrationRepository, IntegrationApiKeyGuard],
 })

--- a/apps/api/src/integration/integration.service.ts
+++ b/apps/api/src/integration/integration.service.ts
@@ -7,20 +7,27 @@ import {
   InternalServerErrorException,
   UnauthorizedException,
 } from "@nestjs/common";
-import { PERMISSIONS } from "@repo/shared";
+import { PERMISSIONS, TENANT_STATUSES } from "@repo/shared";
 
 import { DatabasePg } from "src/common";
+import { hasPermission } from "src/common/permissions/permission.utils";
 import { PermissionsService } from "src/permissions/permissions.service";
 import { DB_ADMIN } from "src/storage/db/db.providers";
+import { TenantsService } from "src/super-admin/tenants.service";
 
 import { IntegrationRepository } from "./integration.repository";
 
 import type {
   CurrentAdminKeyData,
+  IntegrationKeyTenantContext,
   IntegrationTrainingResultsData,
   IntegrationTrainingResultsQuery,
   RotateAdminKeyData,
 } from "./integration.types";
+import type {
+  IntegrationCreateTenantBody,
+  IntegrationTenantLifecycleResponse,
+} from "./schemas/integration.schema";
 import type { CurrentUserType } from "src/common/types/current-user.type";
 
 @Injectable()
@@ -30,6 +37,7 @@ export class IntegrationService {
   constructor(
     private readonly integrationRepository: IntegrationRepository,
     private readonly permissionsService: PermissionsService,
+    private readonly tenantsService: TenantsService,
     @Inject(DB_ADMIN) private readonly dbAdmin: DatabasePg,
   ) {
     if (!process.env.MASTER_KEY) throw new Error("MASTER_KEY is required for integration API keys");
@@ -136,6 +144,32 @@ export class IntegrationService {
     return this.integrationRepository.getAllTenants();
   }
 
+  async createTenantForIntegration(
+    input: IntegrationCreateTenantBody,
+    actor: CurrentUserType,
+    keyTenant: IntegrationKeyTenantContext,
+  ): Promise<IntegrationTenantLifecycleResponse> {
+    this.assertCanManageTenants(actor, keyTenant);
+
+    const keyTenantActor = { ...actor, tenantId: keyTenant.tenantId };
+
+    return this.tenantsService.createTenant(input, keyTenantActor, {
+      actorLookupTenantId: keyTenant.tenantId,
+    });
+  }
+
+  async deactivateTenantForIntegration(
+    tenantId: string,
+    actor: CurrentUserType,
+    keyTenant: IntegrationKeyTenantContext,
+  ): Promise<IntegrationTenantLifecycleResponse> {
+    this.assertCanManageTenants(actor, keyTenant);
+
+    return this.tenantsService.updateTenantById(tenantId, {
+      status: TENANT_STATUSES.INACTIVE,
+    });
+  }
+
   async getTrainingResults(
     actor: CurrentUserType,
     query: IntegrationTrainingResultsQuery,
@@ -165,5 +199,15 @@ export class IntegrationService {
     if (expected.length !== provided.length) return false;
 
     return timingSafeEqual(expected, provided);
+  }
+
+  private assertCanManageTenants(actor: CurrentUserType, keyTenant: IntegrationKeyTenantContext) {
+    if (!hasPermission(actor.permissions, PERMISSIONS.TENANT_MANAGE)) {
+      throw new ForbiddenException("auth.error.missingPermission");
+    }
+
+    if (!keyTenant.isManaging) {
+      throw new ForbiddenException("superAdminTenants.error.managingTenantRequired");
+    }
   }
 }

--- a/apps/api/src/integration/integration.types.ts
+++ b/apps/api/src/integration/integration.types.ts
@@ -35,6 +35,13 @@ export type IntegrationRequest = Request & {
   user?: CurrentUserType;
   integrationTenantValidated?: boolean;
   integrationApiKeyId?: string;
+  integrationKeyTenantId?: string;
+  integrationKeyTenantIsManaging?: boolean;
+};
+
+export type IntegrationKeyTenantContext = {
+  tenantId: string;
+  isManaging: boolean;
 };
 
 export type CurrentAdminKeyData = {

--- a/apps/api/src/integration/schemas/integration.schema.ts
+++ b/apps/api/src/integration/schemas/integration.schema.ts
@@ -4,6 +4,7 @@ import { UUIDSchema } from "src/common";
 import { enrolledCourseGroupsPayload } from "src/courses/schemas/course.schema";
 import { createCoursesEnrollmentSchema } from "src/courses/schemas/createCoursesEnrollment";
 import { INTEGRATION_TRAINING_RESULTS_SCOPES } from "src/integration/integration.types";
+import { createTenantSchema, tenantResponseSchema } from "src/super-admin/schemas/tenant.schema";
 
 import type { createUserSchema } from "src/user/schemas/createUser.schema";
 import type { updateUserSchema } from "src/user/schemas/updateUser.schema";
@@ -27,6 +28,9 @@ export const integrationTenantSchema = Type.Object({
 });
 
 export const integrationTenantsSchema = Type.Array(integrationTenantSchema);
+
+export const integrationCreateTenantSchema = createTenantSchema;
+export const integrationTenantLifecycleResponseSchema = tenantResponseSchema;
 
 export const integrationTrainingResultsScopeSchema = Type.Union([
   Type.Literal(INTEGRATION_TRAINING_RESULTS_SCOPES.TENANT),
@@ -94,6 +98,10 @@ export const unenrollGroupsPayloadSchema = Type.Object({
 
 export type IntegrationCreateUserBody = Static<typeof createUserSchema>;
 export type IntegrationUpdateUserBody = Static<typeof updateUserSchema>;
+export type IntegrationCreateTenantBody = Static<typeof integrationCreateTenantSchema>;
+export type IntegrationTenantLifecycleResponse = Static<
+  typeof integrationTenantLifecycleResponseSchema
+>;
 export type SetUserGroupsBody = Static<typeof setUserGroupsSchema>;
 export type IntegrationTenant = Static<typeof integrationTenantSchema>;
 export type EnrollUsersPayload = Static<typeof enrollUsersPayloadSchema>;

--- a/apps/api/src/super-admin/tenants.module.ts
+++ b/apps/api/src/super-admin/tenants.module.ts
@@ -11,5 +11,6 @@ import { TenantsService } from "./tenants.service";
   imports: [UserModule],
   controllers: [TenantsController],
   providers: [TenantsService, TenantsRepository, ManagingTenantAdminGuard],
+  exports: [TenantsService],
 })
 export class TenantsModule {}

--- a/apps/api/src/super-admin/tenants.service.ts
+++ b/apps/api/src/super-admin/tenants.service.ts
@@ -20,6 +20,7 @@ import { settingsToJSONBuildObject } from "src/utils/settings-to-json-build-obje
 import { TenantsRepository } from "./tenants.repository";
 
 import type {
+  CreateTenantOptions,
   CreateTenantBody,
   ListTenantsQuery,
   TenantsListItemResponse,
@@ -63,7 +64,11 @@ export class TenantsService {
     };
   }
 
-  async createTenant(input: CreateTenantBody, actor: CurrentUserType) {
+  async createTenant(
+    input: CreateTenantBody,
+    actor: CurrentUserType,
+    options: CreateTenantOptions = {},
+  ) {
     const host = this.normalizeHost(input.host);
 
     const existing = await this.tenantsRepository.findIdByHost(host);
@@ -78,7 +83,7 @@ export class TenantsService {
 
     const { adminFirstName, adminLastName } = input;
 
-    const inviter = await this.userService.getUserById(actor.userId);
+    const inviter = await this.getTenantCreator(actor.userId, options);
     const invitedByUserName = `${inviter.firstName} ${inviter.lastName}`.trim();
 
     await this.tenantRunner.runWithTenant(createdTenant.id, async () => {
@@ -95,21 +100,20 @@ export class TenantsService {
         });
       }
 
-      await this.userService.createUser(
-        {
-          email: input.adminEmail,
-          firstName: adminFirstName,
-          lastName: adminLastName,
-          roleSlugs: [SYSTEM_ROLE_SLUGS.ADMIN],
-          language: input.adminLanguage,
-        },
-        undefined,
-        {
-          flowType: USER_CREATION_FLOW_TYPE.INVITE,
-          invitedByUserName,
-          origin: createdTenant.host,
-        },
-      );
+      const adminUser = {
+        email: input.adminEmail,
+        firstName: adminFirstName,
+        lastName: adminLastName,
+        roleSlugs: [SYSTEM_ROLE_SLUGS.ADMIN],
+        language: input.adminLanguage,
+        tenantId: createdTenant.id,
+      };
+
+      await this.userService.createUser(adminUser, this.db, {
+        flowType: USER_CREATION_FLOW_TYPE.INVITE,
+        invitedByUserName,
+        origin: createdTenant.host,
+      });
     });
 
     await invalidateCorsCache();
@@ -153,5 +157,15 @@ export class TenantsService {
     } catch {
       throw new BadRequestException("superAdminTenants.error.invalidHost");
     }
+  }
+
+  private async getTenantCreator(userId: string, options: CreateTenantOptions) {
+    if (options.actorLookupTenantId) {
+      return this.tenantRunner.runWithTenant(options.actorLookupTenantId, () =>
+        this.userService.getUserById(userId),
+      );
+    }
+
+    return this.userService.getUserById(userId);
   }
 }

--- a/apps/api/src/super-admin/types.ts
+++ b/apps/api/src/super-admin/types.ts
@@ -45,6 +45,10 @@ export type CreateTenantRecord = {
   status: TenantStatus;
 };
 
+export type CreateTenantOptions = {
+  actorLookupTenantId?: string;
+};
+
 export type UpdateTenantRecord = {
   name?: string;
   host?: string;

--- a/apps/api/src/swagger/api-schema.json
+++ b/apps/api/src/swagger/api-schema.json
@@ -11854,6 +11854,117 @@
         "tags": [
           "Integration"
         ]
+      },
+      "post": {
+        "operationId": "IntegrationController_createTenant",
+        "summary": "Create tenant via integration API",
+        "description": "Creates a new tenant and invites its initial admin user.\n\nOnly integration API keys owned by a managing tenant with tenant management permission can use this endpoint.",
+        "parameters": [
+          {
+            "name": "X-API-Key",
+            "in": "header",
+            "description": "Integration API key used to authenticate every integration request.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Tenant-Id",
+            "in": "header",
+            "description": "Tenant ID is not required because the integration API key owner is used.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTenantBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateTenantResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid integration API key."
+          },
+          "403": {
+            "description": "Authenticated integration key owner is not authorized."
+          }
+        },
+        "tags": [
+          "Integration"
+        ]
+      }
+    },
+    "/api/integration/tenants/{tenantId}/deactivate": {
+      "post": {
+        "operationId": "IntegrationController_deactivateTenant",
+        "summary": "Deactivate tenant via integration API",
+        "description": "Marks the target tenant as inactive.\n\nOnly integration API keys owned by a managing tenant with tenant management permission can use this endpoint.",
+        "parameters": [
+          {
+            "name": "X-API-Key",
+            "in": "header",
+            "description": "Integration API key used to authenticate every integration request.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "tenantId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Tenant-Id",
+            "in": "header",
+            "description": "Tenant ID is not required because the target tenant is in the path.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeactivateTenantResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid integration API key."
+          },
+          "403": {
+            "description": "Authenticated integration key owner is not authorized."
+          }
+        },
+        "tags": [
+          "Integration"
+        ]
       }
     },
     "/api/integration/users": {
@@ -12830,6 +12941,227 @@
         "tags": [
           "Integration Admin"
         ]
+      }
+    },
+    "/api/super-admin/tenants": {
+      "get": {
+        "operationId": "TenantsController_findAllTenants",
+        "parameters": [
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "minimum": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "perPage",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "minimum": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "search",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FindAllTenantsResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "TenantsController_createTenant",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTenantBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateTenantResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/super-admin/tenants/{id}": {
+      "get": {
+        "operationId": "TenantsController_findTenantById",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FindTenantByIdResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "TenantsController_updateTenantById",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTenantByIdBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateTenantByIdResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/super-admin/tenants/{id}/support-users": {
+      "get": {
+        "operationId": "TenantsController_findSupportUsers",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "minimum": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "perPage",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "minimum": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "search",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FindSupportUsersResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/super-admin/tenants/{id}/support-session": {
+      "post": {
+        "operationId": "TenantsController_createSupportSession",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateSupportSessionBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateSupportSessionResponse"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/api/activity-logs": {
@@ -14386,227 +14718,6 @@
         "responses": {
           "200": {
             "description": ""
-          }
-        }
-      }
-    },
-    "/api/super-admin/tenants": {
-      "get": {
-        "operationId": "TenantsController_findAllTenants",
-        "parameters": [
-          {
-            "name": "page",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "minimum": 1,
-              "type": "number"
-            }
-          },
-          {
-            "name": "perPage",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "minimum": 1,
-              "type": "number"
-            }
-          },
-          {
-            "name": "search",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FindAllTenantsResponse"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "operationId": "TenantsController_createTenant",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateTenantBody"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CreateTenantResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/super-admin/tenants/{id}": {
-      "get": {
-        "operationId": "TenantsController_findTenantById",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FindTenantByIdResponse"
-                }
-              }
-            }
-          }
-        }
-      },
-      "patch": {
-        "operationId": "TenantsController_updateTenantById",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateTenantByIdBody"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UpdateTenantByIdResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/super-admin/tenants/{id}/support-users": {
-      "get": {
-        "operationId": "TenantsController_findSupportUsers",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          },
-          {
-            "name": "page",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "minimum": 1,
-              "type": "number"
-            }
-          },
-          {
-            "name": "perPage",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "minimum": 1,
-              "type": "number"
-            }
-          },
-          {
-            "name": "search",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FindSupportUsersResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/super-admin/tenants/{id}/support-session": {
-      "post": {
-        "operationId": "TenantsController_createSupportSession",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateSupportSessionBody"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CreateSupportSessionResponse"
-                }
-              }
-            }
           }
         }
       }
@@ -44346,6 +44457,181 @@
           "data"
         ]
       },
+      "CreateTenantBody": {
+        "additionalProperties": false,
+        "type": "object",
+        "properties": {
+          "name": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "host": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "const": "active",
+                "type": "string"
+              },
+              {
+                "const": "inactive",
+                "type": "string"
+              }
+            ]
+          },
+          "adminEmail": {
+            "format": "email",
+            "type": "string"
+          },
+          "adminFirstName": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "adminLastName": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "adminLanguage": {
+            "anyOf": [
+              {
+                "const": "en",
+                "type": "string"
+              },
+              {
+                "const": "pl",
+                "type": "string"
+              },
+              {
+                "const": "de",
+                "type": "string"
+              },
+              {
+                "const": "lt",
+                "type": "string"
+              },
+              {
+                "const": "cs",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "host",
+          "adminEmail",
+          "adminFirstName",
+          "adminLastName"
+        ]
+      },
+      "CreateTenantResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "format": "uuid",
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "host": {
+                "type": "string"
+              },
+              "status": {
+                "anyOf": [
+                  {
+                    "const": "active",
+                    "type": "string"
+                  },
+                  {
+                    "const": "inactive",
+                    "type": "string"
+                  }
+                ]
+              },
+              "isManaging": {
+                "type": "boolean"
+              },
+              "createdAt": {
+                "type": "string"
+              },
+              "updatedAt": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "name",
+              "host",
+              "status",
+              "isManaging",
+              "createdAt",
+              "updatedAt"
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "DeactivateTenantResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "format": "uuid",
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "host": {
+                "type": "string"
+              },
+              "status": {
+                "anyOf": [
+                  {
+                    "const": "active",
+                    "type": "string"
+                  },
+                  {
+                    "const": "inactive",
+                    "type": "string"
+                  }
+                ]
+              },
+              "isManaging": {
+                "type": "boolean"
+              },
+              "createdAt": {
+                "type": "string"
+              },
+              "updatedAt": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "name",
+              "host",
+              "status",
+              "isManaging",
+              "createdAt",
+              "updatedAt"
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
       "GetTrainingResultsResponse": {
         "type": "object",
         "properties": {
@@ -45095,6 +45381,349 @@
             "required": [
               "key",
               "metadata"
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "FindAllTenantsResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "allOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "host": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "anyOf": [
+                        {
+                          "const": "active",
+                          "type": "string"
+                        },
+                        {
+                          "const": "inactive",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "isManaging": {
+                      "type": "boolean"
+                    },
+                    "createdAt": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name",
+                    "host",
+                    "status",
+                    "isManaging",
+                    "createdAt",
+                    "updatedAt"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "isCurrentTenant": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "isCurrentTenant"
+                  ]
+                }
+              ]
+            }
+          },
+          "pagination": {
+            "type": "object",
+            "properties": {
+              "totalItems": {
+                "type": "number"
+              },
+              "page": {
+                "type": "number"
+              },
+              "perPage": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "totalItems",
+              "page",
+              "perPage"
+            ]
+          },
+          "appliedFilters": {
+            "type": "object",
+            "patternProperties": {
+              "^(.*)$": {}
+            }
+          }
+        },
+        "required": [
+          "data",
+          "pagination"
+        ]
+      },
+      "FindTenantByIdResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "format": "uuid",
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "host": {
+                "type": "string"
+              },
+              "status": {
+                "anyOf": [
+                  {
+                    "const": "active",
+                    "type": "string"
+                  },
+                  {
+                    "const": "inactive",
+                    "type": "string"
+                  }
+                ]
+              },
+              "isManaging": {
+                "type": "boolean"
+              },
+              "createdAt": {
+                "type": "string"
+              },
+              "updatedAt": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "name",
+              "host",
+              "status",
+              "isManaging",
+              "createdAt",
+              "updatedAt"
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "UpdateTenantByIdBody": {
+        "additionalProperties": false,
+        "type": "object",
+        "properties": {
+          "name": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "host": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "const": "active",
+                "type": "string"
+              },
+              {
+                "const": "inactive",
+                "type": "string"
+              }
+            ]
+          }
+        }
+      },
+      "UpdateTenantByIdResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "format": "uuid",
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "host": {
+                "type": "string"
+              },
+              "status": {
+                "anyOf": [
+                  {
+                    "const": "active",
+                    "type": "string"
+                  },
+                  {
+                    "const": "inactive",
+                    "type": "string"
+                  }
+                ]
+              },
+              "isManaging": {
+                "type": "boolean"
+              },
+              "createdAt": {
+                "type": "string"
+              },
+              "updatedAt": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "name",
+              "host",
+              "status",
+              "isManaging",
+              "createdAt",
+              "updatedAt"
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "FindSupportUsersResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "email": {
+                  "format": "email",
+                  "type": "string"
+                },
+                "firstName": {
+                  "type": "string"
+                },
+                "lastName": {
+                  "type": "string"
+                },
+                "label": {
+                  "type": "string"
+                },
+                "profilePictureUrl": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "id",
+                "email",
+                "firstName",
+                "lastName",
+                "label",
+                "profilePictureUrl"
+              ]
+            }
+          },
+          "pagination": {
+            "type": "object",
+            "properties": {
+              "totalItems": {
+                "type": "number"
+              },
+              "page": {
+                "type": "number"
+              },
+              "perPage": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "totalItems",
+              "page",
+              "perPage"
+            ]
+          },
+          "appliedFilters": {
+            "type": "object",
+            "patternProperties": {
+              "^(.*)$": {}
+            }
+          }
+        },
+        "required": [
+          "data",
+          "pagination"
+        ]
+      },
+      "CreateSupportSessionBody": {
+        "additionalProperties": false,
+        "type": "object",
+        "properties": {
+          "targetUserId": {
+            "format": "uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "targetUserId"
+        ]
+      },
+      "CreateSupportSessionResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "redirectUrl": {
+                "type": "string"
+              },
+              "expiresAt": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "redirectUrl",
+              "expiresAt"
             ]
           }
         },
@@ -48263,471 +48892,6 @@
             },
             "required": [
               "parsedContent"
-            ]
-          }
-        },
-        "required": [
-          "data"
-        ]
-      },
-      "FindAllTenantsResponse": {
-        "type": "object",
-        "properties": {
-          "data": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "allOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "format": "uuid",
-                      "type": "string"
-                    },
-                    "name": {
-                      "type": "string"
-                    },
-                    "host": {
-                      "type": "string"
-                    },
-                    "status": {
-                      "anyOf": [
-                        {
-                          "const": "active",
-                          "type": "string"
-                        },
-                        {
-                          "const": "inactive",
-                          "type": "string"
-                        }
-                      ]
-                    },
-                    "isManaging": {
-                      "type": "boolean"
-                    },
-                    "createdAt": {
-                      "type": "string"
-                    },
-                    "updatedAt": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "id",
-                    "name",
-                    "host",
-                    "status",
-                    "isManaging",
-                    "createdAt",
-                    "updatedAt"
-                  ]
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "isCurrentTenant": {
-                      "type": "boolean"
-                    }
-                  },
-                  "required": [
-                    "isCurrentTenant"
-                  ]
-                }
-              ]
-            }
-          },
-          "pagination": {
-            "type": "object",
-            "properties": {
-              "totalItems": {
-                "type": "number"
-              },
-              "page": {
-                "type": "number"
-              },
-              "perPage": {
-                "type": "number"
-              }
-            },
-            "required": [
-              "totalItems",
-              "page",
-              "perPage"
-            ]
-          },
-          "appliedFilters": {
-            "type": "object",
-            "patternProperties": {
-              "^(.*)$": {}
-            }
-          }
-        },
-        "required": [
-          "data",
-          "pagination"
-        ]
-      },
-      "FindTenantByIdResponse": {
-        "type": "object",
-        "properties": {
-          "data": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "format": "uuid",
-                "type": "string"
-              },
-              "name": {
-                "type": "string"
-              },
-              "host": {
-                "type": "string"
-              },
-              "status": {
-                "anyOf": [
-                  {
-                    "const": "active",
-                    "type": "string"
-                  },
-                  {
-                    "const": "inactive",
-                    "type": "string"
-                  }
-                ]
-              },
-              "isManaging": {
-                "type": "boolean"
-              },
-              "createdAt": {
-                "type": "string"
-              },
-              "updatedAt": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "id",
-              "name",
-              "host",
-              "status",
-              "isManaging",
-              "createdAt",
-              "updatedAt"
-            ]
-          }
-        },
-        "required": [
-          "data"
-        ]
-      },
-      "CreateTenantBody": {
-        "additionalProperties": false,
-        "type": "object",
-        "properties": {
-          "name": {
-            "minLength": 1,
-            "type": "string"
-          },
-          "host": {
-            "minLength": 1,
-            "type": "string"
-          },
-          "status": {
-            "anyOf": [
-              {
-                "const": "active",
-                "type": "string"
-              },
-              {
-                "const": "inactive",
-                "type": "string"
-              }
-            ]
-          },
-          "adminEmail": {
-            "format": "email",
-            "type": "string"
-          },
-          "adminFirstName": {
-            "minLength": 1,
-            "type": "string"
-          },
-          "adminLastName": {
-            "minLength": 1,
-            "type": "string"
-          },
-          "adminLanguage": {
-            "anyOf": [
-              {
-                "const": "en",
-                "type": "string"
-              },
-              {
-                "const": "pl",
-                "type": "string"
-              },
-              {
-                "const": "de",
-                "type": "string"
-              },
-              {
-                "const": "lt",
-                "type": "string"
-              },
-              {
-                "const": "cs",
-                "type": "string"
-              }
-            ]
-          }
-        },
-        "required": [
-          "name",
-          "host",
-          "adminEmail",
-          "adminFirstName",
-          "adminLastName"
-        ]
-      },
-      "CreateTenantResponse": {
-        "type": "object",
-        "properties": {
-          "data": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "format": "uuid",
-                "type": "string"
-              },
-              "name": {
-                "type": "string"
-              },
-              "host": {
-                "type": "string"
-              },
-              "status": {
-                "anyOf": [
-                  {
-                    "const": "active",
-                    "type": "string"
-                  },
-                  {
-                    "const": "inactive",
-                    "type": "string"
-                  }
-                ]
-              },
-              "isManaging": {
-                "type": "boolean"
-              },
-              "createdAt": {
-                "type": "string"
-              },
-              "updatedAt": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "id",
-              "name",
-              "host",
-              "status",
-              "isManaging",
-              "createdAt",
-              "updatedAt"
-            ]
-          }
-        },
-        "required": [
-          "data"
-        ]
-      },
-      "UpdateTenantByIdBody": {
-        "additionalProperties": false,
-        "type": "object",
-        "properties": {
-          "name": {
-            "minLength": 1,
-            "type": "string"
-          },
-          "host": {
-            "minLength": 1,
-            "type": "string"
-          },
-          "status": {
-            "anyOf": [
-              {
-                "const": "active",
-                "type": "string"
-              },
-              {
-                "const": "inactive",
-                "type": "string"
-              }
-            ]
-          }
-        }
-      },
-      "UpdateTenantByIdResponse": {
-        "type": "object",
-        "properties": {
-          "data": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "format": "uuid",
-                "type": "string"
-              },
-              "name": {
-                "type": "string"
-              },
-              "host": {
-                "type": "string"
-              },
-              "status": {
-                "anyOf": [
-                  {
-                    "const": "active",
-                    "type": "string"
-                  },
-                  {
-                    "const": "inactive",
-                    "type": "string"
-                  }
-                ]
-              },
-              "isManaging": {
-                "type": "boolean"
-              },
-              "createdAt": {
-                "type": "string"
-              },
-              "updatedAt": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "id",
-              "name",
-              "host",
-              "status",
-              "isManaging",
-              "createdAt",
-              "updatedAt"
-            ]
-          }
-        },
-        "required": [
-          "data"
-        ]
-      },
-      "FindSupportUsersResponse": {
-        "type": "object",
-        "properties": {
-          "data": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "format": "uuid",
-                  "type": "string"
-                },
-                "email": {
-                  "format": "email",
-                  "type": "string"
-                },
-                "firstName": {
-                  "type": "string"
-                },
-                "lastName": {
-                  "type": "string"
-                },
-                "label": {
-                  "type": "string"
-                },
-                "profilePictureUrl": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                }
-              },
-              "required": [
-                "id",
-                "email",
-                "firstName",
-                "lastName",
-                "label",
-                "profilePictureUrl"
-              ]
-            }
-          },
-          "pagination": {
-            "type": "object",
-            "properties": {
-              "totalItems": {
-                "type": "number"
-              },
-              "page": {
-                "type": "number"
-              },
-              "perPage": {
-                "type": "number"
-              }
-            },
-            "required": [
-              "totalItems",
-              "page",
-              "perPage"
-            ]
-          },
-          "appliedFilters": {
-            "type": "object",
-            "patternProperties": {
-              "^(.*)$": {}
-            }
-          }
-        },
-        "required": [
-          "data",
-          "pagination"
-        ]
-      },
-      "CreateSupportSessionBody": {
-        "additionalProperties": false,
-        "type": "object",
-        "properties": {
-          "targetUserId": {
-            "format": "uuid",
-            "type": "string"
-          }
-        },
-        "required": [
-          "targetUserId"
-        ]
-      },
-      "CreateSupportSessionResponse": {
-        "type": "object",
-        "properties": {
-          "data": {
-            "type": "object",
-            "properties": {
-              "redirectUrl": {
-                "type": "string"
-              },
-              "expiresAt": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "redirectUrl",
-              "expiresAt"
             ]
           }
         },

--- a/apps/api/src/swagger/integration-api-schema.json
+++ b/apps/api/src/swagger/integration-api-schema.json
@@ -46,6 +46,117 @@
         "tags": [
           "Integration"
         ]
+      },
+      "post": {
+        "operationId": "IntegrationController_createTenant",
+        "summary": "Create tenant via integration API",
+        "description": "Creates a new tenant and invites its initial admin user.\n\nOnly integration API keys owned by a managing tenant with tenant management permission can use this endpoint.",
+        "parameters": [
+          {
+            "name": "X-API-Key",
+            "in": "header",
+            "description": "Integration API key used to authenticate every integration request.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Tenant-Id",
+            "in": "header",
+            "description": "Tenant ID is not required because the integration API key owner is used.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTenantBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateTenantResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid integration API key."
+          },
+          "403": {
+            "description": "Authenticated integration key owner is not authorized."
+          }
+        },
+        "tags": [
+          "Integration"
+        ]
+      }
+    },
+    "/api/integration/tenants/{tenantId}/deactivate": {
+      "post": {
+        "operationId": "IntegrationController_deactivateTenant",
+        "summary": "Deactivate tenant via integration API",
+        "description": "Marks the target tenant as inactive.\n\nOnly integration API keys owned by a managing tenant with tenant management permission can use this endpoint.",
+        "parameters": [
+          {
+            "name": "X-API-Key",
+            "in": "header",
+            "description": "Integration API key used to authenticate every integration request.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "tenantId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Tenant-Id",
+            "in": "header",
+            "description": "Tenant ID is not required because the target tenant is in the path.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeactivateTenantResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid integration API key."
+          },
+          "403": {
+            "description": "Authenticated integration key owner is not authorized."
+          }
+        },
+        "tags": [
+          "Integration"
+        ]
       }
     },
     "/api/integration/users": {
@@ -1060,6 +1171,181 @@
                 "host"
               ]
             }
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "CreateTenantBody": {
+        "additionalProperties": false,
+        "type": "object",
+        "properties": {
+          "name": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "host": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "const": "active",
+                "type": "string"
+              },
+              {
+                "const": "inactive",
+                "type": "string"
+              }
+            ]
+          },
+          "adminEmail": {
+            "format": "email",
+            "type": "string"
+          },
+          "adminFirstName": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "adminLastName": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "adminLanguage": {
+            "anyOf": [
+              {
+                "const": "en",
+                "type": "string"
+              },
+              {
+                "const": "pl",
+                "type": "string"
+              },
+              {
+                "const": "de",
+                "type": "string"
+              },
+              {
+                "const": "lt",
+                "type": "string"
+              },
+              {
+                "const": "cs",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "host",
+          "adminEmail",
+          "adminFirstName",
+          "adminLastName"
+        ]
+      },
+      "CreateTenantResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "format": "uuid",
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "host": {
+                "type": "string"
+              },
+              "status": {
+                "anyOf": [
+                  {
+                    "const": "active",
+                    "type": "string"
+                  },
+                  {
+                    "const": "inactive",
+                    "type": "string"
+                  }
+                ]
+              },
+              "isManaging": {
+                "type": "boolean"
+              },
+              "createdAt": {
+                "type": "string"
+              },
+              "updatedAt": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "name",
+              "host",
+              "status",
+              "isManaging",
+              "createdAt",
+              "updatedAt"
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "DeactivateTenantResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "format": "uuid",
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "host": {
+                "type": "string"
+              },
+              "status": {
+                "anyOf": [
+                  {
+                    "const": "active",
+                    "type": "string"
+                  },
+                  {
+                    "const": "inactive",
+                    "type": "string"
+                  }
+                ]
+              },
+              "isManaging": {
+                "type": "boolean"
+              },
+              "createdAt": {
+                "type": "string"
+              },
+              "updatedAt": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "name",
+              "host",
+              "status",
+              "isManaging",
+              "createdAt",
+              "updatedAt"
+            ]
           }
         },
         "required": [

--- a/apps/web/app/api/generated-api.ts
+++ b/apps/web/app/api/generated-api.ts
@@ -5886,6 +5886,47 @@ export interface GetTenantsResponse {
   }[];
 }
 
+export interface CreateTenantBody {
+  /** @minLength 1 */
+  name: string;
+  /** @minLength 1 */
+  host: string;
+  status?: "active" | "inactive";
+  /** @format email */
+  adminEmail: string;
+  /** @minLength 1 */
+  adminFirstName: string;
+  /** @minLength 1 */
+  adminLastName: string;
+  adminLanguage?: "en" | "pl" | "de" | "lt" | "cs";
+}
+
+export interface CreateTenantResponse {
+  data: {
+    /** @format uuid */
+    id: string;
+    name: string;
+    host: string;
+    status: "active" | "inactive";
+    isManaging: boolean;
+    createdAt: string;
+    updatedAt: string;
+  };
+}
+
+export interface DeactivateTenantResponse {
+  data: {
+    /** @format uuid */
+    id: string;
+    name: string;
+    host: string;
+    status: "active" | "inactive";
+    isManaging: boolean;
+    createdAt: string;
+    updatedAt: string;
+  };
+}
+
 export interface GetTrainingResultsResponse {
   data: {
     scope: "tenant" | "student" | "course";
@@ -6048,6 +6089,92 @@ export interface RotateKeyResponse {
       updatedAt: string;
       lastUsedAt: string | null;
     };
+  };
+}
+
+export interface FindAllTenantsResponse {
+  data: ({
+    /** @format uuid */
+    id: string;
+    name: string;
+    host: string;
+    status: "active" | "inactive";
+    isManaging: boolean;
+    createdAt: string;
+    updatedAt: string;
+  } & {
+    isCurrentTenant: boolean;
+  })[];
+  pagination: {
+    totalItems: number;
+    page: number;
+    perPage: number;
+  };
+  appliedFilters?: object;
+}
+
+export interface FindTenantByIdResponse {
+  data: {
+    /** @format uuid */
+    id: string;
+    name: string;
+    host: string;
+    status: "active" | "inactive";
+    isManaging: boolean;
+    createdAt: string;
+    updatedAt: string;
+  };
+}
+
+export interface UpdateTenantByIdBody {
+  /** @minLength 1 */
+  name?: string;
+  /** @minLength 1 */
+  host?: string;
+  status?: "active" | "inactive";
+}
+
+export interface UpdateTenantByIdResponse {
+  data: {
+    /** @format uuid */
+    id: string;
+    name: string;
+    host: string;
+    status: "active" | "inactive";
+    isManaging: boolean;
+    createdAt: string;
+    updatedAt: string;
+  };
+}
+
+export interface FindSupportUsersResponse {
+  data: {
+    /** @format uuid */
+    id: string;
+    /** @format email */
+    email: string;
+    firstName: string;
+    lastName: string;
+    label: string;
+    profilePictureUrl: string | null;
+  }[];
+  pagination: {
+    totalItems: number;
+    page: number;
+    perPage: number;
+  };
+  appliedFilters?: object;
+}
+
+export interface CreateSupportSessionBody {
+  /** @format uuid */
+  targetUserId: string;
+}
+
+export interface CreateSupportSessionResponse {
+  data: {
+    redirectUrl: string;
+    expiresAt: string;
   };
 }
 
@@ -6705,120 +6832,6 @@ export interface GenerateArticlePreviewBody {
 export interface GenerateArticlePreviewResponse {
   data: {
     parsedContent: string;
-  };
-}
-
-export interface FindAllTenantsResponse {
-  data: ({
-    /** @format uuid */
-    id: string;
-    name: string;
-    host: string;
-    status: "active" | "inactive";
-    isManaging: boolean;
-    createdAt: string;
-    updatedAt: string;
-  } & {
-    isCurrentTenant: boolean;
-  })[];
-  pagination: {
-    totalItems: number;
-    page: number;
-    perPage: number;
-  };
-  appliedFilters?: object;
-}
-
-export interface FindTenantByIdResponse {
-  data: {
-    /** @format uuid */
-    id: string;
-    name: string;
-    host: string;
-    status: "active" | "inactive";
-    isManaging: boolean;
-    createdAt: string;
-    updatedAt: string;
-  };
-}
-
-export interface CreateTenantBody {
-  /** @minLength 1 */
-  name: string;
-  /** @minLength 1 */
-  host: string;
-  status?: "active" | "inactive";
-  /** @format email */
-  adminEmail: string;
-  /** @minLength 1 */
-  adminFirstName: string;
-  /** @minLength 1 */
-  adminLastName: string;
-  adminLanguage?: "en" | "pl" | "de" | "lt" | "cs";
-}
-
-export interface CreateTenantResponse {
-  data: {
-    /** @format uuid */
-    id: string;
-    name: string;
-    host: string;
-    status: "active" | "inactive";
-    isManaging: boolean;
-    createdAt: string;
-    updatedAt: string;
-  };
-}
-
-export interface UpdateTenantByIdBody {
-  /** @minLength 1 */
-  name?: string;
-  /** @minLength 1 */
-  host?: string;
-  status?: "active" | "inactive";
-}
-
-export interface UpdateTenantByIdResponse {
-  data: {
-    /** @format uuid */
-    id: string;
-    name: string;
-    host: string;
-    status: "active" | "inactive";
-    isManaging: boolean;
-    createdAt: string;
-    updatedAt: string;
-  };
-}
-
-export interface FindSupportUsersResponse {
-  data: {
-    /** @format uuid */
-    id: string;
-    /** @format email */
-    email: string;
-    firstName: string;
-    lastName: string;
-    label: string;
-    profilePictureUrl: string | null;
-  }[];
-  pagination: {
-    totalItems: number;
-    page: number;
-    perPage: number;
-  };
-  appliedFilters?: object;
-}
-
-export interface CreateSupportSessionBody {
-  /** @format uuid */
-  targetUserId: string;
-}
-
-export interface CreateSupportSessionResponse {
-  data: {
-    redirectUrl: string;
-    expiresAt: string;
   };
 }
 
@@ -13133,6 +13146,40 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
+     * @description Creates a new tenant and invites its initial admin user. Only integration API keys owned by a managing tenant with tenant management permission can use this endpoint.
+     *
+     * @tags Integration
+     * @name IntegrationControllerCreateTenant
+     * @summary Create tenant via integration API
+     * @request POST:/api/integration/tenants
+     */
+    integrationControllerCreateTenant: (data: CreateTenantBody, params: RequestParams = {}) =>
+      this.request<CreateTenantResponse, void>({
+        path: `/api/integration/tenants`,
+        method: "POST",
+        body: data,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Marks the target tenant as inactive. Only integration API keys owned by a managing tenant with tenant management permission can use this endpoint.
+     *
+     * @tags Integration
+     * @name IntegrationControllerDeactivateTenant
+     * @summary Deactivate tenant via integration API
+     * @request POST:/api/integration/tenants/{tenantId}/deactivate
+     */
+    integrationControllerDeactivateTenant: (tenantId: string, params: RequestParams = {}) =>
+      this.request<DeactivateTenantResponse, void>({
+        path: `/api/integration/tenants/${tenantId}/deactivate`,
+        method: "POST",
+        format: "json",
+        ...params,
+      }),
+
+    /**
      * @description Returns users from the tenant selected by X-Tenant-Id. Supports keyword search, role filtering, archived filtering ('true' or 'false'), group filtering, sorting, and pagination so integrations can sync user directories in batches.
      *
      * @tags Integration
@@ -13437,6 +13484,125 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       this.request<RotateKeyResponse, void>({
         path: `/api/integration/key`,
         method: "POST",
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @name TenantsControllerFindAllTenants
+     * @request GET:/api/super-admin/tenants
+     */
+    tenantsControllerFindAllTenants: (
+      query?: {
+        /** @min 1 */
+        page?: number;
+        /** @min 1 */
+        perPage?: number;
+        search?: string;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<FindAllTenantsResponse, any>({
+        path: `/api/super-admin/tenants`,
+        method: "GET",
+        query: query,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @name TenantsControllerCreateTenant
+     * @request POST:/api/super-admin/tenants
+     */
+    tenantsControllerCreateTenant: (data: CreateTenantBody, params: RequestParams = {}) =>
+      this.request<CreateTenantResponse, any>({
+        path: `/api/super-admin/tenants`,
+        method: "POST",
+        body: data,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @name TenantsControllerFindTenantById
+     * @request GET:/api/super-admin/tenants/{id}
+     */
+    tenantsControllerFindTenantById: (id: string, params: RequestParams = {}) =>
+      this.request<FindTenantByIdResponse, any>({
+        path: `/api/super-admin/tenants/${id}`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @name TenantsControllerUpdateTenantById
+     * @request PATCH:/api/super-admin/tenants/{id}
+     */
+    tenantsControllerUpdateTenantById: (
+      id: string,
+      data: UpdateTenantByIdBody,
+      params: RequestParams = {},
+    ) =>
+      this.request<UpdateTenantByIdResponse, any>({
+        path: `/api/super-admin/tenants/${id}`,
+        method: "PATCH",
+        body: data,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @name TenantsControllerFindSupportUsers
+     * @request GET:/api/super-admin/tenants/{id}/support-users
+     */
+    tenantsControllerFindSupportUsers: (
+      id: string,
+      query?: {
+        /** @min 1 */
+        page?: number;
+        /** @min 1 */
+        perPage?: number;
+        search?: string;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<FindSupportUsersResponse, any>({
+        path: `/api/super-admin/tenants/${id}/support-users`,
+        method: "GET",
+        query: query,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @name TenantsControllerCreateSupportSession
+     * @request POST:/api/super-admin/tenants/{id}/support-session
+     */
+    tenantsControllerCreateSupportSession: (
+      id: string,
+      data: CreateSupportSessionBody,
+      params: RequestParams = {},
+    ) =>
+      this.request<CreateSupportSessionResponse, any>({
+        path: `/api/super-admin/tenants/${id}/support-session`,
+        method: "POST",
+        body: data,
+        type: ContentType.Json,
         format: "json",
         ...params,
       }),
@@ -14190,125 +14356,6 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       this.request<void, any>({
         path: `/api/analytics/active-users`,
         method: "GET",
-        ...params,
-      }),
-
-    /**
-     * No description
-     *
-     * @name TenantsControllerFindAllTenants
-     * @request GET:/api/super-admin/tenants
-     */
-    tenantsControllerFindAllTenants: (
-      query?: {
-        /** @min 1 */
-        page?: number;
-        /** @min 1 */
-        perPage?: number;
-        search?: string;
-      },
-      params: RequestParams = {},
-    ) =>
-      this.request<FindAllTenantsResponse, any>({
-        path: `/api/super-admin/tenants`,
-        method: "GET",
-        query: query,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * No description
-     *
-     * @name TenantsControllerCreateTenant
-     * @request POST:/api/super-admin/tenants
-     */
-    tenantsControllerCreateTenant: (data: CreateTenantBody, params: RequestParams = {}) =>
-      this.request<CreateTenantResponse, any>({
-        path: `/api/super-admin/tenants`,
-        method: "POST",
-        body: data,
-        type: ContentType.Json,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * No description
-     *
-     * @name TenantsControllerFindTenantById
-     * @request GET:/api/super-admin/tenants/{id}
-     */
-    tenantsControllerFindTenantById: (id: string, params: RequestParams = {}) =>
-      this.request<FindTenantByIdResponse, any>({
-        path: `/api/super-admin/tenants/${id}`,
-        method: "GET",
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * No description
-     *
-     * @name TenantsControllerUpdateTenantById
-     * @request PATCH:/api/super-admin/tenants/{id}
-     */
-    tenantsControllerUpdateTenantById: (
-      id: string,
-      data: UpdateTenantByIdBody,
-      params: RequestParams = {},
-    ) =>
-      this.request<UpdateTenantByIdResponse, any>({
-        path: `/api/super-admin/tenants/${id}`,
-        method: "PATCH",
-        body: data,
-        type: ContentType.Json,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * No description
-     *
-     * @name TenantsControllerFindSupportUsers
-     * @request GET:/api/super-admin/tenants/{id}/support-users
-     */
-    tenantsControllerFindSupportUsers: (
-      id: string,
-      query?: {
-        /** @min 1 */
-        page?: number;
-        /** @min 1 */
-        perPage?: number;
-        search?: string;
-      },
-      params: RequestParams = {},
-    ) =>
-      this.request<FindSupportUsersResponse, any>({
-        path: `/api/super-admin/tenants/${id}/support-users`,
-        method: "GET",
-        query: query,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * No description
-     *
-     * @name TenantsControllerCreateSupportSession
-     * @request POST:/api/super-admin/tenants/{id}/support-session
-     */
-    tenantsControllerCreateSupportSession: (
-      id: string,
-      data: CreateSupportSessionBody,
-      params: RequestParams = {},
-    ) =>
-      this.request<CreateSupportSessionResponse, any>({
-        path: `/api/super-admin/tenants/${id}/support-session`,
-        method: "POST",
-        body: data,
-        type: ContentType.Json,
-        format: "json",
         ...params,
       }),
 

--- a/docs/specs/environment-integration-configuration-business-spec.md
+++ b/docs/specs/environment-integration-configuration-business-spec.md
@@ -4,7 +4,7 @@
 
 Environment and integration configuration lets administrators manage the operational connections that make tenant-specific features work. It covers two related needs: storing sensitive integration values, and issuing an integration API key for external systems that synchronize with Mentingo.
 
-For HR and L&D teams, this keeps platform connectivity manageable without code changes. Administrators can enable or adjust services such as SSO, payments, AI, video, or live-session infrastructure, while external HRIS, reporting, or provisioning systems can use a governed API for users, groups, enrollments, and results.
+For HR and L&D teams, this keeps platform connectivity manageable without code changes. Administrators can enable or adjust services such as SSO, payments, AI, video, or live-session infrastructure, while external HRIS, reporting, or provisioning systems can use a governed API for tenant lifecycle, users, groups, enrollments, and results.
 
 The main workflows are split between an admin environment screen for secrets and an account settings card for integration API keys.
 
@@ -13,7 +13,7 @@ The main workflows are split between an admin environment screen for secrets and
 - Tenant administrators update integration secrets so configured product features can appear and work.
 - Platform operators verify whether required services such as SSO, Stripe, AI, Luma, or LiveKit are configured.
 - Administrators generate or rotate an integration API key for external automation.
-- External HRIS, reporting, or provisioning systems use the integration API to synchronize people, groups, enrollments, and training results.
+- External HRIS, reporting, or provisioning systems use the integration API to synchronize tenants, people, groups, enrollments, and training results.
 
 ## Feature Functions
 
@@ -23,6 +23,7 @@ The main workflows are split between an admin environment screen for secrets and
 - Record activity when environment values are updated.
 - Generate an integration API key and show the raw key only once.
 - Rotate an existing integration API key after confirmation.
+- Create and deactivate tenants through the integration API when the key belongs to a managing tenant.
 - Let external systems read and update users, groups, course enrollments, and training results through the integration API.
 - Restrict integration calls by API key, tenant selection, and integration permissions.
 
@@ -30,7 +31,7 @@ The main workflows are split between an admin environment screen for secrets and
 
 Administrators can adjust integrations without deployments and without exposing secrets broadly. This makes it easier to maintain SSO, paid-course checkout, AI features, video services, and live-session infrastructure as tenant needs change.
 
-External systems can automate repetitive HR and L&D operations instead of relying on spreadsheets or manual updates. A source-of-truth system can provision users, align group membership, enroll learners, and read training results through a controlled API boundary.
+External systems can automate repetitive HR and L&D operations instead of relying on spreadsheets or manual updates. A source-of-truth system can provision customer tenants, deactivate tenants that should no longer have access, manage users, align group membership, enroll learners, and read training results through a controlled API boundary.
 
 ## How It Works
 
@@ -40,17 +41,20 @@ In account settings, administrators can see integration key status, prefix, crea
 
 External callers authenticate with the integration API key. Most integration endpoints also require a tenant header so the request is scoped to the correct tenant. Managing-tenant administrators can operate across allowed tenants, while ordinary tenant administrators are restricted to their own tenant.
 
+Tenant lifecycle automation is available only to integration keys owned by a managing tenant with tenant-management permission. A successful tenant creation also invites the initial tenant administrator, matching the manual super-admin tenant creation workflow. Deactivation marks the selected tenant inactive instead of deleting tenant data.
+
 ## Key Technical Context
 
 - Environment admin route: `/admin/envs`.
 - Environment API implementation: `apps/api/src/env`.
 - Integration key admin implementation: `apps/api/src/integration/integration-admin.controller.ts` and `apps/web/app/modules/Dashboard/Settings/components/IntegrationApiKeyCard.tsx`.
 - External integration API implementation: `apps/api/src/integration/integration.controller.ts`.
-- Key permissions are `PERMISSIONS.ENV_MANAGE`, `PERMISSIONS.INTEGRATION_KEY_MANAGE`, and `PERMISSIONS.INTEGRATION_API_USE`.
+- Tenant lifecycle behavior reuses the super-admin tenant service in `apps/api/src/super-admin/tenants.service.ts`.
+- Key permissions are `PERMISSIONS.ENV_MANAGE`, `PERMISSIONS.INTEGRATION_KEY_MANAGE`, `PERMISSIONS.INTEGRATION_API_USE`, and `PERMISSIONS.TENANT_MANAGE` for integration tenant lifecycle calls.
 - Supported environment metadata includes OAuth providers, OpenAI, Bunny Stream, Stripe, Slack, Luma, and LiveKit values.
 
 ## Test Evidence
 
 - Web E2E coverage verifies environment screen access control, loading and updating an env value, SSO button visibility from tenant env values, integration key generation, and confirmation before rotating an existing key.
-- API E2E coverage verifies integration key generation, raw-key-once behavior, hash/prefix storage, rotation rate limiting, missing API key rejection, tenant header enforcement, old-key rejection after rotation, tenant scope restrictions, localized/paginated groups, and training-results filtering.
+- API E2E coverage verifies integration key generation, raw-key-once behavior, hash/prefix storage, rotation rate limiting, missing API key rejection, tenant header enforcement, old-key rejection after rotation, tenant scope restrictions, localized/paginated groups, tenant creation, tenant deactivation, rejection for non-managing tenant keys, and training-results filtering.
 - Activity-log E2E coverage verifies that environment updates are recorded.


### PR DESCRIPTION
## Overview

Extends the Integration API with tenant lifecycle endpoints for managing-tenant automation:

- Adds `POST /api/integration/tenants` to create a tenant and invite its initial admin.
- Adds `POST /api/integration/tenants/:tenantId/deactivate` to mark a tenant inactive.
- Restricts tenant lifecycle calls to integration API keys owned by a managing tenant with tenant-management permission.
- Reuses the existing super-admin tenant lifecycle service instead of duplicating tenant creation logic.
- Regenerates Swagger schemas and the web generated API client.
- Updates the environment and integration configuration business spec.

## Business Value

External provisioning systems can now manage tenant lifecycle through the same governed Integration API they already use for users, groups, enrollments, and training results.

This reduces manual super-admin work for platform operators and keeps tenant onboarding/offboarding consistent with the existing Mentingo tenant administration flow. Tenant creation also invites the initial tenant administrator, while deactivation preserves tenant data by marking the tenant inactive.