### PR TITLE
chore: add trainer role to MFA enforcement settings

### DIFF
--- a/apps/web/app/locales/cs/translation.json
+++ b/apps/web/app/locales/cs/translation.json
@@ -3137,7 +3137,8 @@
     "roles": {
       "admin": "Správce",
       "student": "Student",
-      "content_creator": "Tvůrce obsahu"
+      "content_creator": "Tvůrce obsahu",
+      "trainer": "Trenér"
     },
     "switch": {
       "enabled": "Povoleno",

--- a/apps/web/app/locales/de/translation.json
+++ b/apps/web/app/locales/de/translation.json
@@ -3129,7 +3129,8 @@
     "roles": {
       "admin": "Administrator",
       "student": "Student",
-      "content_creator": "Inhaltsersteller"
+      "content_creator": "Inhaltsersteller",
+      "trainer": "Trainer"
     },
     "switch": {
       "enabled": "Ermöglicht",

--- a/apps/web/app/locales/en/translation.json
+++ b/apps/web/app/locales/en/translation.json
@@ -3190,7 +3190,8 @@
     "roles": {
       "admin": "Administrator",
       "student": "Student",
-      "content_creator": "Content Creator"
+      "content_creator": "Content Creator",
+      "trainer": "Trainer"
     },
     "switch": {
       "enabled": "Enabled",

--- a/apps/web/app/locales/lt/translation.json
+++ b/apps/web/app/locales/lt/translation.json
@@ -3137,7 +3137,8 @@
     "roles": {
       "admin": "Administratorius",
       "student": "Studentas",
-      "content_creator": "Turinio kūrėjas"
+      "content_creator": "Turinio kūrėjas",
+      "trainer": "Treneris"
     },
     "switch": {
       "enabled": "Įjungta",

--- a/apps/web/app/locales/pl/translation.json
+++ b/apps/web/app/locales/pl/translation.json
@@ -3471,7 +3471,8 @@
     "roles": {
       "admin": "Administrator",
       "student": "Student",
-      "content_creator": "Twórca treści"
+      "content_creator": "Twórca treści",
+      "trainer": "Trener"
     },
     "switch": {
       "enabled": "Włączone",

--- a/apps/web/app/modules/Dashboard/Settings/components/admin/RoleBasedMFAEnforcementSwitch.tsx
+++ b/apps/web/app/modules/Dashboard/Settings/components/admin/RoleBasedMFAEnforcementSwitch.tsx
@@ -1,3 +1,4 @@
+import { SYSTEM_ROLE_SLUGS } from "@repo/shared";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -12,7 +13,6 @@ import {
   CardTitle,
 } from "~/components/ui/card";
 import { Switch } from "~/components/ui/switch";
-import { USER_ROLE, type UserRole } from "~/config/userRoles";
 
 import { SETTINGS_PAGE_HANDLES } from "../../../../../../e2e/data/settings/handles";
 
@@ -21,16 +21,27 @@ import type { GetPublicGlobalSettingsResponse } from "~/api/generated-api";
 interface MFAEnforcementSwitchProps {
   MFAEnforcedRoles: GetPublicGlobalSettingsResponse["data"]["MFAEnforcedRoles"];
 }
-const USER_ROLE_VALUES = [USER_ROLE.admin, USER_ROLE.student, USER_ROLE.contentCreator] as const;
+
+const MFA_ENFORCEMENT_ROLE_VALUES = [
+  SYSTEM_ROLE_SLUGS.ADMIN,
+  SYSTEM_ROLE_SLUGS.STUDENT,
+  SYSTEM_ROLE_SLUGS.CONTENT_CREATOR,
+  SYSTEM_ROLE_SLUGS.TRAINER,
+] as const;
+
+type MFAEnforcementRole = (typeof MFA_ENFORCEMENT_ROLE_VALUES)[number];
 
 export default function RoleBasedMFAEnforcementSwitch({
   MFAEnforcedRoles,
 }: MFAEnforcementSwitchProps) {
   const { t } = useTranslation();
 
-  const [roleStates, setRoleStates] = useState<Record<UserRole, boolean>>(() => {
-    const initialState: Record<UserRole, boolean> = {} as Record<UserRole, boolean>;
-    USER_ROLE_VALUES.forEach((role) => {
+  const [roleStates, setRoleStates] = useState<Record<MFAEnforcementRole, boolean>>(() => {
+    const initialState: Record<MFAEnforcementRole, boolean> = {} as Record<
+      MFAEnforcementRole,
+      boolean
+    >;
+    MFA_ENFORCEMENT_ROLE_VALUES.forEach((role) => {
       initialState[role] = MFAEnforcedRoles.includes(role);
     });
     return initialState;
@@ -38,7 +49,7 @@ export default function RoleBasedMFAEnforcementSwitch({
 
   const { mutate: updateMFAEnforcedRoles, isPending } = useUpdateMFAEnforcedRoles();
 
-  const toggleRoleSwitch = (role: UserRole) => {
+  const toggleRoleSwitch = (role: MFAEnforcementRole) => {
     setRoleStates((prev) => ({
       ...prev,
       [role]: !prev[role],
@@ -46,7 +57,7 @@ export default function RoleBasedMFAEnforcementSwitch({
   };
 
   const hasChanges = () => {
-    return USER_ROLE_VALUES.some((role) => {
+    return MFA_ENFORCEMENT_ROLE_VALUES.some((role) => {
       const wasEnforced = MFAEnforcedRoles.includes(role);
       const isEnforced = roleStates[role];
       return wasEnforced !== isEnforced;
@@ -55,11 +66,14 @@ export default function RoleBasedMFAEnforcementSwitch({
 
   const saveMFAEnforcement = () => {
     if (hasChanges()) {
-      const updateData = {
-        admin: roleStates[USER_ROLE.admin],
-        student: roleStates[USER_ROLE.student],
-        content_creator: roleStates[USER_ROLE.contentCreator],
-      };
+      const updateData = MFA_ENFORCEMENT_ROLE_VALUES.reduce<Record<string, boolean>>(
+        (roles, role) => {
+          roles[role] = roleStates[role];
+          return roles;
+        },
+        {},
+      );
+
       updateMFAEnforcedRoles(updateData);
     }
   };
@@ -75,7 +89,7 @@ export default function RoleBasedMFAEnforcementSwitch({
       <CardContent className="body-sm-md">
         <div className="mb-4">{t("MFAEnforcementView.description")}</div>
         <div className="space-y-2">
-          {USER_ROLE_VALUES.map((role) => (
+          {MFA_ENFORCEMENT_ROLE_VALUES.map((role) => (
             <div key={role} className="flex items-center justify-between">
               <p>{t(`MFAEnforcementView.roles.${role}`)}</p>
               <div className="group inline-flex items-center gap-2">

--- a/apps/web/e2e/specs/settings/organization-settings.spec.ts
+++ b/apps/web/e2e/specs/settings/organization-settings.spec.ts
@@ -1,3 +1,5 @@
+import { SYSTEM_ROLE_SLUGS } from "@repo/shared";
+
 import { USER_ROLE } from "~/config/userRoles";
 
 import { SETTINGS_PAGE_HANDLES } from "../../data/settings/handles";
@@ -156,6 +158,7 @@ test("admin can enable or disable MFA enforcement per role and save only when ch
       admin: !originalRoles.has(USER_ROLE.admin),
       student: !originalRoles.has(USER_ROLE.student),
       content_creator: !originalRoles.has(USER_ROLE.contentCreator),
+      trainer: !originalRoles.has(SYSTEM_ROLE_SLUGS.TRAINER),
     };
 
     cleanup.add(async () => {
@@ -163,6 +166,7 @@ test("admin can enable or disable MFA enforcement per role and save only when ch
         admin: originalRoles.has(USER_ROLE.admin),
         student: originalRoles.has(USER_ROLE.student),
         content_creator: originalRoles.has(USER_ROLE.contentCreator),
+        trainer: originalRoles.has(SYSTEM_ROLE_SLUGS.TRAINER),
       });
     });
 
@@ -173,6 +177,7 @@ test("admin can enable or disable MFA enforcement per role and save only when ch
     await page.getByTestId(SETTINGS_PAGE_HANDLES.mfaRoleSwitch(USER_ROLE.admin)).click();
     await page.getByTestId(SETTINGS_PAGE_HANDLES.mfaRoleSwitch(USER_ROLE.student)).click();
     await page.getByTestId(SETTINGS_PAGE_HANDLES.mfaRoleSwitch(USER_ROLE.contentCreator)).click();
+    await page.getByTestId(SETTINGS_PAGE_HANDLES.mfaRoleSwitch(SYSTEM_ROLE_SLUGS.TRAINER)).click();
     await expect(page.getByTestId(SETTINGS_PAGE_HANDLES.MFA_ENFORCEMENT_SAVE)).toBeEnabled();
     await page.getByTestId(SETTINGS_PAGE_HANDLES.MFA_ENFORCEMENT_SAVE).click();
 
@@ -184,6 +189,7 @@ test("admin can enable or disable MFA enforcement per role and save only when ch
           admin: currentRoles.has(USER_ROLE.admin),
           student: currentRoles.has(USER_ROLE.student),
           content_creator: currentRoles.has(USER_ROLE.contentCreator),
+          trainer: currentRoles.has(SYSTEM_ROLE_SLUGS.TRAINER),
         };
       })
       .toEqual(targetRoles);


### PR DESCRIPTION
<!--
 1. Make sure you have correct branch name i.e. `ab_prefix_123_task_name`, where `123` is a issue ID, and `ab` is an author
 2. Make sure you have meaningful title related to task with correct prefix: feat/fix/chore/style/docs/refactor
 3. Reference multiple issues in one PR by listing them in the issues section
 4. Make sure all necessary sections are filled, remove obsolete sections
 5. Do a self review first
 6. Check if your PR includes only code related to your task
 7. `Notes` is used for additional info but also to notify if any action is required
-->

## Issue(s)
[1697](https://github.com/Selleo/mentingo/issues/1697)

## Overview

  Adds the Trainer role to role-based MFA enforcement settings.

  Changes included:

  - uses shared SYSTEM_ROLE_SLUGS for the MFA enforcement role list
  - adds the trainer role to the MFA toggle UI and save payload
  - builds the MFA enforcement update payload from the supported role list with reduce
  - adds trainer role labels across supported web locales
  - extends the organization settings E2E scenario to toggle and restore trainer MFA enforcement

  ## Business Value

  Admins can now enforce MFA for trainer users from organization settings, keeping trainer-led workflows aligned with enterprise security requirements.