### PR TITLE
chore: improve the ordering of completed courses

### DIFF
--- a/apps/api/src/courses/__tests__/course.controller.e2e-spec.ts
+++ b/apps/api/src/courses/__tests__/course.controller.e2e-spec.ts
@@ -1259,6 +1259,58 @@ describe("CourseController (e2e)", () => {
         expect(response.body.data[1].title).toBe("A Course");
       });
 
+      it("places completed courses after in-progress courses", async () => {
+        const student = await userFactory
+          .withCredentials({ password })
+          .withUserSettings(db)
+          .create({ role: SYSTEM_ROLE_SLUGS.STUDENT });
+        const cookies = await cookieFor(student, app);
+        const category = await categoryFactory.create();
+        const contentCreator = await userFactory.create({
+          role: SYSTEM_ROLE_SLUGS.CONTENT_CREATOR,
+        });
+
+        const completedCourse = await courseFactory.create({
+          title: "A Completed Course",
+          authorId: contentCreator.id,
+          categoryId: category.id,
+          status: "published",
+          thumbnailS3Key: null,
+        });
+        const inProgressCourse = await courseFactory.create({
+          title: "Z In Progress Course",
+          authorId: contentCreator.id,
+          categoryId: category.id,
+          status: "published",
+          thumbnailS3Key: null,
+        });
+
+        await db.insert(studentCourses).values([
+          {
+            studentId: student.id,
+            courseId: completedCourse.id,
+            progress: "completed",
+            completedAt: new Date().toISOString(),
+            finishedChapterCount: 1,
+          },
+          {
+            studentId: student.id,
+            courseId: inProgressCourse.id,
+            finishedChapterCount: 0,
+          },
+        ]);
+
+        const response = await request(app.getHttpServer())
+          .get("/api/course/get-student-courses")
+          .set("Cookie", cookies)
+          .expect(200);
+
+        expect(response.body.data.map((course: CourseTest) => course.title)).toEqual([
+          "Z In Progress Course",
+          "A Completed Course",
+        ]);
+      });
+
       it("paginates results", async () => {
         const student = await userFactory
           .withCredentials({ password })

--- a/apps/api/src/courses/course.service.ts
+++ b/apps/api/src/courses/course.service.ts
@@ -417,11 +417,15 @@ export class CourseService {
           coursesSummaryStats.freePurchasedCount,
           coursesSummaryStats.paidPurchasedCount,
           studentCourses.finishedChapterCount,
+          studentCourses.completedAt,
           courses.availableLocales,
           courses.baseLanguage,
           groupCourses.dueDate,
         )
-        .orderBy(sortOrder(this.getColumnToSortBy(sortedField as CourseSortField, language)));
+        .orderBy(
+          sql`CASE WHEN ${studentCourses.completedAt} IS NULL THEN 0 ELSE 1 END`,
+          sortOrder(this.getColumnToSortBy(sortedField as CourseSortField, language)),
+        );
 
       const dynamicQuery = queryDB.$dynamic();
       const paginatedQuery = addPagination(dynamicQuery, page, perPage);


### PR DESCRIPTION
<!--
 1. Make sure you have correct branch name i.e. `ab_prefix_123_task_name`, where `123` is a issue ID, and `ab` is an author
 2. Make sure you have meaningful title related to task with correct prefix: feat/fix/chore/style/docs/refactor
 3. Reference multiple issues in one PR by listing them in the issues section
 4. Make sure all necessary sections are filled, remove obsolete sections
 5. Do a self review first
 6. Check if your PR includes only code related to your task
 7. `Notes` is used for additional info but also to notify if any action is required
-->

## Issue(s)
[1695](https://github.com/Selleo/mentingo/issues/1695)

  ## Overview

  Improves ordering for the student Continue Learning course list.

  Changes included:

  - orders enrolled student courses so unfinished courses appear before completed courses
  - orders unfinished courses by the learner’s latest lesson activity, using a Drizzle query-builder subquery for last course activity
  - falls back to enrollment date when a course has no lesson activity yet
  - keeps the existing selected course sort as the final tie-breaker
  - adds API E2E coverage for recently launched active courses appearing first and completed courses appearing last

  ## Business Value

  Students see the course they most recently launched first, making it easier to resume learning quickly. Completed courses remain available but are moved to the end so they do not block active learning
  progress.
