### PR TITLE
chore: add Spanish language support

### DIFF
--- a/apps/api/src/articles/constants/index.ts
+++ b/apps/api/src/articles/constants/index.ts
@@ -4,6 +4,7 @@ export const baseArticleTitle = {
   de: "Unbenannter Artikel",
   lt: "Nenurodytas straipsnis",
   cs: "Nezařazený článek",
+  es: "Artículo sin título",
 };
 
 export const baseArticleSectionTitle = {
@@ -12,4 +13,5 @@ export const baseArticleSectionTitle = {
   de: "Unbenannter Abschnitt",
   lt: "Nenurodyta sekcija",
   cs: "Nezařazená sekce",
+  es: "Sección sin título",
 };

--- a/apps/api/src/certificates/certificates.service.ts
+++ b/apps/api/src/certificates/certificates.service.ts
@@ -15,8 +15,10 @@ import {
   CERTIFICATE_VALIDITY_TYPES,
   CERTIFICATE_VALIDITY_UNITS,
   PERMISSIONS,
+  SUPPORTED_LANGUAGES,
   SHARE_IMAGE_HEIGHT,
   SHARE_IMAGE_WIDTH,
+  isSupportedLanguage,
 } from "@repo/shared";
 import { addDays, addMonths, addYears, format } from "date-fns";
 import { escape } from "lodash";
@@ -784,21 +786,29 @@ export class CertificatesService implements OnModuleDestroy {
         pageDescription: `${context.certificate.fullName} completed "${context.certificate.courseTitle}" and earned a certificate.`,
       },
       de: {
-        openLabel: "Platvorm öffnen",
-        pageTitle: `Course completion certificate for "${context.certificate.courseTitle}"`,
-        pageDescription: `${context.certificate.fullName} completed "${context.certificate.courseTitle}" and earned a certificate.`,
+        openLabel: "Plattform öffnen",
+        pageTitle: `Kursabschlusszertifikat für "${context.certificate.courseTitle}"`,
+        pageDescription: `${context.certificate.fullName} hat "${context.certificate.courseTitle}" abgeschlossen und ein Zertifikat erhalten.`,
       },
       lt: {
         openLabel: "Atidaryti platformą",
-        pageTitle: `Course completion certificate for "${context.certificate.courseTitle}"`,
-        pageDescription: `${context.certificate.fullName} completed "${context.certificate.courseTitle}" and earned a certificate.`,
+        pageTitle: `Kurso baigimo sertifikatas už "${context.certificate.courseTitle}"`,
+        pageDescription: `${context.certificate.fullName} baigė "${context.certificate.courseTitle}" ir gavo sertifikatą.`,
       },
       cs: {
         openLabel: "Otevřít platformu",
-        pageTitle: `Course completion certificate for "${context.certificate.courseTitle}"`,
-        pageDescription: `${context.certificate.fullName} completed "${context.certificate.courseTitle}" and earned a certificate.`,
+        pageTitle: `Certifikát o dokončení kurzu "${context.certificate.courseTitle}"`,
+        pageDescription: `${context.certificate.fullName} dokončil/a "${context.certificate.courseTitle}" a získal/a certifikát.`,
       },
-    } as const;
+      es: {
+        openLabel: "Abrir plataforma",
+        pageTitle: `Certificado de finalización del curso "${context.certificate.courseTitle}"`,
+        pageDescription: `${context.certificate.fullName} completó "${context.certificate.courseTitle}" y obtuvo un certificado.`,
+      },
+    } as const satisfies Record<
+      SupportedLanguages,
+      { openLabel: string; pageTitle: string; pageDescription: string }
+    >;
 
     const localizedContent = translations[context.language];
 
@@ -912,7 +922,7 @@ export class CertificatesService implements OnModuleDestroy {
   }
 
   private normalizeLanguage(language?: string): SupportedLanguages {
-    return language === "pl" ? "pl" : "en";
+    return language && isSupportedLanguage(language) ? language : SUPPORTED_LANGUAGES.EN;
   }
 
   private buildPdfFilename(courseTitle?: string | null): string {
@@ -965,8 +975,9 @@ export class CertificatesService implements OnModuleDestroy {
   private scheduleCertificateImagePrewarm(certificateId: UUIDType): void {
     setTimeout(() => {
       void Promise.all([
-        this.getPublicShareImage(certificateId, "en"),
-        this.getPublicShareImage(certificateId, "pl"),
+        ...Object.values(SUPPORTED_LANGUAGES).map((language) =>
+          this.getPublicShareImage(certificateId, language),
+        ),
       ]).catch((error) => {
         this.logger.warn(`Certificate image prewarm failed for ${certificateId}: ${error}`);
       });

--- a/apps/api/src/common/emails/translations.ts
+++ b/apps/api/src/common/emails/translations.ts
@@ -7,6 +7,7 @@ export const EMAIL_SUBJECTS_TRANSLATIONS = {
     de: "Willkommen auf unserer Plattform!",
     lt: "Sveiki atvykę į mūsų platformą!",
     cs: "Vítejte na naší platformě!",
+    es: "¡Bienvenido a nuestra plataforma!",
   },
   passwordRecoveryEmail: {
     en: "Password recovery",
@@ -14,6 +15,7 @@ export const EMAIL_SUBJECTS_TRANSLATIONS = {
     de: "Passwort-Wiederherstellung",
     lt: "Slaptažodžio atkūrimas",
     cs: "Obnovení hesla",
+    es: "Recuperación de contraseña",
   },
   passwordReminderEmail: {
     en: "Account creation reminder",
@@ -21,6 +23,7 @@ export const EMAIL_SUBJECTS_TRANSLATIONS = {
     de: "Erinnerung zur Kontoerstellung",
     lt: "Paskyros sukūrimo priminimas",
     cs: "Připomenutí vytvoření účtu",
+    es: "Recordatorio de creación de cuenta",
   },
   userInviteEmail: {
     en: "You're invited to the platform!",
@@ -28,6 +31,7 @@ export const EMAIL_SUBJECTS_TRANSLATIONS = {
     de: "Du bist auf die Plattform eingeladen!",
     lt: "Esi pakviestas į platformą!",
     cs: "Jsi pozván(a) na platformu!",
+    es: "¡Te han invitado a la plataforma!",
   },
   userFirstLoginEmail: {
     en: "First login!",
@@ -35,6 +39,7 @@ export const EMAIL_SUBJECTS_TRANSLATIONS = {
     de: "Erste Anmeldung!",
     lt: "Pirmasis prisijungimas!",
     cs: "První přihlášení!",
+    es: "¡Primer inicio de sesión!",
   },
   userCourseAssignmentEmail: {
     en: "New course - {{courseName}}",
@@ -42,6 +47,7 @@ export const EMAIL_SUBJECTS_TRANSLATIONS = {
     de: "Neuer Kurs - {{courseName}}",
     lt: "Naujas kursas - {{courseName}}",
     cs: "Nový kurz - {{courseName}}",
+    es: "Nuevo curso - {{courseName}}",
   },
   userShortInactivityEmail: {
     en: "Continue your course - {{courseName}}",
@@ -49,6 +55,7 @@ export const EMAIL_SUBJECTS_TRANSLATIONS = {
     de: "Setze deinen Kurs fort - {{courseName}}",
     lt: "Tęsk savo kursą - {{courseName}}",
     cs: "Pokračuj ve svém kurzu - {{courseName}}",
+    es: "Continúa tu curso - {{courseName}}",
   },
   userShortInactivityPlatformEmail: {
     en: "Continue your journey on the platform",
@@ -56,6 +63,7 @@ export const EMAIL_SUBJECTS_TRANSLATIONS = {
     de: "Setze deine Lernreise auf der Plattform fort",
     lt: "Tęskite mokymosi kelionę platformoje",
     cs: "Pokračuj ve své cestě na platformě",
+    es: "Continúa tu aprendizaje en la plataforma",
   },
   userLongInactivityEmail: {
     en: "Come back to your courses",
@@ -63,6 +71,7 @@ export const EMAIL_SUBJECTS_TRANSLATIONS = {
     de: "Kehre zu deinen Kursen zurück",
     lt: "Sugrįžk prie savo kursų",
     cs: "Vrať se ke svým kurzům",
+    es: "Vuelve a tus cursos",
   },
   userChapterFinishedEmail: {
     en: "Module completed - {{chapterName}}",
@@ -70,6 +79,7 @@ export const EMAIL_SUBJECTS_TRANSLATIONS = {
     de: "Modul abgeschlossen - {{chapterName}}",
     lt: "Modulis baigtas - {{chapterName}}",
     cs: "Modul dokončen - {{chapterName}}",
+    es: "Módulo completado - {{chapterName}}",
   },
   userCourseFinishedEmail: {
     en: "Course completed - {{courseName}}",
@@ -77,6 +87,7 @@ export const EMAIL_SUBJECTS_TRANSLATIONS = {
     de: "Kurs abgeschlossen - {{courseName}}",
     lt: "Kursas baigtas - {{courseName}}",
     cs: "Kurz dokončen - {{courseName}}",
+    es: "Curso completado - {{courseName}}",
   },
   certificateExpirationWarningEmail: {
     en: "Certificate expires soon - {{courseName}}",
@@ -84,6 +95,7 @@ export const EMAIL_SUBJECTS_TRANSLATIONS = {
     de: "Zertifikat läuft bald ab - {{courseName}}",
     lt: "Pažymėjimas netrukus baigs galioti - {{courseName}}",
     cs: "Certifikát brzy vyprší - {{courseName}}",
+    es: "El certificado caduca pronto - {{courseName}}",
   },
   certificateExpiredEmail: {
     en: "Certificate reset - {{courseName}}",
@@ -91,6 +103,7 @@ export const EMAIL_SUBJECTS_TRANSLATIONS = {
     de: "Zertifikat zurückgesetzt - {{courseName}}",
     lt: "Pažymėjimas nustatytas iš naujo - {{courseName}}",
     cs: "Certifikát resetován - {{courseName}}",
+    es: "Certificado restablecido - {{courseName}}",
   },
   adminNewUserEmail: {
     en: "A new user has registered on your platform",
@@ -98,6 +111,7 @@ export const EMAIL_SUBJECTS_TRANSLATIONS = {
     de: "Ein neuer Benutzer hat sich auf deiner Plattform registriert",
     lt: "Naujas naudotojas užsiregistravo tavo platformoje",
     cs: "Na tvé platformě se zaregistroval nový uživatel",
+    es: "Un nuevo usuario se ha registrado en tu plataforma",
   },
   adminCourseFinishedEmail: {
     en: "A user has completed a course on your platform",
@@ -105,6 +119,7 @@ export const EMAIL_SUBJECTS_TRANSLATIONS = {
     de: "Ein Benutzer hat einen Kurs auf deiner Plattform abgeschlossen",
     lt: "Naudotojas baigė kursą tavo platformoje",
     cs: "Uživatel dokončil kurz na tvé platformě",
+    es: "Un usuario ha completado un curso en tu plataforma",
   },
   adminOverdueCoursesEmail: {
     en: "Overdue courses notification",
@@ -112,6 +127,7 @@ export const EMAIL_SUBJECTS_TRANSLATIONS = {
     de: "Benachrichtigung über überfällige Kurse",
     lt: "Pranešimas apie vėluojančius kursus",
     cs: "Upozornění na kurzy po termínu",
+    es: "Notificación de cursos vencidos",
   },
   courseDueDateReminderEmail: {
     en: "Course deadline approaching - {{courseName}}",
@@ -119,6 +135,7 @@ export const EMAIL_SUBJECTS_TRANSLATIONS = {
     de: "Kursfrist naht - {{courseName}}",
     lt: "Artėja kurso terminas - {{courseName}}",
     cs: "Termín kurzu se blíží - {{courseName}}",
+    es: "Se acerca la fecha límite del curso - {{courseName}}",
   },
   magicLinkEmail: {
     en: "Login link",
@@ -126,6 +143,7 @@ export const EMAIL_SUBJECTS_TRANSLATIONS = {
     de: "Anmeldelink",
     lt: "Prisijungimo nuoroda",
     cs: "Přihlašovací odkaz",
+    es: "Enlace de inicio de sesión",
   },
   courseChatMentionEmail: {
     en: "You were mentioned in {{courseName}}",
@@ -133,6 +151,7 @@ export const EMAIL_SUBJECTS_TRANSLATIONS = {
     de: "Du wurdest in {{courseName}} erwähnt",
     lt: "Buvote paminėti kurse {{courseName}}",
     cs: "Byl(a) jste zmíněn(a) v kurzu {{courseName}}",
+    es: "Te han mencionado en {{courseName}}",
   },
 } as const;
 

--- a/apps/api/src/course-chat/course-chat-email.translations.ts
+++ b/apps/api/src/course-chat/course-chat-email.translations.ts
@@ -8,6 +8,7 @@ export const getCourseChatMentionEmailHeading = (language: SupportedLanguages) =
       de: "Du wurdest im Kurschat erwähnt",
       lt: "Buvote paminėti kurso pokalbyje",
       cs: "Byl(a) jste zmíněn(a) v chatu kurzu",
+      es: "Te han mencionado en el chat del curso",
     }) satisfies Record<SupportedLanguages, string>
   )[language];
 
@@ -19,6 +20,7 @@ export const getCourseChatMentionEmailButtonText = (language: SupportedLanguages
       de: "Kursdiskussion öffnen",
       lt: "Atidaryti kurso diskusiją",
       cs: "Otevřít diskuzi kurzu",
+      es: "Abrir debate del curso",
     }) satisfies Record<SupportedLanguages, string>
   )[language];
 
@@ -50,6 +52,10 @@ export const getCourseChatMentionEmailParagraphs = (
     ],
     cs: [
       `Ahoj ${params.recipientName}, ${params.authorName} vás zmínil(a) v kurzu ${params.courseName}.`,
+      `"${params.messageContent}"`,
+    ],
+    es: [
+      `Hola ${params.recipientName}, ${params.authorName} te ha mencionado en ${params.courseName}.`,
       `"${params.messageContent}"`,
     ],
   } satisfies Record<SupportedLanguages, string[]>;

--- a/apps/api/src/courses/course-duplication.constants.ts
+++ b/apps/api/src/courses/course-duplication.constants.ts
@@ -8,4 +8,5 @@ export const COURSE_DUPLICATION_COPY_SUFFIX: Record<SupportedLanguages, string> 
   [SUPPORTED_LANGUAGES.DE]: "(Kopie)",
   [SUPPORTED_LANGUAGES.LT]: "(Kopija)",
   [SUPPORTED_LANGUAGES.CS]: "(Kopie)",
+  [SUPPORTED_LANGUAGES.ES]: "(Copia)",
 };

--- a/apps/api/src/learning-path/services/learning-path-certificate.service.ts
+++ b/apps/api/src/learning-path/services/learning-path-certificate.service.ts
@@ -7,8 +7,10 @@ import {
 } from "@nestjs/common";
 import {
   CERTIFICATE_KIND,
+  SUPPORTED_LANGUAGES,
   buildCertificateHtmlDocument as buildSharedCertificateHtmlDocument,
   buildCertificateMarkup,
+  isSupportedLanguage,
 } from "@repo/shared";
 import { format } from "date-fns";
 import { escape } from "lodash";
@@ -394,12 +396,38 @@ export class LearningPathCertificateService {
 
   private getSharePageContent(context: any, embeddedImageSrc: string) {
     const title = context.certificate.pathTitle ?? "";
-    const pageTitle = `Learning path completion certificate for "${title}"`;
-    const pageDescription = `${context.certificate.fullName} completed "${title}" and earned a certificate.`;
+    const translations = {
+      pl: {
+        pageTitle: `Certyfikat ukończenia ścieżki rozwoju "${title}"`,
+        pageDescription: `${context.certificate.fullName} ukończył/a ścieżkę rozwoju "${title}" i otrzymał/a certyfikat.`,
+      },
+      en: {
+        pageTitle: `Learning path completion certificate for "${title}"`,
+        pageDescription: `${context.certificate.fullName} completed "${title}" and earned a certificate.`,
+      },
+      de: {
+        pageTitle: `Zertifikat über den Abschluss des Entwicklungspfads "${title}"`,
+        pageDescription: `${context.certificate.fullName} hat "${title}" abgeschlossen und ein Zertifikat erhalten.`,
+      },
+      lt: {
+        pageTitle: `Tobulėjimo kelio baigimo sertifikatas už "${title}"`,
+        pageDescription: `${context.certificate.fullName} baigė "${title}" ir gavo sertifikatą.`,
+      },
+      cs: {
+        pageTitle: `Certifikát o dokončení rozvojové cesty "${title}"`,
+        pageDescription: `${context.certificate.fullName} dokončil/a "${title}" a získal/a certifikát.`,
+      },
+      es: {
+        pageTitle: `Certificado de finalización de la ruta de desarrollo "${title}"`,
+        pageDescription: `${context.certificate.fullName} completó "${title}" y obtuvo un certificado.`,
+      },
+    } as const satisfies Record<SupportedLanguages, { pageTitle: string; pageDescription: string }>;
+
+    const localizedContent = translations[context.language as SupportedLanguages];
 
     return {
-      pageTitle: escape(pageTitle),
-      pageDescription: escape(pageDescription),
+      pageTitle: escape(localizedContent.pageTitle),
+      pageDescription: escape(localizedContent.pageDescription),
       siteName: escape(context.certificate.tenantName),
       courseTitle: escape(title),
       shareUrl: escape(context.shareUrl),
@@ -589,7 +617,7 @@ export class LearningPathCertificateService {
   }
 
   private normalizeLanguage(language?: string): SupportedLanguages {
-    return language === "pl" ? "pl" : "en";
+    return language && isSupportedLanguage(language) ? language : SUPPORTED_LANGUAGES.EN;
   }
 
   private buildPdfFilename(courseTitle?: string | null) {

--- a/apps/api/src/live-training/live-training-announcements.constants.ts
+++ b/apps/api/src/live-training/live-training-announcements.constants.ts
@@ -11,6 +11,7 @@ export const LIVE_TRAINING_ANNOUNCEMENT_TITLES = {
     de: "Live-Schulung beginnt bald",
     lt: "Tiesioginiai mokymai netrukus prasidės",
     cs: "Živé školení brzy začne",
+    es: "La formación en vivo comenzará pronto",
   },
   [ANNOUNCEMENT_EMAIL_TEMPLATES.LIVE_TRAINING_STARTED]: {
     en: "Live Training has started",
@@ -18,6 +19,7 @@ export const LIVE_TRAINING_ANNOUNCEMENT_TITLES = {
     de: "Live-Schulung hat begonnen",
     lt: "Tiesioginiai mokymai prasidėjo",
     cs: "Živé školení začalo",
+    es: "La formación en vivo ha comenzado",
   },
   [ANNOUNCEMENT_EMAIL_TEMPLATES.LIVE_TRAINING_ENDED]: {
     en: "Live Training has ended",
@@ -25,6 +27,7 @@ export const LIVE_TRAINING_ANNOUNCEMENT_TITLES = {
     de: "Live-Schulung wurde beendet",
     lt: "Tiesioginiai mokymai baigėsi",
     cs: "Živé školení skončilo",
+    es: "La formación en vivo ha finalizado",
   },
   [ANNOUNCEMENT_EMAIL_TEMPLATES.DEFAULT]: {
     en: "Announcement",
@@ -32,5 +35,6 @@ export const LIVE_TRAINING_ANNOUNCEMENT_TITLES = {
     de: "Ankündigung",
     lt: "Pranešimas",
     cs: "Oznámení",
+    es: "Anuncio",
   },
 } satisfies Record<AnnouncementEmailTemplate, Record<SupportedLanguages, string>>;

--- a/apps/api/src/live-training/live-training-announcements.service.ts
+++ b/apps/api/src/live-training/live-training-announcements.service.ts
@@ -154,6 +154,7 @@ export class LiveTrainingAnnouncementsService {
           de: `Die Live-Schulung ${linkedTitle} beginnt am ${formattedStart}.`,
           lt: `Tiesioginiai mokymai ${linkedTitle} prasidės ${formattedStart}.`,
           cs: `Živé školení ${linkedTitle} začne ${formattedStart}.`,
+          es: `La formación en vivo ${linkedTitle} comienza el ${formattedStart}.`,
         });
       case ANNOUNCEMENT_EMAIL_TEMPLATES.LIVE_TRAINING_STARTED:
         return this.translate(language, {
@@ -162,6 +163,7 @@ export class LiveTrainingAnnouncementsService {
           de: `Die Live-Schulung ${linkedTitle} ist jetzt aktiv.`,
           lt: `Tiesioginiai mokymai ${linkedTitle} dabar vyksta.`,
           cs: `Živé školení ${linkedTitle} nyní probíhá.`,
+          es: `La formación en vivo ${linkedTitle} está activa ahora.`,
         });
       default:
         return this.translate(language, {
@@ -170,6 +172,7 @@ export class LiveTrainingAnnouncementsService {
           de: `Die Live-Schulung ${linkedTitle} wurde beendet.`,
           lt: `Tiesioginiai mokymai ${linkedTitle} baigėsi.`,
           cs: `Živé školení ${linkedTitle} skončilo.`,
+          es: `La formación en vivo ${linkedTitle} ha finalizado.`,
         });
     }
   }

--- a/apps/api/src/news/constants/index.ts
+++ b/apps/api/src/news/constants/index.ts
@@ -4,4 +4,5 @@ export const baseNewsTitle = {
   de: "Unbenannter Artikel",
   lt: "Nenurodytas straipsnis",
   cs: "Nepojmenovaný článek",
+  es: "Artículo sin título",
 };

--- a/apps/api/src/report/constants/report-headers.ts
+++ b/apps/api/src/report/constants/report-headers.ts
@@ -56,4 +56,13 @@ export const REPORT_HEADERS: Record<SupportedLanguages, ReportHeaders> = {
     progressPercentage: "Progres (%)",
     quizResults: "Výsledky z posledních pokusů (%)",
   },
+  es: {
+    studentName: "Nombre",
+    groupName: "Grupos",
+    courseName: "Nombre del curso",
+    lessonCount: "Número de lecciones",
+    completedLessons: "Lecciones completadas",
+    progressPercentage: "Progreso (%)",
+    quizResults: "Resultados del último intento de cuestionario (%)",
+  },
 };

--- a/apps/api/src/swagger/api-schema.json
+++ b/apps/api/src/swagger/api-schema.json
@@ -682,6 +682,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -1566,6 +1570,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -1613,6 +1621,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -1806,6 +1818,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -2349,6 +2365,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -2404,6 +2424,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -2552,6 +2576,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -2660,6 +2688,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -2713,6 +2745,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -2843,6 +2879,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -3030,6 +3070,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -3200,6 +3244,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -3324,6 +3372,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -3521,6 +3573,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -3700,6 +3756,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -3763,6 +3823,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -3867,6 +3931,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -3922,6 +3990,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -4004,6 +4076,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -4061,6 +4137,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -4117,6 +4197,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -4877,6 +4961,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -4942,6 +5030,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -5081,6 +5173,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -5229,6 +5325,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -5376,6 +5476,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -5423,6 +5527,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -5484,6 +5592,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -5525,6 +5637,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -5585,6 +5701,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -5858,6 +5978,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -6046,6 +6170,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -6270,6 +6398,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -6326,6 +6458,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -6706,7 +6842,8 @@
                       "pl",
                       "de",
                       "lt",
-                      "cs"
+                      "cs",
+                      "es"
                     ]
                   },
                   "title": {
@@ -7027,6 +7164,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -7083,6 +7224,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -7174,6 +7319,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -7317,6 +7466,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -7399,6 +7552,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -7809,6 +7966,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -7865,6 +8026,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -8133,6 +8298,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -8208,6 +8377,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -8374,7 +8547,8 @@
                       "pl",
                       "de",
                       "lt",
-                      "cs"
+                      "cs",
+                      "es"
                     ]
                   }
                 },
@@ -8451,6 +8625,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -8517,6 +8695,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -8572,6 +8754,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -8629,6 +8815,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -8685,6 +8875,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -8740,6 +8934,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -8806,6 +9004,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -8871,6 +9073,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -8928,6 +9134,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -9084,6 +9294,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -9879,6 +10093,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -9959,6 +10177,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -10050,6 +10272,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -10103,6 +10329,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -10475,6 +10705,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -10563,6 +10797,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -10679,6 +10917,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -11254,6 +11496,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -11414,6 +11660,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -11461,6 +11711,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -11813,6 +12067,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -12636,6 +12894,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -13370,6 +13632,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -13424,6 +13690,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -13495,6 +13765,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -13578,6 +13852,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -13629,6 +13907,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -13670,6 +13952,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -13793,6 +14079,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -13938,6 +14228,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -14029,6 +14323,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -14079,7 +14377,8 @@
                       "pl",
                       "de",
                       "lt",
-                      "cs"
+                      "cs",
+                      "es"
                     ]
                   },
                   "title": {
@@ -14177,6 +14476,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -14325,6 +14628,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -14366,6 +14673,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -14414,6 +14725,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -14509,6 +14824,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -14619,6 +14938,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -14741,6 +15064,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -14877,6 +15204,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -14942,6 +15273,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -15361,6 +15696,10 @@
               },
               {
                 "const": "cs",
+                "type": "string"
+              },
+              {
+                "const": "es",
                 "type": "string"
               }
             ]
@@ -16240,6 +16579,10 @@
               {
                 "const": "cs",
                 "type": "string"
+              },
+              {
+                "const": "es",
+                "type": "string"
               }
             ]
           }
@@ -16918,6 +17261,10 @@
                         {
                           "const": "cs",
                           "type": "string"
+                        },
+                        {
+                          "const": "es",
+                          "type": "string"
                         }
                       ]
                     },
@@ -16943,6 +17290,10 @@
                           },
                           {
                             "const": "cs",
+                            "type": "string"
+                          },
+                          {
+                            "const": "es",
                             "type": "string"
                           }
                         ]
@@ -17017,6 +17368,10 @@
                       {
                         "const": "cs",
                         "type": "string"
+                      },
+                      {
+                        "const": "es",
+                        "type": "string"
                       }
                     ]
                   },
@@ -17065,6 +17420,10 @@
                       },
                       {
                         "const": "cs",
+                        "type": "string"
+                      },
+                      {
+                        "const": "es",
                         "type": "string"
                       }
                     ]
@@ -17136,6 +17495,10 @@
                   {
                     "const": "cs",
                     "type": "string"
+                  },
+                  {
+                    "const": "es",
+                    "type": "string"
                   }
                 ]
               },
@@ -17179,6 +17542,10 @@
                   },
                   {
                     "const": "cs",
+                    "type": "string"
+                  },
+                  {
+                    "const": "es",
                     "type": "string"
                   }
                 ]
@@ -17240,6 +17607,10 @@
                       {
                         "const": "cs",
                         "type": "string"
+                      },
+                      {
+                        "const": "es",
+                        "type": "string"
                       }
                     ]
                   },
@@ -17288,6 +17659,10 @@
                       },
                       {
                         "const": "cs",
+                        "type": "string"
+                      },
+                      {
+                        "const": "es",
                         "type": "string"
                       }
                     ]
@@ -17359,6 +17734,10 @@
                   },
                   {
                     "const": "cs",
+                    "type": "string"
+                  },
+                  {
+                    "const": "es",
                     "type": "string"
                   }
                 ]
@@ -19457,6 +19836,10 @@
                   {
                     "const": "cs",
                     "type": "string"
+                  },
+                  {
+                    "const": "es",
+                    "type": "string"
                   }
                 ]
               },
@@ -19525,6 +19908,10 @@
                   },
                   {
                     "const": "cs",
+                    "type": "string"
+                  },
+                  {
+                    "const": "es",
                     "type": "string"
                   }
                 ]
@@ -19878,6 +20265,10 @@
                         "cs": {
                           "minLength": 1,
                           "type": "string"
+                        },
+                        "es": {
+                          "minLength": 1,
+                          "type": "string"
                         }
                       },
                       "minProperties": 1
@@ -19902,6 +20293,10 @@
                         },
                         {
                           "const": "cs",
+                          "type": "string"
+                        },
+                        {
+                          "const": "es",
                           "type": "string"
                         }
                       ]
@@ -19928,6 +20323,10 @@
                           },
                           {
                             "const": "cs",
+                            "type": "string"
+                          },
+                          {
+                            "const": "es",
                             "type": "string"
                           }
                         ]
@@ -20011,6 +20410,10 @@
                     "cs": {
                       "minLength": 1,
                       "type": "string"
+                    },
+                    "es": {
+                      "minLength": 1,
+                      "type": "string"
                     }
                   },
                   "minProperties": 1
@@ -20035,6 +20438,10 @@
                     },
                     {
                       "const": "cs",
+                      "type": "string"
+                    },
+                    {
+                      "const": "es",
                       "type": "string"
                     }
                   ]
@@ -20061,6 +20468,10 @@
                       },
                       {
                         "const": "cs",
+                        "type": "string"
+                      },
+                      {
+                        "const": "es",
                         "type": "string"
                       }
                     ]
@@ -20131,6 +20542,10 @@
                         "cs": {
                           "minLength": 1,
                           "type": "string"
+                        },
+                        "es": {
+                          "minLength": 1,
+                          "type": "string"
                         }
                       },
                       "minProperties": 1
@@ -20155,6 +20570,10 @@
                         },
                         {
                           "const": "cs",
+                          "type": "string"
+                        },
+                        {
+                          "const": "es",
                           "type": "string"
                         }
                       ]
@@ -20181,6 +20600,10 @@
                           },
                           {
                             "const": "cs",
+                            "type": "string"
+                          },
+                          {
+                            "const": "es",
                             "type": "string"
                           }
                         ]
@@ -20465,6 +20888,10 @@
                   },
                   {
                     "const": "cs",
+                    "type": "string"
+                  },
+                  {
+                    "const": "es",
                     "type": "string"
                   }
                 ]
@@ -21813,6 +22240,10 @@
               {
                 "const": "cs",
                 "type": "string"
+              },
+              {
+                "const": "es",
+                "type": "string"
               }
             ]
           }
@@ -22057,6 +22488,10 @@
                       {
                         "const": "cs",
                         "type": "string"
+                      },
+                      {
+                        "const": "es",
+                        "type": "string"
                       }
                     ]
                   }
@@ -22081,6 +22516,10 @@
                     },
                     {
                       "const": "cs",
+                      "type": "string"
+                    },
+                    {
+                      "const": "es",
                       "type": "string"
                     }
                   ]
@@ -22238,6 +22677,10 @@
                     {
                       "const": "cs",
                       "type": "string"
+                    },
+                    {
+                      "const": "es",
+                      "type": "string"
                     }
                   ]
                 }
@@ -22262,6 +22705,10 @@
                   },
                   {
                     "const": "cs",
+                    "type": "string"
+                  },
+                  {
+                    "const": "es",
                     "type": "string"
                   }
                 ]
@@ -22394,6 +22841,10 @@
                       {
                         "const": "cs",
                         "type": "string"
+                      },
+                      {
+                        "const": "es",
+                        "type": "string"
                       }
                     ]
                   }
@@ -22418,6 +22869,10 @@
                     },
                     {
                       "const": "cs",
+                      "type": "string"
+                    },
+                    {
+                      "const": "es",
                       "type": "string"
                     }
                   ]
@@ -22559,6 +23014,10 @@
               {
                 "const": "cs",
                 "type": "string"
+              },
+              {
+                "const": "es",
+                "type": "string"
               }
             ]
           }
@@ -22622,6 +23081,10 @@
               {
                 "const": "cs",
                 "type": "string"
+              },
+              {
+                "const": "es",
+                "type": "string"
               }
             ]
           }
@@ -22673,6 +23136,10 @@
                     {
                       "const": "cs",
                       "type": "string"
+                    },
+                    {
+                      "const": "es",
+                      "type": "string"
                     }
                   ]
                 }
@@ -22697,6 +23164,10 @@
                   },
                   {
                     "const": "cs",
+                    "type": "string"
+                  },
+                  {
+                    "const": "es",
                     "type": "string"
                   }
                 ]
@@ -22838,6 +23309,10 @@
                   {
                     "const": "cs",
                     "type": "string"
+                  },
+                  {
+                    "const": "es",
+                    "type": "string"
                   }
                 ]
               },
@@ -22863,6 +23338,10 @@
                     },
                     {
                       "const": "cs",
+                      "type": "string"
+                    },
+                    {
+                      "const": "es",
                       "type": "string"
                     }
                   ]
@@ -22932,6 +23411,10 @@
                     {
                       "const": "cs",
                       "type": "string"
+                    },
+                    {
+                      "const": "es",
+                      "type": "string"
                     }
                   ]
                 }
@@ -22956,6 +23439,10 @@
                   },
                   {
                     "const": "cs",
+                    "type": "string"
+                  },
+                  {
+                    "const": "es",
                     "type": "string"
                   }
                 ]
@@ -23019,6 +23506,10 @@
               {
                 "const": "cs",
                 "type": "string"
+              },
+              {
+                "const": "es",
+                "type": "string"
               }
             ]
           }
@@ -23063,6 +23554,10 @@
                     {
                       "const": "cs",
                       "type": "string"
+                    },
+                    {
+                      "const": "es",
+                      "type": "string"
                     }
                   ]
                 }
@@ -23087,6 +23582,10 @@
                   },
                   {
                     "const": "cs",
+                    "type": "string"
+                  },
+                  {
+                    "const": "es",
                     "type": "string"
                   }
                 ]
@@ -23245,6 +23744,10 @@
                       {
                         "const": "cs",
                         "type": "string"
+                      },
+                      {
+                        "const": "es",
+                        "type": "string"
                       }
                     ]
                   }
@@ -23269,6 +23772,10 @@
                     },
                     {
                       "const": "cs",
+                      "type": "string"
+                    },
+                    {
+                      "const": "es",
                       "type": "string"
                     }
                   ]
@@ -24114,6 +24621,10 @@
                       {
                         "const": "cs",
                         "type": "string"
+                      },
+                      {
+                        "const": "es",
+                        "type": "string"
                       }
                     ]
                   }
@@ -24138,6 +24649,10 @@
                     },
                     {
                       "const": "cs",
+                      "type": "string"
+                    },
+                    {
+                      "const": "es",
                       "type": "string"
                     }
                   ]
@@ -24964,6 +25479,10 @@
                     {
                       "const": "cs",
                       "type": "string"
+                    },
+                    {
+                      "const": "es",
+                      "type": "string"
                     }
                   ]
                 }
@@ -24988,6 +25507,10 @@
                   },
                   {
                     "const": "cs",
+                    "type": "string"
+                  },
+                  {
+                    "const": "es",
                     "type": "string"
                   }
                 ]
@@ -25339,6 +25862,10 @@
                                           {
                                             "const": "cs",
                                             "type": "string"
+                                          },
+                                          {
+                                            "const": "es",
+                                            "type": "string"
                                           }
                                         ]
                                       }
@@ -25371,6 +25898,10 @@
                                     },
                                     {
                                       "const": "cs",
+                                      "type": "string"
+                                    },
+                                    {
+                                      "const": "es",
                                       "type": "string"
                                     }
                                   ]
@@ -25682,6 +26213,10 @@
                     {
                       "const": "cs",
                       "type": "string"
+                    },
+                    {
+                      "const": "es",
+                      "type": "string"
                     }
                   ]
                 }
@@ -25706,6 +26241,10 @@
                   },
                   {
                     "const": "cs",
+                    "type": "string"
+                  },
+                  {
+                    "const": "es",
                     "type": "string"
                   }
                 ]
@@ -25842,6 +26381,10 @@
                   },
                   {
                     "const": "cs",
+                    "type": "string"
+                  },
+                  {
+                    "const": "es",
                     "type": "string"
                   }
                 ]
@@ -26117,6 +26660,10 @@
               },
               {
                 "const": "cs",
+                "type": "string"
+              },
+              {
+                "const": "es",
                 "type": "string"
               }
             ]
@@ -28471,6 +29018,10 @@
                                     {
                                       "const": "cs",
                                       "type": "string"
+                                    },
+                                    {
+                                      "const": "es",
+                                      "type": "string"
                                     }
                                   ]
                                 }
@@ -28503,6 +29054,10 @@
                               },
                               {
                                 "const": "cs",
+                                "type": "string"
+                              },
+                              {
+                                "const": "es",
                                 "type": "string"
                               }
                             ]
@@ -28970,6 +29525,10 @@
                                         {
                                           "const": "cs",
                                           "type": "string"
+                                        },
+                                        {
+                                          "const": "es",
+                                          "type": "string"
                                         }
                                       ]
                                     }
@@ -29002,6 +29561,10 @@
                                   },
                                   {
                                     "const": "cs",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "const": "es",
                                     "type": "string"
                                   }
                                 ]
@@ -29208,6 +29771,10 @@
                   },
                   {
                     "const": "cs",
+                    "type": "string"
+                  },
+                  {
+                    "const": "es",
                     "type": "string"
                   }
                 ]
@@ -29695,6 +30262,10 @@
                             {
                               "const": "cs",
                               "type": "string"
+                            },
+                            {
+                              "const": "es",
+                              "type": "string"
                             }
                           ]
                         },
@@ -29860,6 +30431,10 @@
                   },
                   {
                     "const": "cs",
+                    "type": "string"
+                  },
+                  {
+                    "const": "es",
                     "type": "string"
                   }
                 ]
@@ -30918,6 +31493,10 @@
                               {
                                 "const": "cs",
                                 "type": "string"
+                              },
+                              {
+                                "const": "es",
+                                "type": "string"
                               }
                             ]
                           }
@@ -30950,6 +31529,10 @@
                         },
                         {
                           "const": "cs",
+                          "type": "string"
+                        },
+                        {
+                          "const": "es",
                           "type": "string"
                         }
                       ]
@@ -31166,6 +31749,10 @@
               {
                 "const": "cs",
                 "type": "string"
+              },
+              {
+                "const": "es",
+                "type": "string"
               }
             ]
           },
@@ -31352,6 +31939,10 @@
               },
               {
                 "const": "cs",
+                "type": "string"
+              },
+              {
+                "const": "es",
                 "type": "string"
               }
             ]
@@ -31733,6 +32324,10 @@
                               {
                                 "const": "cs",
                                 "type": "string"
+                              },
+                              {
+                                "const": "es",
+                                "type": "string"
                               }
                             ]
                           }
@@ -31765,6 +32360,10 @@
                         },
                         {
                           "const": "cs",
+                          "type": "string"
+                        },
+                        {
+                          "const": "es",
                           "type": "string"
                         }
                       ]
@@ -32207,6 +32806,10 @@
                                   {
                                     "const": "cs",
                                     "type": "string"
+                                  },
+                                  {
+                                    "const": "es",
+                                    "type": "string"
                                   }
                                 ]
                               }
@@ -32239,6 +32842,10 @@
                             },
                             {
                               "const": "cs",
+                              "type": "string"
+                            },
+                            {
+                              "const": "es",
                               "type": "string"
                             }
                           ]
@@ -32461,6 +33068,10 @@
                   },
                   {
                     "const": "cs",
+                    "type": "string"
+                  },
+                  {
+                    "const": "es",
                     "type": "string"
                   }
                 ]
@@ -32706,6 +33317,10 @@
                               {
                                 "const": "cs",
                                 "type": "string"
+                              },
+                              {
+                                "const": "es",
+                                "type": "string"
                               }
                             ]
                           }
@@ -32738,6 +33353,10 @@
                         },
                         {
                           "const": "cs",
+                          "type": "string"
+                        },
+                        {
+                          "const": "es",
                           "type": "string"
                         }
                       ]
@@ -33016,6 +33635,10 @@
                                   {
                                     "const": "cs",
                                     "type": "string"
+                                  },
+                                  {
+                                    "const": "es",
+                                    "type": "string"
                                   }
                                 ]
                               }
@@ -33048,6 +33671,10 @@
                             },
                             {
                               "const": "cs",
+                              "type": "string"
+                            },
+                            {
+                              "const": "es",
                               "type": "string"
                             }
                           ]
@@ -33099,6 +33726,10 @@
                   },
                   {
                     "const": "cs",
+                    "type": "string"
+                  },
+                  {
+                    "const": "es",
                     "type": "string"
                   }
                 ]
@@ -33369,6 +34000,10 @@
                                   {
                                     "const": "cs",
                                     "type": "string"
+                                  },
+                                  {
+                                    "const": "es",
+                                    "type": "string"
                                   }
                                 ]
                               }
@@ -33401,6 +34036,10 @@
                             },
                             {
                               "const": "cs",
+                              "type": "string"
+                            },
+                            {
+                              "const": "es",
                               "type": "string"
                             }
                           ]
@@ -33567,6 +34206,10 @@
                   {
                     "const": "cs",
                     "type": "string"
+                  },
+                  {
+                    "const": "es",
+                    "type": "string"
                   }
                 ]
               }
@@ -33704,6 +34347,10 @@
               },
               {
                 "const": "cs",
+                "type": "string"
+              },
+              {
+                "const": "es",
                 "type": "string"
               }
             ]
@@ -33943,6 +34590,10 @@
               },
               {
                 "const": "cs",
+                "type": "string"
+              },
+              {
+                "const": "es",
                 "type": "string"
               }
             ]
@@ -34267,6 +34918,10 @@
               {
                 "const": "cs",
                 "type": "string"
+              },
+              {
+                "const": "es",
+                "type": "string"
               }
             ]
           }
@@ -34583,6 +35238,10 @@
                   },
                   {
                     "const": "cs",
+                    "type": "string"
+                  },
+                  {
+                    "const": "es",
                     "type": "string"
                   }
                 ]
@@ -35190,6 +35849,10 @@
               },
               {
                 "const": "cs",
+                "type": "string"
+              },
+              {
+                "const": "es",
                 "type": "string"
               }
             ]
@@ -36059,6 +36722,10 @@
               {
                 "const": "cs",
                 "type": "string"
+              },
+              {
+                "const": "es",
+                "type": "string"
               }
             ]
           },
@@ -36289,6 +36956,10 @@
                   },
                   {
                     "const": "cs",
+                    "type": "string"
+                  },
+                  {
+                    "const": "es",
                     "type": "string"
                   }
                 ]
@@ -38302,6 +38973,10 @@
                     {
                       "const": "cs",
                       "type": "string"
+                    },
+                    {
+                      "const": "es",
+                      "type": "string"
                     }
                   ]
                 },
@@ -38327,6 +39002,10 @@
                       },
                       {
                         "const": "cs",
+                        "type": "string"
+                      },
+                      {
+                        "const": "es",
                         "type": "string"
                       }
                     ]
@@ -38534,6 +39213,10 @@
                     {
                       "const": "cs",
                       "type": "string"
+                    },
+                    {
+                      "const": "es",
+                      "type": "string"
                     }
                   ]
                 },
@@ -38559,6 +39242,10 @@
                       },
                       {
                         "const": "cs",
+                        "type": "string"
+                      },
+                      {
+                        "const": "es",
                         "type": "string"
                       }
                     ]
@@ -38667,6 +39354,10 @@
               {
                 "const": "cs",
                 "type": "string"
+              },
+              {
+                "const": "es",
+                "type": "string"
               }
             ]
           },
@@ -38696,6 +39387,10 @@
                     },
                     {
                       "const": "cs",
+                      "type": "string"
+                    },
+                    {
+                      "const": "es",
                       "type": "string"
                     }
                   ]
@@ -38857,6 +39552,10 @@
                   {
                     "const": "cs",
                     "type": "string"
+                  },
+                  {
+                    "const": "es",
+                    "type": "string"
                   }
                 ]
               },
@@ -38882,6 +39581,10 @@
                     },
                     {
                       "const": "cs",
+                      "type": "string"
+                    },
+                    {
+                      "const": "es",
                       "type": "string"
                     }
                   ]
@@ -39324,6 +40027,10 @@
               {
                 "const": "cs",
                 "type": "string"
+              },
+              {
+                "const": "es",
+                "type": "string"
               }
             ]
           }
@@ -39478,6 +40185,10 @@
               },
               {
                 "const": "cs",
+                "type": "string"
+              },
+              {
+                "const": "es",
                 "type": "string"
               }
             ]
@@ -40244,6 +40955,10 @@
               {
                 "const": "cs",
                 "type": "string"
+              },
+              {
+                "const": "es",
+                "type": "string"
               }
             ]
           }
@@ -40291,6 +41006,10 @@
                       {
                         "const": "cs",
                         "type": "string"
+                      },
+                      {
+                        "const": "es",
+                        "type": "string"
                       }
                     ]
                   }
@@ -40315,6 +41034,10 @@
                     },
                     {
                       "const": "cs",
+                      "type": "string"
+                    },
+                    {
+                      "const": "es",
                       "type": "string"
                     }
                   ]
@@ -40417,6 +41140,10 @@
                     {
                       "const": "cs",
                       "type": "string"
+                    },
+                    {
+                      "const": "es",
+                      "type": "string"
                     }
                   ]
                 }
@@ -40441,6 +41168,10 @@
                   },
                   {
                     "const": "cs",
+                    "type": "string"
+                  },
+                  {
+                    "const": "es",
                     "type": "string"
                   }
                 ]
@@ -40506,6 +41237,10 @@
               },
               {
                 "const": "cs",
+                "type": "string"
+              },
+              {
+                "const": "es",
                 "type": "string"
               }
             ]
@@ -40574,6 +41309,10 @@
               {
                 "const": "cs",
                 "type": "string"
+              },
+              {
+                "const": "es",
+                "type": "string"
               }
             ]
           }
@@ -40615,6 +41354,10 @@
                     {
                       "const": "cs",
                       "type": "string"
+                    },
+                    {
+                      "const": "es",
+                      "type": "string"
                     }
                   ]
                 }
@@ -40639,6 +41382,10 @@
                   },
                   {
                     "const": "cs",
+                    "type": "string"
+                  },
+                  {
+                    "const": "es",
                     "type": "string"
                   }
                 ]
@@ -41912,6 +42659,10 @@
                         {
                           "const": "cs",
                           "type": "string"
+                        },
+                        {
+                          "const": "es",
+                          "type": "string"
                         }
                       ]
                     },
@@ -41937,6 +42688,10 @@
                           },
                           {
                             "const": "cs",
+                            "type": "string"
+                          },
+                          {
+                            "const": "es",
                             "type": "string"
                           }
                         ]
@@ -42255,6 +43010,10 @@
                       {
                         "const": "cs",
                         "type": "string"
+                      },
+                      {
+                        "const": "es",
+                        "type": "string"
                       }
                     ]
                   },
@@ -42280,6 +43039,10 @@
                         },
                         {
                           "const": "cs",
+                          "type": "string"
+                        },
+                        {
+                          "const": "es",
                           "type": "string"
                         }
                       ]
@@ -42538,6 +43301,10 @@
               {
                 "const": "cs",
                 "type": "string"
+              },
+              {
+                "const": "es",
+                "type": "string"
               }
             ]
           },
@@ -42718,6 +43485,10 @@
                   {
                     "const": "cs",
                     "type": "string"
+                  },
+                  {
+                    "const": "es",
+                    "type": "string"
                   }
                 ]
               },
@@ -42743,6 +43514,10 @@
                     },
                     {
                       "const": "cs",
+                      "type": "string"
+                    },
+                    {
+                      "const": "es",
                       "type": "string"
                     }
                   ]
@@ -42799,6 +43574,10 @@
               },
               {
                 "const": "cs",
+                "type": "string"
+              },
+              {
+                "const": "es",
                 "type": "string"
               }
             ]
@@ -42975,6 +43754,10 @@
                   {
                     "const": "cs",
                     "type": "string"
+                  },
+                  {
+                    "const": "es",
+                    "type": "string"
                   }
                 ]
               },
@@ -43000,6 +43783,10 @@
                     },
                     {
                       "const": "cs",
+                      "type": "string"
+                    },
+                    {
+                      "const": "es",
                       "type": "string"
                     }
                   ]
@@ -44014,6 +44801,10 @@
                       {
                         "const": "cs",
                         "type": "string"
+                      },
+                      {
+                        "const": "es",
+                        "type": "string"
                       }
                     ]
                   },
@@ -44113,6 +44904,10 @@
                       {
                         "const": "cs",
                         "type": "string"
+                      },
+                      {
+                        "const": "es",
+                        "type": "string"
                       }
                     ]
                   }
@@ -44182,6 +44977,10 @@
                       },
                       {
                         "const": "cs",
+                        "type": "string"
+                      },
+                      {
+                        "const": "es",
                         "type": "string"
                       }
                     ]
@@ -44497,6 +45296,10 @@
               {
                 "const": "cs",
                 "type": "string"
+              },
+              {
+                "const": "es",
+                "type": "string"
               }
             ]
           }
@@ -44618,6 +45421,10 @@
               },
               {
                 "const": "cs",
+                "type": "string"
+              },
+              {
+                "const": "es",
                 "type": "string"
               }
             ]
@@ -44776,6 +45583,10 @@
               },
               {
                 "const": "cs",
+                "type": "string"
+              },
+              {
+                "const": "es",
                 "type": "string"
               }
             ]
@@ -45230,6 +46041,10 @@
                       {
                         "const": "cs",
                         "type": "string"
+                      },
+                      {
+                        "const": "es",
+                        "type": "string"
                       }
                     ]
                   }
@@ -45254,6 +46069,10 @@
                     },
                     {
                       "const": "cs",
+                      "type": "string"
+                    },
+                    {
+                      "const": "es",
                       "type": "string"
                     }
                   ]
@@ -46238,6 +47057,10 @@
               {
                 "const": "cs",
                 "type": "string"
+              },
+              {
+                "const": "es",
+                "type": "string"
               }
             ]
           },
@@ -46263,6 +47086,10 @@
                 },
                 {
                   "const": "cs",
+                  "type": "string"
+                },
+                {
+                  "const": "es",
                   "type": "string"
                 }
               ]
@@ -46327,6 +47154,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             },
@@ -46352,6 +47183,10 @@
                   },
                   {
                     "const": "cs",
+                    "type": "string"
+                  },
+                  {
+                    "const": "es",
                     "type": "string"
                   }
                 ]
@@ -46396,6 +47231,10 @@
               },
               {
                 "const": "cs",
+                "type": "string"
+              },
+              {
+                "const": "es",
                 "type": "string"
               }
             ]
@@ -46486,6 +47325,10 @@
                     {
                       "const": "cs",
                       "type": "string"
+                    },
+                    {
+                      "const": "es",
+                      "type": "string"
                     }
                   ]
                 },
@@ -46512,6 +47355,10 @@
                       },
                       {
                         "const": "cs",
+                        "type": "string"
+                      },
+                      {
+                        "const": "es",
                         "type": "string"
                       }
                     ]
@@ -46798,6 +47645,10 @@
               {
                 "const": "cs",
                 "type": "string"
+              },
+              {
+                "const": "es",
+                "type": "string"
               }
             ]
           },
@@ -46879,6 +47730,10 @@
                   {
                     "const": "cs",
                     "type": "string"
+                  },
+                  {
+                    "const": "es",
+                    "type": "string"
                   }
                 ]
               },
@@ -46905,6 +47760,10 @@
                     },
                     {
                       "const": "cs",
+                      "type": "string"
+                    },
+                    {
+                      "const": "es",
                       "type": "string"
                     }
                   ]
@@ -47184,6 +48043,10 @@
                     {
                       "const": "cs",
                       "type": "string"
+                    },
+                    {
+                      "const": "es",
+                      "type": "string"
                     }
                   ]
                 },
@@ -47210,6 +48073,10 @@
                       },
                       {
                         "const": "cs",
+                        "type": "string"
+                      },
+                      {
+                        "const": "es",
                         "type": "string"
                       }
                     ]
@@ -47492,6 +48359,10 @@
               {
                 "const": "cs",
                 "type": "string"
+              },
+              {
+                "const": "es",
+                "type": "string"
               }
             ]
           }
@@ -47547,6 +48418,10 @@
               },
               {
                 "const": "cs",
+                "type": "string"
+              },
+              {
+                "const": "es",
                 "type": "string"
               }
             ]
@@ -47644,6 +48519,10 @@
               },
               {
                 "const": "cs",
+                "type": "string"
+              },
+              {
+                "const": "es",
                 "type": "string"
               }
             ]
@@ -47768,6 +48647,10 @@
               {
                 "const": "cs",
                 "type": "string"
+              },
+              {
+                "const": "es",
+                "type": "string"
               }
             ]
           }
@@ -47834,6 +48717,10 @@
                   {
                     "const": "cs",
                     "type": "string"
+                  },
+                  {
+                    "const": "es",
+                    "type": "string"
                   }
                 ]
               },
@@ -47860,6 +48747,10 @@
                     },
                     {
                       "const": "cs",
+                      "type": "string"
+                    },
+                    {
+                      "const": "es",
                       "type": "string"
                     }
                   ]
@@ -47906,6 +48797,10 @@
               },
               {
                 "const": "cs",
+                "type": "string"
+              },
+              {
+                "const": "es",
                 "type": "string"
               }
             ]
@@ -47965,6 +48860,10 @@
               },
               {
                 "const": "cs",
+                "type": "string"
+              },
+              {
+                "const": "es",
                 "type": "string"
               }
             ]
@@ -48352,6 +49251,10 @@
                   {
                     "const": "cs",
                     "type": "string"
+                  },
+                  {
+                    "const": "es",
+                    "type": "string"
                   }
                 ]
               },
@@ -48378,6 +49281,10 @@
                     },
                     {
                       "const": "cs",
+                      "type": "string"
+                    },
+                    {
+                      "const": "es",
                       "type": "string"
                     }
                   ]
@@ -48902,6 +49809,10 @@
               {
                 "const": "cs",
                 "type": "string"
+              },
+              {
+                "const": "es",
+                "type": "string"
               }
             ]
           },
@@ -48962,6 +49873,10 @@
               },
               {
                 "const": "cs",
+                "type": "string"
+              },
+              {
+                "const": "es",
                 "type": "string"
               }
             ]
@@ -49073,6 +49988,10 @@
               {
                 "const": "cs",
                 "type": "string"
+              },
+              {
+                "const": "es",
+                "type": "string"
               }
             ]
           },
@@ -49137,6 +50056,10 @@
               },
               {
                 "const": "cs",
+                "type": "string"
+              },
+              {
+                "const": "es",
                 "type": "string"
               }
             ]

--- a/apps/api/src/swagger/integration-api-schema.json
+++ b/apps/api/src/swagger/integration-api-schema.json
@@ -721,6 +721,10 @@
                 {
                   "const": "cs",
                   "type": "string"
+                },
+                {
+                  "const": "es",
+                  "type": "string"
                 }
               ]
             }
@@ -1233,6 +1237,10 @@
               },
               {
                 "const": "cs",
+                "type": "string"
+              },
+              {
+                "const": "es",
                 "type": "string"
               }
             ]
@@ -1889,6 +1897,10 @@
               {
                 "const": "cs",
                 "type": "string"
+              },
+              {
+                "const": "es",
+                "type": "string"
               }
             ]
           }
@@ -2093,6 +2105,10 @@
                       {
                         "const": "cs",
                         "type": "string"
+                      },
+                      {
+                        "const": "es",
+                        "type": "string"
                       }
                     ]
                   }
@@ -2117,6 +2133,10 @@
                     },
                     {
                       "const": "cs",
+                      "type": "string"
+                    },
+                    {
+                      "const": "es",
                       "type": "string"
                     }
                   ]

--- a/apps/web/app/api/generated-api.ts
+++ b/apps/web/app/api/generated-api.ts
@@ -110,7 +110,7 @@ export interface RegisterBody {
    */
   lastName: string;
   password: string;
-  language: "en" | "pl" | "de" | "lt" | "cs";
+  language: "en" | "pl" | "de" | "lt" | "cs" | "es";
   formAnswers?: object;
 }
 
@@ -326,7 +326,7 @@ export interface CreatePasswordBody {
   password: string;
   /** @minLength 1 */
   createToken: string;
-  language: "en" | "pl" | "de" | "lt" | "cs";
+  language: "en" | "pl" | "de" | "lt" | "cs" | "es";
 }
 
 export interface CreatePasswordResponse {
@@ -475,8 +475,8 @@ export interface GetPublicRegistrationFormResponse {
       type: "checkbox";
       /** @minLength 1 */
       label: string;
-      baseLanguage: "en" | "pl" | "de" | "lt" | "cs";
-      availableLocales: ("en" | "pl" | "de" | "lt" | "cs")[];
+      baseLanguage: "en" | "pl" | "de" | "lt" | "cs" | "es";
+      availableLocales: ("en" | "pl" | "de" | "lt" | "cs" | "es")[];
       required: boolean;
       displayOrder: number;
       archived: boolean;
@@ -489,13 +489,13 @@ export interface GetPublicRegistrationFormResponse {
 export interface GetUserSettingsResponse {
   data:
     | {
-        language: "en" | "pl" | "de" | "lt" | "cs";
+        language: "en" | "pl" | "de" | "lt" | "cs" | "es";
         /** @default false */
         isMFAEnabled: boolean;
         MFASecret: string | null;
       }
     | {
-        language: "en" | "pl" | "de" | "lt" | "cs";
+        language: "en" | "pl" | "de" | "lt" | "cs" | "es";
         /** @default false */
         isMFAEnabled: boolean;
         MFASecret: string | null;
@@ -507,13 +507,13 @@ export interface GetUserSettingsResponse {
 
 export type UpdateUserSettingsBody =
   | {
-      language?: "en" | "pl" | "de" | "lt" | "cs";
+      language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       /** @default false */
       isMFAEnabled?: boolean;
       MFASecret?: string | null;
     }
   | {
-      language?: "en" | "pl" | "de" | "lt" | "cs";
+      language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       /** @default false */
       isMFAEnabled?: boolean;
       MFASecret?: string | null;
@@ -525,13 +525,13 @@ export type UpdateUserSettingsBody =
 export interface UpdateUserSettingsResponse {
   data:
     | {
-        language: "en" | "pl" | "de" | "lt" | "cs";
+        language: "en" | "pl" | "de" | "lt" | "cs" | "es";
         /** @default false */
         isMFAEnabled: boolean;
         MFASecret: string | null;
       }
     | {
-        language: "en" | "pl" | "de" | "lt" | "cs";
+        language: "en" | "pl" | "de" | "lt" | "cs" | "es";
         /** @default false */
         isMFAEnabled: boolean;
         MFASecret: string | null;
@@ -543,7 +543,7 @@ export interface UpdateUserSettingsResponse {
 
 export interface UpdateAdminNewUserNotificationResponse {
   data: {
-    language: "en" | "pl" | "de" | "lt" | "cs";
+    language: "en" | "pl" | "de" | "lt" | "cs" | "es";
     /** @default false */
     isMFAEnabled: boolean;
     MFASecret: string | null;
@@ -952,7 +952,7 @@ export interface UpdateLearningPathsEnabledResponse {
 
 export interface UpdateAdminFinishedCourseNotificationResponse {
   data: {
-    language: "en" | "pl" | "de" | "lt" | "cs";
+    language: "en" | "pl" | "de" | "lt" | "cs" | "es";
     /** @default false */
     isMFAEnabled: boolean;
     MFASecret: string | null;
@@ -964,7 +964,7 @@ export interface UpdateAdminFinishedCourseNotificationResponse {
 
 export interface UpdateAdminOverdueCourseNotificationResponse {
   data: {
-    language: "en" | "pl" | "de" | "lt" | "cs";
+    language: "en" | "pl" | "de" | "lt" | "cs" | "es";
     /** @default false */
     isMFAEnabled: boolean;
     MFASecret: string | null;
@@ -1047,9 +1047,11 @@ export interface GetAdminRegistrationFormResponse {
         lt?: string;
         /** @minLength 1 */
         cs?: string;
+        /** @minLength 1 */
+        es?: string;
       };
-      baseLanguage: "en" | "pl" | "de" | "lt" | "cs";
-      availableLocales: ("en" | "pl" | "de" | "lt" | "cs")[];
+      baseLanguage: "en" | "pl" | "de" | "lt" | "cs" | "es";
+      availableLocales: ("en" | "pl" | "de" | "lt" | "cs" | "es")[];
       required: boolean;
       displayOrder: number;
       archived: boolean;
@@ -1075,9 +1077,11 @@ export interface UpdateRegistrationFormBody {
       lt?: string;
       /** @minLength 1 */
       cs?: string;
+      /** @minLength 1 */
+      es?: string;
     };
-    baseLanguage?: "en" | "pl" | "de" | "lt" | "cs";
-    availableLocales?: ("en" | "pl" | "de" | "lt" | "cs")[];
+    baseLanguage?: "en" | "pl" | "de" | "lt" | "cs" | "es";
+    availableLocales?: ("en" | "pl" | "de" | "lt" | "cs" | "es")[];
     required: boolean;
     displayOrder: number;
     archived: boolean;
@@ -1101,9 +1105,11 @@ export interface UpdateRegistrationFormResponse {
         lt?: string;
         /** @minLength 1 */
         cs?: string;
+        /** @minLength 1 */
+        es?: string;
       };
-      baseLanguage: "en" | "pl" | "de" | "lt" | "cs";
-      availableLocales: ("en" | "pl" | "de" | "lt" | "cs")[];
+      baseLanguage: "en" | "pl" | "de" | "lt" | "cs" | "es";
+      availableLocales: ("en" | "pl" | "de" | "lt" | "cs" | "es")[];
       required: boolean;
       displayOrder: number;
       archived: boolean;
@@ -1177,7 +1183,7 @@ export interface UpdateConfigWarningDismissedBody {
 
 export interface UpdateConfigWarningDismissedResponse {
   data: {
-    language: "en" | "pl" | "de" | "lt" | "cs";
+    language: "en" | "pl" | "de" | "lt" | "cs" | "es";
     /** @default false */
     isMFAEnabled: boolean;
     MFASecret: string | null;
@@ -1489,7 +1495,7 @@ export interface CreateUserBody {
    */
   lastName: string;
   roleSlugs: string[];
-  language?: "en" | "pl" | "de" | "lt" | "cs";
+  language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
 }
 
 export interface CreateUserResponse {
@@ -1549,8 +1555,8 @@ export interface GetAllGroupsResponse {
     id: string;
     name: string;
     characteristic: string | null;
-    availableLocales: ("en" | "pl" | "de" | "lt" | "cs")[];
-    baseLanguage: "en" | "pl" | "de" | "lt" | "cs";
+    availableLocales: ("en" | "pl" | "de" | "lt" | "cs" | "es")[];
+    baseLanguage: "en" | "pl" | "de" | "lt" | "cs" | "es";
     users?: {
       id: string;
       createdAt: string;
@@ -1579,8 +1585,8 @@ export interface GetGroupByIdResponse {
     id: string;
     name: string;
     characteristic: string | null;
-    availableLocales: ("en" | "pl" | "de" | "lt" | "cs")[];
-    baseLanguage: "en" | "pl" | "de" | "lt" | "cs";
+    availableLocales: ("en" | "pl" | "de" | "lt" | "cs" | "es")[];
+    baseLanguage: "en" | "pl" | "de" | "lt" | "cs" | "es";
     users?: {
       id: string;
       createdAt: string;
@@ -1603,8 +1609,8 @@ export interface GetUserGroupsResponse {
     id: string;
     name: string;
     characteristic: string | null;
-    availableLocales: ("en" | "pl" | "de" | "lt" | "cs")[];
-    baseLanguage: "en" | "pl" | "de" | "lt" | "cs";
+    availableLocales: ("en" | "pl" | "de" | "lt" | "cs" | "es")[];
+    baseLanguage: "en" | "pl" | "de" | "lt" | "cs" | "es";
     users?: {
       id: string;
       createdAt: string;
@@ -1630,7 +1636,7 @@ export interface GetUserGroupsResponse {
 export interface CreateGroupBody {
   name: string;
   characteristic?: string;
-  language: "en" | "pl" | "de" | "lt" | "cs";
+  language: "en" | "pl" | "de" | "lt" | "cs" | "es";
 }
 
 export interface CreateGroupResponse {
@@ -1644,7 +1650,7 @@ export interface CreateGroupResponse {
 export interface UpdateGroupBody {
   name?: string;
   characteristic?: string;
-  language?: "en" | "pl" | "de" | "lt" | "cs";
+  language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
 }
 
 export interface UpdateGroupResponse {
@@ -1653,8 +1659,8 @@ export interface UpdateGroupResponse {
     id: string;
     name: string;
     characteristic?: string | null;
-    availableLocales?: ("en" | "pl" | "de" | "lt" | "cs")[];
-    baseLanguage?: "en" | "pl" | "de" | "lt" | "cs";
+    availableLocales?: ("en" | "pl" | "de" | "lt" | "cs" | "es")[];
+    baseLanguage?: "en" | "pl" | "de" | "lt" | "cs" | "es";
     createdAt: string;
     updatedAt: string;
     isMandatory?: boolean;
@@ -1680,8 +1686,8 @@ export interface CreateLanguageResponse {
     sequenceEnabled: boolean;
     /** @format uuid */
     authorId: string;
-    baseLanguage: "en" | "pl" | "de" | "lt" | "cs";
-    availableLocales: ("en" | "pl" | "de" | "lt" | "cs")[];
+    baseLanguage: "en" | "pl" | "de" | "lt" | "cs" | "es";
+    availableLocales: ("en" | "pl" | "de" | "lt" | "cs" | "es")[];
     createdAt: string;
     updatedAt: string;
   };
@@ -1692,15 +1698,15 @@ export interface DeleteLanguageResponse {
     /** @format uuid */
     id: string;
     title: string;
-    availableLocales: ("en" | "pl" | "de" | "lt" | "cs")[];
-    baseLanguage: "en" | "pl" | "de" | "lt" | "cs";
+    availableLocales: ("en" | "pl" | "de" | "lt" | "cs" | "es")[];
+    baseLanguage: "en" | "pl" | "de" | "lt" | "cs" | "es";
     archived: boolean | null;
     createdAt: string | null;
   };
 }
 
 export interface UpdateBaseLanguageBody {
-  baseLanguage: "en" | "pl" | "de" | "lt" | "cs";
+  baseLanguage: "en" | "pl" | "de" | "lt" | "cs" | "es";
 }
 
 export interface UpdateBaseLanguageResponse {
@@ -1708,8 +1714,8 @@ export interface UpdateBaseLanguageResponse {
     /** @format uuid */
     id: string;
     title: string;
-    availableLocales: ("en" | "pl" | "de" | "lt" | "cs")[];
-    baseLanguage: "en" | "pl" | "de" | "lt" | "cs";
+    availableLocales: ("en" | "pl" | "de" | "lt" | "cs" | "es")[];
+    baseLanguage: "en" | "pl" | "de" | "lt" | "cs" | "es";
     archived: boolean | null;
     createdAt: string | null;
   };
@@ -1743,8 +1749,8 @@ export interface GetGroupsByCourseResponse {
     id: string;
     name: string;
     characteristic?: string | null;
-    availableLocales?: ("en" | "pl" | "de" | "lt" | "cs")[];
-    baseLanguage?: "en" | "pl" | "de" | "lt" | "cs";
+    availableLocales?: ("en" | "pl" | "de" | "lt" | "cs" | "es")[];
+    baseLanguage?: "en" | "pl" | "de" | "lt" | "cs" | "es";
     createdAt: string;
     updatedAt: string;
     isMandatory?: boolean;
@@ -1903,8 +1909,8 @@ export interface GetAvailableCourseCategoriesResponse {
     /** @format uuid */
     id: string;
     title: string;
-    availableLocales: ("en" | "pl" | "de" | "lt" | "cs")[];
-    baseLanguage: "en" | "pl" | "de" | "lt" | "cs";
+    availableLocales: ("en" | "pl" | "de" | "lt" | "cs" | "es")[];
+    baseLanguage: "en" | "pl" | "de" | "lt" | "cs" | "es";
     archived: boolean | null;
     createdAt: string | null;
   }[];
@@ -2051,8 +2057,8 @@ export interface GetCourseResponse {
     slug: string;
     stripeProductId: string | null;
     stripePriceId: string | null;
-    availableLocales: ("en" | "pl" | "de" | "lt" | "cs")[];
-    baseLanguage: "en" | "pl" | "de" | "lt" | "cs";
+    availableLocales: ("en" | "pl" | "de" | "lt" | "cs" | "es")[];
+    baseLanguage: "en" | "pl" | "de" | "lt" | "cs" | "es";
     dueDate: string | null;
   };
 }
@@ -2120,10 +2126,10 @@ export interface GetBetaCourseByIdResponse {
             matchedWord?: string | null;
             scaleAnswer?: number | null;
             /** @default "en" */
-            language?: "en" | "pl" | "de" | "lt" | "cs";
+            language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
           }[];
           /** @default "en" */
-          language?: "en" | "pl" | "de" | "lt" | "cs";
+          language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
         }[];
         aiMentor?: {
           /** @format uuid */
@@ -2170,8 +2176,8 @@ export interface GetBetaCourseByIdResponse {
     thumbnailS3SingedUrl?: string | null;
     trailerUrl?: string | null;
     title: string;
-    availableLocales: ("en" | "pl" | "de" | "lt" | "cs")[];
-    baseLanguage: "en" | "pl" | "de" | "lt" | "cs";
+    availableLocales: ("en" | "pl" | "de" | "lt" | "cs" | "es")[];
+    baseLanguage: "en" | "pl" | "de" | "lt" | "cs" | "es";
     sourceCourseId?: string | null;
     sourceTenantId?: string | null;
   };
@@ -2195,7 +2201,7 @@ export type CreateCourseBody = {
   isScorm?: boolean;
   hasCertificate?: boolean;
   /** @default "en" */
-  language: "en" | "pl" | "de" | "lt" | "cs";
+  language: "en" | "pl" | "de" | "lt" | "cs" | "es";
 } & {
   chapters?: string[];
 };
@@ -2261,7 +2267,7 @@ export interface UpdateCourseBody {
   chapters?: string[];
   archived?: boolean;
   /** @default "en" */
-  language?: "en" | "pl" | "de" | "lt" | "cs";
+  language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
 }
 
 export interface UpdateCourseResponse {
@@ -2799,10 +2805,10 @@ export type BetaCreateChapterBody = {
         matchedWord?: string | null;
         scaleAnswer?: number | null;
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       }[];
       /** @default "en" */
-      language?: "en" | "pl" | "de" | "lt" | "cs";
+      language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
     }[];
     aiMentor?: {
       /** @format uuid */
@@ -2885,10 +2891,10 @@ export type UpdateChapterBody = ({
         matchedWord?: string | null;
         scaleAnswer?: number | null;
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       }[];
       /** @default "en" */
-      language?: "en" | "pl" | "de" | "lt" | "cs";
+      language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
     }[];
     aiMentor?: {
       /** @format uuid */
@@ -2918,7 +2924,7 @@ export type UpdateChapterBody = ({
   courseId?: string;
 }) & {
   /** @default "en" */
-  language: "en" | "pl" | "de" | "lt" | "cs";
+  language: "en" | "pl" | "de" | "lt" | "cs" | "es";
 };
 
 export interface UpdateChapterResponse {
@@ -3018,7 +3024,7 @@ export interface GetLessonByIdResponse {
           questionId?: string;
         }[];
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
         passQuestion: boolean | null;
       }[];
       questionCount: number;
@@ -3036,7 +3042,7 @@ export interface GetLessonByIdResponse {
     displayOrder: number;
     isExternal?: boolean;
     nextLessonId: string | null;
-    userLanguage?: "en" | "pl" | "de" | "lt" | "cs";
+    userLanguage?: "en" | "pl" | "de" | "lt" | "cs" | "es";
     status?: "active" | "completed" | "archived";
     /** @format uuid */
     threadId?: string;
@@ -3207,10 +3213,10 @@ export type BetaCreateLessonBody = {
       matchedWord?: string | null;
       scaleAnswer?: number | null;
       /** @default "en" */
-      language?: "en" | "pl" | "de" | "lt" | "cs";
+      language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
     }[];
     /** @default "en" */
-    language?: "en" | "pl" | "de" | "lt" | "cs";
+    language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
   }[];
   aiMentor?: {
     /** @format uuid */
@@ -3252,7 +3258,7 @@ export interface BetaCreateLiveTrainingLessonBody {
   /** @format uuid */
   chapterId: string;
   /** @default "en" */
-  language: "en" | "pl" | "de" | "lt" | "cs";
+  language: "en" | "pl" | "de" | "lt" | "cs" | "es";
   displayOrder?: number;
   contextId?: string;
   liveTraining?: {
@@ -3307,7 +3313,7 @@ export interface AttachLiveTrainingLessonBody {
    */
   title: string;
   /** @default "en" */
-  language: "en" | "pl" | "de" | "lt" | "cs";
+  language: "en" | "pl" | "de" | "lt" | "cs" | "es";
   liveTraining?: {
     /**
      * @minLength 1
@@ -3399,10 +3405,10 @@ export type BetaCreateAiMentorLessonBody = {
       matchedWord?: string | null;
       scaleAnswer?: number | null;
       /** @default "en" */
-      language?: "en" | "pl" | "de" | "lt" | "cs";
+      language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
     }[];
     /** @default "en" */
-    language?: "en" | "pl" | "de" | "lt" | "cs";
+    language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
   }[];
   aiMentor?: {
     /** @format uuid */
@@ -3479,10 +3485,10 @@ export type BetaUpdateAiMentorLessonBody = ({
       matchedWord?: string | null;
       scaleAnswer?: number | null;
       /** @default "en" */
-      language?: "en" | "pl" | "de" | "lt" | "cs";
+      language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
     }[];
     /** @default "en" */
-    language?: "en" | "pl" | "de" | "lt" | "cs";
+    language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
   }[];
   aiMentor?: {
     /** @format uuid */
@@ -3509,7 +3515,7 @@ export type BetaUpdateAiMentorLessonBody = ({
   customTtsReference?: string | null;
 }) & {
   /** @default "en" */
-  language: "en" | "pl" | "de" | "lt" | "cs";
+  language: "en" | "pl" | "de" | "lt" | "cs" | "es";
 };
 
 export interface BetaUpdateAiMentorLessonResponse {
@@ -3561,10 +3567,10 @@ export type BetaCreateQuizLessonBody = {
       matchedWord?: string | null;
       scaleAnswer?: number | null;
       /** @default "en" */
-      language?: "en" | "pl" | "de" | "lt" | "cs";
+      language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
     }[];
     /** @default "en" */
-    language?: "en" | "pl" | "de" | "lt" | "cs";
+    language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
   }[];
 } & {
   /** @format uuid */
@@ -3623,10 +3629,10 @@ export type BetaUpdateQuizLessonBody = ({
       matchedWord?: string | null;
       scaleAnswer?: number | null;
       /** @default "en" */
-      language?: "en" | "pl" | "de" | "lt" | "cs";
+      language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
     }[];
     /** @default "en" */
-    language?: "en" | "pl" | "de" | "lt" | "cs";
+    language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
   }[];
 } & {
   /** @format uuid */
@@ -3634,7 +3640,7 @@ export type BetaUpdateQuizLessonBody = ({
   displayOrder?: number;
 }) & {
   /** @default "en" */
-  language: "en" | "pl" | "de" | "lt" | "cs";
+  language: "en" | "pl" | "de" | "lt" | "cs" | "es";
 };
 
 export interface BetaUpdateQuizLessonResponse {
@@ -3683,10 +3689,10 @@ export type BetaUpdateLessonBody = ({
       matchedWord?: string | null;
       scaleAnswer?: number | null;
       /** @default "en" */
-      language?: "en" | "pl" | "de" | "lt" | "cs";
+      language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
     }[];
     /** @default "en" */
-    language?: "en" | "pl" | "de" | "lt" | "cs";
+    language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
   }[];
   aiMentor?: {
     /** @format uuid */
@@ -3710,7 +3716,7 @@ export type BetaUpdateLessonBody = ({
   contextId?: string;
 }) & {
   /** @default "en" */
-  language: "en" | "pl" | "de" | "lt" | "cs";
+  language: "en" | "pl" | "de" | "lt" | "cs" | "es";
 };
 
 export interface BetaUpdateLessonResponse {
@@ -3746,7 +3752,7 @@ export interface EvaluationQuizBody {
         }
     )[];
   }[];
-  language: "en" | "pl" | "de" | "lt" | "cs";
+  language: "en" | "pl" | "de" | "lt" | "cs" | "es";
 }
 
 export interface EvaluationQuizResponse {
@@ -3798,7 +3804,7 @@ export interface UpdateEmbedLessonBody {
   /** @format uuid */
   lessonId: string;
   /** @default "en" */
-  language: "en" | "pl" | "de" | "lt" | "cs";
+  language: "en" | "pl" | "de" | "lt" | "cs" | "es";
 }
 
 export interface UpdateEmbedLessonResponse {
@@ -3868,7 +3874,7 @@ export type GetCertificateResponse = {
 export interface DownloadCertificateBody {
   /** @format uuid */
   certificateId: string;
-  language: "en" | "pl" | "de" | "lt" | "cs";
+  language: "en" | "pl" | "de" | "lt" | "cs" | "es";
 }
 
 export interface CreateCertificateShareLinkBody {
@@ -3951,7 +3957,7 @@ export interface GetThreadResponse {
     aiMentorLessonId: string;
     /** @format uuid */
     userId: string;
-    userLanguage: "en" | "pl" | "de" | "lt" | "cs";
+    userLanguage: "en" | "pl" | "de" | "lt" | "cs" | "es";
     createdAt: string;
     updatedAt: string;
     status: "active" | "completed" | "archived";
@@ -4078,7 +4084,7 @@ export interface UploadAssetBody {
   /** @format uuid */
   contextId?: string;
   /** @default "en" */
-  language: "en" | "pl" | "de" | "lt" | "cs";
+  language: "en" | "pl" | "de" | "lt" | "cs" | "es";
   title: string;
   description: string;
 }
@@ -4226,7 +4232,7 @@ export interface GetLiveTrainingResponse {
 
 export interface CreateLiveTrainingBody {
   /** @default "en" */
-  language: "en" | "pl" | "de" | "lt" | "cs";
+  language: "en" | "pl" | "de" | "lt" | "cs" | "es";
   /**
    * @minLength 1
    * @maxLength 120
@@ -4278,7 +4284,7 @@ export interface GetHostCandidatesResponse {
 
 export type UpdateLiveTrainingBody = {
   /** @default "en" */
-  language: "en" | "pl" | "de" | "lt" | "cs";
+  language: "en" | "pl" | "de" | "lt" | "cs" | "es";
 } & {
   /**
    * @minLength 1
@@ -4606,8 +4612,8 @@ export interface GetAllAnnouncementsResponse {
     sourceId: string | null;
     title: string;
     content: string;
-    baseLanguage: "en" | "pl" | "de" | "lt" | "cs";
-    availableLocales: ("en" | "pl" | "de" | "lt" | "cs")[];
+    baseLanguage: "en" | "pl" | "de" | "lt" | "cs" | "es";
+    availableLocales: ("en" | "pl" | "de" | "lt" | "cs" | "es")[];
     deletedAt: string | null;
   }[];
   pagination: {
@@ -4640,8 +4646,8 @@ export interface GetAnnouncementsForUserResponse {
     sourceId: string | null;
     title: string;
     content: string;
-    baseLanguage: "en" | "pl" | "de" | "lt" | "cs";
-    availableLocales: ("en" | "pl" | "de" | "lt" | "cs")[];
+    baseLanguage: "en" | "pl" | "de" | "lt" | "cs" | "es";
+    availableLocales: ("en" | "pl" | "de" | "lt" | "cs" | "es")[];
     deletedAt: string | null;
     isRead: boolean;
   }[];
@@ -4656,10 +4662,10 @@ export interface GetAnnouncementsForUserResponse {
 export interface CreateAnnouncementBody {
   /** @default null */
   groupId: string | null;
-  baseLanguage: "en" | "pl" | "de" | "lt" | "cs";
+  baseLanguage: "en" | "pl" | "de" | "lt" | "cs" | "es";
   /** @minItems 1 */
   translations: {
-    language: "en" | "pl" | "de" | "lt" | "cs";
+    language: "en" | "pl" | "de" | "lt" | "cs" | "es";
     /**
      * @minLength 1
      * @maxLength 120
@@ -4689,8 +4695,8 @@ export interface CreateAnnouncementResponse {
     sourceId: string | null;
     title: string;
     content: string;
-    baseLanguage: "en" | "pl" | "de" | "lt" | "cs";
-    availableLocales: ("en" | "pl" | "de" | "lt" | "cs")[];
+    baseLanguage: "en" | "pl" | "de" | "lt" | "cs" | "es";
+    availableLocales: ("en" | "pl" | "de" | "lt" | "cs" | "es")[];
     deletedAt: string | null;
   };
 }
@@ -4806,7 +4812,7 @@ export interface UpsertProgressBody {
    */
   activeWatchSecondsDelta?: number;
   /** @default "en" */
-  language?: "en" | "pl" | "de" | "lt" | "cs";
+  language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
 }
 
 export interface UpsertProgressResponse {
@@ -4840,7 +4846,7 @@ export interface CreateCheckoutSessionBody {
   productDescription?: string;
   courseId: string;
   customerId: string;
-  locale: "en" | "pl" | "de" | "lt" | "cs";
+  locale: "en" | "pl" | "de" | "lt" | "cs" | "es";
   priceId: string;
 }
 
@@ -4980,7 +4986,7 @@ export interface PrepareAiMentorStatisticsProgressBody {
   /** @format uuid */
   studentId: string;
   /** @default "en" */
-  language?: "en" | "pl" | "de" | "lt" | "cs";
+  language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
 }
 
 export interface GetAllCategoriesResponse {
@@ -4988,8 +4994,8 @@ export interface GetAllCategoriesResponse {
     /** @format uuid */
     id: string;
     title: string;
-    availableLocales: ("en" | "pl" | "de" | "lt" | "cs")[];
-    baseLanguage: "en" | "pl" | "de" | "lt" | "cs";
+    availableLocales: ("en" | "pl" | "de" | "lt" | "cs" | "es")[];
+    baseLanguage: "en" | "pl" | "de" | "lt" | "cs" | "es";
     archived: boolean | null;
     createdAt: string | null;
   }[];
@@ -5006,8 +5012,8 @@ export interface GetCategoryByIdResponse {
     /** @format uuid */
     id: string;
     title: string;
-    availableLocales: ("en" | "pl" | "de" | "lt" | "cs")[];
-    baseLanguage: "en" | "pl" | "de" | "lt" | "cs";
+    availableLocales: ("en" | "pl" | "de" | "lt" | "cs" | "es")[];
+    baseLanguage: "en" | "pl" | "de" | "lt" | "cs" | "es";
     archived: boolean | null;
     createdAt: string | null;
   };
@@ -5015,7 +5021,7 @@ export interface GetCategoryByIdResponse {
 
 export interface CreateCategoryBody {
   title: string;
-  language: "en" | "pl" | "de" | "lt" | "cs";
+  language: "en" | "pl" | "de" | "lt" | "cs" | "es";
 }
 
 export interface CreateCategoryResponse {
@@ -5031,7 +5037,7 @@ export interface UpdateCategoryBody {
   id?: string;
   title?: string;
   archived?: boolean;
-  language?: "en" | "pl" | "de" | "lt" | "cs";
+  language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
 }
 
 export interface UpdateCategoryResponse {
@@ -5039,8 +5045,8 @@ export interface UpdateCategoryResponse {
     /** @format uuid */
     id: string;
     title: string;
-    availableLocales: ("en" | "pl" | "de" | "lt" | "cs")[];
-    baseLanguage: "en" | "pl" | "de" | "lt" | "cs";
+    availableLocales: ("en" | "pl" | "de" | "lt" | "cs" | "es")[];
+    baseLanguage: "en" | "pl" | "de" | "lt" | "cs" | "es";
     archived: boolean | null;
     createdAt: string | null;
   };
@@ -5328,8 +5334,8 @@ export interface GetLearningPathsResponse {
     sequenceEnabled: boolean;
     /** @format uuid */
     authorId: string;
-    baseLanguage: "en" | "pl" | "de" | "lt" | "cs";
-    availableLocales: ("en" | "pl" | "de" | "lt" | "cs")[];
+    baseLanguage: "en" | "pl" | "de" | "lt" | "cs" | "es";
+    availableLocales: ("en" | "pl" | "de" | "lt" | "cs" | "es")[];
     createdAt: string;
     updatedAt: string;
   } & {
@@ -5383,8 +5389,8 @@ export interface GetLearningPathByIdResponse {
     sequenceEnabled: boolean;
     /** @format uuid */
     authorId: string;
-    baseLanguage: "en" | "pl" | "de" | "lt" | "cs";
-    availableLocales: ("en" | "pl" | "de" | "lt" | "cs")[];
+    baseLanguage: "en" | "pl" | "de" | "lt" | "cs" | "es";
+    availableLocales: ("en" | "pl" | "de" | "lt" | "cs" | "es")[];
     createdAt: string;
     updatedAt: string;
   } & {
@@ -5424,7 +5430,7 @@ export interface GetLearningPathByIdResponse {
 }
 
 export interface CreateLearningPathBody {
-  language: "en" | "pl" | "de" | "lt" | "cs";
+  language: "en" | "pl" | "de" | "lt" | "cs" | "es";
   title: string;
   description: string;
   thumbnailReference?: string | null;
@@ -5459,15 +5465,15 @@ export interface CreateLearningPathResponse {
     sequenceEnabled: boolean;
     /** @format uuid */
     authorId: string;
-    baseLanguage: "en" | "pl" | "de" | "lt" | "cs";
-    availableLocales: ("en" | "pl" | "de" | "lt" | "cs")[];
+    baseLanguage: "en" | "pl" | "de" | "lt" | "cs" | "es";
+    availableLocales: ("en" | "pl" | "de" | "lt" | "cs" | "es")[];
     createdAt: string;
     updatedAt: string;
   };
 }
 
 export interface UpdateLearningPathBody {
-  language?: "en" | "pl" | "de" | "lt" | "cs";
+  language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
   title?: string;
   description?: string;
   thumbnailReference?: string | null;
@@ -5502,8 +5508,8 @@ export interface UpdateLearningPathResponse {
     sequenceEnabled: boolean;
     /** @format uuid */
     authorId: string;
-    baseLanguage: "en" | "pl" | "de" | "lt" | "cs";
-    availableLocales: ("en" | "pl" | "de" | "lt" | "cs")[];
+    baseLanguage: "en" | "pl" | "de" | "lt" | "cs" | "es";
+    availableLocales: ("en" | "pl" | "de" | "lt" | "cs" | "es")[];
     createdAt: string;
     updatedAt: string;
   };
@@ -5756,7 +5762,7 @@ export type InitScormImportBody =
         /** @format uuid */
         categoryId: string;
         /** @default "en" */
-        language: "en" | "pl" | "de" | "lt" | "cs";
+        language: "en" | "pl" | "de" | "lt" | "cs" | "es";
         status?: "draft" | "published" | "private";
         thumbnailS3Key?: string;
         priceInCents?: number;
@@ -5777,7 +5783,7 @@ export type InitScormImportBody =
         chapterId: string;
         title: string;
         /** @default "en" */
-        language: "en" | "pl" | "de" | "lt" | "cs";
+        language: "en" | "pl" | "de" | "lt" | "cs" | "es";
       };
     }
   | {
@@ -5793,7 +5799,7 @@ export type InitScormImportBody =
       metadata: {
         title: string;
         /** @default "en" */
-        language: "en" | "pl" | "de" | "lt" | "cs";
+        language: "en" | "pl" | "de" | "lt" | "cs" | "es";
       };
     };
 
@@ -5880,7 +5886,7 @@ export interface CommitScormAttemptBody {
   /** @format uuid */
   courseId: string;
   values: object;
-  language?: "en" | "pl" | "de" | "lt" | "cs";
+  language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
 }
 
 export interface CommitScormAttemptResponse {
@@ -5905,7 +5911,7 @@ export interface FinishScormAttemptBody {
   /** @format uuid */
   courseId: string;
   values: object;
-  language?: "en" | "pl" | "de" | "lt" | "cs";
+  language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
 }
 
 export interface FinishScormAttemptResponse {
@@ -5939,7 +5945,7 @@ export interface CreateTenantBody {
   adminFirstName: string;
   /** @minLength 1 */
   adminLastName: string;
-  adminLanguage?: "en" | "pl" | "de" | "lt" | "cs";
+  adminLanguage?: "en" | "pl" | "de" | "lt" | "cs" | "es";
 }
 
 export interface CreateTenantResponse {
@@ -6033,8 +6039,8 @@ export interface GetGroupsResponse {
     id: string;
     name: string;
     characteristic: string | null;
-    availableLocales: ("en" | "pl" | "de" | "lt" | "cs")[];
-    baseLanguage: "en" | "pl" | "de" | "lt" | "cs";
+    availableLocales: ("en" | "pl" | "de" | "lt" | "cs" | "es")[];
+    baseLanguage: "en" | "pl" | "de" | "lt" | "cs" | "es";
     users?: {
       id: string;
       createdAt: string;
@@ -6266,8 +6272,8 @@ export interface GetQAResponse {
   id: string;
   title: string | null;
   description: string | null;
-  baseLanguage: "en" | "pl" | "de" | "lt" | "cs";
-  availableLocales: ("en" | "pl" | "de" | "lt" | "cs")[];
+  baseLanguage: "en" | "pl" | "de" | "lt" | "cs" | "es";
+  availableLocales: ("en" | "pl" | "de" | "lt" | "cs" | "es")[];
 }
 
 export type GetAllQAResponse = {
@@ -6275,14 +6281,14 @@ export type GetAllQAResponse = {
   id: string;
   title: string | null;
   description: string | null;
-  baseLanguage: "en" | "pl" | "de" | "lt" | "cs";
-  availableLocales: ("en" | "pl" | "de" | "lt" | "cs")[];
+  baseLanguage: "en" | "pl" | "de" | "lt" | "cs" | "es";
+  availableLocales: ("en" | "pl" | "de" | "lt" | "cs" | "es")[];
 }[];
 
 export interface CreateQABody {
   title: string;
   description: string;
-  language: "en" | "pl" | "de" | "lt" | "cs";
+  language: "en" | "pl" | "de" | "lt" | "cs" | "es";
 }
 
 export interface CreateQAResponse {
@@ -6306,8 +6312,8 @@ export interface GetDraftNewsListResponse {
     status: string;
     isPublic: boolean;
     /** @default "en" */
-    baseLanguage: "en" | "pl" | "de" | "lt" | "cs";
-    availableLocales: ("en" | "pl" | "de" | "lt" | "cs")[];
+    baseLanguage: "en" | "pl" | "de" | "lt" | "cs" | "es";
+    availableLocales: ("en" | "pl" | "de" | "lt" | "cs" | "es")[];
     publishedAt: string | null;
     authorName: string;
     resources?: {
@@ -6365,7 +6371,7 @@ export interface GenerateNewsPreviewBody {
   /** @format uuid */
   newsId: string;
   /** @default "en" */
-  language: "en" | "pl" | "de" | "lt" | "cs";
+  language: "en" | "pl" | "de" | "lt" | "cs" | "es";
   content: string;
 }
 
@@ -6385,8 +6391,8 @@ export interface GetNewsResponse {
     status: string;
     isPublic: boolean;
     /** @default "en" */
-    baseLanguage: "en" | "pl" | "de" | "lt" | "cs";
-    availableLocales: ("en" | "pl" | "de" | "lt" | "cs")[];
+    baseLanguage: "en" | "pl" | "de" | "lt" | "cs" | "es";
+    availableLocales: ("en" | "pl" | "de" | "lt" | "cs" | "es")[];
     publishedAt: string | null;
     authorName: string;
     resources?: {
@@ -6443,8 +6449,8 @@ export interface GetNewsListResponse {
     status: string;
     isPublic: boolean;
     /** @default "en" */
-    baseLanguage: "en" | "pl" | "de" | "lt" | "cs";
-    availableLocales: ("en" | "pl" | "de" | "lt" | "cs")[];
+    baseLanguage: "en" | "pl" | "de" | "lt" | "cs" | "es";
+    availableLocales: ("en" | "pl" | "de" | "lt" | "cs" | "es")[];
     publishedAt: string | null;
     authorName: string;
     resources?: {
@@ -6500,7 +6506,7 @@ export interface GetNewsListResponse {
 
 export interface CreateNewsBody {
   /** @default "en" */
-  language: "en" | "pl" | "de" | "lt" | "cs";
+  language: "en" | "pl" | "de" | "lt" | "cs" | "es";
 }
 
 export interface CreateNewsResponse {
@@ -6512,7 +6518,7 @@ export interface CreateNewsResponse {
 
 export interface UpdateNewsBody {
   /** @default "en" */
-  language: "en" | "pl" | "de" | "lt" | "cs";
+  language: "en" | "pl" | "de" | "lt" | "cs" | "es";
   title?: string;
   summary?: string;
   content?: string;
@@ -6534,7 +6540,7 @@ export interface UpdateNewsResponse {
 
 export interface AddNewLanguageBody {
   /** @default "en" */
-  language: "en" | "pl" | "de" | "lt" | "cs";
+  language: "en" | "pl" | "de" | "lt" | "cs" | "es";
 }
 
 export interface AddNewLanguageResponse {
@@ -6568,7 +6574,7 @@ export interface UploadFileToNewsResponse {
 
 export interface CreateArticleSectionBody {
   /** @default "en" */
-  language: "en" | "pl" | "de" | "lt" | "cs";
+  language: "en" | "pl" | "de" | "lt" | "cs" | "es";
 }
 
 export interface CreateArticleSectionResponse {
@@ -6584,15 +6590,15 @@ export interface GetArticleSectionResponse {
     id: string;
     title: string;
     /** @default "en" */
-    baseLanguage: "en" | "pl" | "de" | "lt" | "cs";
-    availableLocales: ("en" | "pl" | "de" | "lt" | "cs")[];
+    baseLanguage: "en" | "pl" | "de" | "lt" | "cs" | "es";
+    availableLocales: ("en" | "pl" | "de" | "lt" | "cs" | "es")[];
     assignedArticlesCount: number;
   };
 }
 
 export interface UpdateArticleSectionBody {
   /** @default "en" */
-  language: "en" | "pl" | "de" | "lt" | "cs";
+  language: "en" | "pl" | "de" | "lt" | "cs" | "es";
   title?: string;
 }
 
@@ -6605,7 +6611,7 @@ export interface UpdateArticleSectionResponse {
 
 export interface AddNewLanguageToSectionBody {
   /** @default "en" */
-  language: "en" | "pl" | "de" | "lt" | "cs";
+  language: "en" | "pl" | "de" | "lt" | "cs" | "es";
 }
 
 export interface AddNewLanguageToSectionResponse {
@@ -6697,8 +6703,8 @@ export interface GetArticleResponse {
     status: string;
     isPublic: boolean;
     /** @default "en" */
-    baseLanguage: "en" | "pl" | "de" | "lt" | "cs";
-    availableLocales: ("en" | "pl" | "de" | "lt" | "cs")[];
+    baseLanguage: "en" | "pl" | "de" | "lt" | "cs" | "es";
+    availableLocales: ("en" | "pl" | "de" | "lt" | "cs" | "es")[];
     publishedAt: string | null;
     authorName: string;
     /** @format uuid */
@@ -6811,7 +6817,7 @@ export type GetArticlesResponse = {
 
 export interface CreateArticleBody {
   /** @default "en" */
-  language: "en" | "pl" | "de" | "lt" | "cs";
+  language: "en" | "pl" | "de" | "lt" | "cs" | "es";
   /** @format uuid */
   sectionId: string;
 }
@@ -6825,7 +6831,7 @@ export interface CreateArticleResponse {
 
 export interface UpdateArticleBody {
   /** @default "en" */
-  language: "en" | "pl" | "de" | "lt" | "cs";
+  language: "en" | "pl" | "de" | "lt" | "cs" | "es";
   title?: string;
   summary?: string;
   content?: string;
@@ -6852,7 +6858,7 @@ export interface UploadFileToArticleBody {
    */
   file?: File;
   /** @default "en" */
-  language: "en" | "pl" | "de" | "lt" | "cs";
+  language: "en" | "pl" | "de" | "lt" | "cs" | "es";
   title: string;
   description: string;
 }
@@ -6868,7 +6874,7 @@ export interface GenerateArticlePreviewBody {
   /** @format uuid */
   articleId: string;
   /** @default "en" */
-  language: "en" | "pl" | "de" | "lt" | "cs";
+  language: "en" | "pl" | "de" | "lt" | "cs" | "es";
   content: string;
 }
 
@@ -7669,7 +7675,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     settingsControllerGetPublicRegistrationForm: (
       query?: {
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -8341,7 +8347,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     statisticsControllerGetUserStatistics: (
       query?: {
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -8362,7 +8368,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     statisticsControllerGetStats: (
       query?: {
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -8436,7 +8442,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         /** @format uuid */
         id: string;
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -8779,7 +8785,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         page?: number;
         perPage?: number;
         sort?: string;
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -8800,7 +8806,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     groupControllerGetGroupById: (
       groupId: string,
       query?: {
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -8860,7 +8866,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         page?: number;
         perPage?: number;
         sort?: string;
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -8913,7 +8919,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     groupControllerCreateLanguage: (
       groupId: string,
       query?: {
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -8934,7 +8940,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     groupControllerDeleteLanguage: (
       groupId: string,
       query?: {
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -8999,7 +9005,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     groupControllerGetGroupsByCourse: (
       courseId: string,
       query?: {
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -9042,7 +9048,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         page?: number;
         perPage?: number;
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -9085,7 +9091,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
           | "-chapterCount"
           | "-enrolledParticipantsCount";
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -9120,7 +9126,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
           | "-isEnrolledByGroup";
         groups?: string[];
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
         /** @min 1 */
         page?: number;
         perPage?: number;
@@ -9168,7 +9174,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         /** @format uuid */
         excludeCourseId?: string;
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -9213,7 +9219,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         /** @format uuid */
         excludeCourseId?: string;
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -9236,7 +9242,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         limit?: number;
         days?: number;
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -9264,7 +9270,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         title?: string;
         description?: string;
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -9286,7 +9292,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       query: {
         id: string;
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -9324,7 +9330,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       query: {
         id: string;
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -9347,7 +9353,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         /** @format uuid */
         id: string;
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -9370,7 +9376,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         /** @format uuid */
         id: string;
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -9763,7 +9769,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       courseId: string,
       query?: {
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -9787,7 +9793,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         /** @format uuid */
         groupId?: string;
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -9825,7 +9831,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
           | "-lastActivity"
           | "-lastCompletedLessonName";
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -9864,7 +9870,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
           | "-attempts"
           | "-lastAttempt";
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -9903,7 +9909,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
           | "-lastSession"
           | "-lastCompletedLessonName";
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -9925,7 +9931,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       courseId: string,
       query?: {
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -9946,7 +9952,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       courseId: string,
       query?: {
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -9967,7 +9973,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       courseId: string,
       query?: {
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -9988,7 +9994,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       courseId: string,
       query?: {
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -10147,7 +10153,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         integrationId?: string;
         /** @minLength 1 */
         draftName?: string;
-        courseLanguage?: "en" | "pl" | "de" | "lt" | "cs";
+        courseLanguage?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -10257,7 +10263,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         /** @format uuid */
         id: string;
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -10385,7 +10391,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         description?: string;
         lessonCompleted?: string;
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -10407,7 +10413,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       id: string,
       query: {
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
         studentId: string;
       },
       params: RequestParams = {},
@@ -10648,7 +10654,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         lessonId?: string;
         /** @format binary */
         file: File;
-        language: "en" | "pl" | "de" | "lt" | "cs";
+        language: "en" | "pl" | "de" | "lt" | "cs" | "es";
         title: string;
         description: string;
         contextId?: string;
@@ -10824,7 +10830,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         /** @format uuid */
         id: string;
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -10847,7 +10853,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         /** @format uuid */
         userId?: string;
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
         /** @min 1 */
         page?: number;
         perPage?: number;
@@ -10876,7 +10882,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         /** @format uuid */
         courseId?: string;
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -10955,7 +10961,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       courseId: string,
       query?: {
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -10982,7 +10988,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         perPage?: number;
         search?: string;
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -11205,7 +11211,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         search?: string;
         type?: "image" | "video" | "pdf" | "presentation" | "document" | "other";
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -11227,7 +11233,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       id: string,
       query?: {
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -11330,7 +11336,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         /** @format uuid */
         courseId?: string;
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -11370,7 +11376,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       id: string,
       query?: {
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -11455,7 +11461,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         /** @format binary */
         file: File;
         relationshipType: "live_training_before" | "live_training_after";
-        language: "en" | "pl" | "de" | "lt" | "cs";
+        language: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -11479,7 +11485,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       resourceId: string,
       query?: {
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -11502,7 +11508,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       resourceId: string,
       query?: {
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -11523,7 +11529,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     liveTrainingSessionsControllerGetSessions: (
       liveTrainingId: string,
       query?: {
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -11544,7 +11550,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     liveTrainingSessionsControllerStartSession: (
       liveTrainingId: string,
       query?: {
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -11565,7 +11571,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     liveTrainingSessionsControllerJoinCurrentSession: (
       liveTrainingId: string,
       query?: {
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -11586,7 +11592,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     liveTrainingSessionsControllerGetParticipantProfilePictures: (
       liveTrainingId: string,
       query?: {
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -11608,7 +11614,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       liveTrainingId: string,
       sessionId: string,
       query?: {
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -11630,7 +11636,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       liveTrainingId: string,
       sessionId: string,
       query?: {
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -11663,7 +11669,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      */
     announcementsControllerGetAllAnnouncements: (
       query?: {
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
         status?: "scheduled" | "published";
         /** @min 1 */
         page?: number;
@@ -11725,7 +11731,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         content?: string;
         search?: string;
         isRead?: string;
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
         /** @min 1 */
         page?: number;
         /** @min 1 */
@@ -12180,7 +12186,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         page?: number;
         perPage?: number;
         sort?: "title" | "creationDate" | "-title" | "-creationDate";
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -12217,7 +12223,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     categoryControllerGetCategoryById: (
       id: string,
       query?: {
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -12258,7 +12264,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     categoryControllerCreateLanguage: (
       id: string,
       query?: {
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -12279,7 +12285,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     categoryControllerDeleteLanguage: (
       id: string,
       query?: {
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -12471,7 +12477,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         /** @min 1 */
         page?: number;
         perPage?: number;
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
         searchQuery?: string;
       },
       params: RequestParams = {},
@@ -12512,7 +12518,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     learningPathControllerGetLearningPathById: (
       learningPathId: string,
       query?: {
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -12570,7 +12576,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     learningPathControllerCreateLanguage: (
       learningPathId: string,
       query?: {
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -12857,7 +12863,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         /** @format uuid */
         learningPathId?: string;
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -12956,7 +12962,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       query?: {
         searchQuery?: string;
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -12977,7 +12983,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     reportControllerDownloadSummaryReport: (
       query?: {
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -13179,7 +13185,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         /** @format uuid */
         lessonId?: string;
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
         /** @format uuid */
         scoId?: string;
       },
@@ -13443,7 +13449,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         page?: number;
         perPage?: number;
         sort?: "name" | "createdAt";
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -13752,7 +13758,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       qaId: string,
       query?: {
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -13775,7 +13781,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       data: UpdateQABody,
       query?: {
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -13810,7 +13816,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     qaControllerGetAllQa: (
       query?: {
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -13848,7 +13854,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       qaId: string,
       query?: {
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -13869,7 +13875,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       qaId: string,
       query?: {
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -13889,7 +13895,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     newsControllerGetDraftNewsList: (
       query?: {
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
         /** @min 1 */
         page?: number;
       },
@@ -13952,7 +13958,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       id: string,
       query?: {
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -14024,7 +14030,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     newsControllerGetNewsList: (
       query?: {
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
         /** @min 1 */
         page?: number;
       },
@@ -14064,7 +14070,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       id: string,
       query?: {
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -14087,7 +14093,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       data: {
         /** @format binary */
         file: File;
-        language: "en" | "pl" | "de" | "lt" | "cs";
+        language: "en" | "pl" | "de" | "lt" | "cs" | "es";
         title: string;
         description: string;
       },
@@ -14131,7 +14137,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       id: string,
       query?: {
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -14207,7 +14213,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       id: string,
       query?: {
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -14227,7 +14233,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     articlesControllerGetDraftArticles: (
       query?: {
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -14248,7 +14254,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     articlesControllerGetArticleToc: (
       query?: {
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
         isDraftMode?: boolean;
       },
       params: RequestParams = {},
@@ -14291,7 +14297,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       id: string,
       query?: {
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
         isDraftMode?: boolean;
       },
       params: RequestParams = {},
@@ -14346,7 +14352,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     articlesControllerGetArticles: (
       query?: {
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -14405,7 +14411,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       id: string,
       query?: {
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>
@@ -14481,7 +14487,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         /** @minLength 1 */
         end?: string;
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
         /** @minLength 1 */
         timezone?: string;
       },
@@ -14505,7 +14511,7 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       eventId: string,
       query?: {
         /** @default "en" */
-        language?: "en" | "pl" | "de" | "lt" | "cs";
+        language?: "en" | "pl" | "de" | "lt" | "cs" | "es";
       },
       params: RequestParams = {},
     ) =>

--- a/apps/web/app/api/mutations/useAddNewsLanguage.ts
+++ b/apps/web/app/api/mutations/useAddNewsLanguage.ts
@@ -5,11 +5,12 @@ import { NEWS_QUERY_KEY } from "../queries/useNews";
 import { NEWS_LIST_QUERY_KEY } from "../queries/useNewsList";
 
 import type { AddNewLanguageBody } from "../generated-api";
+import type { SupportedLanguages } from "@repo/shared";
 
 type AddNewsLanguageOptions = {
   id: string;
   data: AddNewLanguageBody;
-  language?: "en" | "pl";
+  language?: SupportedLanguages;
 };
 
 export function useAddNewsLanguage() {

--- a/apps/web/app/api/mutations/useUpdateNews.ts
+++ b/apps/web/app/api/mutations/useUpdateNews.ts
@@ -6,11 +6,12 @@ import { NEWS_LIST_QUERY_KEY } from "../queries/useNewsList";
 import { RESOURCE_LIBRARY_ASSETS_QUERY_KEY } from "../queries/useResourceLibraryAssets";
 
 import type { UpdateNewsBody } from "../generated-api";
+import type { SupportedLanguages } from "@repo/shared";
 
 type UpdateNewsOptions = {
   id: string;
   data: UpdateNewsBody;
-  language?: "en" | "pl";
+  language?: SupportedLanguages;
 };
 
 export function useUpdateNews() {

--- a/apps/web/app/assets/svgs/flags/es-flag.svg
+++ b/apps/web/app/assets/svgs/flags/es-flag.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="18" viewBox="0 0 24 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="24" height="18" rx="2" fill="#AA151B"/>
+  <rect y="4.5" width="24" height="9" fill="#F1BF00"/>
+</svg>

--- a/apps/web/app/assets/svgs/flags/index.ts
+++ b/apps/web/app/assets/svgs/flags/index.ts
@@ -3,3 +3,4 @@ export { default as PL } from "./pl-flag.svg?react";
 export { default as DE } from "./de-flag.svg?react";
 export { default as CS } from "./cs-flag.svg?react";
 export { default as LT } from "./lt-flag.svg?react";
+export { default as ES } from "./es-flag.svg?react";

--- a/apps/web/app/components/LanguageSelector/languageOptions.ts
+++ b/apps/web/app/components/LanguageSelector/languageOptions.ts
@@ -13,4 +13,5 @@ export const languageOptions: LanguageOption[] = [
   { key: "de", iconName: "DE", translationKey: "changeUserLanguageView.options.german" },
   { key: "cs", iconName: "CS", translationKey: "changeUserLanguageView.options.czech" },
   { key: "lt", iconName: "LT", translationKey: "changeUserLanguageView.options.lithuanian" },
+  { key: "es", iconName: "ES", translationKey: "changeUserLanguageView.options.spanish" },
 ];

--- a/apps/web/app/lib/formatters/priceFormatter.ts
+++ b/apps/web/app/lib/formatters/priceFormatter.ts
@@ -92,6 +92,7 @@ export function getCurrencySymbol(language: string): CurrencyCode {
   const languageCurrencyMap: Record<string, CurrencyCode> = {
     pl: "PLN",
     en: "USD",
+    es: "EUR",
   };
 
   return languageCurrencyMap[loweCaseLanguage];

--- a/apps/web/app/locales/cs/translation.json
+++ b/apps/web/app/locales/cs/translation.json
@@ -42,7 +42,8 @@
       "pl": "Polština",
       "de": "Němčina",
       "lt": "Litevština",
-      "cs": "Čeština"
+      "cs": "Čeština",
+      "es": "španělština"
     },
     "lessonTypes": {
       "content": "Obsah",
@@ -807,7 +808,8 @@
       "polish": "polština",
       "german": "Němčina",
       "czech": "Čeština",
-      "lithuanian": "Litevština"
+      "lithuanian": "Litevština",
+      "spanish": "Španělština"
     }
   },
   "resetOnboarding": {

--- a/apps/web/app/locales/de/translation.json
+++ b/apps/web/app/locales/de/translation.json
@@ -42,7 +42,8 @@
       "pl": "Polnisch",
       "de": "Deutsch",
       "lt": "Litauisch",
-      "cs": "Tschechisch"
+      "cs": "Tschechisch",
+      "es": "Spanisch"
     },
     "lessonTypes": {
       "content": "Inhalt",
@@ -801,7 +802,8 @@
       "polish": "Polieren",
       "german": "Deutsch",
       "czech": "Tschechisch",
-      "lithuanian": "Litauisch"
+      "lithuanian": "Litauisch",
+      "spanish": "Spanisch"
     }
   },
   "resetOnboarding": {

--- a/apps/web/app/locales/en/translation.json
+++ b/apps/web/app/locales/en/translation.json
@@ -42,7 +42,8 @@
       "pl": "Polish",
       "de": "German",
       "lt": "Lithuanian",
-      "cs": "Czech"
+      "cs": "Czech",
+      "es": "Spanish"
     },
     "lessonTypes": {
       "content": "Content",
@@ -802,7 +803,8 @@
       "polish": "Polish",
       "german": "German",
       "czech": "Czech",
-      "lithuanian": "Lithuanian"
+      "lithuanian": "Lithuanian",
+      "spanish": "Spanish"
     }
   },
   "resetOnboarding": {

--- a/apps/web/app/locales/es/translation.json
+++ b/apps/web/app/locales/es/translation.json
@@ -1,0 +1,4493 @@
+{
+  "common": {
+    "button": {
+      "save": "Guardar",
+      "saving": "Guardando...",
+      "delete": "Eliminar",
+      "create": "Crear",
+      "cancel": "Cancelar",
+      "back": "Atrás",
+      "proceed": "Continuar",
+      "add": "Añadir",
+      "close": "Cerrar",
+      "goToDashboard": "Ir al panel",
+      "goBack": "Volver",
+      "ignore": "Ignorar",
+      "clearAll": "Borrar todo",
+      "validate": "Validar",
+      "edit": "Editar",
+      "uploading": "Subiendo...",
+      "sending": "Enviando..."
+    },
+    "toast": {
+      "noAccess": "No tienes permiso para acceder a este recurso.",
+      "globalSettingsNotFound": "No se encontraron los ajustes globales",
+      "somethingWentWrong": "Algo salió mal...",
+      "notFound": "Recurso no encontrado",
+      "lessonAccessDenied": "No tienes permiso para acceder a esta lección.",
+      "tooManyRequests": "Demasiadas solicitudes. Inténtalo de nuevo en {{seconds}} segundos."
+    },
+    "tooltip": {
+      "soon": "Próximamente"
+    },
+    "tableOfContents": "Tabla de contenidos",
+    "roles": {
+      "admin": "Administrador",
+      "contentCreator": "Creador de contenido",
+      "trainer": "Formador",
+      "student": "Estudiante"
+    },
+    "languages": {
+      "en": "Inglés",
+      "pl": "Polaco",
+      "de": "Alemán",
+      "lt": "Lituano",
+      "cs": "Checo",
+      "es": "Español"
+    },
+    "lessonTypes": {
+      "content": "Contenido",
+      "quiz": "Cuestionario",
+      "ai_mentor": "AI Mentor",
+      "embed": "Insertar",
+      "scorm": "SCORM",
+      "live_training": "Formación en vivo"
+    },
+    "error": {
+      "somethingWentWrong": "¡Ups! Algo salió mal."
+    },
+    "loader": {
+      "textSequence": {
+        "aiMentor": {
+          "warmingUp": "Preparando AI Mentor...",
+          "preparingSimulation": "Preparando simulación para ti...",
+          "buildingContext": "Creando el contexto del escenario...",
+          "takingLonger": "Esto está tardando más de lo habitual..."
+        }
+      }
+    },
+    "other": {
+      "active": "Activo",
+      "archived": "Archivado",
+      "selected": "Seleccionado",
+      "allStatuses": "Todos los estados",
+      "draft": "Borrador",
+      "all": "Todos",
+      "search": "Buscar",
+      "published": "Publicado",
+      "private": "Privado",
+      "publish": "Publicar",
+      "uploadingImage": "Subiendo imagen...",
+      "copyUrl": "La URL se ha copiado al portapapeles",
+      "dueDate": "Fecha límite: {{date}}",
+      "appVersion": "Versión de la aplicación: {{version}}"
+    },
+    "continueWithGoogle": "Continuar con Google",
+    "continueWithMicrosoft": "Continuar con Microsoft",
+    "continueWithSlack": "Continuar con Slack",
+    "enterFullscreen": "Pantalla completa",
+    "exitFullscreen": "Salir de pantalla completa"
+  },
+  "lessons": {
+    "sequenceUpdatedSuccessfully": "Secuencia de lecciones actualizada correctamente",
+    "sequenceUpdateFailed": "No se pudo actualizar la secuencia de la lección",
+    "quizFeedbackUpdatedSuccessfully": "La opción \"Comentarios del cuestionario\" se actualizó correctamente",
+    "quizFeedbackUpdateFailed": "No se pudo actualizar la opción \"Comentarios del cuestionario\"",
+    "videoCompletionTrackingUpdatedSuccessfully": "La opción \"Seguimiento de finalización de vídeo\" se actualizó correctamente",
+    "videoCompletionTrackingUpdateFailed": "No se pudo actualizar la opción \"Seguimiento de finalización de video\"",
+    "settingsUpdatedSuccessfully": "Ajustes actualizados correctamente",
+    "settingsUpdateFailed": "No se pudo actualizar la configuración"
+  },
+  "uploadFile": {
+    "header": "Haz clic para subir",
+    "subHeader": "o arrastrar y soltar",
+    "replace": "Haz clic para reemplazar",
+    "toast": {
+      "fileUploadedSuccessfully": "Archivo subido correctamente",
+      "videoFailed": "Error al subir el vídeo",
+      "videoTooLarge": "El archivo de vídeo supera el tamaño máximo permitido",
+      "videoReady": "El vídeo está listo para usarse",
+      "videoUploading": "Estamos subiendo tu vídeo. Por favor, no cierres la pestaña.",
+      "videoUploadedProcessing": "La subida ha finalizado. Ahora el vídeo se está procesando. Puedes cerrar la pestaña."
+    },
+    "details": {
+      "imageCrop": "PNG, JPG, JPEG o SVG",
+      "video": "MP4, MOV, MPEG-2 o HEVC (máx. 5 GB)",
+      "presentation": "PPT/PPTX (máx. 100 MB)"
+    },
+    "processing": {
+      "title": "El vídeo se está procesando",
+      "body": "Puedes seguir editando. Te avisaremos cuando esté listo."
+    },
+    "remove": {
+      "video": "Eliminar vídeo",
+      "presentation": "Eliminar presentación"
+    }
+  },
+  "deleteFile": {
+    "toast": {
+      "success": "Archivo eliminado correctamente"
+    }
+  },
+  "resourceLibrary": {
+    "toast": {
+      "assetDeletedSuccessfully": "Recurso eliminado correctamente"
+    },
+    "error": {
+      "fileRequired": "El archivo es obligatorio",
+      "assetNotFound": "Recurso no encontrado",
+      "entityNotFound": "Entidad no encontrada"
+    }
+  },
+  "adminCourseDuplication": {
+    "duplicate": "Duplicar curso",
+    "duplicateFailed": "No se pudo iniciar la duplicación del curso.",
+    "processing": "La duplicación del curso está en progreso. Puedes seguir trabajando mientras termina.",
+    "completed": "La duplicación del curso ha finalizado.",
+    "failed": "Error al duplicar el curso.",
+    "processingTitle": "Duplicación del curso en curso",
+    "processingDescription": "La edición del currículo y los ajustes está desactivada hasta que el contenido copiado esté listo.",
+    "failedTitle": "Error al duplicar el curso",
+    "failedDescription": "El curso provisional sigue disponible, pero la edición del currículo y los ajustes permanece desactivada para esta tarea de duplicación."
+  },
+  "adminScorm": {
+    "header": "Subir SCORM",
+    "subHeader": "Sube tu archivo .zip de SCORM.",
+    "field": {
+      "price": "Precio",
+      "title": "Título del curso",
+      "category": "Categoría",
+      "description": "Descripción",
+      "thumbnail": "Subir miniatura"
+    },
+    "placeholder": {
+      "price": "Cantidad",
+      "title": "Introduce el título...",
+      "category": "Seleccionar categoría",
+      "description": "Proporcionar descripción sobre el curso..."
+    },
+    "other": {
+      "setUpCourse": "Configurar curso",
+      "provideDetails": "Proporcione los detalles para configurar un nuevo curso.",
+      "uploadFileHeader": "Haga clic para cargar o arrastre y suelte",
+      "uploadFileBody": "Archivo .zip de SCORM (máx. 500 MB)",
+      "pricing": "Precios",
+      "status": "Estado",
+      "setUpPricing": "Establecer precios para el curso.",
+      "setUpStatus": "Establecer estado del curso",
+      "noDescription": "Aún no hay descripción.",
+      "untitled": "Sin título",
+      "free": "Gratis",
+      "paidCourse": "Curso de pago",
+      "freeCourseBody": "Los estudiantes pueden inscribirse y acceder al contenido del curso sin pagar.",
+      "paidCourseBody": "Los estudiantes pueden comprar y acceder al contenido del curso. Una vez seleccionado, puede definir la moneda y el precio.",
+      "draftBody": "Los estudiantes no pueden comprar ni inscribirse en este curso. Para aquellos que ya están inscritos, el curso no aparecerá en su Lista de cursos para estudiantes.",
+      "publishBody": "Los estudiantes pueden comprar, inscribirse y acceder al contenido del curso. Una vez inscrito, el curso se mostrará en su Panel de Estudiantes.",
+      "charactersLeft": "Caracteres restantes"
+    },
+    "button": {
+      "back": "Atrás",
+      "status": "Estado",
+      "creatingCourse": "Creando curso...",
+      "createCourse": "Crear curso"
+    },
+    "upload": {
+      "uploading": "Cargando paquete SCORM...",
+      "uploadedProcessing": "Carga del paquete SCORM finalizada. El proceso de importación ha comenzado."
+    },
+    "importFailure": {
+      "courseDescription": "El curso se eliminó porque no se pudo importar el paquete SCORM.",
+      "lessonDescription": "La lección o paquete SCORM se eliminó porque no se pudo importar el paquete."
+    },
+    "importProcessing": {
+      "description": "El paquete aún se está importando. Puedes seguir trabajando mientras termina."
+    },
+    "importSuccess": {
+      "description": "El paquete SCORM está listo."
+    },
+    "errors": {
+      "packageRequired": "Se requiere el paquete SCORM.",
+      "emptyPackage": "El paquete SCORM está vacío.",
+      "tooManyFiles": "El paquete SCORM contiene demasiados archivos.",
+      "packageTooLarge": "El paquete SCORM es demasiado grande después de la extracción.",
+      "manifestMissing": "Falta el archivo de manifiesto SCORM.",
+      "manifestInvalid": "El archivo de manifiesto SCORM no es válido.",
+      "organizationMissing": "El manifiesto SCORM no contiene una organización.",
+      "scoMissing": "El manifiesto SCORM no contiene ningún SCO ejecutable.",
+      "resourceIdentifierMissing": "Falta el identificador de recurso SCORM.",
+      "itemIdentifierMissing": "Falta el identificador de elemento SCORM.",
+      "launchFileMissing": "Falta el archivo de inicio SCORM.",
+      "uploadIdMissing": "Falta el ID de la sesión de carga de SCORM.",
+      "uploadOffsetMissing": "Falta el desplazamiento de carga de SCORM.",
+      "unsupportedTusVersion": "Esta versión del protocolo de carga SCORM no es compatible.",
+      "uploadAlreadyCompleted": "La carga de SCORM ya se completó.",
+      "emptyUploadChunk": "El fragmento de carga SCORM está vacío.",
+      "uploadExceedsDeclaredLength": "La carga de SCORM excede el tamaño del archivo declarado.",
+      "uploadChunkTooSmall": "El fragmento de carga SCORM es demasiado pequeño.",
+      "uploadIncomplete": "La carga de SCORM está incompleta.",
+      "uploadSessionNotFound": "No se encontró la sesión de carga de SCORM.",
+      "uploadForbidden": "Esta carga de SCORM no pertenece al usuario actual.",
+      "packageAlreadyAttached": "Esta lección SCORM ya tiene un paquete para el idioma seleccionado.",
+      "invalidPackagePath": "El paquete SCORM contiene una ruta de archivo no válida.",
+      "externalPackagePath": "El paquete SCORM contiene una ruta de archivo externa.",
+      "importFailed": "Error al importar el paquete SCORM.",
+      "unknownImportJob": "No se reconoce el trabajo de importación SCORM.",
+      "unsupportedImportAction": "No se admite la acción de importación SCORM.",
+      "runtime": {
+        "launchNotFound": "No se encontró el contenido de lanzamiento de SCORM.",
+        "unsupportedStandard": "Este estándar SCORM no es compatible.",
+        "invalidAttempt": "El intento SCORM no es válido.",
+        "invalidCmiValue": "Los datos de tiempo de ejecución de SCORM no son válidos.",
+        "contentNotFound": "No se encontró contenido de SCORM.",
+        "contentForbidden": "No tienes acceso a este contenido de SCORM."
+      }
+    },
+    "coursePlaceholder": {
+      "back": "Volver al tipo de curso",
+      "status": "Importación de cursos SCORM",
+      "title": "La creación del curso SCORM viene a continuación",
+      "description": "Este punto de entrada está listo, pero el flujo de importación SCORM a nivel del curso aún se está implementando. Cree un curso estándar por ahora o regrese a la lista de cursos.",
+      "createStandard": "Crear curso estándar",
+      "viewCourses": "Ver cursos"
+    },
+    "create": {
+      "eyebrow": "SCORM 1.2",
+      "title": "Crear curso SCORM",
+      "subtitle": "Agregue los metadatos del curso y adjunte el paquete SCORM que se convertirá en el contenido del curso.",
+      "requirements": {
+        "title": "Requisitos del paquete",
+        "version": "Paquete SCORM 1.2",
+        "archive": "Archivo .zip de hasta 500 MB",
+        "metadata": "Los metadatos del curso se pueden editar antes de importarlos."
+      },
+      "packageSection": "Paquete SCORM",
+      "packageSectionDescription": "Adjunte el paquete SCORM 1.2 que debe importarse como contenido de este curso.",
+      "importNotice": "Los paquetes grandes de SCORM pueden tardar unos minutos en importarse. Mantenga esta página abierta hasta que finalice la carga.",
+      "metadataSection": "Detalles del curso",
+      "metadataSectionDescription": "Estos campos coinciden con la configuración estándar del curso y se utilizarán como metadatos del curso base.",
+      "uploadPackage": "Subir paquete SCORM",
+      "dropPackage": "Suelte el paquete SCORM aquí",
+      "uploadPackageDescription": "Arrastre y suelte un archivo .zip SCORM 1.2, o haga clic para elegirlo desde su dispositivo.",
+      "packageReady": "Listo para importar",
+      "replacePackage": "Reemplazar paquete",
+      "removePackage": "Quitar paquete",
+      "uploadThumbnail": "Subir miniatura",
+      "uploadThumbnailDescription": "PNG, JPG o JPEG hasta 20 MB",
+      "thumbnailPreviewAlt": "Vista previa en miniatura del curso",
+      "submit": "Crear curso SCORM",
+      "creating": "Creando curso SCORM...",
+      "toastDraftReady": "El formulario del curso SCORM está listo para la integración con la API"
+    },
+    "lesson": {
+      "packageSection": "Paquete SCORM",
+      "packageAttached": "Paquete SCORM adjunto",
+      "packageLocked": "Este paquete no se puede reemplazar una vez creada la lección.",
+      "importNotice": "Los paquetes grandes de SCORM pueden tardar unos minutos en importarse. Mantenga esta página abierta hasta que finalice la carga.",
+      "replacePackageTooltip": "Si desea agregar un paquete SCORM diferente, elimine esta lección y cree una nueva.",
+      "languagePackageTooltip": "Cargue un paquete SCORM para el idioma seleccionado. Los paquetes de idiomas existentes no se pueden reemplazar.",
+      "validation": {
+        "titleRequired": "Se requiere título",
+        "packageRequired": "Se requiere el paquete SCORM",
+        "packageTooLarge": "El paquete SCORM debe tener menos de 500 MB",
+        "packageInvalidType": "El paquete SCORM debe ser un archivo .zip"
+      }
+    }
+  },
+  "adminCourseTypeSelector": {
+    "back": "Atrás",
+    "eyebrow": "Configuración del curso",
+    "title": "Crear nuevo curso",
+    "subtitle": "Elija si desea crear el curso con el editor estándar o crearlo desde un paquete SCORM.",
+    "standard": {
+      "title": "Estándar",
+      "description": "Cree un curso con el plan de estudios, las lecciones, los cuestionarios y la configuración integrados.",
+      "features": {
+        "authoring": "Construido con el editor de cursos nativo",
+        "curriculum": "Capítulos, lecciones y cuestionarios administrados en Mentingo",
+        "translations": "Idiomas del curso y traducciones compatibles.",
+        "settings": "Precios, estado y certificados incluidos"
+      }
+    },
+    "scorm": {
+      "title": "SCORM",
+      "description": "Cree un curso a partir de un paquete SCORM 1.2.",
+      "features": {
+        "import": "Construido a partir de un paquete .zip SCORM 1.2",
+        "tracking": "Se admite la finalización de SCO y el seguimiento del tiempo de ejecución",
+        "structure": "Se conserva la estructura del paquete importado.",
+        "future": "Precios, estado y certificados incluidos"
+      }
+    }
+  },
+  "studentChapterCardView": {
+    "other": {
+      "chapterProgress": "Progreso del capítulo:"
+    }
+  },
+  "navigationSideBar": {
+    "settings": "Configuración",
+    "logout": "Cerrar sesión",
+    "panel": "Panel",
+    "menu": "Menú",
+    "close": "Cerrar",
+    "profile": "Perfil",
+    "dashboard": "Panel de control",
+    "statistics": "Estadísticas",
+    "analytics": "Analítica",
+    "progress": "Progreso",
+    "findInApplication": "Buscar en la aplicación",
+    "courses": "Cursos",
+    "learningPaths": "Rutas de desarrollo",
+    "calendar": "Calendario",
+    "content": "Contenido",
+    "categories": "Categorías",
+    "users": "Usuarios",
+    "groups": "Grupos",
+    "articles": "Base de conocimientos",
+    "news": "Noticias",
+    "providerInformation": "Información",
+    "announcements": "Anuncios",
+    "notifications": "Notificaciones",
+    "promotionCodes": "Códigos de promoción",
+    "manage": "Administrar",
+    "ariaLabels": {
+      "goToAvailableCourses": "Ir a cursos disponibles"
+    },
+    "qa": "Preguntas y respuestas",
+    "tenants": "Organizaciones",
+    "activityLogs": "Registros de actividad"
+  },
+  "calendarView": {
+    "title": "Calendario",
+    "description": "Consulta los eventos de aprendizaje programados.",
+    "loading": "Cargando eventos",
+    "empty": "No hay eventos para mostrar",
+    "today": "Hoy",
+    "view": {
+      "month": "Mes",
+      "week": "Semana",
+      "day": "Día",
+      "monthShort": "M",
+      "weekShort": "Sem.",
+      "dayShort": "D."
+    },
+    "create": {
+      "title": "Añadir al calendario",
+      "description": "Elige lo que deseas agregar durante el tiempo seleccionado.",
+      "noOptions": "No hay elementos de calendario disponibles para crear.",
+      "liveKitRequired": "Configura LiveKit en la configuración del entorno para habilitar la formación en vivo en línea. Las sesiones presenciales seguirán disponibles.",
+      "submit": "Crear formación en vivo",
+      "toast": {
+        "success": "La formación en vivo se ha creado."
+      },
+      "liveTrainingOption": {
+        "title": "Formación en vivo",
+        "description": "Programa una sesión de formación en línea o presencial."
+      },
+      "section": {
+        "basics": "Conceptos básicos",
+        "schedule": "Horario",
+        "delivery": "Entrega",
+        "permissions": "Permisos"
+      },
+      "field": {
+        "title": "Título",
+        "description": "Descripción",
+        "language": "Idioma",
+        "allDay": "Todo el día",
+        "deliveryType": "Modalidad",
+        "startsAt": "Empieza a las",
+        "endsAt": "Termina a las",
+        "maxParticipants": "Máximo de participantes",
+        "location": "Ubicación",
+        "viewerPermissions": "Permisos de espectadores",
+        "microphoneEnabled": "Micrófono",
+        "cameraEnabled": "Cámara"
+      },
+      "placeholder": {
+        "title": "Título de formación",
+        "description": "Descripción de la sesión opcional",
+        "location": "Habitación, dirección o lugar de reunión"
+      },
+      "deliveryType": {
+        "online": "En línea",
+        "offline": "En persona"
+      },
+      "tooltip": {
+        "title": "Este nombre se muestra en el calendario y en los detalles de la formación en vivo.",
+        "description": "Contexto opcional para los participantes antes de unirse a la formación.",
+        "language": "El idioma base usado para este título y la descripción de la formación en vivo.",
+        "allDay": "Utilice fechas del calendario de todo el día y desactive la selección de hora de inicio/finalización.",
+        "deliveryType": "Las sesiones online son remotas. Las sesiones presenciales requieren una ubicación física.",
+        "startsAt": "La hora de inicio planificada que se muestra en el calendario.",
+        "endsAt": "La hora de finalización planificada que se muestra en el calendario.",
+        "maxParticipants": "El límite de participantes para esta formación en vivo. El máximo actual es 100.",
+        "location": "Lugar opcional para capacitaciones presenciales.",
+        "viewerPermissions": "Controla lo que los estudiantes pueden usar cuando se unen como espectadores.",
+        "microphoneEnabled": "Permita que los espectadores usen su micrófono durante la sesión.",
+        "cameraEnabled": "Permita que los espectadores usen su cámara durante la sesión."
+      },
+      "validation": {
+        "titleRequired": "El título es obligatorio.",
+        "invalidDateRange": "La hora de finalización debe ser posterior a la hora de inicio."
+      }
+    },
+    "details": {
+      "title": "Detalles del evento",
+      "description": "Metadatos del evento del calendario",
+      "unknown": "Desconocido",
+      "author": "Autor: {{name}}",
+      "trainers": "Formador {{count}}",
+      "trainers_plural": "Formadores {{count}}",
+      "noTrainers": "Sin entrenadores adicionales",
+      "hosts": "Organizador {{count}}",
+      "hosts_plural": "Organizadores {{count}}",
+      "noHosts": "Sin organizadores adicionales",
+      "action": {
+        "edit": "Editar evento",
+        "goToLiveTraining": "Ir a la formación en vivo",
+        "goToCourse": "Ir al curso"
+      },
+      "sourceType": {
+        "liveTraining": "Formación en vivo",
+        "courseDueDate": "Fecha límite del curso"
+      },
+      "field": {
+        "time": "Hora",
+        "training": "Formato de entrenamiento",
+        "linkedCourses": "Cursos vinculados",
+        "location": "Ubicación",
+        "people": "Personas",
+        "dueDate": "Fecha límite",
+        "course": "Curso",
+        "group": "Grupo"
+      },
+      "deliveryType": {
+        "online": "En línea",
+        "offline": "En persona"
+      },
+      "status": {
+        "scheduled": "Programado",
+        "cancelled": "Cancelado",
+        "ended": "Terminado",
+        "expired": "Caducado"
+      },
+      "role": {
+        "admin": "Administrador",
+        "author": "Autor",
+        "host": "Anfitrión",
+        "trainer": "Entrenador",
+        "observer": "Observador"
+      }
+    },
+    "errors": {
+      "courseDueDateRequired": "Se requiere una fecha de vencimiento para crear el evento del calendario del curso.",
+      "courseTitleRequired": "Se requiere el título del curso para crear el evento del calendario del curso."
+    }
+  },
+  "liveTrainingView": {
+    "title": "Formación en vivo",
+    "description": "Esta página contendrá el espacio de trabajo completo de formación en vivo.",
+    "errors": {
+      "idRequired": "El ID de la formación en vivo es obligatorio."
+    },
+    "status": {
+      "scheduled": "Programado",
+      "active": "Activo",
+      "ended": "Terminado",
+      "cancelled": "Cancelado",
+      "expired": "Caducado"
+    },
+    "deliveryType": {
+      "online": "En línea",
+      "offline": "En persona"
+    },
+    "visibility": {
+      "all": "Todos los usuarios",
+      "linked_courses": "Cursos vinculados"
+    },
+    "actions": {
+      "edit": "Editar",
+      "delete": "Eliminar",
+      "start": "Iniciar sesión",
+      "join": "Unirse a la sesión",
+      "finish": "Finalizar sesión"
+    },
+    "stage": {
+      "preview": "Vista previa de la sesión",
+      "activeTitle": "La sesión en vivo está activa.",
+      "waitingTitle": "La sesión está esperando",
+      "runtimeDeferred": "El tiempo de ejecución de la reunión se conectará en un segmento posterior. Los dispositivos multimedia no se inician desde esta vista previa.",
+      "activeBadge": "Activo",
+      "waitingBadge": "En espera",
+      "participants": "Participantes",
+      "viewerMic": "Micrófono del visor",
+      "viewerCamera": "Cámara del visor",
+      "scheduleTooltip": "Tiempo de entrenamiento planificado",
+      "timezoneTooltip": "Zona horaria de entrenamiento",
+      "maxParticipantsTooltip": "Participantes máximos",
+      "locationTooltip": "Lugar de entrenamiento",
+      "offlineTitle": "Entrenamiento presencial",
+      "locationMissing": "La ubicación no ha sido establecida."
+    },
+    "sidebar": {
+      "lifecycle": "Ciclo de vida de la sesión",
+      "status": "Estado",
+      "participants": "Participantes",
+      "peak": "Pico",
+      "people": "Personas",
+      "author": "Autor",
+      "host": "Anfitrión",
+      "hosts": "Anfitriones",
+      "noHosts": "No hay hosts asignados",
+      "trainer": "Formador",
+      "trainers": "Formadores",
+      "noTrainers": "No hay entrenadores asignados",
+      "unknownUser": "Usuario desconocido",
+      "details": "Detalles del entrenamiento",
+      "maxParticipants": "Máximo de participantes",
+      "visibility": "Visibilidad",
+      "courses": "Cursos vinculados",
+      "location": "Ubicación",
+      "addHost": "Añadir",
+      "addHostHint": "Agregar anfitrión",
+      "removeHost": "Eliminar el host {{name}}",
+      "addTrainer": "Añadir",
+      "addTrainerHint": "Agregar entrenador",
+      "removeTrainer": "Quitar entrenador {{name}}",
+      "searchPeople": "Buscar personas",
+      "noUserResults": "No se encontraron usuarios",
+      "loadingUsers": "Cargando usuarios",
+      "loadMoreUsers": "Cargar más"
+    },
+    "tabs": {
+      "overview": "Resumen",
+      "files": "Archivos",
+      "sessions": "Sesiones",
+      "settings": "Configuración"
+    },
+    "files": {
+      "title": "Archivos de formación en vivo",
+      "description": "Los materiales se dividen según cuándo los estudiantes deben usarlos.",
+      "beforeHeading": "Antes del entrenamiento",
+      "beforeDescription": "Materiales disponibles antes de que comience la capacitación.",
+      "afterHeading": "Después del entrenamiento",
+      "afterDescription": "Materiales disponibles una vez finalizada la formación.",
+      "empty": "Aún no hay archivos adjuntos.",
+      "afterLocked": "Los archivos posteriores a la sesión se desbloquean cuando finaliza la capacitación.",
+      "addFile": "Agregar archivo",
+      "download": "Descargar",
+      "removeFile": "Eliminar {{title}}",
+      "sizeInMb": "{{size}} MB",
+      "toast": {
+        "uploaded": "Se ha agregado el archivo.",
+        "removed": "El archivo ha sido eliminado."
+      }
+    },
+    "meeting": {
+      "previewLabel": "Sesión en vivo",
+      "waitingTitle": "La sesión está lista para unirse",
+      "activeTitle": "La sesión está activa.",
+      "inSession": "En sesión",
+      "roomTitle": "Sala en vivo",
+      "participants_one": "{{count}} participante",
+      "participants_other": "{{count}} participantes",
+      "microphone": "Micrófono",
+      "camera": "Cámara",
+      "screenShare": "Compartir pantalla",
+      "screen": "Pantalla",
+      "presentOnStage": "Presente en el escenario",
+      "leave": "Salir",
+      "finish": "Finalizar sesión",
+      "sessionEndedToast": "Tu sesión {{trainingName}} ha finalizado",
+      "finishDialog": {
+        "title": "¿Terminar sesión?",
+        "lastHostDescription": "Eres el único anfitrión en esta sala. Al salir finalizará la sesión para todos.",
+        "otherHostsDescription": "Otros anfitriones todavía están en esta sala. Puedes salir y la sesión continuará.",
+        "cancel": "Cancelar",
+        "confirmEnd": "Finalizar sesión",
+        "confirmLeave": "Salir de la sesión"
+      },
+      "empty": "Esperando a los participantes",
+      "materials": "Materiales",
+      "beforeMaterials": "Antes",
+      "afterMaterials": "Después",
+      "noMaterials": "Sin archivos"
+    },
+    "sessions": {
+      "title": "Sesiones",
+      "description": "Cada sesión iniciada se almacena por separado con su asistencia.",
+      "empty": "Aún no se han iniciado sesiones.",
+      "activeParticipants_one": "{{count}} participante activo",
+      "activeParticipants_other": "{{count}} participantes activos",
+      "uniqueParticipants_one": "{{count}} participante único",
+      "uniqueParticipants_other": "{{count}} participantes únicos",
+      "peakParticipants": "Pico {{count}}",
+      "startedBy": "Iniciado por",
+      "endedBy": "Terminado por",
+      "notEnded": "No terminado",
+      "notAvailable": "N/D",
+      "endReason": "Razón final",
+      "noEndReason": "No hay razón final",
+      "status": {
+        "waiting": "En espera",
+        "active": "Activo",
+        "ended": "Terminado",
+        "failed": "Fallido"
+      },
+      "roles": {
+        "host": "Anfitrión",
+        "co_trainer": "Coformador",
+        "moderator": "Moderador",
+        "observer": "Observador",
+        "admin": "Administrador"
+      },
+      "attendance": {
+        "empty": "Aún no se ha registrado asistencia a esta sesión.",
+        "user": "Usuario",
+        "role": "Rol",
+        "totalTime": "Tiempo de asistencia",
+        "firstJoinedAt": "Se unió por primera vez",
+        "lastLeftAt": "Última salida",
+        "joinCount": "Se une"
+      },
+      "toast": {
+        "started": "Se ha iniciado la sesión.",
+        "ended": "La sesión ha finalizado."
+      }
+    },
+    "attendance": {
+      "title": "Asistencia",
+      "description": "Los intervalos de asistencia y participantes se implementarán en el segmento de tiempo de ejecución."
+    },
+    "settings": {
+      "title": "Configuración",
+      "description": "Las configuraciones de sesión utilizadas con menos frecuencia vivirán aquí."
+    },
+    "boolean": {
+      "yes": "Sí",
+      "no": "No"
+    },
+    "deleteDialog": {
+      "title": "¿Eliminar formación en vivo?",
+      "description": "Esto cancelará la formación en vivo y la eliminará del calendario. Esta acción no se puede deshacer.",
+      "assignedToLessonsDescription": "Esta formación en vivo está vinculada a {{count}} lección. Elimina primero la lección relacionada antes de eliminar la formación en vivo.",
+      "assignedToLessonsDescription_plural": "Esta formación en vivo está vinculada a {{count}} lecciones. Elimina primero las lecciones relacionadas antes de eliminar la formación en vivo.",
+      "toast": {
+        "success": "La formación en vivo se eliminó correctamente."
+      }
+    },
+    "edit": {
+      "saveChanges": "Guardar cambios",
+      "toast": {
+        "success": "La formación en vivo se actualizó correctamente."
+      }
+    }
+  },
+  "newsView": {
+    "header": "Noticias",
+    "notFound": "Noticias no encontradas.",
+    "resourceNotFound": "Recurso de noticias no encontrado.",
+    "previousNews": "Noticias anteriores",
+    "nextNews": "Próxima noticia",
+    "prompt": {
+      "photoUrl": "URL de la foto",
+      "photoCaption": "Pie de foto (opcional)",
+      "videoUrl": "URL del vídeo (mp4, etc.)",
+      "videoCaption": "Título del vídeo (opcional)"
+    },
+    "field": {
+      "title": "Título",
+      "summary": "Resumen",
+      "intro": "Introducción",
+      "content": "Contenido",
+      "image": "Imagen",
+      "status": "Estado",
+      "isPublic": "Es público"
+    },
+    "placeholder": {
+      "title": "Introduzca el título de la noticia",
+      "summary": "Añadir un breve resumen",
+      "intro": "Añade una breve introducción"
+    },
+    "create": "Crear",
+    "edit": "Editar",
+    "status": {
+      "draft": "Borrador",
+      "published": "Publicado",
+      "draftMany": "Borradores",
+      "publishedMany": "Publicado"
+    },
+    "button": {
+      "delete": "Eliminar"
+    },
+    "validation": {
+      "titleRequired": "Se requiere título",
+      "introRequired": "Se requiere introducción",
+      "contentRequired": "Se requiere contenido",
+      "imageRequired": "Se requiere imagen",
+      "statusRequired": "Se requiere estado"
+    },
+    "editor": "Editor",
+    "preview": "Vista previa",
+    "isPublicDescription": "Comparta esta noticia también para usuarios que no hayan iniciado sesión.",
+    "language": {
+      "label": "Idioma",
+      "baseLanguage": "Predeterminado",
+      "notAddedLanguages": "Idiomas para agregar",
+      "createTitle": "Crear traducción",
+      "createDescription": "¿Crear una traducción para esta noticia en {{language}}?",
+      "deleteTitle": "Eliminar traducción",
+      "deleteDescription": "¿Eliminar la traducción {{language}}? Su contenido será eliminado."
+    }
+  },
+  "globalSearch": {
+    "notFound": "Lamentablemente no se encontró nada",
+    "tryAgain": "Inténtalo de nuevo usando palabras clave diferentes.",
+    "search": "Buscar...",
+    "searchIn": "Buscar en {{companyName}}",
+    "searchInDescription": "Empiece a escribir para buscar cursos, anuncios y más.",
+    "navigate": "Navegar",
+    "goTo": "Ir a",
+    "close": "Cerrar",
+    "entries": {
+      "users": "Usuarios",
+      "categories": "Categorías",
+      "groups": "Grupos",
+      "allCourses": "Todos los cursos",
+      "myCourses": "Mis cursos",
+      "availableCourses": "Cursos disponibles",
+      "noSearchResults": "No hay resultados de búsqueda para:",
+      "announcements": "Anuncios",
+      "lessons": "Lecciones",
+      "learningPaths": "Rutas de desarrollo",
+      "news": "Noticias",
+      "articles": "Artículos",
+      "qa": "Preguntas y respuestas"
+    }
+  },
+  "providerInformation": {
+    "title": "Información del proveedor",
+    "description": "Información sobre su empresa que será visible para los usuarios",
+    "editTitle": "Editar información del proveedor",
+    "companyName": "Nombre de la empresa",
+    "companyShortName": "Nombre corto de la empresa",
+    "registeredAddress": "Dirección registrada",
+    "taxNumber": "Número de Impuesto (NIP)",
+    "emailAddress": "Dirección de correo electrónico",
+    "courtRegisterNumber": "Número de registro judicial (KRS)",
+    "noDataAvailable": "No hay información del proveedor disponible",
+    "createSuccess": "Información del proveedor creada exitosamente",
+    "updateSuccess": "Información del proveedor actualizada exitosamente",
+    "createError": "No se pudo crear la información del proveedor",
+    "updateError": "No se pudo actualizar la información del proveedor",
+    "saveError": "No se pudo guardar la información del proveedor",
+    "validation": {
+      "nipMustBe10Digits": "NIP debe tener 10 dígitos",
+      "krsMustBe10Digits": "KRS debe tener 10 dígitos",
+      "invalidEmailFormat": "Formato de correo electrónico no válido"
+    },
+    "noCompanyInformationAvailable": "No hay información de la empresa disponible",
+    "breadcrumbs": {
+      "providerInformation": "Información del proveedor"
+    }
+  },
+  "changeUserLanguageView": {
+    "header": "Cambiar idioma",
+    "subHeader": "Selecciona tu idioma preferido",
+    "field": {
+      "language": "Idioma"
+    },
+    "options": {
+      "english": "Inglés",
+      "polish": "Polaco",
+      "german": "Alemán",
+      "czech": "Checo",
+      "lithuanian": "Lituano",
+      "spanish": "Español"
+    }
+  },
+  "resetOnboarding": {
+    "header": "Reiniciar introducción",
+    "subHeader": "Aquí puede restablecer la introducción de la aplicación.",
+    "button": {
+      "reset": "Reiniciar introducción"
+    },
+    "toast": {
+      "success": "La introducción se ha restablecido correctamente.",
+      "error": "No se pudo restablecer la introducción"
+    }
+  },
+  "changeUserEmailView": {
+    "header": "Cambiar información de usuario",
+    "subHeader": "Actualice su información de usuario aquí.",
+    "field": {
+      "email": "Correo electrónico"
+    },
+    "validation": {
+      "email": "Se requiere correo electrónico"
+    }
+  },
+  "ssoEnforcementView": {
+    "header": "SSO Cumplimiento",
+    "subHeader": "Aplicar el inicio de sesión SSO para todos los usuarios",
+    "description": "Este cambio aplicará el inicio de sesión Google/Microsoft para todos los usuarios. Si está deshabilitado, los usuarios podrán iniciar sesión utilizando el formulario de inicio de sesión tradicional.",
+    "switch": {
+      "enabled": "Habilitado",
+      "disabled": "Discapacitado"
+    },
+    "toast": {
+      "ssoEnforcementUpdatedSuccessfully": "La aplicación de SSO se actualizó correctamente",
+      "ssoEnforcementUpdateFailed": "No se pudo actualizar la aplicación de SSO",
+      "registerRedirect": "El registro con correo electrónico está deshabilitado porque se aplica SSO."
+    }
+  },
+  "userEmailTriggers": {
+    "header": "Activadores de correo electrónico del usuario",
+    "subHeader": "Administrar notificaciones automáticas por correo electrónico enviadas a los usuarios",
+    "settings": {
+      "userFirstLogin": "Primer inicio de sesión",
+      "userFirstLoginDescription": "Enviar un correo electrónico al usuario después de su primer inicio de sesión en el sistema.",
+      "userCourseAssignment": "Inscripción al curso",
+      "userCourseAssignmentDescription": "Envíe un correo electrónico al usuario después de que un administrador lo haya inscrito en un curso.",
+      "userShortInactivity": "Inactividad corta (14 días)",
+      "userShortInactivityDescription": "Enviar un correo electrónico al usuario después de 14 días de inactividad.",
+      "userLongInactivity": "Inactividad prolongada (30 días)",
+      "userLongInactivityDescription": "Enviar un correo electrónico al usuario después de 30 días de inactividad.",
+      "userChapterFinished": "Capítulo completado",
+      "userChapterFinishedDescription": "Envíe un correo electrónico al usuario después de completar un capítulo.",
+      "userCourseFinished": "Curso completado",
+      "userCourseFinishedDescription": "Envíe un correo electrónico al usuario después de completar un curso."
+    },
+    "switch": {
+      "enabled": "Habilitado",
+      "disabled": "Discapacitado"
+    },
+    "toast": {
+      "userEmailTriggersUpdatedSuccessfully": "Los activadores de correo electrónico se han actualizado correctamente",
+      "userEmailTriggersUpdateFailed": "No se pudieron actualizar los activadores de correo electrónico"
+    }
+  },
+  "inviteOnlyRegistrationView": {
+    "header": "Aplicación del registro solo por invitación",
+    "subHeader": "Requerir una invitación para registrarse",
+    "description": "Habilite esta configuración para restringir el registro solo a usuarios invitados. Cuando está deshabilitado, cualquiera puede registrarse sin invitación.",
+    "switch": {
+      "enabled": "Habilitado",
+      "disabled": "Discapacitado"
+    },
+    "toast": {
+      "inviteOnlyRegistrationUpdatedSuccessfully": "La configuración de registro solo por invitación se actualizó correctamente",
+      "inviteOnlyRegistrationUpdateFailed": "No se pudo actualizar la configuración de registro solo por invitación",
+      "registerRedirect": "La inscripción sólo es posible mediante invitación."
+    }
+  },
+  "environmentConfigurationView": {
+    "header": "Configuración del entorno",
+    "description": "Vea información detallada sobre la configuración de su entorno, incluidos los servicios completamente configurados, los servicios parcialmente configurados y las variables de entorno faltantes.",
+    "button": {
+      "viewStatus": "Ver estado",
+      "loading": "Cargando...",
+      "dismissWarning": "Descartar advertencia"
+    },
+    "dialog": {
+      "title": "Estado de configuración del entorno",
+      "fullyConfigured": "Completamente configurado",
+      "partiallyConfigured": "Parcialmente configurado",
+      "youMightWantToSetThisUp": "Quizás quieras configurar esto",
+      "noFullyConfigured": "No hay servicios completamente configurados.",
+      "noPartiallyConfigured": "No hay servicios parcialmente configurados.",
+      "allConfigured": "Todas las claves de entorno están configuradas correctamente.",
+      "dismissWarning": "Descartar",
+      "serviceNames": {
+        "stripe": "Pago de Stripe",
+        "bunny": "Bunny CDN",
+        "google_authorization": "Google OAuth",
+        "microsoft_authorization": "Microsoft OAuth",
+        "slack_authorization": "Slack OAuth",
+        "openAI": "OpenAI",
+        "luma": "Luma",
+        "livekit": "LiveKit"
+      },
+      "serviceDescriptions": {
+        "stripe": "Procesar pagos de cursos y gestionar suscripciones",
+        "bunny": "Transmita videos y entregue contenido de manera eficiente",
+        "google_authorization": "Permitir que los usuarios inicien sesión con su cuenta Google",
+        "microsoft_authorization": "Permitir que los usuarios inicien sesión con su cuenta Microsoft",
+        "slack_authorization": "Permitir que los usuarios inicien sesión con su cuenta Slack",
+        "openAI": "Habilitar las funciones de AI Mentor",
+        "luma": "Habilite las funciones de generación de cursos de IA",
+        "livekit": "Configura LiveKit para habilitar sesiones de vídeo de formación en vivo en línea. Sin él, solo estarán disponibles las formaciones presenciales."
+      }
+    }
+  },
+  "mostPopularCoursesView": {
+    "header": "Más popular",
+    "subHeader": "Los 5 mejores cursos",
+    "other": {
+      "noData": "No hay datos disponibles",
+      "students": "Estudiantes"
+    }
+  },
+  "enrollmentChartView": {
+    "header": "Inscripción",
+    "subHeader": "Números de matrícula",
+    "other": {
+      "noData": "No hay datos disponibles",
+      "enrollments": "Inscripciones"
+    }
+  },
+  "createPasswordView": {
+    "header": "Crear nueva contraseña",
+    "subHeader": "Ingrese una nueva contraseña",
+    "field": {
+      "password": "Contraseña",
+      "confirmPassword": "Confirmar contraseña"
+    },
+    "validation": {
+      "passwordsDontMatch": "Las contraseñas no coinciden"
+    },
+    "button": {
+      "changePassword": "Crear contraseña"
+    },
+    "error": {
+      "invalidToken": "Este enlace de configuración de contraseña no es válido o ha caducado."
+    }
+  },
+  "changePasswordView": {
+    "header": "Cambiar contraseña",
+    "subHeader": "Actualice su contraseña aquí.",
+    "setPasswordHeader": "Establecer contraseña",
+    "setPasswordSubHeader": "Crea una contraseña para tu cuenta.",
+    "field": {
+      "oldPassword": "Contraseña antigua",
+      "newPassword": "Nueva contraseña",
+      "confirmPassword": "Confirmar contraseña"
+    },
+    "validation": {
+      "oldPassword": "Se requiere contraseña antigua",
+      "newPassword": "Se requiere nueva contraseña",
+      "passwordsDontMatch": "Las contraseñas no coinciden"
+    },
+    "toast": {
+      "passwordChangedSuccessfully": "La contraseña se cambió correctamente",
+      "passwordCreatedSuccessfully": "Contraseña creada exitosamente"
+    }
+  },
+  "passwordValidationDisplay": {
+    "title": "Requisitos de contraseña",
+    "header": "Su contraseña debe contener:",
+    "passwordMinLength": "al menos 8 caracteres",
+    "passwordUppercase": "al menos una letra mayúscula",
+    "passwordLowercase": "al menos una letra minúscula",
+    "passwordNumber": "al menos un numero",
+    "passwordSpecial": "al menos un carácter especial",
+    "passwordsMatch": "Las contraseñas coinciden"
+  },
+  "contentCreatorView": {
+    "button": {
+      "collapse": "Colapso",
+      "showMore": "Mostrar más",
+      "edit": "Editar",
+      "share": "Compartir perfil",
+      "cancel": "Cancelar",
+      "confirm": "Confirmar",
+      "deleteProfilePicture": "Eliminar foto de perfil"
+    },
+    "field": {
+      "firstName": "Nombre",
+      "firstNamePlaceholder": "Introduce tu nombre",
+      "lastName": "Apellido",
+      "lastNamePlaceholder": "Introduce tus apellidos",
+      "contactEmail": "Dirección de correo electrónico",
+      "contactEmailPlaceholder": "Introduce tu correo electrónico",
+      "contactPhone": "Número de teléfono",
+      "contactPhonePlaceholder": "Introduce tu número de teléfono",
+      "jobTitle": "Título",
+      "jobTitlePlaceholder": "Introduce tu cargo",
+      "description": "Nota biográfica",
+      "descriptionPlaceholder": "Introduce una breve nota biográfica",
+      "uploadThumbnailLabel": "Subir miniatura"
+    },
+    "toast": {
+      "profileLinkCopied": "Enlace de perfil copiado!",
+      "profileLinkCopyError": "¡Error al copiar el enlace del perfil!"
+    },
+    "other": {
+      "personalInfoTitle": "Información principal",
+      "personalInfoDescription": "Administre la información básica de su cuenta",
+      "aboutTitle": "Acerca de",
+      "aboutDescription": "Cuenta más sobre ti",
+      "appearanceTitle": "Apariencia",
+      "appearanceDescription": "Sube tu foto de perfil",
+      "pageTitle": "Perfil",
+      "about": "Acerca de",
+      "contact": "Contacto",
+      "courses": "Cursos",
+      "title": "Título"
+    }
+  },
+  "changeUserInformationView": {
+    "header": "Cambiar información de detalles del usuario",
+    "subHeader": "Actualiza tu biografía aquí.",
+    "toast": {
+      "userUpdatedSuccessfully": "Usuario actualizado exitosamente",
+      "userDetailsUpdatedSuccessfully": "Detalles del usuario actualizados exitosamente",
+      "updatedSelectedUsersSuccessfully": "Usuarios seleccionados actualizados correctamente",
+      "deletedSelectedUsersSuccessfully": "Usuarios seleccionados eliminados exitosamente",
+      "archivedSelectedUsersSuccessfully": "Usuarios seleccionados archivados exitosamente",
+      "archiveSelectedUsersError": "No se pudieron archivar los usuarios seleccionados",
+      "passwordResetEmailsSent": "Correos electrónicos de restablecimiento de contraseña enviados: {{sentCount}}. Omitido: {{skippedCount}}.",
+      "passwordResetEmailsError": "No se pudieron enviar correos electrónicos para restablecer la contraseña",
+      "passwordCreationEmailsSent": "Correos electrónicos de creación de contraseña enviados: {{sentCount}}. Omitido: {{skippedCount}}.",
+      "passwordCreationEmailsError": "No se pudieron enviar correos electrónicos de creación de contraseña"
+    },
+    "field": {
+      "description": "Descripción",
+      "email": "Correo electrónico",
+      "phoneNumber": "Número de teléfono",
+      "jobTitle": "Título del trabajo"
+    },
+    "placeholder": {
+      "description": "Tu descripción",
+      "phoneNumber": "Tu número de teléfono",
+      "jobTitle": "Tu puesto de trabajo"
+    }
+  },
+  "clientStatisticsView": {
+    "header": "Bienvenido de nuevo,",
+    "button": {
+      "enroll": "Inscribirse",
+      "searchCourses": "Buscar cursos",
+      "continue": "Continuar",
+      "start": "Empezar",
+      "readMore": "Leer más",
+      "tryAgain": "Inténtalo de nuevo",
+      "view": "Ver"
+    },
+    "other": {
+      "completedCourses": "Cursos completados",
+      "startedCourses": "Cursos iniciados",
+      "correctAnswers": "Respuestas correctas",
+      "wrongAnswers": "Respuestas incorrectas",
+      "avgQuizScorePercentage": "Puntuación porcentual media de los cuestionarios",
+      "avgQuizCompletionPercentage": "Porcentaje medio de finalización del cuestionario",
+      "noData": "Sin datos",
+      "courses": "Cursos",
+      "lessons": "Lecciones",
+      "completed": "Completado",
+      "started": "Iniciado",
+      "noDataAvailable": "No hay datos disponibles",
+      "rates": "Tarifas",
+      "numberOf": "Número de",
+      "noLessonsToContinue": "Actualmente no tengo lecciones para continuar.",
+      "continueLearning": "Continuar aprendiendo en:"
+    }
+  },
+  "profileWithCalendarView": {
+    "header": "Mi perfil",
+    "button": {
+      "settings": "Configuración"
+    },
+    "other": {
+      "dailyStreak": "Racha de días"
+    }
+  },
+  "adminStatisticsView": {
+    "header": "Bienvenido de nuevo,",
+    "other": {
+      "courseCompletionPercentage": "Porcentaje de finalización del curso",
+      "conversionsAfterFreemiumLesson": "Conversiones después de la lección Freemium",
+      "avgQuizScore": "Puntuación media en todos los cuestionarios",
+      "purchasedCourse": "Curso comprado",
+      "remainedOnFreemium": "Permaneció en Freemium",
+      "correct": "Correcto",
+      "incorrect": "Incorrecto",
+      "completed": "Completado",
+      "enrolled": "Inscrito",
+      "noData": "Sin datos",
+      "downloadReport": "Descargar informe",
+      "downloadingReport": "Descargando informe..."
+    },
+    "toast": {
+      "reportDownloadSuccess": "Informe descargado exitosamente",
+      "reportDownloadError": "No se pudo descargar el informe. Por favor inténtalo de nuevo."
+    }
+  },
+  "adminPromotionCodesView": {
+    "notifications": {
+      "createdSuccessfully": "Código de promoción creado exitosamente",
+      "updatedSuccessfully": "Código de promoción actualizado correctamente"
+    },
+    "headers": {
+      "create": "Crear código de promoción",
+      "update": "Actualizar código de promoción"
+    },
+    "status": {
+      "active": "Activo",
+      "deactivated": "Desactivado",
+      "expired": "Caducado",
+      "usageLimitReached": "Límite de uso alcanzado"
+    },
+    "field": {
+      "code": "Código",
+      "status": "Estado",
+      "uses": "Recuento de usos",
+      "associatedCourses": "Cursos asociados",
+      "discountType": "Tipo de descuento",
+      "discountTypePercent": "Porcentaje",
+      "discountTypeFixed": "Fijo",
+      "discountValue": "Valor de descuento",
+      "maxRedemptions": "Canjes máximos",
+      "expiresAt": "Vence en",
+      "assignedCourses": "Cursos asignados",
+      "type": "Tipo",
+      "associateCourse": {
+        "checkAll": "Aplicar a todos los cursos"
+      },
+      "discount": "Descuento",
+      "createdAt": "Creado en"
+    },
+    "breadcrumbs": {
+      "promotionCodes": "Códigos de promoción",
+      "createNew": "Crear nuevo",
+      "update": "Actualizar",
+      "back": "Atrás"
+    },
+    "button": {
+      "createNew": "Crear nuevo",
+      "createCoupon": "Crear código de promoción",
+      "deactivatePromotionCode": "Este código promocional está activo",
+      "activatePromotionCode": "Este código promocional no está activo"
+    },
+    "other": {
+      "noCourses": "Sin cursos",
+      "usageInfo": "Información de uso",
+      "usageAmount": "Cantidad de uso",
+      "baseInfo": "Información básica"
+    }
+  },
+  "adminCoursesView": {
+    "filters": {
+      "placeholder": {
+        "title": "Buscar por título...",
+        "categories": "Categorías",
+        "states": "Estados"
+      },
+      "other": {
+        "draft": "Borrador",
+        "published": "Publicado",
+        "private": "Privado"
+      }
+    },
+    "courses": {
+      "header": "Administrar cursos",
+      "subHeader": "Todos los cursos que puedes ver y editar"
+    },
+    "field": {
+      "title": "Título",
+      "author": "Autor",
+      "category": "Categoría",
+      "price": "Precio",
+      "type": "Tipo",
+      "scorm": "SCORM",
+      "state": "Estado",
+      "status": "Estado",
+      "sharedCourse": "Compartido",
+      "createdAt": "Creado en"
+    },
+    "lessonCard": {
+      "mappedTypes": {
+        "video": "Vídeo",
+        "presentation": "Presentación",
+        "content": "Contenido",
+        "quiz": "Cuestionario",
+        "ai_mentor": "AI Mentor",
+        "embed": "Insertar"
+      }
+    },
+    "other": {
+      "selected": "Seleccionado",
+      "noLessons": "Sin lecciones"
+    },
+    "button": {
+      "uploadScorm": "Subir SCORM",
+      "createNew": "Crear nuevo",
+      "deleteSelected": "Eliminar seleccionado",
+      "bulkEdit": "Edición masiva"
+    },
+    "dropdown": {
+      "changeCategory": "Cambiar categoría",
+      "changeStatus": "Cambiar estado",
+      "delete": "Eliminar"
+    },
+    "deleteModal": {
+      "titleSingle": "Eliminar curso",
+      "titleMultiple": "Eliminar cursos",
+      "descriptionSingle": "¿Estás seguro de que deseas eliminar este curso? Esta acción no se puede deshacer.",
+      "descriptionMultiple": "¿Está seguro de que desea eliminar los cursos {{count}}? Esta acción no se puede deshacer."
+    },
+    "statusModal": {
+      "title": "Cambiar estado del curso",
+      "description": "Elija el nuevo estado para los cursos seleccionados {{count}}."
+    },
+    "categoryModal": {
+      "title": "Cambiar categoría de curso",
+      "description": "Elija la nueva categoría para los cursos seleccionados {{count}}."
+    },
+    "toast": {
+      "deleteCourseSuccessfully": "Curso eliminado exitosamente",
+      "deleteCourseFailed": "No se pudo eliminar el curso",
+      "deletePublishedCourseFailed": "No se puede eliminar un curso publicado. Primero establezca su estado en Borrador.",
+      "bulkCategoryUpdateSuccessfully": "Categorías de cursos actualizadas exitosamente",
+      "bulkCategoryUpdateFailed": "No se pudieron actualizar las categorías del curso",
+      "bulkCategoryUpdateForbidden": "No tienes permiso para actualizar uno o más cursos seleccionados.",
+      "bulkCategoryUpdateCategoryNotFound": "No se encontró la categoría seleccionada.",
+      "bulkStatusUpdateSuccessfully": "Estados del curso actualizados exitosamente",
+      "bulkStatusUpdateFailed": "No se pudieron actualizar los estados del curso",
+      "bulkStatusUpdateForbidden": "No tienes permiso para actualizar uno o más cursos seleccionados.",
+      "noCoursesSelected": "Seleccione al menos un curso."
+    }
+  },
+  "adminCategoriesView": {
+    "filters": {
+      "placeholder": {
+        "title": "Buscar por título..."
+      }
+    },
+    "field": {
+      "title": "Título",
+      "status": "Estado",
+      "createdAt": "Creado en"
+    },
+    "button": {
+      "createNew": "Crear nuevo",
+      "clearAll": "Borrar todo",
+      "deleteSelected": "Eliminar seleccionado"
+    },
+    "deleteModal": {
+      "titleSingle": "Eliminar categoría",
+      "titleMultiple": "Eliminar categorías",
+      "descriptionSingle": "¿Estás seguro de que deseas eliminar esta categoría? Esta acción no se puede deshacer.",
+      "descriptionMultiple": "¿Está seguro de que desea eliminar las categorías {{count}}? Esta acción no se puede deshacer."
+    },
+    "toast": {
+      "deleteCategorySuccessfully": "Categoría eliminada exitosamente",
+      "deleteCategoryFailed": "No se pudo eliminar la categoría",
+      "deleteCategoryAssignedToCourses": "No se puede eliminar la categoría. Está asignado al curso(s) {{courseCount}}: {{courseTitles}}...",
+      "noCategoriesFoundToDelete": "No se encontraron categorías para eliminar"
+    },
+    "breadcrumbs": {
+      "categories": "Categorías",
+      "createNew": "Crear nueva categoría",
+      "back": "Atrás"
+    }
+  },
+  "adminCategoryView": {
+    "header": "Crear nueva categoría",
+    "subHeader": "Ingrese un título para su nueva categoría. Haga clic en guardar cuando haya terminado.",
+    "editCategoryHeader": "Información de categoría",
+    "field": {
+      "title": "Título",
+      "status": "Estado",
+      "newCategoryName": "Nuevo nombre de categoría"
+    },
+    "placeholder": {
+      "categoryName": "Introduzca el nombre de la categoría..."
+    },
+    "button": {
+      "createCategory": "Crear categoría"
+    },
+    "language": {
+      "label": "Idioma",
+      "baseLanguage": "Predeterminado",
+      "notAddedLanguages": "Idiomas para agregar",
+      "setBaseLanguage": "Establecer como predeterminado",
+      "setBaseTitle": "Cambiar idioma predeterminado",
+      "setBaseDescription": "¿Utilizar {{language}} como idioma predeterminado para esta categoría?",
+      "createTitle": "Crear traducción",
+      "createDescription": "¿Crear una traducción para esta categoría en {{language}}?",
+      "deleteTitle": "Eliminar traducción",
+      "deleteDescription": "¿Eliminar la traducción {{language}}? Su contenido será eliminado."
+    },
+    "toast": {
+      "categoryCreatedSuccessfully": "Categoría creada exitosamente",
+      "categoryUpdatedSuccessfully": "Categoría actualizada exitosamente",
+      "baseLanguageUpdatedSuccessfully": "Idioma predeterminado actualizado exitosamente",
+      "baseLanguageUpdateFailed": "No se pudo actualizar el idioma predeterminado",
+      "languageNotSupported": "Esta categoría no admite este idioma.",
+      "alreadyExists": "La categoría ya existe.",
+      "categoryNotCreated": "No se pudo crear la categoría.",
+      "languageAlreadyExists": "Este idioma de categoría ya existe.",
+      "invalidLanguageToDelete": "El idioma de esta categoría no se puede eliminar.",
+      "baseLanguageTitleRequired": "El idioma predeterminado seleccionado necesita un título."
+    },
+    "error": {
+      "categoryNotFound": "Categoría no encontrada",
+      "categoryIdNotFound": "ID de categoría no encontrada"
+    },
+    "breadcrumbs": {
+      "categories": "Categorías",
+      "categoryDetails": "Detalles de la categoría",
+      "back": "Atrás"
+    }
+  },
+  "adminUsersView": {
+    "filters": {
+      "placeholder": {
+        "searchByKeyword": "Buscar por palabra clave...",
+        "roles": "Roles",
+        "groups": "Todos los grupos"
+      }
+    },
+    "field": {
+      "firstName": "Nombre",
+      "lastName": "Apellido",
+      "email": "Correo electrónico",
+      "role": "Rol",
+      "status": "Estado",
+      "createdAt": "Creado en",
+      "group": "Grupo"
+    },
+    "other": {
+      "selected": "Seleccionado"
+    },
+    "toast": {
+      "cannotUpdateOwnRole": "El administrador no puede cambiar su propio rol",
+      "noUserSelected": "Ningún usuario seleccionado",
+      "noGroupSelected": "Seleccione al menos un grupo.",
+      "userMustHaveAtLeastOneRole": "El usuario debe tener al menos un rol.",
+      "trainerRoleRequiresLiveTraining": "El rol de formador está disponible solo cuando la formación en vivo está habilitada."
+    },
+    "import": {
+      "toast": {
+        "processing": "La importación de usuarios se está procesando...",
+        "success": "Importación completada exitosamente.\nUsuarios {{ importedUsersAmount }} importados.\nSe omitieron los usuarios existentes de {{ skippedUsersAmount }}."
+      }
+    },
+    "button": {
+      "createNew": "Crear nuevo",
+      "deleteSelected": "Eliminar seleccionado",
+      "edit": "Editar",
+      "import": "Importar usuarios",
+      "bulkEdit": "Edición masiva",
+      "permissionsMatrix": "Matriz de permisos"
+    },
+    "permissionsMatrix": {
+      "title": "Matriz de permisos de roles del sistema",
+      "permission": "Permiso",
+      "empty": "No hay roles disponibles.",
+      "descriptionTemplates": {
+        "base": "Permite al usuario {{action}} {{resource}}.",
+        "withScope": "Permite al usuario {{action}} {{scope}} {{resource}}."
+      },
+      "actions": {
+        "read": "ver",
+        "update": "editar",
+        "manage": "gestionar",
+        "create": "crear",
+        "delete": "eliminar",
+        "share": "compartir",
+        "render": "generar",
+        "upload": "subir",
+        "use": "usar",
+        "enrollment": "gestionar la inscripción para",
+        "statistics": "ver estadísticas de",
+        "export": "exportar",
+        "checkout": "acceder al pago para",
+        "ai_generation": "generar con IA para"
+      },
+      "scopes": {
+        "self": "propio",
+        "own": "propio",
+        "public": "publico",
+        "assigned": "asignado",
+        "manageable": "gestionable"
+      },
+      "resources": {
+        "account": "detalles de la cuenta",
+        "user": "perfiles de usuario",
+        "settings": "ajustes",
+        "env": "configuración del entorno",
+        "category": "categorias",
+        "group": "grupos",
+        "course": "cursos",
+        "course_discussion": "discusiones del curso",
+        "learning_path": "caminos de desarrollo",
+        "learning_mode": "modo de aprendizaje",
+        "learning_progress": "progreso del aprendizaje",
+        "certificate": "certificados",
+        "file": "archivos",
+        "ai": "Funciones de IA",
+        "announcement": "anuncios",
+        "news": "noticias",
+        "article": "artículos de base de conocimientos",
+        "qa": "Entradas Q&A",
+        "report": "informes",
+        "statistics": "estadísticas",
+        "billing": "facturación",
+        "integration_key": "claves de integración",
+        "integration_api": "integración API",
+        "tenant": "configuración de la organización",
+        "calendar": "calendario",
+        "live_training": "entrenamientos en vivo",
+        "activity_log": "registro de actividad",
+        "other": "capacidades de la plataforma"
+      },
+      "descriptions": {
+        "account_read_self": "Ver los detalles de su propia cuenta.",
+        "account_update_self": "Editar los detalles de su propia cuenta.",
+        "user_read_self": "Ver su propio perfil de usuario.",
+        "user_manage": "Administre usuarios, incluidos roles y estado de cuenta.",
+        "settings_read_self": "Ver su propio perfil y configuración de preferencias.",
+        "settings_update_self": "Actualice su propio perfil y configuración de preferencias.",
+        "settings_manage": "Administrar la configuración global de la plataforma.",
+        "env_read_public": "Ver los valores de configuración del entorno público.",
+        "env_manage": "Administrar los valores de configuración del entorno.",
+        "category_read": "Ver categorías de cursos.",
+        "category_manage": "Cree, edite y elimine categorías de cursos.",
+        "group_read": "Ver grupos de usuarios.",
+        "group_manage": "Cree, edite y elimine grupos de usuarios.",
+        "learning_path_read": "Ver rutas de desarrollo.",
+        "learning_path_create": "Crear caminos de desarrollo.",
+        "learning_path_update": "Edite cualquier ruta de desarrollo.",
+        "learning_path_update_own": "Edite las rutas de desarrollo creadas por este usuario.",
+        "learning_path_delete": "Eliminar rutas de desarrollo.",
+        "learning_path_course_update": "Agregue, elimine y reordene cursos en cualquier ruta de desarrollo.",
+        "learning_path_course_update_own": "Agregue, elimine y reordene cursos en sus propias rutas de desarrollo.",
+        "learning_path_enrollment": "Gestionar las inscripciones en la ruta de desarrollo.",
+        "learning_path_export": "Exportar rutas de desarrollo a los inquilinos.",
+        "course_read_assigned": "Ver cursos asignados a este usuario.",
+        "course_read_manageable": "Ver cursos que este usuario puede administrar.",
+        "course_read": "Ver el contenido del curso.",
+        "course_create": "Crear nuevos cursos.",
+        "course_update": "Edita cualquier curso.",
+        "course_update_own": "Editar cursos creados por este usuario.",
+        "course_delete": "Eliminar cursos.",
+        "course_enrollment": "Gestionar inscripciones a cursos.",
+        "course_statistics": "Ver análisis y estadísticas del curso.",
+        "course_export": "Exportar datos del curso.",
+        "course_discussion_read": "Ver discusiones del curso.",
+        "course_discussion_message_create": "Crear mensajes en las discusiones del curso.",
+        "course_discussion_message_react": "Reaccionar a los mensajes de discusión del curso.",
+        "course_discussion_message_delete_own": "Eliminar mensajes de discusión del propio curso.",
+        "course_discussion_message_delete": "Eliminar mensajes de discusión del curso.",
+        "learning_mode_use": "Utilice las funciones del modo de aprendizaje.",
+        "learning_progress_update": "Actualizar el estado de progreso del alumno.",
+        "certificate_read": "Ver certificados.",
+        "certificate_share": "Certificados de acciones.",
+        "certificate_render": "Generar archivos de certificados.",
+        "file_upload": "Subir archivos a la plataforma.",
+        "file_delete": "Eliminar archivos cargados.",
+        "ai_use": "Utilice funciones de plataforma impulsadas por IA.",
+        "announcement_read": "Ver anuncios.",
+        "announcement_create": "Crear anuncios.",
+        "announcement_delete": "Eliminar anuncios.",
+        "news_read_public": "Ver publicaciones de noticias públicas.",
+        "news_manage": "Cree, edite y elimine todas las publicaciones de noticias.",
+        "news_manage_own": "Crea, edita y elimina publicaciones de noticias propias.",
+        "article_read_public": "Ver artículos públicos de la base de conocimientos.",
+        "article_manage": "Cree, edite y elimine todos los artículos de la base de conocimientos.",
+        "article_manage_own": "Cree, edite y elimine artículos propios de su base de conocimientos.",
+        "qa_read_public": "Ver entradas públicas de Q&A.",
+        "qa_manage": "Cree, edite y elimine todas las entradas Q&A.",
+        "qa_manage_own": "Cree, edite y elimine entradas propias de Q&A.",
+        "report_read": "Ver informes.",
+        "statistics_read_self": "Ver estadísticas propias.",
+        "statistics_read": "Ver estadísticas de toda la plataforma.",
+        "billing_checkout": "Acceda a los flujos de pago y facturación.",
+        "billing_manage": "Administre la configuración de facturación y las suscripciones.",
+        "integration_key_manage": "Gestionar claves de integración API.",
+        "integration_api_use": "Utilice puntos finales de integración API.",
+        "tenant_manage": "Gestionar la configuración a nivel de organización.",
+        "calendar_read": "Ver eventos del calendario.",
+        "live_training_read": "Ver entrenamientos en vivo.",
+        "live_training_create": "Crea entrenamientos en vivo.",
+        "live_training_update": "Edita cualquier entrenamiento en vivo.",
+        "live_training_update_own": "Edite entrenamientos en vivo creados por este usuario.",
+        "live_training_delete": "Eliminar entrenamientos en vivo.",
+        "live_training_delete_own": "Eliminar entrenamientos en vivo creados por este usuario.",
+        "live_training_join": "Únete a sesiones de entrenamiento en vivo.",
+        "live_training_start": "Iniciar sesiones de entrenamiento en vivo.",
+        "live_training_end": "Finalizar las sesiones de entrenamiento en vivo.",
+        "live_training_statistics": "Vea la asistencia y las estadísticas de entrenamiento en vivo.",
+        "activity_log_read": "Ver registros de actividad.",
+        "course_ai_generation": "Genere la estructura y el contenido del curso con herramientas de inteligencia artificial."
+      }
+    },
+    "dropdown": {
+      "roles": "Roles",
+      "groups": "Grupos",
+      "passwordReset": "Enviar correo electrónico para restablecer contraseña",
+      "passwordCreation": "Reenviar correo electrónico de creación de contraseña",
+      "delete": "Eliminar",
+      "archive": "Archivo"
+    },
+    "modal": {
+      "title": {
+        "delete": "¿Quieres eliminar estas cuentas?",
+        "role": "Modificar roles",
+        "group": "Modificar grupos",
+        "passwordReset": "Enviar correo electrónico para restablecer contraseña",
+        "passwordCreation": "Reenviar correo electrónico de creación de contraseña",
+        "archive": "Archivar cuentas de usuario",
+        "confirmation": "¿Estás seguro de que quieres continuar?",
+        "import": "Importar usuarios",
+        "importResult": "Resultado de importación"
+      },
+      "button": {
+        "delete": "Eliminar",
+        "role": "Guardar",
+        "group": "Guardar",
+        "passwordReset": "Enviar",
+        "passwordCreation": "Enviar",
+        "archive": "Archivar",
+        "continue": "Confirmar",
+        "downloadSample": "Descargar archivo de muestra"
+      },
+      "description": {
+        "delete": "¿Estás seguro de que deseas eliminar estas cuentas? Esta acción es irreversible.",
+        "confirmationForGroup_one": "Cambiarás de grupo a {{ group }} para 1 usuario",
+        "confirmationForGroup_other": "Cambiará el grupo a {{ group }} para los usuarios de {{ count }}",
+        "confirmationForRole_one": "Cambiará el rol a {{ role }} para 1 usuario.",
+        "confirmationForRole_other": "Cambiará el rol a {{ role }} para los usuarios de {{ count }}",
+        "passwordReset": "Envíe correos electrónicos de restablecimiento de contraseña a usuarios seleccionados con contraseñas existentes. Se omitirán los usuarios sin contraseñas.",
+        "passwordCreation": "Reenviar correos electrónicos de creación de contraseñas a usuarios seleccionados sin contraseñas. Se omitirán los usuarios con contraseñas existentes.",
+        "archive": "¿Está seguro de que desea archivar estas cuentas?",
+        "import": "Cargue un archivo .csv o .xlsx con las siguientes columnas: nombre, apellido, correo electrónico, rol (administrador, estudiante o creador de contenido), grupos (\"grupo1, grupo2\"), idioma (en o pl).",
+        "noUsersImported": "No se importaron usuarios.",
+        "noUsersSkipped": "No se omitió ningún usuario."
+      },
+      "placeholder": {
+        "group": "Seleccionar grupo",
+        "role": "Seleccionar rol"
+      },
+      "note": {
+        "import": "Nota: Se omitirán los usuarios existentes. Si se especifica un grupo y no existe, no se creará un grupo nuevo. El campo de idioma es opcional; Si no se proporciona o no es válido, el idioma predeterminado se establecerá en el idioma del administrador."
+      },
+      "sampleFile": {
+        "filename": "usuarios-importar-muestra.csv",
+        "row": {
+          "firstName": "Ejemplo",
+          "lastName": "Estudiante",
+          "email": "muestra.estudiante@ejemplo.com",
+          "groupOne": "grupo1",
+          "groupTwo": "grupo2"
+        }
+      },
+      "tabs": {
+        "imported": "Importado",
+        "skipped": "Saltado"
+      },
+      "importResult": {
+        "email": "Correo electrónico",
+        "processed": "{{count}} filas procesadas",
+        "reason": "Razón"
+      }
+    },
+    "breadcrumbs": {
+      "users": "Usuarios",
+      "createNew": "Crear nuevo usuario",
+      "back": "Atrás",
+      "news": "Noticias"
+    }
+  },
+  "adminUserView": {
+    "header": "Crear nuevo usuario",
+    "subHeader": "Complete los detalles para crear un nuevo usuario. Haga clic en guardar cuando haya terminado.",
+    "editUserHeader": "Información del usuario",
+    "tabs": {
+      "information": "Información del usuario",
+      "permissions": "Permisos"
+    },
+    "permissions": {
+      "title": "Permisos efectivos",
+      "effective": "Permisos de usuario"
+    },
+    "placeholder": {
+      "role": "Seleccione un rol",
+      "groupId": "Seleccione un grupo",
+      "language": "Seleccione un idioma"
+    },
+    "field": {
+      "firstName": "Nombre",
+      "lastName": "Apellido",
+      "email": "Correo electrónico",
+      "role": "Rol",
+      "language": "Idioma",
+      "status": "Estado",
+      "groups": "Grupo"
+    },
+    "toast": {
+      "userCreatedSuccessfully": "Usuario creado exitosamente",
+      "userWithAttemptsError": "No se puede eliminar un usuario con resultados de cuestionarios vinculados. Sólo están disponibles la anonimización y el archivado.",
+      "userWithCreatedCoursesError": "No se puede eliminar un usuario que es autor de cursos existentes. Sólo están disponibles la anonimización y el archivado."
+    },
+    "button": {
+      "createUser": "Crear usuario",
+      "passwordResetEmail": "Enviar correo electrónico para restablecer contraseña",
+      "passwordCreationEmail": "Reenviar correo electrónico de creación de contraseña"
+    },
+    "error": {
+      "userNotFound": "Usuario no encontrado"
+    },
+    "breadcrumbs": {
+      "users": "Usuarios",
+      "userDetails": "Detalles del usuario",
+      "back": "Atrás"
+    }
+  },
+  "adminEnvsView": {
+    "name": "Variables de entorno",
+    "keysTitle": "Claves",
+    "updateSuccessful": "Secretos actualizados con éxito",
+    "form": {
+      "placeholder": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      "MICROSOFT_CLIENT_ID": {
+        "label": "Microsoft ID de cliente"
+      },
+      "MICROSOFT_CLIENT_SECRET": {
+        "label": "Secreto del cliente de Microsoft"
+      },
+      "MICROSOFT_OAUTH_ENABLED": {
+        "label": "Microsoft OAuth Habilitado (verdadero/falso)"
+      },
+      "VITE_MICROSOFT_OAUTH_ENABLED": {
+        "label": "OAuth de Microsoft en Vite habilitado (verdadero/falso)"
+      },
+      "OPENAI_API_KEY": {
+        "label": "Clave de API de OpenAI"
+      },
+      "BUNNY_STREAM_API_KEY": {
+        "label": "Clave de API de Bunny Stream"
+      },
+      "BUNNY_STREAM_SIGNING_KEY": {
+        "label": "Clave de firma de Bunny Stream"
+      },
+      "BUNNY_STREAM_LIBRARY_ID": {
+        "label": "Bunny ID de biblioteca de secuencias"
+      },
+      "BUNNY_STREAM_TOKEN_SIGNING_KEY": {
+        "label": "Clave de firma de token de transmisión Bunny"
+      },
+      "BUNNY_STREAM_CDN_URL": {
+        "label": "URL CDN de transmisión de Bunny"
+      },
+      "GOOGLE_CLIENT_ID": {
+        "label": "Google ID de cliente"
+      },
+      "GOOGLE_CLIENT_SECRET": {
+        "label": "Secreto del cliente de Google"
+      },
+      "GOOGLE_OAUTH_ENABLED": {
+        "label": "Google OAuth Habilitado (verdadero/falso)"
+      },
+      "VITE_GOOGLE_OAUTH_ENABLED": {
+        "label": "OAuth de Google en Vite habilitado (verdadero/falso)"
+      },
+      "STRIPE_WEBHOOK_SECRET": {
+        "label": "Secreto del webhook de Stripe"
+      },
+      "STRIPE_SECRET_KEY": {
+        "label": "Clave secreta de Stripe"
+      },
+      "VITE_STRIPE_PUBLISHABLE_KEY": {
+        "label": "Clave publicable de Stripe en Vite"
+      },
+      "SLACK_CLIENT_ID": {
+        "label": "Slack ID de cliente"
+      },
+      "SLACK_CLIENT_SECRET": {
+        "label": "Secreto del cliente de Slack"
+      },
+      "SLACK_OAUTH_ENABLED": {
+        "label": "Slack OAuth Habilitado (verdadero/falso)"
+      },
+      "VITE_SLACK_OAUTH_ENABLED": {
+        "label": "OAuth de Slack en Vite habilitado (verdadero/falso)"
+      },
+      "LUMA_API_KEY": {
+        "label": "Luma API Clave"
+      },
+      "LIVEKIT_URL": {
+        "label": "URL de LiveKit"
+      },
+      "LIVEKIT_API_KEY": {
+        "label": "Clave de API de LiveKit"
+      },
+      "LIVEKIT_API_SECRET": {
+        "label": "Secreto de API de LiveKit"
+      },
+      "save": "Guardar"
+    },
+    "breadcrumbs": {
+      "envs": "Variables de entorno"
+    }
+  },
+  "adminGroupsView": {
+    "name": "Nombre del grupo",
+    "characteristic": "Característica",
+    "buttons": {
+      "create": "Crear nuevo",
+      "deleteSelected": "Eliminar seleccionado"
+    },
+    "groupSelect": {
+      "label": "Seleccionar grupos",
+      "noGroups": "No se encontraron grupos"
+    },
+    "newGroup": {
+      "header": "Crear nuevo grupo",
+      "card": {
+        "header": "Información detallada",
+        "subheader": "Define el nombre de tu grupo y sus características.",
+        "footer": "Recuerde, AI Mentor lo usará en las conversaciones."
+      },
+      "fields": {
+        "name": "Nombre",
+        "characteristic": "Característica"
+      },
+      "cancel": "Cancelar",
+      "submit": "Publicar"
+    },
+    "updateGroup": {
+      "header": "Grupo de actualización",
+      "fields": {
+        "name": "Nombre",
+        "description": "Descripción"
+      },
+      "submit": "Editar grupo",
+      "groupUpdatedSuccessfully": "Grupo actualizado exitosamente",
+      "groupNotFound": "Grupo no encontrado"
+    },
+    "language": {
+      "languageCreated": "Idioma del grupo creado exitosamente",
+      "languageDeleted": "Idioma del grupo eliminado correctamente",
+      "baseLanguageUpdated": "Idioma predeterminado del grupo actualizado correctamente",
+      "setBaseLanguage": "Establecer predeterminado",
+      "setBaseTitle": "Establecer idioma predeterminado",
+      "setBaseDescription": "¿Está seguro de que desea configurar {{language}} como idioma predeterminado?"
+    },
+    "deleteGroup": {
+      "title": "Confirmar eliminación",
+      "description": "¿Estás seguro de que deseas eliminar estos grupos?",
+      "cancel": "Cancelar",
+      "submit": "Eliminar"
+    },
+    "breadcrumbs": {
+      "groups": "Grupos",
+      "createNew": "Crear nuevo",
+      "editGroup": "Editar grupo",
+      "back": "Atrás"
+    }
+  },
+  "enrollCourseView": {
+    "toast": {
+      "unenrollCourseSuccessfully": "Curso cancelado exitosamente"
+    }
+  },
+  "paymentView": {
+    "toast": {
+      "successful": "Pago exitoso",
+      "failed": "No se pudo crear la intención de pago",
+      "somethingWentWrong": "Algo salió mal"
+    },
+    "other": {
+      "buyFor": "Comprar por",
+      "enrollCourse": "Inscríbete al curso"
+    }
+  },
+  "adminCourseView": {
+    "mandatoryCourse": "Curso obligatorio",
+    "mandatoryCourseTooltip": "Marcar este curso como obligatorio para el grupo seleccionado. Debe establecer una fecha límite de finalización. Después de la fecha límite, el administrador recibirá una notificación por correo electrónico con una lista de los participantes que no han completado el curso.",
+    "deadline": "Fecha límite",
+    "selectDate": "Seleccionar fecha",
+    "deadlineRequired": "Se requiere fecha límite para el curso obligatorio.",
+    "common": {
+      "settings": "Configuración",
+      "curriculum": "Plan de estudios",
+      "status": "Estado",
+      "pricing": "Precios",
+      "preview": "Vista previa",
+      "generateMissingTranslations": "Generar traducciones faltantes",
+      "enrolledStudents": "Estudiantes matriculados",
+      "testAiMentor": "Mentor de prueba de IA",
+      "aiCourseCreation": "Creación de cursos de IA",
+      "notAddedLanguages": "No agregado",
+      "baseLanguage": "Predeterminado",
+      "generateMissingTranslationsDescription": "¿Está seguro de que desea generar traducciones faltantes? Esta acción puede tardar unos momentos."
+    },
+    "toast": {
+      "courseNotFound": "Curso no encontrado",
+      "candidateNotAvailable": "La propiedad del curso no se puede transferir a este usuario",
+      "createCourseSuccessfully": "Curso creado exitosamente",
+      "courseUpdatedSuccessfully": "Curso actualizado exitosamente",
+      "courseTrailerUpdatedSuccessfully": "Avance del curso actualizado exitosamente",
+      "courseTrailerRemovedSuccessfully": "El tráiler del curso se eliminó correctamente",
+      "certificateUpdatedSuccessfully": "Certificado actualizado exitosamente",
+      "certificateUpdateError": "Error al actualizar el certificado",
+      "certificatesResetSuccessfully": "Restablecimiento de certificados para usuarios de {{count}}",
+      "certificatesResetError": "Error al restablecer los certificados",
+      "maxTitleLengthExceeded_one": "El título no puede tener más del carácter {{count}}",
+      "maxTitleLengthExceeded_other": "El título no puede tener más de {{count}} caracteres",
+      "aiMentorAvatarIncorrectType": "Tipo de archivo no válido. Cargue una imagen JPG, JPEG, PNG o SVG.",
+      "languageNotSupported": "Este curso no es compatible con este idioma.",
+      "updateCourseMissingLanguage": "No se proporciona ningún idioma para la traducción.",
+      "successfullyDeletedLanguage": "Idioma eliminado del curso exitosamente",
+      "invalidLanguageToDelete": "No puedes eliminar este idioma.",
+      "cannotModifyQuestionsInNonBaseLanguage": "No puede modificar las preguntas en un idioma que no sea el predeterminado.",
+      "noMissingTranslations": "No faltan traducciones",
+      "mismatchContentLength": "El número de traducciones no coincide con el número de traducciones generadas",
+      "translationsGeneratedSuccessfully": "Traducciones generadas exitosamente",
+      "lumaNotConfigured": "La clave Luma API no está configurada.",
+      "lumaBadRequest": "La solicitud Luma no era válida.",
+      "lumaUnauthorized": "La autorización Luma falló.",
+      "lumaResourceNotFound": "No se encontró el recurso Luma solicitado.",
+      "lumaRequestTimeout": "Se agotó el tiempo de espera de la solicitud Luma.",
+      "lumaConflict": "Luma informó un conflicto.",
+      "lumaValidationFailed": "La validación de Luma falló.",
+      "lumaRateLimited": "Se alcanzó el límite de tasa Luma. Inténtelo de nuevo en breve.",
+      "lumaServiceUnavailable": "El servicio Luma no está disponible actualmente.",
+      "courseHasChapters": "Este curso ya tiene capítulos.",
+      "courseGeneratedSavedSuccessfully": "Curso generado guardado correctamente.",
+      "lumaCourseGenerationSyncProcessed": "Curso generado guardado exitosamente.",
+      "lumaCourseGenerationSyncProcessedWithAssetWarnings": "El curso generado se guardó, pero no se pudieron incluir algunas imágenes.",
+      "lumaCourseGenerationSyncFailed": "No se pudo guardar el curso generado.",
+      "lumaCourseGenerationSyncDismissed": "Sincronización del curso generada descartada.",
+      "maxOneVideoUploaded": "No puedes subir más de 1 vídeo.",
+      "successfullyTransferredCourseOwnership": "La propiedad del curso se transfirió correctamente"
+    },
+    "errors": {
+      "featureUnavailable": {
+        "curriculum": "La edición del plan de estudios no está disponible para los cursos SCORM.",
+        "lessonSequence": "La aplicación de la secuencia de lecciones no está disponible para los cursos SCORM.",
+        "quizFeedback": "La configuración de comentarios de las pruebas no está disponible para los cursos SCORM.",
+        "videoCompletionTracking": "El seguimiento de finalización de videos no está disponible para los cursos SCORM."
+      },
+      "notFound": {
+        "course": "Curso no encontrado.",
+        "category": "Categoría no encontrada.",
+        "chapter": "Capítulo no encontrado.",
+        "lesson": "Lección no encontrada."
+      },
+      "create": {
+        "courseFailed": "No se pudo crear el curso.",
+        "stripeProductFailed": "No se pudo crear el producto de pago del curso."
+      },
+      "lesson": {
+        "aiMentorRequiredContent": "Se requieren instrucciones del mentor de IA y condiciones de finalización.",
+        "customTtsReferenceRequired": "Se requiere una referencia TTS personalizada para el modo de voz personalizado.",
+        "aiMentorCreateFailed": "No se pudo crear la lección de AI Mentor.",
+        "questionsRequired": "Se requiere al menos una pregunta.",
+        "quizCreateFailed": "No se pudo crear la lección de prueba.",
+        "optionUpdateFailed": "No se pudo actualizar la opción de prueba.",
+        "optionInsertFailed": "No se pudo agregar la opción de prueba.",
+        "embedCreateFailed": "No se pudo crear la lección para insertar.",
+        "signedUrlDownloadFailed": "No se pudo descargar el archivo desde la URL firmada."
+      }
+    },
+    "thinking": {
+      "PLANNING_NEXT_STEP": "Planificando el próximo paso...",
+      "USING_TOOLS": "Usando herramientas para buscar contexto...",
+      "SUMMARIZING_CONTEXT": "Resumiendo el contexto recuperado...",
+      "ANALYZING_OBJECTIVES": "Analizando objetivos...",
+      "SCANNING_LEARNING_EVIDENCE": "Escaneando evidencia de aprendizaje...",
+      "RUNNING_CURRICULUM_DESIGN": "Ejecutando el diseño curricular...",
+      "INITIALIZING_CURRICULUM_PLAN": "Iniciando plan curricular...",
+      "DESIGNING_CHAPTERS": "Diseñando capítulos...",
+      "DESIGNING_LESSON_BLUEPRINTS": "Diseñando planos de lecciones...",
+      "FINALIZING_COURSE_STRUCTURE": "Finalizando la estructura del curso...",
+      "PREPARING_FINAL_COURSE_SHELL": "Preparando el shell final del curso...",
+      "FINALIZING_LESSON_PAYLOADS": "Finalizando cargas útiles de lecciones...",
+      "COURSE_FINISHED": "Guardando curso generado...",
+      "WRITING_RESPONSE": "Escribiendo respuesta...",
+      "WAITING_FOR_CONFIRMATION": "Esperando tu confirmación...",
+      "THINKING": "Pensando..."
+    },
+    "generation": {
+      "processingTitle": "Generando curso en segundo plano",
+      "exitHint": "Mantenga esta página abierta. La generación puede tardar unos minutos.",
+      "exitDialogTitle": "¿Dejar esta página?",
+      "exitWarning": "La generación del curso está en progreso. ¿Estás seguro de que quieres abandonar esta página?",
+      "finishedTitle": "Generación del curso finalizada",
+      "finishedDescription": "Sus capítulos y lecciones están listos para revisar.",
+      "preparingStructure": "Preparando la estructura del capítulo...",
+      "syncProcessingTitle": "Finalizando el curso generado",
+      "syncProcessingDescription": "Estamos guardando los capítulos, lecciones, cuestionarios y recursos generados. Podrás revisar el curso cuando este finalice.",
+      "syncProcessingAction": "Procesando...",
+      "syncFailedTitle": "Error en la sincronización del curso generado",
+      "syncFailedDescription": "Algo salió mal al guardar el curso generado.",
+      "syncRetry": "Reintentar",
+      "syncDismiss": "Descartar"
+    },
+    "settings": {
+      "breadcrumbs": {
+        "back": "Atrás",
+        "myCourses": "Mis cursos",
+        "createNew": "Crear nuevo"
+      },
+      "button": {
+        "removeThumbnail": "Quitar miniatura",
+        "removeTrailer": "Quitar remolque",
+        "removeCertificateSignature": "Quitar firma",
+        "includesCertificate": "Incluye certificado",
+        "doesNotIncludeCertificate": "No incluye certificado",
+        "saveValidity": "Guardar validez",
+        "resetCertificates": "Restablecer certificados",
+        "futureOnly": "Aplicar solo a nuevos",
+        "applyToExisting": "Aplicar a todos (incluido el pasado)"
+      },
+      "selectButton": {
+        "uploadFile": "Subir archivo",
+        "External": "Externo (URL)"
+      },
+      "sideSection": {
+        "header": "Vista previa de la tarjeta",
+        "subHeader": "Así es como su curso será visible para los estudiantes.",
+        "button": {
+          "enroll": "Inscribirse"
+        },
+        "other": {
+          "noDescription": "Aún no hay descripción.",
+          "untitled": "Sin título"
+        }
+      },
+      "field": {
+        "title": "Título del curso",
+        "category": "Categoría",
+        "description": "Descripción",
+        "thumbnail": "Miniatura",
+        "trailer": "Tráiler del curso",
+        "baseLanguage": "Idioma base",
+        "validityType": "Tipo de validez",
+        "validityValue": "Valor",
+        "validityUnit": "Unidad",
+        "validUntil": "Válido hasta"
+      },
+      "placeholder": {
+        "title": "Introduce el título",
+        "category": "Seleccionar categoría",
+        "description": "Proporcionar descripción sobre el curso..."
+      },
+      "other": {
+        "charactersLeft": "Caracteres restantes",
+        "reachedCharactersLimit": "Has alcanzado el límite de caracteres.",
+        "reachedCharactersLimitHtml": "Demasiado formato. Reduzca la cantidad de formato para que se ajuste al límite.",
+        "trailerUploadDetails": "MP4, MOV, MPEG-2 o Hevc (máx. 200 MB)",
+        "enableCertificate": "Habilitar certificado",
+        "enableCertificateDescription": "Active esta opción para emitir certificados para este curso y configure su firma y vista previa a continuación.",
+        "certificateValidity": "Validez del certificado",
+        "certificateValidityDescription": "Establezca cuándo caducan los certificados emitidos y activa el reinicio del progreso del curso.",
+        "enableCertificateValidityConfirmationTitle": "¿Habilitar la validez del certificado?",
+        "enableCertificateValidityConfirmationDescription": "Esta configuración afecta las estadísticas del curso únicamente para este curso. Cuando un certificado llega al final de su validez, los usuarios afectados perderán su progreso en este curso.",
+        "enableCertificateValidityConfirmationConfirm": "Habilitar validez",
+        "confirmValidityChangesTitle": "Confirmar cambios de validez del certificado",
+        "noActiveCertificatesValidityDescription": "No hay certificados activos para actualizar en este momento. Los certificados futuros utilizarán esta configuración de validez.",
+        "activeCertificatesStat": "Certificados activos",
+        "immediatelyExpiringStat": "Expira inmediatamente",
+        "validityPeriod": "Periodo",
+        "validityFixedDate": "Fecha fija",
+        "days": "Días",
+        "months": "Meses",
+        "years": "Años",
+        "applyValidityTitle": "¿Aplicar validez a los certificados existentes?",
+        "applyValidityDescription": "Existen certificados activos {{activeCount}}. {{expiringCount}} caducaría inmediatamente si esta configuración se aplica a los certificados existentes.",
+        "resetCertificates": "Restablecimiento manual del certificado",
+        "resetCertificatesDescription": "Archive los certificados seleccionados y restablezca el progreso del curso.",
+        "resetCertificatesDialogDescription": "Esto archiva los certificados activos, restablece el progreso del curso y puede notificar a los usuarios afectados. Esta acción afecta únicamente a este curso.",
+        "sendResetEmail": "Enviar correo electrónico de reinicio a los usuarios afectados",
+        "activeCertificateCount": "{{count}} activo",
+        "noActiveCertificate": "Sin certificado activo",
+        "resetUsersSearchPlaceholder": "Buscar estudiantes por nombre o correo electrónico",
+        "resetUsersStudent": "Estudiante",
+        "resetUsersEmail": "Correo electrónico",
+        "resetUsersLoading": "Cargando estudiantes...",
+        "noResetUsers": "No se encontraron estudiantes con certificados activos",
+        "resetScope": {
+          "all": "Todos los usuarios",
+          "groups": "Grupos",
+          "users": "Usuarios"
+        },
+        "certificateSignatureRequirements": "PNG o SVG (fondo transparente recomendado)",
+        "certificatePreviewTitle": "Vista previa del certificado",
+        "certificatePreviewDescription": "Abre la vista previa para ajustar el idioma y el color.",
+        "certificatePreviewButton": "Vista previa",
+        "certificatePreviewStudentName": "Nombre del estudiante",
+        "certificatePreviewCourseName": "Nombre del curso",
+        "enforceLessonSequence": "Hacer cumplir la secuencia de las lecciones",
+        "requireSequentialLessons": "Requerir que los estudiantes completen las lecciones en orden",
+        "enableQuizFeedback": "Comentarios del cuestionario",
+        "enableQuizFeedbackDescription": "Después de enviar el cuestionario, el estudiante verá qué respuestas fueron correctas, incorrectas o no respondidas.",
+        "enableVideoCompletionTracking": "Seguimiento de finalización de vídeo",
+        "enableVideoCompletionTrackingDescription": "Exija que los alumnos vean al menos el 90 % de cada vídeo de una lección antes de que se marque como completado.",
+        "fallbackLanguageWarningTitle": "Nota: faltan traducciones",
+        "fallbackLanguageWarningDescription": "Algunos campos en esta versión de idioma están vacíos. En esos lugares, los estudiantes verán el contenido del idioma predeterminado hasta que usted agregue traducciones.",
+        "baseLanguageTooltip": "No puede cambiar ni eliminar este idioma. Es el valor predeterminado y siempre será parte del curso."
+      },
+      "validation": {
+        "titleMinLength": "El título debe tener al menos 2 caracteres.",
+        "titleMaxLength": "El título debe tener como máximo 250 caracteres.",
+        "descriptionMinLength": "La descripción debe tener al menos 2 caracteres.",
+        "categoryRequired": "Se requiere categoría",
+        "certificateManageDenied": "No puedes gestionar certificados para este curso.",
+        "validityDateRequired": "Seleccione una fecha de validez del certificado.",
+        "groupIdsRequired": "Seleccione al menos un grupo.",
+        "userIdsRequired": "Seleccione al menos un usuario."
+      },
+      "header": "Crear un nuevo curso",
+      "subHeader": "Proporcione los detalles para configurar un nuevo curso. Tendrás más opciones para personalizarlo más adelante.",
+      "editHeader": "Configuraciones básicas",
+      "editSubHeader": "Complete los detalles para crear un nuevo curso.",
+      "transferOwnership": {
+        "title": "Transferir propiedad",
+        "description": "Transfiere este curso a otro usuario. Se convertirá en el nuevo propietario y tendrá control total sobre el campo.",
+        "label": "Seleccionar nuevo propietario",
+        "placeholder": "Elige un usuario...",
+        "button": "Transferir",
+        "dialog": {
+          "title": "Confirmar transferencia",
+          "description": "Estás a punto de transferir este curso a {{user}}. Esta acción no se puede deshacer.",
+          "confirm": "Confirmar transferencia",
+          "cancel": "Cancelar"
+        }
+      }
+    },
+    "curriculum": {
+      "emptyState": {
+        "header": "Añade contenido a tu capítulo",
+        "subHeader": "Utilice el panel de la izquierda para crear capítulos nuevos o actualizar los existentes."
+      },
+      "other": {
+        "lessonNumber": "Número de lecciones",
+        "chapter": "Capítulo",
+        "lesson": "Lección",
+        "edit": "Editar",
+        "create": "Crear",
+        "resources": "Recursos",
+        "removeContentQuestionBody": "Esto eliminará la pregunta del cuestionario.",
+        "removeContentBody": "Esto eliminará todos los datos proporcionados, incluidos los medios cargados.",
+        "removeContentLesson": "¿Está seguro de que desea eliminar esta lección de contenido del capítulo?",
+        "removeQuizLesson": "¿Está seguro de que desea eliminar esta lección de prueba del capítulo?",
+        "removeAiMentorLesson": "¿Está seguro de que desea eliminar esta lección de AI Mentor del capítulo?",
+        "removeEmbedLesson": "¿Está seguro de que desea eliminar esta lección incrustada del capítulo?",
+        "removeScormLesson": "¿Está seguro de que desea eliminar esta lección SCORM del capítulo?",
+        "removeLiveTrainingLesson": "¿Seguro que deseas eliminar esta lección de formación en vivo del capítulo?",
+        "removeChapter": "¿Estás seguro de que deseas eliminar este capítulo?",
+        "removeQuestion": "¿Estás seguro de que deseas eliminar la pregunta?",
+        "removeContent": "¿Estás seguro de que deseas eliminar contenido?"
+      },
+      "chapter": {
+        "button": {
+          "addChapter": "Agregar capítulo",
+          "addChapterDisabledTooltip": "Solo puede agregar nuevos capítulos en el idioma predeterminado.",
+          "generateWithAI": "Generar con IA"
+        },
+        "toast": {
+          "chapterCreatedSuccessfully": "Capítulo creado exitosamente",
+          "chapterUpdatedSuccessfully": "Capítulo actualizado exitosamente",
+          "chapterDisplayOrderUpdatedSuccessfully": "Orden de visualización de capítulos actualizado correctamente",
+          "errorWhileUpdating": "Se produjo un error durante la actualización.",
+          "unexpectedError": "Se produjo un error inesperado."
+        },
+        "field": {
+          "title": "Título"
+        },
+        "errors": {
+          "freemiumRequiresContentLessons": "Sólo los capítulos con lecciones de contenido pueden hacerse públicos o gratuitos.",
+          "publicRequiresCourseAccess": "Habilite el acceso al curso para los visitantes en la configuración de la plataforma para hacer públicos los capítulos del curso gratuito."
+        },
+        "other": {
+          "freemium": "Capítulo gratuito",
+          "freemiumToolTip": "Los estudiantes pueden acceder a capítulos freemium sin inscribirse en el curso.",
+          "public": "Público",
+          "publicToolTip": "Este capítulo estará disponible para todos.",
+          "freemiumDisabledLockedTooltip": "Este interruptor está deshabilitado mientras la generación del curso está en progreso."
+        }
+      },
+      "lesson": {
+        "button": {
+          "addLesson": "Agregar lección",
+          "addQuestion": "Agregar pregunta",
+          "addOption": "Agregar opción",
+          "deleteQuestion": "Eliminar pregunta",
+          "addWords": "Agregar palabras",
+          "saveLesson": "Guardar",
+          "addResource": "Agregar recurso",
+          "removeResource": "Eliminar recurso",
+          "uploadFiles": "Subir archivos",
+          "addLessonDisabledTooltip": "Para crear una lección, debes estar en el idioma base."
+        },
+        "breadcrumbs": {
+          "back": "Atrás"
+        },
+        "settings": {
+          "title": "Configuración",
+          "passingThreshold": "Umbral de superación (%)",
+          "attemptsLimit": "Límite de intentos",
+          "quizCooldownInHours": "Bloqueo de tiempo después de intentos fallidos (en horas)",
+          "numberOfQuestions": "{{count1}} de preguntas {{count2}}",
+          "noQuestions": "Sin preguntas"
+        },
+        "tooltip": {
+          "switch": "Si está habilitado, el estudiante tiene un número limitado de intentos de prueba.",
+          "passingThreshold": "El umbral porcentual para aprobar el cuestionario. Si un estudiante alcanza esta puntuación, la prueba se considerará aprobada.",
+          "attemptsLimit": "Número de intentos de prueba permitidos antes de que se active el bloqueo de tiempo.",
+          "quizCooldownInHours": "Duración del bloqueo del cuestionario después de utilizar todos los intentos."
+        },
+        "validation": {
+          "optionTextRequired": "El texto de la opción es obligatorio",
+          "optionTextMaxLength": "El texto no puede tener más de 250 caracteres.",
+          "atLeastOneOptionRequired": "Se requiere al menos una opción",
+          "imageRequired": "Se requiere imagen",
+          "descriptionLength": "La descripción debe tener al menos 10 caracteres.",
+          "descriptionMaxLength": "El contenido puede tener un máximo de 20000 caracteres.",
+          "atLeastOneOptionCorrect": "Al menos una opción debe estar marcada como correcta para la pregunta.",
+          "allOptionsCorrect": "Todas las opciones deben ser correctas.",
+          "titleRequired": "Se requiere título",
+          "descriptionRequired": "Se requiere descripción",
+          "aiMentorInstructionsRequired": "Se requieren instrucciones del mentor de IA",
+          "aiMentorInstructionsMaxLength": "Las instrucciones del mentor de IA son demasiado largas (máximo 20 000 caracteres)",
+          "completionConditionsRequired": "Se requieren condiciones de finalización",
+          "completionConditionsMaxLength": "Las condiciones de finalización son demasiado largas (máximo 20 000 caracteres)",
+          "customTTSReferenceRequired": "Se requiere una referencia TTS personalizada en el modo personalizado",
+          "taskDescriptionMaxLength": "La descripción de la tarea es demasiado larga (máximo de caracteres {{ count }})",
+          "passThresholdMin": "El umbral de aprobación debe ser al menos 1",
+          "passThresholdMax": "El umbral de aprobación no puede exceder 10",
+          "titleMinLength": "El título es demasiado corto (mínimo 2 caracteres)",
+          "titleMaxLength": "El título es demasiado largo (máximo 250 caracteres)",
+          "maxFileSize": "El tamaño del archivo debe ser inferior a {{ MAX_MB_PER_FILE }} MB",
+          "maxFileNumber_one": "No puedes subir más de 1 archivo",
+          "maxFileNumber_other": "No puedes cargar más de archivos {{ count }}",
+          "maxResources_five": "No puedes agregar más de 5 recursos.",
+          "sourceUrlRequired": "La URL de origen es obligatoria"
+        },
+        "toast": {
+          "lessonDisplayOrderUpdatedSuccessfully": "Orden de visualización de lecciones actualizado correctamente",
+          "errorWhileUpdating": "Se produjo un error durante la actualización.",
+          "unexpectedError": "Se produjo un error inesperado.",
+          "lessonCreatedSuccessfully": "Lección creada exitosamente",
+          "fileLessonCreatedSuccessfully": "Elemento de archivo creado correctamente",
+          "contentLessonCreatedSuccessfully": "Lección de contenido creada exitosamente",
+          "scormLessonCreatedSuccessfully": "Lección SCORM creada exitosamente",
+          "scormLessonPackageAttachedSuccessfully": "Paquete SCORM adjunto correctamente",
+          "quizLessonCreatedSuccessfully": "Prueba creada con éxito",
+          "aiMentorLessonCreatedSuccessfully": "Lección de AI Mentor creada con éxito",
+          "liveTrainingLessonCreated": "Lección de formación en vivo creada correctamente",
+          "liveTrainingLessonUpdated": "Lección de formación en vivo actualizada correctamente",
+          "liveTrainingLessonAttached": "La formación en vivo se vinculó correctamente",
+          "aiMentorLessonUpdatedSuccessfully": "Lección de AI Mentor actualizada con éxito",
+          "aiMentorLessonFileAddedSuccessfully": "Los archivos de lecciones de AI Mentor se cargaron correctamente",
+          "courseGenerationFileAddedToUploadQueue": "Archivo agregado a la cola de carga",
+          "aiMentorLessonFileDeletedSuccessfully": "Los archivos de lecciones de AI Mentor se eliminaron correctamente",
+          "lessonUpdatedSuccessfully": "Lección actualizada con éxito",
+          "lessonDeletedSuccessfully": "Lección eliminada exitosamente",
+          "lessonDeleteError": "No se pudo eliminar la lección",
+          "contentLessonUpdatedSuccessfully": "Lección de contenido actualizada con éxito",
+          "fileLessonUpdatedSuccessfully": "Elemento de archivo actualizado correctamente",
+          "questionOptionsUpdatedSuccessfully": "Opciones de preguntas actualizadas exitosamente",
+          "embedLessonCreatedSuccessfully": "Insertar lección creada exitosamente",
+          "embedLessonUpdatedSuccessfully": "Insertar lección actualizada correctamente",
+          "embedLessonCreateError": "No se pudo crear la lección para insertar. Por favor revisa todos los campos y vuelve a intentarlo.",
+          "embedLessonUpdateError": "No se pudo actualizar la lección para insertar. Por favor revisa todos los campos y vuelve a intentarlo."
+        },
+        "liveTraining": {
+          "createTitle": "Crear lección de formación en vivo",
+          "editTitle": "Editar lección de formación en vivo",
+          "lessonTitle": "Título de la lección",
+          "lessonTitlePlaceholder": "Título de la lección que se muestra en el curso.",
+          "createNewTab": "Crear nuevo",
+          "linkExistingTab": "Enlace existente",
+          "linkExistingLoading": "Cargando formaciones en vivo programadas...",
+          "linkExistingEmpty": "No hay formaciones en vivo programadas disponibles.",
+          "linkedTitle": "Formación en vivo vinculada",
+          "linkedDescription": "La programación, los formadores, los archivos y la configuración de la sesión se gestionan en la página de formación en vivo.",
+          "openLiveTraining": "Abrir formación en vivo",
+          "openBaseLiveTraining": "Abrir formación en vivo base",
+          "languageMissingTitle": "No hay formación en vivo asignada para este idioma",
+          "languageMissingDescription": "Esta lección usa el idioma base del curso. Crea o vincula una formación en vivo programada para sobrescribirla en el idioma seleccionado.",
+          "validation": {
+            "liveTrainingRequired": "Selecciona una formación en vivo programada para vincularla."
+          }
+        },
+        "field": {
+          "title": "Título",
+          "sourceType": "Tipo de fuente",
+          "video": "Subir vídeo",
+          "presentation": "Subir presentación",
+          "description": "Descripción",
+          "questions": "Preguntas",
+          "options": "Opciones",
+          "image": "Imagen",
+          "type": "Tipo",
+          "words": "Palabras",
+          "sentence": "Oración",
+          "sourceUrl": "URL de origen",
+          "aiMentorInstructions": "Instrucciones del mentor de IA",
+          "completionConditions": "Condiciones de finalización",
+          "aiMentor": "AI Mentor",
+          "mentorName": "Nombre del mentor",
+          "taskDescription": "Descripción de la tarea",
+          "passThreshold": "Umbral de paso",
+          "additionalContext": "Contexto adicional",
+          "aiMentorTypes": "Tipo de mentor de IA",
+          "voiceConfig": "Configuración de voz",
+          "voiceMode": "Modo de voz",
+          "ttsPreset": "Preajuste TTS",
+          "customTTSReference": "Referencia TTS personalizada",
+          "includeFiles_one": "Adjunte hasta 1 archivo debajo de {{ MAX_FILE_SIZE }} MB para usarlo como contexto en las lecciones",
+          "includeFiles_other": "Adjunte hasta archivos {{ count }} debajo de {{ MAX_FILE_SIZE }} MB para usarlos como contexto en las lecciones"
+        },
+        "placeholder": {
+          "title": "Proporcione el título de la lección...",
+          "fileDescription": "Proporcionar una descripción sobre el {{type}}...",
+          "option": "Opción",
+          "matchedWords": "Palabras coincidentes",
+          "singleChoice": "Elección única",
+          "multipleChoice": "Opción múltiple",
+          "enterWord": "Introduce una palabra",
+          "enterURL": "Ingrese la URL…",
+          "sourceUrl": "Introduzca la URL de origen...",
+          "allowFullscreen": "Permitir pantalla completa",
+          "aiMentorInstructions": "Describe cómo debe comportarse el mentor de IA durante la lección...",
+          "completionConditions": "Enumere lo que el estudiante debe lograr para aprobar esta lección...",
+          "taskDescription": "Describa la tarea que el participante debe completar...",
+          "passThreshold": "por ejemplo, 70%",
+          "customTTSReference": "Ingrese el ID de referencia TTS personalizado...",
+          "aiMentorTypes": "Mentor"
+        },
+        "courseGenerationComposer": {
+          "placeholders": {
+            "topic": "Conceptos básicos de la legislación laboral para equipos de software, incluidos contratos, propiedad intelectual y cumplimiento.",
+            "targetAudience": "Desarrolladores en equipos de productos que colaboran con partes interesadas legales y de recursos humanos.",
+            "currentLevel": "Principiante a intermedio sin necesidad de formación jurídica formal.",
+            "desiredOutcomes": "Identifique con confianza el riesgo legal en las decisiones de ingeniería diarias y sepa cuándo escalarlo.",
+            "constraintsPrerequisites": "De cuatro a cinco horas por semana en un entorno totalmente remoto y se requiere experiencia básica en software.",
+            "preferredFormatAssessment": "Formato mixto con lecturas concisas, escenarios prácticos y evaluaciones breves basadas en casos.",
+            "timeBudget": "Un mes en total con hitos semanales y una sesión de resumen final.",
+            "successCriteriaDomainContext": "Los alumnos pueden explicar claramente el tema y resolver situaciones legales laborales realistas en el contexto de una empresa de tecnología."
+          }
+        },
+        "other": {
+          "lessonNumber": "Número de lecciones",
+          "chooseType": "Elige tipo",
+          "chooseLessonTypeAriaLabel": "Elija el tipo de lección {{type}}",
+          "content": "Contenido",
+          "quiz": "Cuestionario",
+          "aiMentor": "AI Mentor",
+          "embed": "Insertar",
+          "scorm": "SCORM",
+          "liveTraining": "Formación en vivo",
+          "correct": "Correcto",
+          "true": "Verdadero",
+          "false": "Falso",
+          "option": "Opción",
+          "singleChoice": "Elección única",
+          "multipleChoice": "Opción múltiple",
+          "matchWords": "Coincidencia",
+          "trueOrFalse": "Verdadero o falso",
+          "fillInTheBlanks": "Relleno de huecos (arrastrar y soltar)",
+          "photoQuestion": "Pregunta de foto",
+          "fillInTheBlanksText": "Relleno de huecos (texto)",
+          "briefResponse": "Respuesta corta",
+          "detailedResponse": "Texto libre",
+          "scale1_5": "Escala del 1 al 5",
+          "selectQuestionType": "Seleccionar tipo de pregunta",
+          "contentLessonDescription": "Texto con multimedia (imágenes, vídeos, presentaciones).",
+          "quizLessonDescription": "Un conjunto de preguntas para comprobar conocimientos.",
+          "aiMentorLessonDescription": "Conversación interactiva con un mentor virtual de IA.",
+          "scormLessonDescription": "Contenido de la lección del paquete SCORM.",
+          "liveTrainingLessonDescription": "Sesión en vivo programada conectada a este curso.",
+          "fillInTheBlanksDescription": "Esta pregunta contiene una oración; los estudiantes deben arrastrar y soltar la palabra correcta en el espacio en blanco.",
+          "gapFillDescription": "Esta pregunta tendrá una oración a la que le faltan palabras que los estudiantes deberán escribir.",
+          "embedLessonDescription": "Recurso externo (por ejemplo, formulario Google, presentación Canva o transmisión en vivo YouTube).",
+          "fillInTheBlanksSentenceTip": "Escribe una oración y coloca palabras en ella.",
+          "fillInTheBlanksWordTip": "Crea y coloca la palabra en la oración.",
+          "leaveContentHeader": "¿Estás seguro de que quieres salir de este editor de preguntas?",
+          "leaveContentBody": "Eliminará todo el progreso no guardado.",
+          "dropOrClick": "Suelta la imagen aquí o haz clic para subirla.",
+          "allowedFormats": "PNG, JPG o SVG",
+          "leaveContentBodyValidate": "Si desea guardar los cambios, primero debe validar el formulario",
+          "aiMentorInstructionsTooltip": "Describe cómo debe comportarse el mentor de IA durante la lección. Incluya el contexto, rol o escenario que debe seguir la IA. Esto define cómo la IA guiará la conversación.",
+          "updateAiMentorAvatarDescription": "Cargue una nueva imagen para el mentor de IA o elimine la actual.",
+          "updateAiMentorAvatar": "Actualizar avatar de mentor de IA",
+          "aiMentorTypesTooltip": "Elija el tipo de mentor de IA: el mentor lo guía hacia las respuestas, el maestro instruye directamente, el juego de roles simula escenarios reales (por ejemplo, cliente y vendedor).",
+          "aiMentorTypeTooltip": "Actúa como un personaje en un escenario, pero hace preguntas durante la escena y ayuda a sacar conclusiones.\nEjemplo: \"¿Qué harías ahora en el rol de gerente?\"",
+          "aiTeacherTypeTooltip": "Explica, enseña y hace preguntas, como un profesor.\nEjemplo: \"En esta situación, el cliente plantea una objeción sobre el precio. ¿Qué debería responder y por qué?\"",
+          "aiRoleplayTypeTooltip": "Simula un personaje y una situación realistas, sin romper el personaje.\nEjemplo: \"Esta es la segunda vez que tu servicio falla. ¿Qué vas a hacer al respecto?\"",
+          "completionConditionsTooltip": "Enumere lo que el estudiante debe lograr para aprobar esta lección. Proporcione puntos claros y mensurables. La IA utilizará esta lista para comprobar el progreso. También puede definir un umbral de aprobación (por ejemplo, porcentaje o número mínimo de puntos a cubrir). Si no se proporciona ningún umbral, se deben cumplir todas las condiciones para aprobar la lección.",
+          "passThresholdTooltip": "Establezca el porcentaje mínimo (1-100%) requerido para aprobar. Déjelo vacío si no hay umbral.",
+          "voiceConfigFishAudioTooltip": "El modo de voz utiliza Cartesia. Para usar una voz personalizada, abra Cartesia, busque la voz que desee y copie su ID de voz aquí.",
+          "aiMentorPersonaTooltip": "Esto define la personalidad de la lección. Puede seleccionar un nombre y un avatar para el mentor de IA. La persona se identificará con este nombre y el avatar seleccionado se mostrará durante las lecciones.",
+          "suggestedExamples": "Ejemplos sugeridos",
+          "charactersLeft": "Caracteres restantes",
+          "optional": "Opcional",
+          "overwriteContent": "Sobrescribir contenido",
+          "overwriteContentDescription": "Esto reemplazará su contenido actual con el ejemplo seleccionado. ¿Estás seguro de que quieres continuar?",
+          "scenarioSimulation": "Simulación de escenario",
+          "problemSolving": "Resolución de problemas",
+          "creativeTask": "Tarea creativa",
+          "knowledgeSharing": "Diálogo de intercambio de conocimientos",
+          "voiceModePreset": "Preestablecido",
+          "voiceModeCustom": "Personalizado",
+          "voicePresetMale": "Masculino",
+          "voicePresetFemale": "Mujer",
+          "emoji": {
+            "search": "Buscar",
+            "loading": "Cargando..."
+          },
+          "aiMentorSuggestionExamples": {
+            "instructions": {
+              "scenarioSimulation": "Usted desempeña el papel de un cliente empresarial que busca un proveedor de servicios de desarrollo de software. Tienes requisitos específicos: la aplicación debe estar lista en 3 meses, tienes un presupuesto limitado y esperas una comunicación clara. El estudiante desempeña el papel del representante de ventas que quiere ganar su negocio. El mentor de IA debe responder como el cliente, haciendo preguntas y expresando inquietudes.",
+              "problemSolving": "Juegas el papel de un empleado que solicita un aumento de salario. Crees que te lo mereces por tus recientes contribuciones. Sin embargo, la empresa actualmente no tiene presupuesto disponible para aumentos. El estudiante interpreta al gerente que necesita manejar la conversación de manera constructiva, mostrando empatía e intentando encontrar una solución alternativa.",
+              "creativeTask": "Le pides al estudiante que proponga una idea para un nuevo servicio que la empresa podría ofrecer a sus clientes. Su función es fomentar la creatividad, hacer preguntas de seguimiento y ayudar al estudiante a perfeccionar su concepto.",
+              "knowledgeSharing": "Usted desempeña el papel de un mentor experimentado que comparte conocimientos sobre técnicas de gestión del tiempo. La conversación es informal: introduces conceptos, das ejemplos y animas al alumno a reflexionar. De vez en cuando hace preguntas ligeras y abiertas para comprobar su comprensión. El objetivo es guiar, no probar."
+            },
+            "conditions": {
+              "scenarioSimulation": "<ul><li>El estudiante pregunta sobre el presupuesto del cliente.</li><li>El estudiante pregunta sobre el cronograma.</li><li>El estudiante utiliza la venta SPIN u otra técnica de ventas.</li><li>El estudiante identifica los puntos débiles clave del cliente.</li><li>El estudiante ofrece una propuesta que coincide con las limitaciones del cliente.</li></ul><strong>Umbral:</strong> se deben cumplir al menos 3 de 5 condiciones.",
+              "problemSolving": "<ul><li>El estudiante reconoce la contribución del empleado.</li><li>El estudiante explica la situación presupuestaria honestamente.</li><li>El estudiante propone una alternativa no financiera (por ejemplo, beneficios adicionales, oportunidades de desarrollo).</li><li>El estudiante acepta volver a abordar el tema en una fecha posterior.</li><li>El estudiante mantiene un tono respetuoso y de apoyo.</li></ul><strong>Umbral:</strong> al menos 3 de 5 condiciones deben cumplirse ser cumplido.",
+              "creativeTask": "<ul><li>El estudiante presenta una idea original.</li><li>El estudiante explica quién es el público objetivo.</li><li>El estudiante describe cómo el servicio podría proporcionar valor a los clientes.</li><li>El estudiante identifica desafíos potenciales.</li></ul><em>(No se define ningún umbral; se deben cumplir todas las condiciones).</em>",
+              "knowledgeSharing": "<ul><li>El estudiante participa activamente en la conversación (hace preguntas o comparte reflexiones).</li><li>El estudiante puede nombrar al menos una técnica de gestión del tiempo mencionada en el diálogo.</li><li>El estudiante expresa cómo podría aplicar una técnica en su trabajo.</li></ul><em>(No hay umbral definido; todas las condiciones se recomiendan, pero no son obligatorias para aprobar).</em>"
+            }
+          },
+          "betaTooltip": "Esta funcionalidad se proporciona en una versión de prueba. Puede contener errores o no funcionar completamente según lo previsto y se utiliza bajo su propio riesgo.",
+          "dragWord": "Arrastra la palabra a la oración",
+          "taskDescriptionTooltip": "Describa brevemente lo que debe hacer el participante durante la conversación con el mentor de IA."
+        }
+      }
+    },
+    "status": {
+      "header": "Estado",
+      "subHeader": "Establecer estado para el curso",
+      "draftHeader": "Borrador",
+      "draftBody": "Los estudiantes no pueden comprar ni inscribirse en este curso. Para aquellos que ya están inscritos, el curso no aparecerá en su Lista de cursos para estudiantes.",
+      "publishedHeader": "Publicado",
+      "publishedBody": "Los estudiantes pueden comprar, inscribirse y acceder al contenido del curso. Una vez inscrito, el curso se mostrará en su Panel de Estudiantes.",
+      "privateHeader": "Privado",
+      "privateBody": "Los estudiantes no pueden comprar ni inscribirse en este curso. Para aquellos inscritos (por ejemplo, por administrador), el curso aparecerá en su lista de cursos para estudiantes y podrán seguirlo."
+    },
+    "pricing": {
+      "header": "Precios",
+      "subHeader": "Establecer precios para el curso.",
+      "freeCourseHeader": "Gratis",
+      "freeCourseBody": "Los estudiantes pueden inscribirse y acceder al contenido del curso sin pagar.",
+      "paidCourseHeader": "Curso pago",
+      "paidCourseBody": "Los estudiantes pueden comprar y acceder al contenido del curso. Una vez seleccionado, puede definir la moneda y el precio.",
+      "field": {
+        "price": "Precio"
+      },
+      "placeholder": {
+        "amount": "Cantidad"
+      },
+      "validation": {
+        "priceInCents": "El precio debe ser al menos 2.00 o gratis"
+      }
+    },
+    "enrolled": {
+      "filters": {
+        "placeholder": {
+          "searchByKeyword": "Buscar por palabra clave...",
+          "groups": "Todos los grupos"
+        }
+      },
+      "enroll": "Inscribirse",
+      "enrollSelected": "Inscribir seleccionado",
+      "unenrollSelected": "Darse de baja seleccionado",
+      "unenrollGroups": "Dar de baja grupos",
+      "table": {
+        "name": "Nombre",
+        "surname": "Apellido",
+        "email": "Correo electrónico",
+        "status": "Estado de inscripción",
+        "enrollmentDate": "Fecha de inscripción"
+      },
+      "statuses": {
+        "enrolled": "Inscrito",
+        "enrolledByGroup": "Inscrito por grupo",
+        "individuallyEnrolled": "Inscrito individualmente",
+        "notEnrolled": "No inscrito"
+      },
+      "confirmation": {
+        "title": "Confirmar inscripción",
+        "description": "¿Está seguro de que desea inscribir a los estudiantes seleccionados en este curso?"
+      },
+      "enrollGroups": "Inscribir grupos",
+      "enrollGroupsModal": {
+        "title": "Inscribir grupos al curso",
+        "description": "Seleccione grupos para inscribirse. Todos los miembros de los grupos seleccionados quedarán inscritos automáticamente en este curso. Puedes marcar el curso como obligatorio y establecer una fecha de vencimiento."
+      },
+      "alreadyEnrolled": "Ya inscrito",
+      "members": "Miembros de {{count}}",
+      "unenrollConfirmation": {
+        "title": "Confirmación de baja",
+        "description": "¿Está seguro de que desea cancelar la inscripción de los estudiantes seleccionados de este curso?"
+      },
+      "toast": {
+        "someStudentsUnenrolled": "No puede cancelar la inscripción de estos estudiantes porque {{count}} de ellos no están inscritos.",
+        "studentsEnrolledByGroup": "No puede cancelar la inscripción de estos estudiantes porque {{count}} de ellos están inscritos a través de un grupo.",
+        "groupsUnenrolledSuccessfully": "Grupos cancelados exitosamente",
+        "alreadyEnrolledByGroup": {
+          "title": "Algunos usuarios ya están inscritos por grupo."
+        }
+      },
+      "successResponse": "Los estudiantes han sido asignados al curso."
+    },
+    "breadcrumbs": {
+      "courses": "Cursos",
+      "back": "Atrás"
+    },
+    "statistics": {
+      "title": "Estadísticas",
+      "subtitle": "Descripción general del rendimiento del curso",
+      "details": "Detalles",
+      "filterByQuiz": "Filtrar por cuestionario",
+      "allQuizzes": "Todos los cuestionarios",
+      "filterByLesson": "Filtrar por lección",
+      "allLessons": "Todas las lecciones",
+      "tabs": {
+        "progress": "Progreso",
+        "quizResults": "Resultados del examen",
+        "aiMentorResults": "Resultados del mentor de IA",
+        "learningTime": "Tiempo de aprendizaje"
+      },
+      "field": {
+        "studentName": "Estudiante",
+        "groupName": "Grupo",
+        "completedLessonsCount": "Lecciones completadas",
+        "lastActivity": "Última actividad",
+        "lastCompletedLesson": "Última lección completada",
+        "quizName": "Cuestionario",
+        "quizScore": "Puntuación",
+        "attempts": "Intentos",
+        "lastAttempt": "Último intento",
+        "lessonName": "Lección",
+        "lastSession": "Última sesión",
+        "score": "Puntuación",
+        "totalTime": "Tiempo total"
+      },
+      "overview": {
+        "enrolledCount": "Conteo de estudiantes matriculados",
+        "enrolledCountTooltip": "Número de usuarios matriculados en este curso.",
+        "completionRate": "Tasa de finalización",
+        "completionRateTooltip": "Porcentaje de usuarios que han completado todo el curso.",
+        "averageCompletionPercentage": "Progreso promedio",
+        "averageCompletionPercentageTooltip": "Nivel promedio de finalización del curso entre todos los usuarios inscritos.",
+        "averageScorePerQuiz": "Puntuación media por prueba",
+        "averageScorePerQuizSubtitle": "Ver resultados promedio de pruebas individuales en el curso",
+        "averageQuizScore": "Puntuación media del cuestionario",
+        "completedBy_one": "Completado por el estudiante {{count}}",
+        "completedBy_other": "Completado por estudiantes de {{count}}",
+        "courseStatusDistribution": "Distribución del estado del curso",
+        "courseStatusDistributionTooltip": "Muestra cuántos usuarios han completado, iniciado o no iniciado el curso.",
+        "averageLearningTime": "Tiempo promedio de aprendizaje",
+        "averageLearningTimeTooltip": "Tiempo medio dedicado por todos los usuarios a este curso.",
+        "activeStudents": "Estudiantes activos",
+        "activeStudentsTooltip": "Número de estudiantes que han participado en el curso."
+      },
+      "empty": {
+        "noUsers": "Sin usuarios",
+        "enrolled": "Inscrito",
+        "noGroups": "Sin grupos"
+      },
+      "groupFilter": {
+        "placeholder": "Todos los grupos"
+      }
+    },
+    "createLanguage": {
+      "title": "Crear nuevo idioma",
+      "description": "¿Está seguro de que desea crear un nuevo idioma para este curso?",
+      "success": "Idioma creado exitosamente",
+      "alreadyExists": "Este idioma ya existe.",
+      "editConstraints": "En idiomas distintos de {{baseLanguage}}, no puede crear nuevas lecciones, capítulos ni agregar nuevas preguntas a los cuestionarios."
+    },
+    "deleteLanguage": {
+      "title": "Eliminar idioma",
+      "description": "¿Estás seguro de que deseas eliminar este idioma?"
+    },
+    "sharedCourse": {
+      "badgeMaster": "Compartido",
+      "badgeExported": "Compartido",
+      "badgeExportedTooltip": "Este curso se gestiona de forma centralizada. Puedes publicarlo y asignar participantes, pero no puedes editar su contenido.",
+      "exportedNoticeTitle": "Este curso fue exportado a esta organización.",
+      "exportedNoticeDescription": "El contenido se administra en la organización de origen y es de solo lectura en esta organización.",
+      "exportsTitle": "Compartir",
+      "exportsDescription": "Comparte este curso con organizaciones seleccionadas.",
+      "selectTenants": "Seleccionar organizaciones",
+      "selectedCount": "Seleccionado:",
+      "exportButton": "Compartir",
+      "exportingButton": "Compartiendo..."
+    },
+    "scormExport": {
+      "title": "Paquete SCORM",
+      "description": "Exporte este curso como un paquete SCORM 1.2 autónomo para otro LMS.",
+      "versionBadge": "SCORM 1.2",
+      "button": "Exportar paquete SCORM",
+      "exportingButton": "Exportando...",
+      "success": "Se inició la descarga del paquete SCORM.",
+      "warning": {
+        "title": "Se omitirán las lecciones no admitidas.",
+        "description": "Este curso contiene {{count}} lección que no es compatible con los paquetes SCORM. Las lecciones de AI Mentor y formación en vivo se omiten durante la exportación. ¿Quieres continuar?",
+        "description_other": "Este curso contiene {{count}} lecciones que no son compatibles con los paquetes SCORM. Las lecciones de AI Mentor y formación en vivo se omiten durante la exportación. ¿Quieres continuar?",
+        "confirm": "Exportar de todos modos"
+      },
+      "error": {
+        "courseNotFound": "No se encontró el curso.",
+        "accessDenied": "No tienes permiso para exportar este curso.",
+        "noExportableLessons": "Este curso no tiene lecciones que se puedan exportar a SCORM.",
+        "unsupportedLessonType": "Este curso contiene un tipo de lección que no se puede exportar a SCORM.",
+        "missingAsset": "Este curso contiene un archivo o recurso que no se pudo resolver para exportar.",
+        "bunnyNotConfigured": "La exportación de vídeo no está configurada. Configure Bunny Stream antes de exportar cursos con lecciones en video.",
+        "invalidSnapshot": "Este curso no se pudo preparar para la exportación SCORM.",
+        "fallback": "Error al exportar SCORM."
+      }
+    }
+  },
+  "registerView": {
+    "header": "Registrarse",
+    "subHeader": "Ingresa tus datos para crear una cuenta",
+    "subHeaderSSO": "Regístrese usando su cuenta Google/Microsoft",
+    "field": {
+      "firstName": "Nombre",
+      "lastName": "Apellido",
+      "email": "Correo electrónico",
+      "password": "Contraseña",
+      "birthday": "Fecha de nacimiento",
+      "birthdayPlaceholder": "Seleccionar fecha",
+      "requiredBadge": "Requerido",
+      "optionalBadge": "Opcional"
+    },
+    "other": {
+      "alreadyHaveAccount": "¿Ya tienes una cuenta?",
+      "orContinueWith": "O continuar con"
+    },
+    "button": {
+      "createAccount": "Crea una cuenta",
+      "signIn": "Iniciar sesión"
+    },
+    "validation": {
+      "firstName": "El nombre es obligatorio",
+      "lastName": "Se requiere apellido",
+      "email": "Correo electrónico no válido",
+      "birthday": "Debes tener al menos {{ageLimit}} años",
+      "requiredCheckbox": "Este consentimiento es necesario."
+    },
+    "toast": {
+      "userAlreadyExists": "El usuario con este correo electrónico ya existe",
+      "createAccountFailed": "No se puede crear la cuenta. Por favor inténtalo de nuevo.",
+      "requiredFormFieldMissing": "Por favor acepte todos los consentimientos requeridos.",
+      "invalidFormField": "Uno de los campos de registro enviados no es válido."
+    }
+  },
+  "courseChapterView": {
+    "other": {
+      "lesson": "Lección",
+      "lessons": "Lecciones",
+      "quiz": "Cuestionario",
+      "quizzes": "Cuestionarios",
+      "free": "Gratis",
+      "public": "Público"
+    }
+  },
+  "forgotPasswordView": {
+    "header": "¿Has olvidado tu contraseña?",
+    "subHeader": "Ingrese la dirección de correo electrónico asociada con su cuenta y le enviaremos un enlace para restablecer su contraseña.",
+    "field": {
+      "email": "Dirección de correo electrónico"
+    },
+    "validation": {
+      "email": "Correo electrónico no válido"
+    },
+    "button": {
+      "resetPassword": "Restablecer contraseña",
+      "backToLogin": "Volver a iniciar sesión"
+    },
+    "toast": {
+      "resetPassword": "Se ha enviado a su correo electrónico un enlace para restablecer su contraseña."
+    }
+  },
+  "loginView": {
+    "header": "Iniciar sesión",
+    "subHeader": "Ingrese su correo electrónico a continuación para iniciar sesión en su cuenta",
+    "subHeaderSSO": "Inicie sesión con su cuenta Google/Microsoft",
+    "validation": {
+      "email": "Correo electrónico no válido",
+      "password": "Se requiere contraseña"
+    },
+    "other": {
+      "forgotPassword": "¿Olvidaste tu contraseña?",
+      "useMagicLink": "Envíeme un correo electrónico con un enlace de inicio de sesión",
+      "dontHaveAccount": "¿No tienes una cuenta?",
+      "rememberMe": "Recuérdame",
+      "signUp": "Regístrate",
+      "orContinueWith": "O continuar con"
+    },
+    "button": {
+      "login": "Iniciar sesión"
+    },
+    "field": {
+      "email": "Correo electrónico",
+      "password": "Contraseña"
+    },
+    "magicLink": {
+      "subHeader": "Estamos validando su enlace de inicio de sesión. Esto puede tardar un momento.",
+      "checking": "Comprobando su enlace de inicio de sesión...",
+      "success": "Enlace de inicio de sesión verificado. Redirigiendo...",
+      "error": "El enlace de inicio de sesión no es válido o ha caducado.",
+      "backToLogin": "Volver a iniciar sesión"
+    }
+  },
+  "magicLinkView": {
+    "header": "Obtener enlace de inicio de sesión",
+    "subHeader": "Ingrese su correo electrónico y le enviaremos un enlace de inicio de sesión para iniciar sesión.",
+    "validation": {
+      "email": "Correo electrónico no válido"
+    },
+    "field": {
+      "email": "Dirección de correo electrónico"
+    },
+    "button": {
+      "sendLink": "Obtener enlace de inicio de sesión",
+      "backToLogin": "Volver a iniciar sesión"
+    },
+    "toast": {
+      "sent": "Enlace de inicio de sesión enviado a su correo electrónico."
+    }
+  },
+  "magicLink": {
+    "error": {
+      "createToken": "No se puede generar el enlace de inicio de sesión. Por favor inténtalo de nuevo.",
+      "invalidToken": "El enlace de inicio de sesión no es válido.",
+      "expiredToken": "El enlace de inicio de sesión ha caducado."
+    }
+  },
+  "user": {
+    "error": {
+      "archived": "Su cuenta ha sido archivada."
+    }
+  },
+  "studentCoursesView": {
+    "other": {
+      "cannotFindCourses": "No pudimos encontrar ningún curso.",
+      "changeSearchCriteria": "Por favor cambie los criterios de búsqueda o vuelva a intentarlo más tarde.",
+      "freeLessons": "¡Lecciones gratis!",
+      "successfullyEnrolledToCourse": "Inscrito exitosamente en el curso."
+    },
+    "breadcrumbs": {
+      "courses": "Cursos"
+    },
+    "button": {
+      "continue": "Continuar",
+      "enroll": "Inscribirse",
+      "view": "Ver",
+      "readMore": "Leer más",
+      "playChapter": "Reproducir capítulo"
+    },
+    "enrolledCourses": {
+      "header": "Tus cursos",
+      "subHeader": "Cursos en los que estás inscrito actualmente"
+    },
+    "availableCourses": {
+      "header": "Cursos disponibles",
+      "subHeader": "Todos los cursos profesionales disponibles disponibles para inscribirse",
+      "filters": {
+        "placeholder": {
+          "title": "Buscar por título...",
+          "categories": "Categorías",
+          "sort": "Ordenar"
+        }
+      },
+      "headerOptions": {
+        "image": "Imagen",
+        "title": "Nombre del curso",
+        "category": "Categoría",
+        "description": "Descripción",
+        "author": "Autor"
+      }
+    },
+    "modernView": {
+      "continueLearning": "Continuar aprendiendo",
+      "topCourses": "Los 5 cursos más populares",
+      "hero": {
+        "start": "Empezar",
+        "moreInfo": "Más información",
+        "info": "Información"
+      },
+      "lessonsCount_one": "Lección {{count}}",
+      "lessonsCount_other": "Lecciones {{count}}"
+    }
+  },
+  "studentQuizSummaryView": {
+    "header": "¡Felicitaciones!",
+    "subHeader": "¡Has terminado el cuestionario!",
+    "other": {
+      "yourScore": "Tu puntuación:",
+      "tryAgain": "Inténtalo de nuevo"
+    },
+    "button": {
+      "backToCourse": "Volver al curso"
+    }
+  },
+  "studentLessonView": {
+    "error": {
+      "lessonIdNotFound": "ID de lección no encontrada",
+      "notAuthorizedTitle": "No autorizado",
+      "notAuthorizedDescription": "No estás autorizado a acceder a esta lección.",
+      "goBackToCourse": "Volver al curso"
+    },
+    "other": {
+      "lesson": "Lección",
+      "chapter": "Capítulo",
+      "correctAnswers": "Respuestas correctas:",
+      "correctSentence": "Oración correcta:",
+      "question": "Pregunta",
+      "answers": "Respuestas:",
+      "true": "Verdadero",
+      "false": "Falso",
+      "oneOrTwoWordSentence": "Instrucción: Proporcione una respuesta breve (1-2 oraciones).",
+      "threeOrFiveWordSentence": "Instrucción: Escriba una respuesta detallada (3-5 oraciones).",
+      "single": "Única",
+      "multiple": "Múltiple",
+      "fillInTheBlanks": "Complete los espacios en blanco.",
+      "selectQuestion": "seleccione la pregunta.",
+      "trueOrFalseQuestion": "Pregunta de verdadero o falso.",
+      "multipleChoice": "Pregunta de opción múltiple.",
+      "singleChoice": "Pregunta de opción única",
+      "passingThreshold": "Umbral de aprobación: {{threshold}}% ({{correct}} de preguntas {{questionsNumber}})",
+      "score": "Puntuación: {{score}}% ({{correct}} de preguntas {{questionsNumber}})",
+      "contentCantBeEmbedded": "Este contenido no se puede incrustar.",
+      "openInNewTab": "Abrir en nueva pestaña"
+    },
+    "aiMentor": {
+      "title": "Sesión de mentores de IA",
+      "description": "Esta es una sesión de tutoría impulsada por IA. La IA lo guiará a través de la lección según las pautas del instructor."
+    },
+    "scorm": {
+      "loading": "Cargando contenido SCORM...",
+      "launchFailed": "No se pudo iniciar el contenido SCORM.",
+      "launchFailedBody": "Por favor inténtalo de nuevo. Si el problema continúa, es posible que sea necesario volver a cargar el paquete SCORM.",
+      "saveFailed": "No se pudo guardar el progreso de SCORM.",
+      "saving": "Guardando progreso",
+      "previousSco": "Sección anterior",
+      "nextSco": "Siguiente sección",
+      "tryAgain": "Inténtalo de nuevo",
+      "lessonFinished": "SCORM lección terminada.",
+      "progressReset": "Restablecimiento del progreso de SCORM.",
+      "progressUpdated": "Progreso de SCORM actualizado."
+    },
+    "liveTraining": {
+      "activeLabel": "Formación en vivo",
+      "activeTitle": "La sesión está activa.",
+      "scheduledLabel": "Programado",
+      "scheduledTitle": "La formación en vivo está programada",
+      "endedLabel": "Terminado",
+      "endedTitle": "La formación en vivo ya ha finalizado",
+      "inactiveLabel": "Formación en vivo",
+      "inactiveTitle": "No hay ninguna formación en vivo activa",
+      "locationNotice": "Ubicación",
+      "notAvailable": "La formación en vivo no está disponible para esta lección."
+    },
+    "videoProcessing": {
+      "title": "El vídeo se está procesando.",
+      "body": "Espere un momento. Aparecerá aquí una vez que esté listo."
+    },
+    "videoProgress": {
+      "errors": {
+        "resourceNotFound": "No se pudo guardar el progreso del video para esta lección.",
+        "unsupportedLessonType": "El progreso del video solo está disponible para lecciones de contenido.",
+        "unsupportedBucketSize": "El progreso del vídeo utiliza un intervalo de seguimiento no admitido.",
+        "invalidResourceType": "Este recurso no se puede seguir como un video de lección.",
+        "trackingDisabled": "El seguimiento de finalización de video está deshabilitado para este curso.",
+        "accessDenied": "No tienes acceso para actualizar el progreso del video para esta lección."
+      }
+    },
+    "playNext": {
+      "title": "A continuación",
+      "description": "Jugando a continuación en {{seconds}}s",
+      "descriptionNoCountdown": "Jugando a continuación",
+      "playNow": "Juega ahora",
+      "cancel": "Cancelar"
+    },
+    "placeholder": {
+      "openQuestion": "Escribe tu respuesta aquí"
+    },
+    "tooltip": {
+      "retakeAvailableIn": "Bloqueado durante {{time}} horas después de la última repetición.",
+      "cooldown": "El cuestionario se bloqueará durante {{time}} horas después del último intento.",
+      "noCooldown": "Sin período de recuperación.",
+      "beta": "Esta funcionalidad se proporciona en una versión de prueba. Puede contener errores o no funcionar completamente según lo previsto y se utiliza bajo su propio riesgo."
+    },
+    "breadcrumbs": {
+      "availableCourses": "Cursos disponibles",
+      "yourCourses": "Tus cursos",
+      "back": "Atrás"
+    },
+    "button": {
+      "previous": "Anterior",
+      "complete": "Completar",
+      "next": "Siguiente",
+      "submit": "Enviar",
+      "retake": "Retomar",
+      "autoplay": "Reproducción automática"
+    },
+    "sideSection": {
+      "header": "Tabla de contenido:",
+      "other": {
+        "courseProgress": "Progreso del curso:"
+      }
+    },
+    "validation": {
+      "answerCannotBeEmpty": "La respuesta no puede estar vacía.",
+      "atLeastOneOptionMustBeSelected": "Se debe seleccionar al menos una opción para la pregunta {{questionId}}.",
+      "answerCannotBeEmptyForDragAndDropQuestion": "La respuesta no puede estar vacía para la pregunta de arrastrar y soltar {{questionId}}.",
+      "answerCannotBeEmptyForTextQuestion": "La respuesta no puede estar vacía para la pregunta de texto {{questionId}}.",
+      "invalidSelectionForSingleAnswer": "Selección no válida para una pregunta de respuesta única.",
+      "invalidFormatForMultiAnswer": "Formato no válido para preguntas de múltiples respuestas.",
+      "trueOrFalseRequired": "Se requiere una respuesta verdadera o falsa.",
+      "photoQuestionMustHaveAnswer": "Se requiere una respuesta para esta pregunta fotográfica.",
+      "unansweredQuestions": "Parece que aún no has comprobado todas las respuestas. ¡Revíselos e inténtelo de nuevo!",
+      "unansweredQuestionsWithNames": "Por favor responda las preguntas que faltan: {{questionNames}}",
+      "quizAlreadyAnswered": "Ya has respondido este cuestionario.",
+      "lessonAssignmentRequired": "No estás asignado a esta lección.",
+      "quizEvaluationFailed": "La evaluación del cuestionario falló. Por favor inténtalo de nuevo.",
+      "quizNotAnsweredYet": "Aún no has respondido este cuestionario.",
+      "courseEnrollmentRequired": "No estás inscrito en este curso.",
+      "quizRetakeUnavailable": "Las respuestas del cuestionario no se pueden restablecer debido al límite de intentos o al tiempo de reutilización.",
+      "quizResetFailed": "No se pudieron restablecer las respuestas del cuestionario. Por favor inténtalo de nuevo."
+    }
+  },
+  "studentCourseView": {
+    "header": "Capítulos",
+    "subHeader": "A continuación puedes ver todos los capítulos dentro de este curso.",
+    "recommendedHeader": "Quizás te interese",
+    "recommendedSubheader": "A continuación puede ver cursos con temas o dominios de conocimiento similares.",
+    "otherAuthorCoursesHeader": "Más cursos de",
+    "otherAuthorCoursesSubheader": "A continuación puedes ver más cursos creados por el mismo autor.",
+    "other": {
+      "cannotFindCourses": "No pudimos encontrar ningún curso.",
+      "changeSearchCriteria": "Por favor cambie los criterios de búsqueda o vuelva a intentarlo más tarde."
+    },
+    "lesson": {
+      "missingAnswer": "Respuesta faltante",
+      "yourAnswer": "Tu respuesta",
+      "studentsAnswer": "Respuesta del estudiante",
+      "singleChoice": "Pregunta de opción única",
+      "multipleChoice": "Pregunta de opción múltiple",
+      "trueOfFalseChoice": "Pregunta verdadera o falsa",
+      "oneOrTwoWordSentence": "Proporcione una respuesta breve (1-2 oraciones).",
+      "threeOrFiveWordSentence": "Escriba una respuesta detallada (3-5 oraciones).",
+      "aiMentorLesson": {
+        "sendMessage": "Escribe un mensaje...",
+        "check": "Comprobar",
+        "aiMentorName": "AI Mentor",
+        "retake": "Retomar",
+        "userName": "Usuario",
+        "typing": "Escribiendo una respuesta...",
+        "send": "Enviar",
+        "addEmoji": "Agregar emojis",
+        "closeVoiceMode": "Cerrar modo de voz",
+        "toggleVoiceInput": "Alternar entrada de voz",
+        "dictateVoiceInput": "Dictar mensaje",
+        "startVoiceMentor": "Hablar con el mentor",
+        "stopVoiceRecording": "Detener grabación de voz",
+        "taskDescription": "Descripción de la tarea",
+        "taskButton": "Descripción de la tarea",
+        "resultButton": "Resultado",
+        "resultButtonDisabledTooltip": "Consulte la lección primero para ver el resultado.",
+        "taskDescriptionExpand": "Haga clic para expandir",
+        "taskDescriptionCollapse": "Haga clic para colapsar",
+        "evaluation": {
+          "passedTitle": "Lección pasada",
+          "failedTitle": "Lección no aprobada",
+          "passedDescription": "Su respuesta cumplió con los requisitos para esta lección.",
+          "failedDescription": "Revise los comentarios y vuelva a intentarlo cuando esté listo.",
+          "scoreLabel": "Puntuación",
+          "scoreValue": "Condiciones {{score}}/{{maxScore}} cumplidas ({{percentage}}%)",
+          "thresholdLabel": "Umbral de paso",
+          "thresholdValue": "{{requiredScore}}/{{maxScore}} requerido ({{threshold}}%)",
+          "feedbackTitle": "Qué mejorar",
+          "openDetails": "Abrir detalles de evaluación"
+        },
+        "voiceOverlay": {
+          "headerEyebrow": "Interfaz de usuario de voz",
+          "exit": "Salir del modo de voz",
+          "mute": "Silenciar",
+          "unmute": "Dejar de silenciar",
+          "micOn": "Micrófono encendido",
+          "muted": "Silenciado",
+          "mutedHint": "Tu micrófono está silenciado. El mentor no puede oírte.",
+          "youSaid": "Dijiste",
+          "states": {
+            "idle": {
+              "title": "Listo",
+              "subtitle": "Toca para empezar a hablar"
+            },
+            "listening": {
+              "title": "Escuchando",
+              "subtitle": "Capturando tu voz"
+            },
+            "thinking": {
+              "title": "Pensando",
+              "subtitle": "Modelo está preparando una respuesta."
+            },
+            "speaking": {
+              "title": "Hablando",
+              "subtitle": "La respuesta del modelo está reproduciéndose."
+            }
+          },
+          "responsePlaceholder": {
+            "thinking": "Pensando en tu petición...",
+            "listening": "Escuchando tu próxima pregunta...",
+            "default": "La vista previa de la respuesta aparecerá aquí."
+          }
+        },
+        "retakeModalTitle": "¿Estás seguro de que quieres volver a tomar la lección?",
+        "retakeModalDescription": "Esto restablecerá su progreso en esta lección. Esta acción no se puede deshacer.",
+        "retakeAccessDenied": "Puede volver a tomar esta lección solo si está inscrito en el curso o es el autor del curso."
+      }
+    },
+    "sideSection": {
+      "optionHeader": "Opción",
+      "courseProgressHeader": "Progreso del curso",
+      "other": {
+        "author": "Autor",
+        "title": "Título",
+        "about": "Acerca de",
+        "collapse": "Colapso",
+        "courseProgress": "Progreso del curso",
+        "options": "Opciones",
+        "remainingChapters": "Capítulos restantes",
+        "completedChapters": "Capítulos completados",
+        "noData": "Sin datos",
+        "informationText": "Continúe rápidamente donde lo dejó con su lección más reciente."
+      },
+      "button": {
+        "shareCourse": "Comparte este curso",
+        "continueLearning": "Continuar aprendiendo",
+        "startLearning": "Empezar a aprender",
+        "enrollCourse": "Inscríbete al curso",
+        "goToContentCreatorPage": "Ir a la página del creador de contenido",
+        "repeatLessons": "Repetir lecciones",
+        "enrollGroups": "Inscribir grupos"
+      }
+    },
+    "breadcrumbs": {
+      "availableCourses": "Cursos disponibles",
+      "yourCourses": "Tus cursos",
+      "back": "Atrás"
+    },
+    "certificate": {
+      "button": {
+        "viewCertificate": "Ver certificado"
+      },
+      "courseCompleted": "¡Felicitaciones! ¡Has completado el curso! Ahora tienes acceso a tu certificado."
+    },
+    "studentMode": {
+      "enter": "Ingrese al modo de aprendizaje",
+      "exit": "Salir del modo de aprendizaje",
+      "bannerTitle": "Estás tomando este curso en modo de aprendizaje.",
+      "bannerDescription": "Se realiza un seguimiento de su progreso de aprendizaje. Las lecciones completadas cuentan para sus estadísticas personales de finalización y del curso.",
+      "exitBanner": "Salir del modo de aprendizaje",
+      "learningModeRequired": "El modo de aprendizaje no está activo para este curso.",
+      "draftCourseTooltip": "Este curso se encuentra en estado de borrador. No puedes inscribirte en él ni seguir aprendiendo."
+    },
+    "tabs": {
+      "chapters": "Capítulos",
+      "chat": "Discusión",
+      "moreFromAuthor": "Más del autor",
+      "statistics": "Estadísticas"
+    },
+    "courseChat": {
+      "title": "Discusión del curso",
+      "newThreadPlaceholder": "Iniciar una nueva discusión...",
+      "startThread": "Iniciar hilo",
+      "messagesTitle": "Mensajes",
+      "noThreadSelected": "Seleccione un hilo",
+      "emptyThreads": "Aún no hay discusiones. Empieza el primero.",
+      "emptyMessages": "Aún no hay mensajes.",
+      "replyPlaceholder": "Escribe una respuesta...",
+      "reply": "Responder",
+      "reactWith": "Reaccionar con {{reaction}}",
+      "deleteMessage": "Eliminar mensaje",
+      "deleteMessageConfirmationTitle": "¿Eliminar mensaje?",
+      "deleteMessageConfirmationDescription": "Este mensaje será eliminado de la discusión. Las respuestas pueden mantener un marcador de posición eliminado para que la conversación siga siendo legible.",
+      "deletedMessage": "Este mensaje fue eliminado.",
+      "repliesCount_one": "{{countLabel}} respuesta",
+      "repliesCount_other": "{{countLabel}} responde",
+      "loadMoreReplies": "Cargar más respuestas",
+      "send": "Enviar",
+      "selectThread": "Seleccione un hilo para leer mensajes.",
+      "users": "Usuarios",
+      "onlineCount": "{{online}}/{{total}} en línea",
+      "online": "En línea",
+      "offline": "Sin conexión",
+      "emptyUsers": "Aún no hay usuarios registrados.",
+      "mentionedToast": "Alguien te mencionó en la discusión del curso."
+    }
+  },
+  "studentChapterView": {
+    "chapterProgress": {
+      "header": "Tabla de contenido:",
+      "courseProgress": "Progreso del curso"
+    },
+    "button": {
+      "open": "Abierto",
+      "continue": "Continuar",
+      "playChapter": "Reproducir capítulo"
+    },
+    "other": {
+      "enrollmentRequired": "Inscríbete en el curso para abrir.",
+      "purchaseRequired": "Desbloquea esta lección comprando el curso."
+    }
+  },
+  "settings": {
+    "title": "Configuración",
+    "buttons": {
+      "cancel": "Cancelar",
+      "save": "Guardar"
+    },
+    "tabs": {
+      "account": "Cuenta",
+      "organization": "Organización",
+      "platformCustomization": "Personalización de la plataforma"
+    },
+    "breadcrumbs": {
+      "settings": "Configuración"
+    },
+    "toast": {
+      "error": {
+        "globalNotFound": "Configuración global no encontrada"
+      },
+      "qaSettingUpdatedSuccessfully": "La configuración de control de calidad se actualizó correctamente",
+      "ageLimitUpdatedSuccessfully": "Límite de edad actualizado correctamente",
+      "newsSettingUpdatedSuccessfully": "Configuración de noticias actualizada exitosamente",
+      "articlesSettingUpdatedSuccessfully": "La configuración de la base de conocimientos se actualizó correctamente",
+      "learningPathsUpdatedSuccessfully": "La configuración de las rutas de desarrollo se actualizó correctamente"
+    }
+  },
+  "certificateBackgroundUpload": {
+    "title": "Carga de antecedentes del certificado",
+    "description": "Cargue una imagen de fondo para el certificado.",
+    "button": {
+      "removeCertificateBackgroundImage": "Eliminar fondo del certificado",
+      "preview": "Vista previa"
+    },
+    "field": {
+      "imageRequirements": "PNG, JPG o JPEG (máx. 20 MB)"
+    },
+    "other": {
+      "uploading": "Subiendo...",
+      "removing": "Eliminando..."
+    },
+    "toast": {
+      "success": "La imagen de fondo del certificado se cambió correctamente",
+      "error": "Error al cambiar la imagen de fondo del certificado"
+    }
+  },
+  "adminPreferences": {
+    "header": "Preferencias globales del administrador",
+    "subHeader": "Configurar los ajustes del curso",
+    "notificationSettings": "Configuración de notificaciones",
+    "courseSettings": "Configuración del curso",
+    "field": {
+      "newUserNotifications": "Notificaciones de nuevos usuarios",
+      "newUserNotificationsDescription": "Recibir notificaciones cuando se crea un nuevo usuario",
+      "coursesVisibility": "Mostrar cursos a los visitantes",
+      "coursesVisibilityDescription": "Permita que los visitantes vean la lista de cursos y accedan a lecciones gratuitas sin iniciar sesión",
+      "modernCourseList": "Utilice la vista de lista de cursos moderna",
+      "modernCourseListDescription": "Habilite el nuevo diseño de lista de cursos con secciones destacadas y de cursos principales",
+      "courseDiscussions": "Habilitar debates del curso",
+      "courseDiscussionsDescription": "Permitir a los usuarios inscritos ver y participar en los hilos de discusión del curso.",
+      "calendar": "Habilitar calendario",
+      "calendarDescription": "Permitir a los usuarios ver eventos programados en el calendario",
+      "liveTraining": "Habilitar formación en vivo",
+      "liveTrainingDescription": "Permitir a los formadores crear y ejecutar sesiones de formación en vivo.",
+      "liveTrainingMaxParallelSessions": "Máximo de sesiones paralelas de formación en vivo",
+      "liveTrainingMaxParallelSessionsDescription": "Limita cuántas sesiones de formación en vivo pueden estar activas al mismo tiempo.",
+      "liveTrainingTooltip": "Habilite esto solo cuando el inquilino deba utilizar sesiones en vivo dirigidas por un capacitador.",
+      "liveTrainingDisableBlockedTooltip_one": "Actualmente tienes el usuario {{count}} con el rol de Entrenador. Revocarlo para desactivar esta función.",
+      "liveTrainingDisableBlockedTooltip_other": "Actualmente tienes usuarios {{count}} con el rol de Entrenador. Revocarlos para desactivar esta función.",
+      "finishedCourseNotification": "Notificaciones de cursos terminados",
+      "finishedCourseNotificationDescription": "Recibir notificaciones cuando un usuario finalice un curso.",
+      "studentsWithOverdueCourseNotification": "Estudiantes con notificaciones de cursos vencidos",
+      "studentsWithOverdueCourseNotificationDescription": "Recibir notificaciones cuando los estudiantes tengan cursos atrasados"
+    },
+    "toast": {
+      "newUserNotificationsPreferenceChangeSuccess": "Las preferencias de notificación de nuevos usuarios se han actualizado correctamente.",
+      "coursesVisibilityPreferenceChangeSuccess": "Las preferencias de visibilidad del curso para usuarios no autenticados se actualizaron correctamente",
+      "modernCourseListPreferenceChangeSuccess": "La preferencia de la lista de cursos modernos se ha actualizado correctamente",
+      "courseDiscussionsPreferenceChangeSuccess": "La preferencia de debates del curso se ha actualizado correctamente.",
+      "calendarPreferenceChangeSuccess": "La preferencia del calendario se ha actualizado correctamente.",
+      "liveTrainingPreferenceChangeSuccess": "La preferencia de formación en vivo se actualizó correctamente",
+      "liveTrainingMaxParallelSessionsChangeSuccess": "El límite de sesiones de formación en vivo se actualizó correctamente",
+      "finishedCourseNotificationsPreferenceChangeSuccess": "Las preferencias de notificación de cursos finalizados se han actualizado correctamente.",
+      "finishedCourseNotificationsPreferenceChangeError": "No se pudieron actualizar las preferencias de notificación del curso terminado",
+      "overdueCourseNotificationsPreferenceChangeSuccess": "Las preferencias de notificación de cursos vencidos se han actualizado correctamente",
+      "overdueCourseNotificationsPreferenceChangeError": "No se pudieron actualizar las preferencias de notificación de cursos vencidos"
+    }
+  },
+  "registrationFormBuilder": {
+    "title": "Creador de formularios de registro",
+    "description": "Administre casillas de verificación adicionales que se muestran durante el registro de usuario.",
+    "badge": "Registrarse",
+    "loading": "Cargando casillas de verificación del formulario de registro...",
+    "empty": "Aún no hay casillas de verificación de registro adicionales.",
+    "addFieldTitle": "Agregar consentimiento de casilla de verificación",
+    "addFieldDescription": "Cree casillas de verificación opcionales o obligatorias para el registro.",
+    "summaryLabel": "Casillas de verificación",
+    "addField": "Agregar casilla de verificación",
+    "save": "Guardar formulario de registro",
+    "validation": {
+      "labelRequired": "El contenido de la etiqueta es obligatorio.",
+      "toastLabelRequired": "Agregue el texto de la casilla de verificación en inglés y polaco antes de guardar.",
+      "toastGeneric": "Corrija el texto de la casilla de verificación resaltada antes de guardar."
+    },
+    "toast": {
+      "saved": "Formulario de registro guardado exitosamente."
+    },
+    "field": {
+      "heading": "Casilla de verificación {{index}}",
+      "typeCheckbox": "Casilla de verificación",
+      "cardDescription": "Configure la copia, el estado requerido y el pedido para este consentimiento.",
+      "required": "Casilla de verificación obligatoria",
+      "requiredDescription": "Los usuarios deben marcar esta casilla antes de crear una cuenta.",
+      "requiredBadge": "Requerido",
+      "optionalBadge": "Opcional",
+      "archivedBadge": "Archivado",
+      "languageLabel": "Etiqueta en {{language}}",
+      "languageDescription": "Este contenido se muestra a los usuarios que se registran en este idioma.",
+      "labelPlaceholder": "Ingrese el texto de consentimiento y agregue enlaces cuando sea necesario.",
+      "linkOnlyHint": "Texto sin formato solo con enlaces.",
+      "addLink": "Agregar enlace",
+      "archive": "Archivo",
+      "restore": "Restaurar"
+    }
+  },
+  "mfa": {
+    "setup": {
+      "title": "Configurar la autenticación multifactor",
+      "description": "Siga los pasos a continuación para configurar la autenticación multifactor (MFA) para su cuenta.",
+      "scanQr": "Escanee el código QR a continuación con su aplicación de autenticación (Google Authenticator, Authy, etc.).",
+      "manualEntry": "Si no puede escanear, ingrese el secreto manualmente en su aplicación.",
+      "enterCode": "Ingrese el código de 6 dígitos de su aplicación a continuación y haga clic en 'Verificar y habilitar MFA'.",
+      "loadingQr": "Cargando tu código QR...",
+      "secretLabel": "Secreto",
+      "tokenLabel": "Token MFA",
+      "verifyButton": "Verificar y habilitar MFA"
+    },
+    "verify": {
+      "title": "Verificar la autenticación multifactor",
+      "description": "Siga los pasos a continuación para verificar la autenticación multifactor (MFA) para su cuenta.",
+      "openAuthenticator": "Abra su aplicación de autenticación",
+      "enterCode": "Ingresa el código de 6 dígitos de tu aplicación",
+      "verifyToken": "Verifica tu token MFA",
+      "tokenLabel": "Token MFA",
+      "toast": {
+        "success": "MFA se ha verificado correctamente.",
+        "error": "Error en la verificación de MFA."
+      }
+    }
+  },
+  "MFAEnforcementView": {
+    "header": "Aplicación de autenticación multifactor basada en roles",
+    "subHeader": "Aplicar MFA para roles de usuario específicos",
+    "description": "Esta configuración le permite aplicar la autenticación multifactor (MFA) para roles de usuario específicos dentro de su organización.",
+    "roles": {
+      "admin": "Administrador",
+      "student": "Estudiante",
+      "content_creator": "Creador de contenido"
+    },
+    "switch": {
+      "enabled": "Habilitado",
+      "disabled": "Discapacitado"
+    },
+    "toast": {
+      "mfaEnforcementUpdatedSuccessfully": "La configuración de cumplimiento de MFA se ha actualizado correctamente.",
+      "mfaEnforcementUpdateFailed": "No se pudo actualizar la configuración de cumplimiento de MFA."
+    }
+  },
+  "progressBadge": {
+    "completed": "Completado",
+    "inProgress": "En progreso",
+    "notStarted": "No iniciado",
+    "blocked": "Bloqueado"
+  },
+  "studentCertificateView": {
+    "header": "Certificados",
+    "informations": {
+      "loading": "Cargando certificados...",
+      "noCertificates": "Aún no hay certificados disponibles. Complete cursos para obtener certificados.",
+      "failedToLoad": "No se pudieron cargar los certificados. Inténtelo de nuevo más tarde.",
+      "failedToFetch": "No se pudieron recuperar los certificados. Inténtelo de nuevo más tarde.",
+      "preparingDownload": "Su certificado se está preparando para descargar...",
+      "failedToDownload": "No se pudo descargar el certificado. Inténtelo de nuevo más tarde.",
+      "shareFailed": "No se pudo preparar el enlace para compartir de LinkedIn. Inténtelo de nuevo más tarde.",
+      "htmlRequired": "Falta el contenido del certificado. Actualice e inténtelo de nuevo.",
+      "pdfGenerationFailed": "No se pudo generar el PDF del certificado. Por favor inténtalo de nuevo.",
+      "shareImageGenerationFailed": "No se pudo generar la imagen compartida del certificado. Inténtelo de nuevo más tarde.",
+      "alreadyExists": "El certificado ya existe.",
+      "createFailed": "No se pudo crear el certificado. Inténtelo de nuevo más tarde.",
+      "certificateNotFound": "Certificado no encontrado.",
+      "userNotFound": "Usuario no encontrado.",
+      "courseNotFound": "Curso no encontrado.",
+      "courseCertificateDisabled": "Los certificados están deshabilitados para este curso.",
+      "courseCompletionRequired": "Debes completar el curso antes de generar un certificado."
+    },
+    "button": {
+      "download": "Descargar",
+      "preview": "Vista previa",
+      "shareLinkedIn": "Compartir en LinkedIn"
+    },
+    "controls": {
+      "languageToggle": "Selector de idioma",
+      "fontColor": "Color de fuente"
+    }
+  },
+  "announcements": {
+    "breadcrumbs": {
+      "announcements": "Anuncios",
+      "createAnnouncement": "Crear anuncio"
+    },
+    "page": {
+      "header": "Anuncios",
+      "tooltips": {
+        "markAsRead": "Marcar como leído"
+      },
+      "buttons": {
+        "new": "Crear nuevo"
+      }
+    },
+    "createPage": {
+      "header": "Crear anuncio",
+      "subheader": "Proporcione los detalles para configurar un nuevo anuncio.",
+      "buttons": {
+        "confirm": "Confirmar",
+        "cancel": "Cancelar",
+        "addLanguage": "Agregar idioma",
+        "removeLanguage": "Eliminar idioma",
+        "setDefaultLanguage": "Establecer como idioma predeterminado"
+      },
+      "fields": {
+        "title": "Título",
+        "content": "Contenido",
+        "group": "Grupo",
+        "language": "Idioma",
+        "everyone": "Todos",
+        "schedule": "Anuncio de programación",
+        "scheduledAt": "Publicar en",
+        "sendEmail": "Enviar correo electrónico"
+      },
+      "descriptions": {
+        "schedule": "Publicar este anuncio automáticamente a una hora seleccionada.",
+        "sendEmail": "Enviar el contenido del anuncio por correo electrónico cuando se publique."
+      },
+      "tooltips": {
+        "scheduledAt": "Elija cuándo este anuncio debería ser visible."
+      },
+      "addedLanguages": "Idiomas agregados",
+      "placeholders": {
+        "title": "Introduce el título",
+        "content": "Escribe tu anuncio aquí...",
+        "group": "Seleccionar grupo",
+        "everyone": "Seleccionar a todos"
+      },
+      "validation": {
+        "title": {
+          "required": "Se requiere título",
+          "maxLength": "El título debe tener menos de 120 caracteres."
+        },
+        "content": {
+          "required": "Se requiere contenido"
+        },
+        "schedule": {
+          "invalid": "Seleccione un tiempo válido en intervalos de 5 minutos",
+          "past": "La hora programada debe ser en el futuro."
+        }
+      }
+    },
+    "buttons": {
+      "readMore": "Leer más"
+    },
+    "other": {
+      "noNewAnnouncements": "No hay nuevos anuncios disponibles para usted hoy",
+      "of": "de"
+    },
+    "toast": {
+      "markedAsRead": "Los anuncios se han marcado como leídos correctamente.",
+      "markAsReadFailed": "No se pudieron marcar los anuncios como leídos",
+      "createdSuccessfully": "Anuncio creado exitosamente",
+      "createFailed": "No se pudo crear el anuncio",
+      "deletedSuccessfully": "Anuncio eliminado exitosamente",
+      "deleteFailed": "No se pudo eliminar el anuncio",
+      "notFound": "Anuncio no encontrado",
+      "invalidSchedule": "Calendario de anuncios no válido",
+      "invalidScheduleStep": "El cronograma de anuncios debe utilizar intervalos de 5 minutos.",
+      "scheduleInPast": "El calendario de anuncios debe ser en el futuro."
+    }
+  },
+  "notifications": {
+    "title": "Notificaciones",
+    "tabs": {
+      "all": "Todos",
+      "adminAnnouncements": "Anuncios de administrador"
+    },
+    "actions": {
+      "refresh": "Actualizar",
+      "create": "Crear anuncio",
+      "delete": "Eliminar anuncio",
+      "markRead": "Marcar como leído",
+      "markAllRead": "Marcar todo como leído",
+      "loadMore": "Cargar más",
+      "loadingMore": "Cargando más...",
+      "goToNotificationCenter": "Ir al centro de notificaciones"
+    },
+    "status": {
+      "unread": "No leído",
+      "scheduled": "Programado",
+      "published": "Publicado"
+    },
+    "empty": "Aún no hay notificaciones",
+    "deleteDialog": {
+      "title": "Eliminar anuncio",
+      "description": "Este anuncio será eliminado para todos."
+    }
+  },
+  "platformLogo": {
+    "header": "Logotipo de la plataforma",
+    "subHeader": "Cargue un logotipo personalizado para su plataforma. Formatos soportados: PNG, SVG",
+    "field": {
+      "uploadLabel": "Imagen del logotipo",
+      "imageRequirements": "PNG o SVG (máx. 10 MB)"
+    },
+    "button": {
+      "removeLogo": "Eliminar logo de plataforma"
+    },
+    "toast": {
+      "logoUploadedSuccessfully": "Logotipo de la plataforma subido correctamente",
+      "logoRemovedSuccessfully": "El logotipo de la plataforma se eliminó correctamente",
+      "logoFetchError": "Error al obtener el logotipo de la plataforma"
+    }
+  },
+  "platformSimpleLogo": {
+    "header": "Logotipo simple de plataforma (icono)",
+    "subHeader": "Cargue un logotipo personalizado que se utilizará como sello y favicon. Formatos soportados: PNG, SVG",
+    "field": {
+      "uploadLabel": "Imagen del logotipo",
+      "imageRequirements": "PNG o SVG (máx. 10 MB)"
+    },
+    "button": {
+      "removeLogo": "Eliminar el logotipo del icono de la plataforma"
+    },
+    "toast": {
+      "logoUploadedSuccessfully": "Logotipo simple de plataforma cargado exitosamente",
+      "logoRemovedSuccessfully": "El logotipo simple de la plataforma se eliminó correctamente",
+      "logoFetchError": "Error al buscar el logotipo simple de la plataforma"
+    }
+  },
+  "organizationTheme": {
+    "title": "Tema de organización",
+    "description": "Personalice la apariencia de su plataforma seleccionando un color de tema que refleje la marca de su organización."
+  },
+  "organizationLoginBackgroundImageUpload": {
+    "title": "Iniciar sesión Subir imagen de fondo",
+    "description": "Cargue una imagen de fondo personalizada para la página de inicio de sesión de la organización.",
+    "field": {
+      "imageRequirements": "PNG, JPG o JPEG (máx. 20 MB)"
+    },
+    "button": {
+      "removeBackgroundImage": "Eliminar imagen de fondo de inicio de sesión"
+    },
+    "toast": {
+      "success": "La imagen de fondo de inicio de sesión se cambió correctamente",
+      "error": "Error al cambiar la imagen de fondo de inicio de sesión"
+    }
+  },
+  "files": {
+    "toast": {
+      "invalidData": "Error al cargar el archivo: datos de archivo no válidos",
+      "fileEmpty": "Error al cargar el archivo: el archivo está vacío",
+      "contentTypeMismatch": "El tipo de contenido del archivo no coincide con el tipo de contenido proporcionado",
+      "invalidFileType": "Tipo de archivo no válido. Cargue un archivo PNG o SVG.",
+      "missingTenantContext": "Falta contexto de inquilino para la carga de archivos",
+      "presentationFileTooLarge": "El archivo de presentación es demasiado grande. Cargue una presentación hasta {{size}} {{unit}}."
+    },
+    "import": {
+      "noFileUploaded": "No se ha subido ningún archivo",
+      "invalidFileData": "Error al cargar el archivo: datos de archivo no válidos",
+      "fileEmpty": "El archivo está vacío.",
+      "noValidUsers": "La importación falló: no se encontraron usuarios válidos.",
+      "requiredDataMissing": "Falló la importación: faltan datos requeridos.",
+      "invalidFileType": "Tipo de archivo no válido. Por favor cargue un archivo válido.",
+      "userFailReason": {
+        "alreadyExists": "El usuario con este correo electrónico ya existe",
+        "duplicateEmail": "Correo electrónico duplicado en archivo de importación",
+        "invalidRole": "Rol no válido",
+        "trainerRoleUnavailable": "La función de formador requiere que se habilite la formación en vivo",
+        "unknownGroup": "Grupo desconocido"
+      }
+    }
+  },
+  "defaultCourseCurrencyView": {
+    "header": "Moneda del curso predeterminada",
+    "subHeader": "Establecer la moneda predeterminada para todos los cursos nuevos",
+    "toast": {
+      "defaultCourseCurrencyChangeSuccess": "La moneda del curso predeterminada se ha actualizado correctamente",
+      "defaultCourseCurrencyChangeError": "No se pudo actualizar la moneda del curso predeterminada"
+    },
+    "select": {
+      "pln": {
+        "label": "Zloty polaco",
+        "sign": "zł"
+      },
+      "eur": {
+        "label": "Euro",
+        "sign": "€"
+      },
+      "usd": {
+        "label": "Dólar estadounidense",
+        "sign": "$"
+      },
+      "gbp": {
+        "label": "Libra esterlina",
+        "sign": "£"
+      }
+    }
+  },
+  "ageLimitView": {
+    "header": "Establecer límite de edad",
+    "subHeader": "Establecer límite de edad para nuevos usuarios",
+    "select": {
+      "placeholder": "Seleccionar límite de edad",
+      "null": {
+        "label": "Sin limitación"
+      }
+    }
+  },
+  "loginFilesUpload": {
+    "header": "Archivos de página de inicio de sesión",
+    "subHeader": "Agregue hasta archivos {{count}} y nombre cada uno.",
+    "emptyState": "Aún no se han agregado archivos.",
+    "selectedFile": "Archivo seleccionado",
+    "unnamedFile": "Archivo sin nombre",
+    "deleteDialog": {
+      "title": "¿Quitar archivo?",
+      "description": "Esto eliminará \"{{name}}\" de la página de inicio de sesión.",
+      "confirm": "Eliminar archivo"
+    },
+    "previewDialog": {
+      "subtitle": "Vista previa del archivo de la página de inicio de sesión",
+      "loading": "Cargando vista previa...",
+      "error": "No pudimos cargar una vista previa de este archivo."
+    },
+    "fileName": {
+      "label": "Nombre",
+      "placeholder": "Introduce el nombre"
+    },
+    "toast": {
+      "invalidFileType": "Tipo de archivo no válido. Por favor cargue un archivo válido.",
+      "successfullyUploadedFile": "Archivo cargado exitosamente",
+      "maxResourceCount": "Se alcanzó el recuento máximo de recursos ({{count}})",
+      "resourceNotFound": "Recurso no encontrado",
+      "successfullyDeletedFile": "Archivo eliminado exitosamente"
+    },
+    "addButton": "Agregar nuevo archivo"
+  },
+  "richTextEditor": {
+    "placeholder": {
+      "lineHint": "Pegue un enlace YouTube/Vimeo/Canva, agregue documentos Google o cargue un archivo."
+    },
+    "upload": {
+      "videoProgress": "Subiendo vídeo..."
+    },
+    "toolbar": {
+      "format": {
+        "placeholder": "Seleccionar formato",
+        "paragraph": "Párrafo",
+        "h1": "Título 1",
+        "h2": "Título 2",
+        "h3": "Título 3",
+        "h4": "Título 4"
+      },
+      "bold": {
+        "tooltip": "Negrita: pone el texto seleccionado en negrita"
+      },
+      "italic": {
+        "tooltip": "Cursiva: pone en cursiva el texto seleccionado."
+      },
+      "strikethrough": {
+        "tooltip": "Tachado: agrega una línea a través del texto seleccionado"
+      },
+      "bulletList": {
+        "tooltip": "Lista de viñetas: inicia una lista con viñetas"
+      },
+      "orderedList": {
+        "tooltip": "Lista numerada: inicia una lista numerada"
+      },
+      "taskList": {
+        "tooltip": "Lista de verificación: agrega una lista de verificación"
+      },
+      "blockquote": {
+        "tooltip": "Cita: formatea el texto como una cita en bloque"
+      },
+      "codeBlock": {
+        "tooltip": "Bloque de código: formatea el texto como código"
+      },
+      "horizontalRule": {
+        "tooltip": "Regla horizontal: inserta una línea divisoria"
+      },
+      "table": {
+        "tooltip": "Tabla: insertar o editar una tabla",
+        "groups": {
+          "columns": "Columnas",
+          "rows": "Filas",
+          "cells": "Células",
+          "headers": "Encabezados"
+        },
+        "actions": {
+          "insert": "Insertar tabla",
+          "addColumnBefore": "Agregar columna antes",
+          "addColumnAfter": "Agregar columna después",
+          "deleteColumn": "Eliminar columna",
+          "addRowBefore": "Agregar fila antes",
+          "addRowAfter": "Agregar fila después",
+          "deleteRow": "Eliminar fila",
+          "mergeCells": "Fusionar celdas",
+          "splitCell": "Dividir celda",
+          "mergeOrSplit": "Fusionar o dividir",
+          "toggleHeaderRow": "Alternar fila de encabezado",
+          "toggleHeaderColumn": "Alternar columna de encabezado",
+          "toggleHeaderCell": "Alternar celda de encabezado",
+          "fixTables": "Arreglar la estructura de la tabla",
+          "deleteTable": "Eliminar tabla"
+        }
+      },
+      "undo": {
+        "tooltip": "Deshacer: revierte el último cambio"
+      },
+      "redo": {
+        "tooltip": "Rehacer: vuelve a aplicar el último cambio deshecho"
+      },
+      "link": {
+        "tooltip": "Enlace: convierte el texto seleccionado en un hipervínculo.",
+        "dialog": {
+          "title": "Insertar enlace",
+          "urlLabel": "Ingrese la URL del enlace",
+          "linkTextLabel": "Introduce el texto del enlace",
+          "linkTextPlaceholder": "Texto del enlace...",
+          "urlRequired": "La URL es obligatoria",
+          "urlInvalid": "Formato de URL no válido",
+          "linkTextRequired": "Se requiere el texto del enlace"
+        }
+      },
+      "upload": {
+        "uploadFailed": "Error al subir el archivo",
+        "tooltip": "Cargar: Le permite cargar un archivo."
+      },
+      "assetLibrary": {
+        "tooltip": "Biblioteca de activos: inserte un archivo cargado anteriormente"
+      }
+    }
+  },
+  "richText": {
+    "uploadDisplayModeDialog": {
+      "title": "Elija cómo mostrar este archivo",
+      "description": "Seleccione cómo debe aparecer \"{{name}}\" para los estudiantes.",
+      "options": {
+        "preview": {
+          "title": "Vista previa",
+          "description": "Muestre el archivo en línea para que los estudiantes puedan verlo directamente."
+        },
+        "download": {
+          "title": "Descargar",
+          "description": "Insertar como enlace de archivo descargable."
+        }
+      }
+    },
+    "video": {
+      "tooltip": {
+        "bunnyMissing": "El vídeo no está disponible. Verifique la configuración de CDN de Bunny."
+      },
+      "ariaLabel": {
+        "drag": "Arrastrar vídeo para insertar",
+        "remove": "Quitar inserción de vídeo"
+      }
+    },
+    "presentation": {
+      "title": "Presentación",
+      "ariaLabel": {
+        "drag": "Arrastrar incrustación de presentación",
+        "remove": "Quitar inserción de presentación"
+      }
+    },
+    "image": {
+      "ariaLabel": {
+        "drag": "Arrastrar imagen",
+        "remove": "Quitar imagen"
+      }
+    },
+    "downloadableFile": {
+      "ariaLabel": {
+        "drag": "Arrastrar archivo",
+        "remove": "Eliminar archivo descargable"
+      }
+    },
+    "pdfPreview": {
+      "ariaLabel": {
+        "drag": "Arrastrar vista previa de PDF",
+        "remove": "Eliminar vista previa de PDF"
+      },
+      "loading": "Cargando vista previa...",
+      "openFile": "Abrir archivo",
+      "showingPage": "Mostrando la página {{page}} de {{total}}",
+      "previous": "Anterior",
+      "next": "Siguiente"
+    },
+    "loadingAiAsset": {
+      "processing": "El recurso se está procesando actualmente."
+    },
+    "assetLibrary": {
+      "title": "Biblioteca de activos",
+      "description": "Busque, cargue, inserte o elimine archivos utilizados en contenido de texto enriquecido.",
+      "searchPlaceholder": "Buscar por nombre de archivo o título...",
+      "upload": "Cargar recurso",
+      "insert": "Insertar",
+      "delete": "Eliminar",
+      "loading": "Cargando recursos...",
+      "loadingUsages": "Cargando usos...",
+      "disabledUntilSaved": "Guarde este contenido antes de insertar o eliminar recursos existentes. La carga de un nuevo activo todavía está disponible.",
+      "empty": {
+        "title": "No se encontraron activos",
+        "description": "Cargue un archivo o ajuste la búsqueda para encontrar activos existentes."
+      },
+      "types": {
+        "image": "Imagen",
+        "video": "Vídeo",
+        "pdf": "PDF",
+        "presentation": "Presentación",
+        "document": "Documento",
+        "other": "Otro"
+      },
+      "entities": {
+        "lesson": "Lección",
+        "articles": "Artículo",
+        "news": "Noticias"
+      },
+      "deleteConfirmation": {
+        "title": "¿Eliminar {{name}}?",
+        "description": "Esto elimina las incrustaciones y enlaces coincidentes de cada elemento de contenido enumerado y archiva el recurso.",
+        "usages": "Usos conocidos",
+        "noUsages": "No se encontraron usos."
+      },
+      "usageCount_one": "Uso de {{count}}",
+      "usageCount_other": "Usos de {{count}}"
+    }
+  },
+  "pages": {
+    "dashboard": "Panel de control",
+    "settings": "Configuración",
+    "providerInformation": "Información del proveedor",
+    "courses": "Cursos",
+    "profile": "Perfil",
+    "lesson": "Lección",
+    "lessonPreview": "Vista previa de la lección",
+    "register": "Registrarse",
+    "passwordRecovery": "Recuperación de contraseña",
+    "login": "Iniciar sesión",
+    "magicLink": "Enlace de inicio de sesión",
+    "createNewPassword": "Crear nueva contraseña",
+    "createAnnouncement": "Crear anuncio",
+    "announcements": "Anuncios",
+    "notifications": "Notificaciones",
+    "users": "Usuarios",
+    "userDetails": "Detalles del usuario",
+    "createNewUser": "Crear nuevo usuario",
+    "promotionCodes": "Códigos de promoción",
+    "promotionCodeDetails": "Detalles del código de promoción",
+    "createPromotionCode": "Crear código de promoción",
+    "groups": "Grupos",
+    "editGroup": "Editar grupo",
+    "createGroup": "Crear grupo",
+    "editCourse": "Editar curso",
+    "createNewCategory": "Crear nueva categoría",
+    "categoryDetails": "Detalles de la categoría",
+    "categories": "Categorías",
+    "createNewCourse": "Crear un nuevo curso",
+    "admin": "Administrador",
+    "qa": "Preguntas y respuestas",
+    "createQA": "Crear pregunta y respuesta",
+    "analytics": "Analítica",
+    "progress": "Progreso",
+    "calendar": "Calendario",
+    "activityLogs": "Registros de actividad",
+    "tenant": "Detalles de la organización",
+    "createTenant": "Crear organización",
+    "tenants": "Organizaciones",
+    "learningPaths": "Rutas de desarrollo",
+    "adminLearningPaths": "Rutas de desarrollo",
+    "adminLearningPathEditor": "Editor de ruta de desarrollo"
+  },
+  "learningPathsView": {
+    "title": "Rutas de desarrollo",
+    "description": "Explore las rutas de desarrollo asignadas y continúe con sus secuencias de cursos ordenadas.",
+    "searchPlaceholder": "Buscar rutas de desarrollo",
+    "summary": "Las rutas de desarrollo {{count}} están disponibles.",
+    "detailsTitle": "Camino de desarrollo",
+    "detailsDescription": "Revise la secuencia ordenada del curso, el progreso, los bloqueos y el estado del certificado.",
+    "detailsSummary": "Esta ruta contiene cursos {{count}}. Progreso actual: {{progress}}.",
+    "emptyDescription": "Aún no se ha agregado ninguna descripción.",
+    "status": {
+      "draft": "Borrador",
+      "published": "Publicado",
+      "private": "Privado",
+      "not_started": "No iniciado",
+      "in_progress": "En progreso",
+      "completed": "Completado",
+      "blocked": "Bloqueado"
+    },
+    "badges": {
+      "sequenceEnabled": "Secuencial",
+      "freeOrder": "Orden flexible",
+      "certificate": "Certificado"
+    },
+    "card": {
+      "openPath": "Camino de desarrollo abierto"
+    },
+    "empty": {
+      "title": "No se encontraron rutas de desarrollo",
+      "description": "Ajuste su búsqueda o vuelva a consultar después de asignar las rutas."
+    },
+    "progress": {
+      "title": "Progreso del camino",
+      "summary": "{{completed}} de {{total}} cursos completados"
+    },
+    "certificate": {
+      "available": "Certificado disponible",
+      "ready": "Certificado listo",
+      "pathCompleted": "Ruta de desarrollo completada. Su certificado está listo."
+    },
+    "courseState": {
+      "completed": "Terminado",
+      "inProgress": "En progreso",
+      "inProgressDescription": "Has iniciado este curso.",
+      "notStarted": "No iniciado",
+      "notStartedDescription": "Este curso está disponible para comenzar.",
+      "locked": "Bloqueado",
+      "lockedDescription": "Termina el curso anterior para desbloquearlo."
+    },
+    "detail": {
+      "courses": "Cursos en este camino",
+      "courseTitle": "Curso {{number}}",
+      "completedAt": "Completado {{date}}",
+      "emptyCourses": "Esta ruta de desarrollo aún no incluye ningún curso."
+    },
+    "enrollment": {
+      "manage": "Inscribirse",
+      "title": "Inscribir alumnos",
+      "description": "Gestione la inscripción de estudiantes y grupos para este camino de desarrollo.",
+      "students": "Estudiantes",
+      "selectStudents": "Seleccionar estudiantes",
+      "groups": "Grupos",
+      "selectGroups": "Seleccionar grupos",
+      "filters": {
+        "placeholder": {
+          "searchByKeyword": "Buscar por palabra clave..."
+        }
+      },
+      "enrollSelected": "Inscribir seleccionado",
+      "unenrollSelected": "Darse de baja seleccionado",
+      "enrollGroups": "Inscribir grupos",
+      "unenrollGroups": "Dar de baja grupos",
+      "enrolled": "Inscrito",
+      "enroll": "Inscribirse",
+      "studentsEnrolled": "Estudiantes matriculados",
+      "groupsEnrolled": "Grupos inscritos",
+      "studentsUnenrolled": "Estudiantes dados de baja",
+      "groupsUnenrolled": "Grupos dados de baja",
+      "enrolledSuccessfully": "Ruta de desarrollo inscrita",
+      "enrollGroupsDescription": "Seleccione grupos para inscribirse en esta ruta de desarrollo.",
+      "unenrollGroupsDescription": "Seleccione grupos para cancelar su inscripción en esta ruta de desarrollo.",
+      "table": {
+        "selectAll": "Seleccionar todos los alumnos",
+        "select": "Seleccionar alumno",
+        "name": "Nombre",
+        "email": "Correo electrónico",
+        "status": "Estado de inscripción",
+        "enrollmentDate": "Fecha de inscripción"
+      },
+      "statuses": {
+        "enrolledByGroup": "Inscrito por grupo",
+        "individuallyEnrolled": "Inscrito individualmente",
+        "notEnrolled": "No inscrito"
+      },
+      "confirmation": {
+        "title": "Confirmar inscripción",
+        "description": "¿Está seguro de que desea inscribir a los estudiantes seleccionados en esta ruta de desarrollo? Esta acción no se puede deshacer."
+      },
+      "unenrollConfirmation": {
+        "title": "Confirmación de baja",
+        "description": "¿Está seguro de que desea cancelar la inscripción de los estudiantes seleccionados de esta ruta de desarrollo? Esta acción no se puede deshacer."
+      },
+      "noGroups": "No hay grupos disponibles"
+    },
+    "breadcrumbs": {
+      "learningPaths": "Rutas de desarrollo",
+      "details": "Detalles"
+    },
+    "buttons": {
+      "openFirst": "Abrir el primer camino"
+    }
+  },
+  "adminLearningPathsView": {
+    "title": "Rutas de desarrollo",
+    "description": "Administre metadatos de ruta, configuración de secuencia, cursos ordenados, inscripción, exportaciones y certificados.",
+    "summary": "Las rutas de desarrollo de {{count}} están disponibles en este espacio de trabajo.",
+    "breadcrumbs": {
+      "learningPaths": "Rutas de desarrollo",
+      "create": "Crear",
+      "edit": "Editar"
+    },
+    "buttons": {
+      "create": "Crear ruta de desarrollo",
+      "edit": "Editar",
+      "save": "Guardar cambios",
+      "removeImage": "Quitar imagen"
+    },
+    "editor": {
+      "createTitle": "Crear ruta de desarrollo",
+      "editTitle": "Editar ruta de desarrollo",
+      "description": "Configure los detalles de la ruta de desarrollo, la configuración de secuencia, los cursos y el estado de publicación.",
+      "createSummary": "Comience con los detalles de la ruta de desarrollo.",
+      "editSummary": "Esta ruta de desarrollo cuenta actualmente con cursos {{coursesCount}}.",
+      "details": "Detalles",
+      "courses": "Cursos",
+      "image": "Imagen",
+      "settings": "Configuración"
+    },
+    "table": {
+      "title": "Título",
+      "status": "Estado",
+      "settings": "Configuración",
+      "language": "Idioma",
+      "createdAt": "Creado",
+      "actions": "Acciones",
+      "untitled": "Ruta de desarrollo sin título",
+      "emptyDescription": "Sin descripción",
+      "sequential": "Secuencial",
+      "flexible": "Flexibles",
+      "certificate": "Certificado",
+      "empty": "Aún no se han creado vías de desarrollo."
+    },
+    "form": {
+      "language": "Idioma",
+      "status": "Estado",
+      "statusDescription": "Controla si esta ruta es visible, solo borrador o privada.",
+      "title": "Título",
+      "titlePlaceholder": "Nombra la ruta de desarrollo",
+      "description": "Descripción",
+      "descriptionPlaceholder": "Describe lo que los estudiantes completarán en este camino.",
+      "imageHint": "PNG, JPG o JPEG (máx. 20 MB, recomendado 1200x1200 o superior)",
+      "sequenceEnabled": "Aprendizaje secuencial",
+      "sequenceEnabledDescription": "Los estudiantes deben completar los cursos en orden de visualización.",
+      "includesCertificate": "Certificado",
+      "includesCertificateDescription": "Los estudiantes pueden recibir un certificado después de completar el camino.",
+      "certificateSignature": "Firma del certificado",
+      "certificateSignatureDescription": "Cargue la firma que se muestra en los certificados para esta ruta de desarrollo.",
+      "certificateFontColor": "Color de fuente del certificado",
+      "certificateFontColorDescription": "Utilice el selector de color de vista previa para actualizar el texto del certificado y el color de la línea.",
+      "certificatePreview": "Vista previa del certificado",
+      "certificatePreviewDescription": "Obtenga una vista previa del certificado y ajuste el color de fuente."
+    },
+    "detailsContent": {
+      "title": "Detalles de la ruta de desarrollo",
+      "description": "Defina el nombre localizado y la descripción orientada al estudiante."
+    },
+    "detailsImage": {
+      "title": "Imagen de portada",
+      "description": "Utilice un elemento visual que ayude a los administradores y estudiantes a reconocer este camino."
+    },
+    "detailsSettings": {
+      "title": "Publicación y comportamiento",
+      "description": "Visibilidad del grupo, orden de los cursos y comportamiento de los certificados en un solo lugar."
+    },
+    "common": {
+      "baseLanguage": "Idioma base"
+    },
+    "languageSelector": {
+      "tooltip": "Este lenguaje base de ruta de desarrollo es {{baseLanguage}}."
+    },
+    "courses": {
+      "select": "Seleccione un curso",
+      "add": "Agregar curso",
+      "drag": "Arrastra para reordenar el curso",
+      "delete": "Eliminar curso",
+      "order": "Orden",
+      "course": "Curso",
+      "chapter_one": "Capítulo {{count}}",
+      "chapter_other": "Capítulos {{count}}",
+      "empty": "Aún no se han agregado cursos a esta ruta de desarrollo.",
+      "saveFirst": "Guarde la ruta de desarrollo antes de agregar cursos.",
+      "unknownCourse": "Detalles del curso no disponibles"
+    },
+    "sharedLearningPath": {
+      "badgeExported": "Compartido",
+      "exportButton": "Compartir",
+      "exportSuccess": "Se exportó el camino del desarrollo",
+      "exportsDescription": "Comparta esta ruta de desarrollo con organizaciones seleccionadas.",
+      "exportsTitle": "Compartir",
+      "exportingButton": "Compartiendo...",
+      "selectTenants": "Seleccionar organizaciones",
+      "selectedCount": "Seleccionado:"
+    },
+    "deleteModal": {
+      "title": "Eliminar ruta de desarrollo",
+      "description": "Esto eliminará la ruta de desarrollo y eliminará su acceso al curso basado en rutas."
+    },
+    "toast": {
+      "created": "Ruta de desarrollo creada con éxito",
+      "updated": "Ruta de desarrollo actualizada con éxito",
+      "deleted": "Ruta de desarrollo eliminada con éxito",
+      "languageCreated": "Lenguaje de ruta de desarrollo creado con éxito",
+      "coursesAdded": "Cursos agregados exitosamente a la ruta de desarrollo",
+      "courseRemoved": "Curso eliminado exitosamente de la ruta de desarrollo",
+      "coursesReordered": "Cursos de ruta de desarrollo reordenados exitosamente"
+    }
+  },
+  "lessonPreview": {
+    "breadcrumbs": {
+      "browseCourses": "Explorar cursos",
+      "lessonPreview": "Vista previa"
+    },
+    "button": {
+      "back": "Atrás"
+    }
+  },
+  "studentOnboarding": {
+    "dashboard": {
+      "clientStatistics": "Este es su panel de control: aquí puede encontrar su progreso, estadísticas y actividad reciente.",
+      "dailyStreak": "Mantenga la racha: realice un seguimiento de su serie de inicios de sesión diarios aquí."
+    },
+    "courses": {
+      "yourList": "Aquí encontrarás tus cursos...",
+      "availableListFilters": "Y aquí puede explorar los cursos disponibles en los que puede inscribirse."
+    },
+    "announcements": {
+      "stayInformed": "Aquí encontrará anuncios de instructores o coordinadores de cursos."
+    },
+    "settings": {
+      "welcome": "Aquí puede administrar su perfil: editar detalles, establecer preferencias y cambiar su contraseña.",
+      "language": "Establezca aquí su idioma de interfaz preferido: adapte la plataforma a sus necesidades.",
+      "password": "Cambie su contraseña periódicamente para mantener la seguridad de su cuenta."
+    },
+    "profile": {
+      "info": "Aquí puede ver y editar los detalles de su perfil.",
+      "certificates": "Aquí puede consultar los certificados de finalización de sus cursos."
+    },
+    "providerInformation": {
+      "welcome": "Conozca más sobre el proveedor y sus datos de contacto."
+    }
+  },
+  "pagination": {
+    "showing": "Mostrando {{startItem}}-{{endItem}} de los resultados de {{totalItems}}",
+    "previous": "Anterior",
+    "next": "Siguiente",
+    "noData": "No se encontraron datos"
+  },
+  "QA": {
+    "header": "Preguntas frecuentes",
+    "subHeader": "Encuentra respuestas a preguntas frecuentes sobre nuestra plataforma"
+  },
+  "qaPreferences": {
+    "subHeader": "Configurar los ajustes de Q&A",
+    "header": "Ajustes de preguntas y respuestas",
+    "settings": {
+      "qaEnabled": {
+        "label": "Habilitar la sección Q&A",
+        "description": "Habilite la sección Q&A. Cuando está deshabilitada, la sección Q&A está oculta para todos los usuarios."
+      },
+      "qaPublic": {
+        "label": "Mostrar la sección Q&A a usuarios no registrados",
+        "description": "Permitir que los usuarios no registrados vean la sección Q&A (solo se puede alternar cuando la sección Q&A está habilitada)"
+      }
+    },
+    "toast": {
+      "QANotEnabled": "La sección Q&A no está habilitada"
+    },
+    "tooltip": {
+      "disabled": "Para alternar este campo, habilite primero la sección Q&A."
+    }
+  },
+  "newsPreferences": {
+    "subHeader": "Configurar ajustes de noticias",
+    "header": "Configuración de noticias",
+    "settings": {
+      "newsEnabled": {
+        "label": "Habilitar sección de noticias",
+        "description": "Habilitar la sección de noticias. Cuando está deshabilitada, la sección de noticias está oculta para todos los usuarios."
+      },
+      "newsPublic": {
+        "label": "Mostrar sección de noticias a usuarios no registrados",
+        "description": "Permitir que los usuarios no registrados vean la sección de noticias (solo se puede alternar cuando la sección de noticias está habilitada)"
+      }
+    },
+    "toast": {
+      "newsNotEnabled": "La sección de noticias no está habilitada."
+    },
+    "tooltip": {
+      "disabled": "Para alternar este campo, habilite primero la sección de noticias."
+    }
+  },
+  "articlesPreferences": {
+    "subHeader": "Configurar los ajustes de la base de conocimientos",
+    "header": "Configuración de la base de conocimientos",
+    "settings": {
+      "articlesEnabled": {
+        "label": "Habilitar la sección de la base de conocimientos",
+        "description": "Habilite la sección de la base de conocimientos. Cuando está deshabilitada, la sección de la base de conocimientos está oculta para todos los usuarios."
+      },
+      "articlesPublic": {
+        "label": "Mostrar la sección de la base de conocimientos a usuarios no registrados",
+        "description": "Permitir que los usuarios no registrados vean la sección de la base de conocimientos (solo se puede alternar cuando la sección de la base de conocimientos está habilitada)"
+      }
+    },
+    "toast": {
+      "articlesNotEnabled": "La sección de la base de conocimientos no está habilitada."
+    },
+    "tooltip": {
+      "disabled": "Para alternar este campo, habilite primero la sección de la base de conocimientos."
+    }
+  },
+  "learningPathsPreferences": {
+    "subHeader": "Configurar los ajustes de las rutas de desarrollo",
+    "header": "Configuración de rutas de desarrollo",
+    "settings": {
+      "learningPathsEnabled": {
+        "label": "Habilitar rutas de desarrollo",
+        "description": "Habilitar rutas de desarrollo. Cuando está deshabilitado, las rutas de desarrollo están ocultas y bloqueadas para todos los usuarios."
+      }
+    }
+  },
+  "qaView": {
+    "button": {
+      "createNew": "Crear nueva pregunta y respuesta"
+    },
+    "toast": {
+      "qaCreatedSuccessfully": "Q&A se ha creado con éxito",
+      "qaUpdatedSuccessfully": "Q&A se ha actualizado correctamente",
+      "languageCreatedSuccessfully": "El idioma se ha creado correctamente.",
+      "languageDeletedSuccessfully": "El idioma se ha eliminado correctamente.",
+      "qaDeletedSuccessfully": "Q&A se ha eliminado correctamente",
+      "cannotDeleteLanguage": "Este idioma no se puede eliminar",
+      "languageNotSupported": "Este idioma no es compatible",
+      "languageAlreadyExists": "Este idioma ya existe.",
+      "notFound": "Q&A no encontrado",
+      "noDataToUpdate": "No hay datos para actualizar"
+    },
+    "aria": {
+      "editQuestion": "Editar pregunta"
+    },
+    "edit": {
+      "header": "Editar pregunta y respuesta",
+      "subheader": "Edite los detalles de Q&A a continuación",
+      "language": "Idioma"
+    },
+    "fields": {
+      "title": "Pregunta",
+      "description": "Respuesta"
+    },
+    "create": {
+      "header": "Crear Q&A",
+      "subheader": "Agregue una pregunta y una respuesta para los estudiantes.",
+      "baseLanguageTooltip": "No puede cambiar ni eliminar este idioma. Es el valor predeterminado y siempre será parte de Q&A."
+    },
+    "delete": {
+      "title": "Eliminar pregunta y respuesta",
+      "confirm": "¿Está seguro de que desea eliminar Q&A?"
+    }
+  },
+  "adminArticleView": {
+    "toc": {
+      "title": "Base de conocimientos",
+      "actions": {
+        "add": "Añadir",
+        "newLabel": "Nuevo",
+        "newSection": "Nueva sección",
+        "newArticle": "Nueva entrada a la base de conocimientos"
+      }
+    },
+    "dialog": {
+      "createArticle": {
+        "title": "Crear entrada en la base de conocimientos",
+        "sectionLabel": "Sección",
+        "sectionPlaceholder": "Seleccione una sección",
+        "create": "Crear"
+      }
+    },
+    "toast": {
+      "createSectionError": "No se pudo crear la sección",
+      "updateError": "No se pudo actualizar",
+      "languageAlreadyExists": "Este idioma ya existe.",
+      "createLanguageError": "No se pudo agregar el idioma",
+      "minimumLanguageError": "Se requiere al menos un idioma",
+      "cannotRemoveBaseLanguage": "El idioma base no se puede eliminar",
+      "removeLanguageError": "No se pudo eliminar el idioma",
+      "sectionHasAssignedArticles": "No se puede eliminar una sección con entradas asignadas de la base de conocimientos",
+      "deleteSectionError": "No se pudo eliminar la sección",
+      "createError": "No se pudo crear la entrada de la base de conocimientos",
+      "deleteError": "No se pudo eliminar la entrada de la base de conocimientos",
+      "notFoundError": "Entrada de la base de conocimientos no encontrada",
+      "invalidCoverType": "Tipo de cobertura no válido",
+      "invalidLanguageError": "Idioma no válido"
+    },
+    "section": {
+      "editTitle": "Editar sección",
+      "editDescription": "Actualiza el título de la sección y gestiona las traducciones.",
+      "sectionId": "ID de sección: {{id}}",
+      "cannotDeleteWithArticles": "No puede eliminar una sección que tenga entradas asignadas de la base de conocimientos.",
+      "languageLabel": "Idioma",
+      "languageHelp": "Cambie de idioma para editar el título. Si aún no está creado, se le pedirá que lo cree.",
+      "fields": {
+        "title": "Título",
+        "titleError": "Se requiere título"
+      },
+      "delete": {
+        "title": "Eliminar sección",
+        "description": "¿Estás seguro de que deseas eliminar esta sección? Esta acción no se puede deshacer."
+      },
+      "language": {
+        "label": "Idioma",
+        "baseLanguage": "Predeterminado",
+        "notAddedLanguages": "No agregado",
+        "createTitle": "Crear idioma",
+        "createDescription": "¿Crear la versión {{language}} para esta sección?",
+        "deleteTitle": "Eliminar idioma",
+        "deleteDescription": "¿Eliminar la versión {{language}} para esta sección?"
+      }
+    },
+    "form": {
+      "createTitle": "Crear entrada en la base de conocimientos",
+      "editTitle": "Editar entrada de la base de conocimientos",
+      "createButton": "Crear y editar",
+      "saveButton": "Guardar",
+      "fields": {
+        "title": "Título",
+        "summary": "Introducción",
+        "content": "Contenido",
+        "status": "Estado",
+        "isPublic": "Público",
+        "cover": "Imagen de portada"
+      },
+      "placeholders": {
+        "title": "Introduce el título",
+        "summary": "Introducir introducción"
+      },
+      "status": {
+        "draft": "Borrador",
+        "published": "Publicado"
+      },
+      "isPublicDescription": "Visible para todos los usuarios",
+      "preview": "Vista previa",
+      "editor": "Redactor"
+    }
+  },
+  "articlesView": {
+    "notFound": "Entrada de la base de conocimientos no encontrada",
+    "resourceNotFound": "Recurso de base de conocimientos no encontrado",
+    "previousArticle": "Entrada previa a la base de conocimientos",
+    "nextArticle": "Próxima entrada de la base de conocimientos",
+    "deleteModal": {
+      "title": "Eliminar entrada de la base de conocimientos",
+      "description": "¿Está seguro de que desea eliminar esta entrada de la base de conocimientos? Esta acción no se puede deshacer."
+    }
+  },
+  "supportMode": {
+    "banner": {
+      "message": "Estás ejecutando en modo de soporte",
+      "timeLeft": "{{minutes}} minutos restantes",
+      "exit": "Salir del modo de soporte"
+    },
+    "errors": {
+      "generic": "No se pudo iniciar el modo de soporte",
+      "targetAdminRequired": "Elija un usuario administrador activo de la organización seleccionada",
+      "invalidSession": "La sesión de soporte no es válida"
+    }
+  },
+  "superAdminTenantsView": {
+    "title": "Organizaciones",
+    "description": "Administre nombres de organizaciones, dominios, estados y banderas de administración.",
+    "actions": {
+      "create": "Crear organización"
+    },
+    "search": {
+      "placeholder": "Buscar organizaciones..."
+    },
+    "table": {
+      "name": "Nombre",
+      "host": "Anfitrión",
+      "status": "Estado",
+      "managing": "Gestionando",
+      "loading": "Cargando organizaciones...",
+      "empty": "No se encontraron organizaciones.",
+      "yes": "Sí",
+      "no": "No",
+      "edit": "Editar",
+      "actions": {
+        "title": "Acciones",
+        "enterSupportMode": "Ingrese al modo de soporte",
+        "impersonateAdmin": "Suplantar administrador"
+      }
+    },
+    "supportModePopover": {
+      "searchPlaceholder": "Buscar por nombre o correo electrónico...",
+      "loading": "Cargando usuarios administradores...",
+      "empty": "No se encontraron usuarios administradores activos.",
+      "loadMore": "Cargar más usuarios"
+    },
+    "status": {
+      "active": "Activo",
+      "inactive": "Inactivo"
+    },
+    "create": {
+      "title": "Crear organización",
+      "description": "Cree una nueva organización e invite al primer administrador.",
+      "submit": "Crear organización"
+    },
+    "edit": {
+      "title": "Editar organización",
+      "description": "Actualizar los detalles y el estado de la organización.",
+      "submit": "Guardar cambios"
+    },
+    "form": {
+      "tenantName": "Nombre de la organización",
+      "tenantHost": "Anfitrión de la organización (URL completa)",
+      "tenantHostPlaceholder": "https://organización.ejemplo.com",
+      "status": "Estado",
+      "statusPlaceholder": "Seleccionar estado",
+      "adminFirstName": "Nombre del administrador",
+      "adminLastName": "Apellido del administrador",
+      "adminEmail": "Correo electrónico del administrador"
+    },
+    "validation": {
+      "nameRequired": "El nombre es obligatorio",
+      "hostInvalid": "El host debe ser una URL válida",
+      "adminEmailRequired": "Se requiere correo electrónico de administrador",
+      "adminFirstNameRequired": "Se requiere el nombre del administrador",
+      "adminLastNameRequired": "El apellido del administrador es obligatorio."
+    },
+    "toast": {
+      "tenantCreatedSuccessfully": "Organización creada exitosamente",
+      "tenantUpdatedSuccessfully": "Organización actualizada con éxito"
+    }
+  },
+  "superAdminTenants": {
+    "error": {
+      "hostAlreadyExists": "El host de la organización ya existe",
+      "notFound": "Organización no encontrada",
+      "invalidHost": "URL del host de la organización no válida",
+      "managingTenantRequired": "Se requiere administrador de la organización gestora",
+      "currentTenantSupportNotAllowed": "El modo de soporte no está disponible para la organización actual"
+    }
+  },
+  "auth": {
+    "error": {
+      "unauthenticated": "Usuario no autenticado",
+      "invalidEmailOrPassword": "Correo electrónico o contraseña no válidos",
+      "adminRoleRequired": "Se requiere rol de administrador",
+      "missingPermission": "No tienes permiso para acceder a este recurso.",
+      "sessionRevoked": "Tu sesión fue revocada. Por favor actualice su sesión."
+    }
+  },
+  "sessionRevocation": {
+    "permissionsUpdated": "Tus permisos fueron actualizados. Actualizando su sesión para aplicar un nuevo acceso.",
+    "refreshFailed": "Sus permisos cambiaron, pero falló la actualización de la sesión. Por favor inicia sesión nuevamente."
+  },
+  "tenantInactive": {
+    "title": "Organización deshabilitada",
+    "description": "Este espacio de trabajo está actualmente inactivo. Si cree que se trata de un error, comuníquese con su administrador para restaurar el acceso."
+  },
+  "integrationApiKey": {
+    "title": "Integración clave API",
+    "description": "Genere una clave de larga duración para integraciones externas. La sustitución de la llave anula inmediatamente la anterior.",
+    "status": "Estado",
+    "active": "Activo",
+    "inactive": "No generado",
+    "prefix": "Prefijo clave",
+    "createdAt": "Creado en",
+    "lastUsedAt": "Usado por última vez en",
+    "loading": "Cargando metadatos clave...",
+    "generate": "Generar clave",
+    "override": "Sobrescribir clave",
+    "copy": "Copiar clave",
+    "generated": {
+      "title": "Copie esta clave ahora. No se volverá a mostrar."
+    },
+    "confirm": {
+      "title": "¿Anular la clave API actual?",
+      "description": "Esta acción revoca la clave actual inmediatamente. Las integraciones que lo utilicen dejarán de funcionar.",
+      "action": "Sobrescribir clave"
+    },
+    "toast": {
+      "fetchSuccess": "Integración clave API cargada exitosamente",
+      "rotateSuccess": "Clave de integración API actualizada correctamente",
+      "rotateError": "No se pudo actualizar la clave de integración API",
+      "copySuccess": "Integración clave API copiada",
+      "copyError": "No se pudo copiar la clave de integración API"
+    },
+    "errors": {
+      "rotateFailed": "No se pudo rotar la clave de integración API",
+      "invalidApiKey": "Clave de integración API no válida",
+      "ownerInactive": "El propietario de la clave API ya no está activo",
+      "ownerNotAdmin": "El propietario de la clave API ya no tiene permisos de administrador",
+      "missingApiKeyHeader": "Falta el encabezado X-API-Key",
+      "missingTenantIdHeader": "Falta el encabezado X-Tenant-Id"
+    }
+  },
+  "masterCourse": {
+    "error": {
+      "sourceCourseNotFound": "Curso fuente no encontrado",
+      "sourceCategoryNotFound": "Categoría del curso fuente no encontrada",
+      "courseNotFound": "Curso no encontrado",
+      "chapterNotFound": "Capítulo no encontrado",
+      "lessonNotFound": "Lección no encontrada",
+      "noTargetTenants": "Seleccione al menos un inquilino objetivo",
+      "sourceTenantMissing": "Inquilino de origen no encontrado",
+      "exportedCourseCannotBeSource": "El curso exportado no se puede utilizar como fuente",
+      "exportLinkMissing": "Enlace de exportación del curso no encontrado",
+      "jobNotFound": "Trabajo de exportación de cursos no encontrado",
+      "targetTenantMissing": "Inquilino objetivo no encontrado",
+      "targetCategoryMissing": "Categoría de curso objetivo no encontrada",
+      "targetAuthorMissing": "No se encontró el autor del inquilino de destino",
+      "targetCourseMissing": "Curso objetivo no encontrado",
+      "videoStorageNotConfigured": "El almacenamiento de vídeo no está configurado para este inquilino",
+      "sourceVideoMissing": "Vídeo fuente no encontrado",
+      "exportedCourseReadonly": "El curso exportado es de solo lectura"
+    }
+  },
+  "learningPathExport": {
+    "error": {
+      "noTargetTenants": "Seleccione al menos un inquilino objetivo",
+      "exportLinkMissing": "Enlace de exportación de ruta de desarrollo no encontrado",
+      "noCourses": "La ruta de desarrollo debe incluir al menos un curso antes de la exportación.",
+      "courseExportFailed": "No se pudo exportar uno de los cursos de la ruta de desarrollo.",
+      "targetAuthorMissing": "No se encontró el autor del inquilino de destino",
+      "jobNotFound": "Trabajo de exportación de ruta de desarrollo no encontrado",
+      "invalidJobData": "Datos de trabajo de exportación de ruta de desarrollo no válidos",
+      "invalidExportId": "ID de exportación de ruta de desarrollo no válido",
+      "invalidExportLink": "Enlace de exportación de ruta de desarrollo no válido"
+    }
+  },
+  "learningPathCertificate": {
+    "error": {
+      "disabled": "Los certificados de ruta de desarrollo están deshabilitados"
+    }
+  },
+  "activityLogsView": {
+    "filters": {
+      "placeholder": {
+        "searchByEmail": "Buscar por correo electrónico...",
+        "from": "Desde la fecha",
+        "to": "Hasta la fecha"
+      }
+    },
+    "description": "Cronología de los cambios en la plataforma, agrupados como un simple feed ampliable.",
+    "breadcrumbs": {
+      "activityLogs": "Registros de actividad"
+    },
+    "emptyState": {
+      "title": "No se encontraron registros de actividad.",
+      "description": "Cuando ocurran acciones en la plataforma, aparecerán aquí."
+    },
+    "details": {
+      "before": "Antes",
+      "after": "Después",
+      "context": "Contexto",
+      "noMetadata": "No hay metadatos disponibles."
+    },
+    "fallbacks": {
+      "unknown": "Desconocido",
+      "notAvailable": "N/D"
+    },
+    "labels": {
+      "action": "Acción:",
+      "entity": "Recurso:",
+      "resource": "Recurso:"
+    },
+    "actions": {
+      "create": "Creado",
+      "update": "Actualizado",
+      "bulk_course_category_update": "Categoría de cursos masivos actualizada",
+      "bulk_course_status_update": "Estado del curso masivo actualizado",
+      "delete": "Eliminado",
+      "login": "Iniciado sesión",
+      "login_failed": "Error al iniciar sesión",
+      "logout": "Cerrado sesión",
+      "enroll_course": "Inscrito",
+      "unenroll_course": "Dado de baja",
+      "start_course": "Iniciado",
+      "group_assignment": "Asignado",
+      "users_import": "Usuarios importados",
+      "send_password_reset_email": "Correo electrónico de restablecimiento de contraseña enviado",
+      "resend_password_creation_email": "Correo electrónico de creación de contraseña reenviado",
+      "complete_lesson": "Completado",
+      "complete_course": "Completado",
+      "complete_chapter": "Completado",
+      "expire_certificate": "Certificado caducado",
+      "reset_certificate": "Restablecimiento del certificado",
+      "view_announcement": "Visto"
+    },
+    "entity": {
+      "course": "Curso",
+      "chapter": "Capítulo",
+      "lesson": "Lección",
+      "question": "Pregunta",
+      "news": "Noticias",
+      "articles": "Artículo",
+      "user": "Usuario",
+      "category": "Categoría",
+      "announcement": "Anuncio",
+      "live_training": "Formación en vivo",
+      "global_settings": "Configuración"
+    },
+    "table": {
+      "datetime": "Fecha y hora",
+      "email": "Correo electrónico",
+      "action": "Acción",
+      "resource": "Recurso",
+      "details": "Detalles",
+      "showDetails": "Mostrar detalles",
+      "loading": "Cargando registros de actividad...",
+      "empty": "No se encontraron registros de actividad."
+    }
+  },
+  "luma": {
+    "errors": {
+      "invalidBlankAnswerId": "El cuestionario generado contiene una identificación de respuesta en blanco no válida. Vuelva a intentar generar el curso."
+    }
+  },
+  "liveTraining": {
+    "errors": {
+      "invalidLocalizedField": "Proporcione un texto válido para el idioma seleccionado.",
+      "notFound": "No se encontró la formación en vivo.",
+      "sessionNotFound": "No se encontró la sesión de formación en vivo.",
+      "invalidDateRange": "Proporcione las fechas de inicio y finalización, o déjelas vacías.",
+      "invalidSchedule": "La hora de finalización debe ser posterior a la hora de inicio.",
+      "invalidTrainer": "No se pudieron encontrar uno o más entrenadores seleccionados.",
+      "invalidCourse": "No se pudieron encontrar uno o más cursos vinculados.",
+      "invalidResource": "No se pudieron encontrar uno o más recursos seleccionados.",
+      "resourceNotFound": "No se encontró el archivo.",
+      "invalidResourceRelationshipType": "La sección del archivo seleccionado no es válida.",
+      "hostAssignmentForbidden": "No tienes permiso para asignar hosts.",
+      "hostMustHaveTrainerRole": "Los anfitriones asignados deben tener el rol de Entrenador.",
+      "trainerAssignmentForbidden": "No tienes permiso para asignar entrenadores.",
+      "linkNotCreated": "No se pudo crear el enlace de formación en vivo.",
+      "lessonAlreadyLinked": "Esta lección ya tiene una formación en vivo vinculada.",
+      "invalidLessonLinkMode": "Elige si deseas crear una nueva formación en vivo o vincular una existente.",
+      "onlyScheduledCanBeLinked": "Solo las formaciones en vivo programadas se pueden vincular a las lecciones.",
+      "trainingAlreadyLinkedToLesson": "Esta formación en vivo ya está vinculada a una lección de este curso.",
+      "lessonOnlyTitleEditable": "Aquí solo se puede editar el título de la lección. Abre la formación en vivo para cambiar los detalles de la sesión.",
+      "unsupportedLessonLanguage": "Este curso no es compatible con el idioma seleccionado.",
+      "baseLanguageAssignmentRequired": "Las lecciones de formación en vivo deben crearse primero en el idioma base del curso.",
+      "invalidLessonType": "Solo las lecciones de formación en vivo pueden tener asignaciones de formación en vivo.",
+      "deleteAssignedToLesson": "Esta formación en vivo está vinculada a una lección. Elimina primero la lección antes de eliminar la formación en vivo.",
+      "liveKitNotConfigured": "LiveKit no está configurado.",
+      "maxParticipantsReached": "Se ha alcanzado el número máximo de participantes.",
+      "maxParallelSessionsReached": "Se alcanzó el número máximo de sesiones de formación en vivo activas."
+    }
+  }
+}

--- a/apps/web/app/locales/lt/translation.json
+++ b/apps/web/app/locales/lt/translation.json
@@ -42,7 +42,8 @@
       "pl": "Lenkų",
       "de": "Vokiečių",
       "lt": "Lietuvių",
-      "cs": "Čekų"
+      "cs": "Čekų",
+      "es": "ispanų"
     },
     "lessonTypes": {
       "content": "Turinys",
@@ -807,7 +808,8 @@
       "polish": "lenkų",
       "german": "Vokiečių",
       "czech": "Čekų",
-      "lithuanian": "Lietuvių"
+      "lithuanian": "Lietuvių",
+      "spanish": "Ispanų"
     }
   },
   "resetOnboarding": {

--- a/apps/web/app/locales/pl/translation.json
+++ b/apps/web/app/locales/pl/translation.json
@@ -43,7 +43,8 @@
       "pl": "Polski",
       "de": "Niemiecki",
       "lt": "Litewski",
-      "cs": "Czeski"
+      "cs": "Czeski",
+      "es": "hiszpański"
     },
     "lessonTypes": {
       "content": "Treść",
@@ -1041,7 +1042,8 @@
       "polish": "Polski",
       "german": "Niemiecki",
       "czech": "Czeski",
-      "lithuanian": "Litewski"
+      "lithuanian": "Litewski",
+      "spanish": "Hiszpański"
     }
   },
   "resetOnboarding": {

--- a/apps/web/app/modules/Admin/EditCourse/EditCourse.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/EditCourse.tsx
@@ -9,12 +9,11 @@ import {
   type SupportedLanguages,
 } from "@repo/shared";
 import { isAxiosError } from "axios";
-import { Building, Copy } from "lucide-react";
+import { Building } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { useDismissGeneratedCourseSync } from "~/api/mutations/admin/useDismissGeneratedCourseSync";
-import { useDuplicateCourse } from "~/api/mutations/admin/useDuplicateCourse";
 import { useExportMasterCourse } from "~/api/mutations/admin/useExportMasterCourse";
 import useGenerateMissingTranslations from "~/api/mutations/admin/useGenerateMissingTranslations";
 import { useSyncGeneratedCourse } from "~/api/mutations/admin/useSyncGeneratedCourse";
@@ -120,9 +119,6 @@ const EditCourse = () => {
     useSyncGeneratedCourse();
   const { mutateAsync: dismissGeneratedCourseSync, isPending: isDismissSyncPending } =
     useDismissGeneratedCourseSync();
-  const { mutateAsync: duplicateCourse, isPending: isDuplicateCoursePending } =
-    useDuplicateCourse();
-
   const { mutateAsync: exportMasterCourse, isPending: isExportPending } = useExportMasterCourse();
 
   const [searchParams, setSearchParams] = useSearchParams();
@@ -284,15 +280,6 @@ const EditCourse = () => {
     if (!course?.id) return;
     await dismissGeneratedCourseSync({ integrationId: course.id });
   }, [course?.id, dismissGeneratedCourseSync]);
-
-  const handleDuplicateCourse = useCallback(async () => {
-    if (!course?.id) return;
-
-    const response = await duplicateCourse(course.id);
-    navigate(
-      `/admin/beta-courses/${response.data.courseId}?duplicationJobId=${response.data.jobId}`,
-    );
-  }, [course?.id, duplicateCourse, navigate]);
 
   useCourseGenerationSyncSocket({
     courseId: course?.id ?? "",
@@ -552,17 +539,6 @@ const EditCourse = () => {
                   <Separator orientation="vertical" className="h-10" decorative />
                 </>
               )}
-
-              <Button
-                type="button"
-                variant="outline"
-                className="gap-2"
-                disabled={!course?.id || isDuplicateCoursePending || isDuplicationLocked}
-                onClick={() => void handleDuplicateCourse()}
-              >
-                <Copy className="size-4" />
-                {t("adminCourseDuplication.duplicate")}
-              </Button>
 
               <Button
                 asChild

--- a/apps/web/app/modules/News/NewsForm.page.tsx
+++ b/apps/web/app/modules/News/NewsForm.page.tsx
@@ -1,6 +1,10 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useNavigate, useParams } from "@remix-run/react";
-import { ALLOWED_LESSON_IMAGE_FILE_TYPES, ENTITY_TYPES } from "@repo/shared";
+import {
+  ALLOWED_LESSON_IMAGE_FILE_TYPES,
+  ENTITY_TYPES,
+  type SupportedLanguages,
+} from "@repo/shared";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
@@ -59,7 +63,7 @@ type NewsFormValues = {
 };
 
 type UpdateNewsPayload = {
-  language: "en" | "pl";
+  language: SupportedLanguages;
   title?: string;
   summary?: string;
   content?: string;

--- a/apps/web/app/modules/Profile/Certificates/CertificateContent.test.tsx
+++ b/apps/web/app/modules/Profile/Certificates/CertificateContent.test.tsx
@@ -1,0 +1,33 @@
+import { SUPPORTED_LANGUAGES, type SupportedLanguages } from "@repo/shared";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import CertificateContent from "./CertificateContent";
+
+describe("CertificateContent", () => {
+  it("renders certificate copy in every supported language", () => {
+    const expectedLabels = {
+      [SUPPORTED_LANGUAGES.EN]: "THIS IS TO CERTIFY THAT",
+      [SUPPORTED_LANGUAGES.PL]: "NINIEJSZYM ZAŚWIADCZA SIĘ, ŻE",
+      [SUPPORTED_LANGUAGES.DE]: "HIERMIT WIRD BESTÄTIGT, DASS",
+      [SUPPORTED_LANGUAGES.LT]: "ŠIUO PATVIRTINAMA, KAD",
+      [SUPPORTED_LANGUAGES.CS]: "TÍMTO SE POTVRZUJE, ŽE",
+      [SUPPORTED_LANGUAGES.ES]: "SE CERTIFICA QUE",
+    };
+
+    for (const [language, label] of Object.entries(expectedLabels)) {
+      const { unmount } = render(
+        <CertificateContent
+          isDownload
+          lang={language as SupportedLanguages}
+          studentName="Ada Lovelace"
+          courseName="Analytical Engines"
+          completionDate="30.06.2026"
+        />,
+      );
+
+      expect(screen.getByText(label)).toBeInTheDocument();
+      unmount();
+    }
+  });
+});

--- a/apps/web/app/modules/Profile/Certificates/CertificateContent.tsx
+++ b/apps/web/app/modules/Profile/Certificates/CertificateContent.tsx
@@ -8,6 +8,7 @@ import { defaultCertificateColorTheme } from "./certificateTheme";
 
 import type { CertificateKind } from "./certificateKind";
 import type { CertificateColorTheme } from "./certificateTheme";
+import type { SupportedLanguages } from "@repo/shared";
 
 interface CertificateContentProps {
   studentName?: string;
@@ -19,7 +20,7 @@ interface CertificateContentProps {
   backgroundImageUrl?: string | null;
   platformLogo?: string | null;
   signatureImageUrl?: string | null;
-  lang?: "pl" | "en";
+  lang?: SupportedLanguages;
   colorTheme?: CertificateColorTheme;
   certificateKind?: CertificateKind;
 }
@@ -49,7 +50,66 @@ const translations = {
     expiryDate: "Expires",
     signature: "Signature",
   },
-};
+  de: {
+    certificate: "ZERTIFIKAT",
+    certifyThat: "HIERMIT WIRD BESTÄTIGT, DASS",
+    successfulCompletion: {
+      [CERTIFICATE_KIND.COURSE]: "hat den Kurs erfolgreich abgeschlossen",
+      [CERTIFICATE_KIND.LEARNING_PATH]: "hat den Entwicklungspfad erfolgreich abgeschlossen",
+    },
+    confirmation: "und bestätigt damit die Teilnahme am gesamten Schulungsprogramm.",
+    date: "Datum",
+    expiryDate: "Läuft ab",
+    signature: "Unterschrift",
+  },
+  lt: {
+    certificate: "SERTIFIKATAS",
+    certifyThat: "ŠIUO PATVIRTINAMA, KAD",
+    successfulCompletion: {
+      [CERTIFICATE_KIND.COURSE]: "sėkmingai baigė kursą",
+      [CERTIFICATE_KIND.LEARNING_PATH]: "sėkmingai baigė tobulėjimo kelią",
+    },
+    confirmation: "taip patvirtindamas dalyvavimą visoje mokymo programoje.",
+    date: "Data",
+    expiryDate: "Galioja iki",
+    signature: "Parašas",
+  },
+  cs: {
+    certificate: "CERTIFIKÁT",
+    certifyThat: "TÍMTO SE POTVRZUJE, ŽE",
+    successfulCompletion: {
+      [CERTIFICATE_KIND.COURSE]: "úspěšně absolvoval/a kurz",
+      [CERTIFICATE_KIND.LEARNING_PATH]: "úspěšně dokončil/a rozvojovou cestu",
+    },
+    confirmation: "čímž potvrzuje účast na celém školicím programu.",
+    date: "Datum",
+    expiryDate: "Platí do",
+    signature: "Podpis",
+  },
+  es: {
+    certificate: "CERTIFICADO",
+    certifyThat: "SE CERTIFICA QUE",
+    successfulCompletion: {
+      [CERTIFICATE_KIND.COURSE]: "ha completado correctamente el curso",
+      [CERTIFICATE_KIND.LEARNING_PATH]: "ha completado correctamente la ruta de desarrollo",
+    },
+    confirmation: "confirmando así su participación en todo el programa formativo.",
+    date: "Fecha",
+    expiryDate: "Caduca",
+    signature: "Firma",
+  },
+} satisfies Record<
+  SupportedLanguages,
+  {
+    certificate: string;
+    certifyThat: string;
+    successfulCompletion: Record<CertificateKind, string>;
+    confirmation: string;
+    date: string;
+    expiryDate: string;
+    signature: string;
+  }
+>;
 const hrClasses = "mx-auto mb-3 w-full";
 const textClasses = "text-[18px] uppercase text-gray-800";
 const text2Classes = "text-[18px] text-gray-600";

--- a/apps/web/app/modules/Profile/Certificates/CertificateControls.tsx
+++ b/apps/web/app/modules/Profile/Certificates/CertificateControls.tsx
@@ -5,18 +5,27 @@ import { useTranslation } from "react-i18next";
 
 import { Linkedin } from "~/assets/svgs";
 import { ColorPickerField } from "~/components/ColorPickerField";
-import RectangularSwitch from "~/components/RectangularSwitch";
+import { Icon } from "~/components/Icon";
+import { languageOptions } from "~/components/LanguageSelector/languageOptions";
 import { Button } from "~/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/components/ui/select";
 import { cn } from "~/lib/utils";
 
 import { applyUniformCertificateColor } from "./certificateTheme";
 
 import type { CertificateColorTheme } from "./certificateTheme";
+import type { SupportedLanguages } from "@repo/shared";
 
 interface CertificateControlsProps {
   onClose?: () => void;
-  languageToggled: boolean;
-  setLanguageToggled: (languageToggled: boolean) => void;
+  selectedLanguage: SupportedLanguages;
+  setSelectedLanguage: (language: SupportedLanguages) => void;
   downloadCertificatePdf: () => Promise<void>;
   isPreparingDownload: boolean;
   onShareToLinkedIn?: () => Promise<void>;
@@ -35,8 +44,8 @@ const buttonClasses =
 
 const CertificateControls = ({
   onClose,
-  languageToggled,
-  setLanguageToggled,
+  selectedLanguage,
+  setSelectedLanguage,
   downloadCertificatePdf,
   isPreparingDownload,
   onShareToLinkedIn,
@@ -72,13 +81,27 @@ const CertificateControls = ({
 
   return (
     <div className="flex flex-wrap items-center justify-end gap-3">
-      <RectangularSwitch
-        switchLabel={t("studentCertificateView.controls.languageToggle")}
-        onLabel="PL"
-        offLabel="EN"
-        toggled={languageToggled}
-        setToggled={setLanguageToggled}
-      />
+      <Select
+        value={selectedLanguage}
+        onValueChange={(value) => setSelectedLanguage(value as SupportedLanguages)}
+      >
+        <SelectTrigger
+          className="h-[42px] w-[152px]"
+          aria-label={t("studentCertificateView.controls.languageToggle")}
+        >
+          <SelectValue placeholder={t("changeUserLanguageView.field.language")} />
+        </SelectTrigger>
+        <SelectContent>
+          {languageOptions.map((item) => (
+            <SelectItem key={item.key} value={item.key} className="w-full">
+              <div className="flex w-full min-w-0 items-center gap-2 whitespace-nowrap">
+                <Icon name={item.iconName} className="size-4 shrink-0" />
+                <span className="truncate font-semibold">{t(item.translationKey)}</span>
+              </div>
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
 
       {showColorPicker && (
         <PopoverPrimitive.Root open={isColorPickerOpen} onOpenChange={handleColorPickerOpenChange}>

--- a/apps/web/app/modules/Profile/Certificates/CertificatePreview.tsx
+++ b/apps/web/app/modules/Profile/Certificates/CertificatePreview.tsx
@@ -1,9 +1,11 @@
+import { SUPPORTED_LANGUAGES, type SupportedLanguages } from "@repo/shared";
 import { useEffect, useState } from "react";
 import { match } from "ts-pattern";
 
 import { useCreateCertificateShareLink } from "~/api/mutations/useCreateCertificateShareLink";
 import { useCreateLearningPathCertificateShareLink } from "~/api/mutations/useCreateLearningPathCertificateShareLink";
 import { cn } from "~/lib/utils";
+import { useLanguageStore } from "~/modules/Dashboard/Settings/Language/LanguageStore";
 
 import CertificateContent from "./CertificateContent";
 import CertificateControls from "./CertificateControls";
@@ -53,6 +55,7 @@ const CertificatePreview = ({
   onColorPickerOpenChange,
   certificateKind = CERTIFICATE_KIND.COURSE,
 }: CertificatePreviewProps) => {
+  const currentLanguage = useLanguageStore((state) => state.language);
   const { downloadCertificatePdf, isPreparingDownload } = useCertificatePDF(certificateKind);
   const { mutateAsync: createCertificateShareLink, isPending: isPreparingShare } =
     useCreateCertificateShareLink();
@@ -60,7 +63,9 @@ const CertificatePreview = ({
     mutateAsync: createLearningPathCertificateShareLink,
     isPending: isPreparingLearningPathShare,
   } = useCreateLearningPathCertificateShareLink();
-  const [toggled, setToggled] = useState<boolean>(false);
+  const [selectedLanguage, setSelectedLanguage] = useState<SupportedLanguages>(
+    currentLanguage || SUPPORTED_LANGUAGES.EN,
+  );
   const [colorTheme, setColorTheme] = useState<CertificateColorTheme>(
     getCertificateColorTheme(initialColor),
   );
@@ -68,8 +73,6 @@ const CertificatePreview = ({
   useEffect(() => {
     setColorTheme(getCertificateColorTheme(initialColor));
   }, [initialColor]);
-
-  const lang = toggled ? "pl" : "en";
 
   const handleShareToLinkedIn = async () => {
     if (!certificateId || isPreparingShare || isPreparingLearningPathShare) return;
@@ -80,19 +83,19 @@ const CertificatePreview = ({
       .exhaustive();
     const { linkedinShareUrl } = await createShareLink({
       certificateId,
-      language: lang,
+      language: selectedLanguage,
     });
 
     window.open(linkedinShareUrl, "_blank", "noopener,noreferrer");
   };
 
   const handleDownloadCertificate = async () => {
-    await downloadCertificatePdf({ certificateId, lang });
+    await downloadCertificatePdf({ certificateId, lang: selectedLanguage });
   };
 
   return (
-    <div className="flex w-[min(1120px,95vw)] justify-center">
-      <div className="w-full">
+    <div className="flex max-h-[90vh] w-[min(1120px,95vw)] justify-center overflow-y-auto">
+      <div className="w-full pr-1">
         <div
           className={cn("mx-auto w-full bg-white", {
             "rounded-t-lg": !minimalFrame,
@@ -113,8 +116,8 @@ const CertificatePreview = ({
 
             <CertificateControls
               onClose={onClose}
-              languageToggled={toggled}
-              setLanguageToggled={setToggled}
+              selectedLanguage={selectedLanguage}
+              setSelectedLanguage={setSelectedLanguage}
               downloadCertificatePdf={handleDownloadCertificate}
               isPreparingDownload={isPreparingDownload}
               onShareToLinkedIn={handleShareToLinkedIn}
@@ -138,7 +141,7 @@ const CertificatePreview = ({
             platformLogo={platformLogo}
             backgroundImageUrl={certificateBackgroundImageUrl}
             signatureImageUrl={certificateSignatureUrl}
-            lang={lang}
+            lang={selectedLanguage}
             colorTheme={colorTheme}
             certificateKind={certificateKind}
           />

--- a/apps/web/app/utils/getDateLocale.ts
+++ b/apps/web/app/utils/getDateLocale.ts
@@ -1,5 +1,5 @@
 import { SUPPORTED_LANGUAGES } from "@repo/shared";
-import { cs, de, enUS, lt, pl } from "date-fns/locale";
+import { cs, de, enUS, es, lt, pl } from "date-fns/locale";
 import { match } from "ts-pattern";
 
 export function getDateLocale(language: string) {
@@ -10,5 +10,6 @@ export function getDateLocale(language: string) {
     .with(SUPPORTED_LANGUAGES.DE, () => de)
     .with(SUPPORTED_LANGUAGES.CS, () => cs)
     .with(SUPPORTED_LANGUAGES.LT, () => lt)
+    .with(SUPPORTED_LANGUAGES.ES, () => es)
     .otherwise(() => enUS);
 }

--- a/apps/web/i18n.ts
+++ b/apps/web/i18n.ts
@@ -5,6 +5,7 @@ import { initReactI18next } from "react-i18next";
 import csTranslations from "app/locales/cs/translation.json";
 import deTranslations from "app/locales/de/translation.json";
 import enTranslations from "app/locales/en/translation.json";
+import esTranslations from "app/locales/es/translation.json";
 import ltTranslations from "app/locales/lt/translation.json";
 import plTranslations from "app/locales/pl/translation.json";
 
@@ -32,6 +33,9 @@ i18n.use(initReactI18next).init({
     },
     cs: {
       translation: csTranslations,
+    },
+    es: {
+      translation: esTranslations,
     },
   },
 });

--- a/docs/specs/certificates-business-spec.md
+++ b/docs/specs/certificates-business-spec.md
@@ -17,7 +17,7 @@ The feature also gives course managers controlled ways to handle certificate val
 
 - List active certificates for a learner profile.
 - Open certificate previews for completed courses and learning paths.
-- Switch certificate preview language between supported certificate languages.
+- Switch certificate preview language between all supported platform languages.
 - Download certificate PDFs with generated filenames.
 - Share certificates externally through LinkedIn/public share links.
 - Configure whether a course issues certificates.
@@ -35,7 +35,7 @@ For administrators, the reset and validity tools reduce operational risk. When a
 
 ## How It Works
 
-Learners access certificates from the profile certificate area. Each certificate can be previewed, rendered as a PDF, and shared when sharing is enabled. Public share endpoints serve external certificate pages and images, while protected certificate listing, rendering, and share-link creation remain permission-gated.
+Learners access certificates from the profile certificate area. Each certificate can be previewed, rendered as a PDF, and shared when sharing is enabled. Certificate rendering is available in every supported platform language, including Spanish, even when the related course or learning path does not have a translation in that language; in that case Mentingo falls back to the base title. Public share endpoints serve external certificate pages and images, while protected certificate listing, rendering, and share-link creation remain permission-gated.
 
 Course certificate settings are managed from the admin course settings workflow. Administrators can enable certificate issuance, define validity, inspect how a validity change affects active certificates, and choose whether the change applies only to future certificates or also to existing active certificates.
 
@@ -49,6 +49,7 @@ Certificate reset actions archive matching active certificates, reset the releva
 - Core permissions include `PERMISSIONS.CERTIFICATE_READ`, `PERMISSIONS.CERTIFICATE_RENDER`, and `PERMISSIONS.CERTIFICATE_SHARE`.
 - Course certificate validity and reset operations require `PERMISSIONS.COURSE_UPDATE` or `PERMISSIONS.COURSE_UPDATE_OWN`.
 - Public share endpoints intentionally allow external certificate page and image access for share workflows.
+- Certificate PDFs, previews, share pages, and share images use the shared supported-language list, so new platform languages become available to certificates through the same contract.
 
 ## Test Evidence
 

--- a/docs/specs/language-localization-business-spec.md
+++ b/docs/specs/language-localization-business-spec.md
@@ -19,7 +19,7 @@ The main workflow is simple for learners: choose a preferred interface language 
 
 - Switch and persist the user interface language.
 - Apply the selected language to navigation, page text, and the browser document language.
-- Support English, Polish, German, Lithuanian, and Czech.
+- Support English, Polish, German, Lithuanian, Czech, and Spanish.
 - Use browser or stored language for unauthenticated visitor experiences.
 - Add and remove translated versions of authored content.
 - Resolve localized content with fallback behavior when the requested language is unavailable.

--- a/packages/email-templates/src/translations/announcementEmail.ts
+++ b/packages/email-templates/src/translations/announcementEmail.ts
@@ -33,7 +33,12 @@ export const getAnnouncementEmailTranslations = (
       paragraphs: [content],
       buttonText: "Otevřít oznámení",
     },
+    es: {
+      heading: title,
+      paragraphs: [content],
+      buttonText: "Abrir notificaciones",
+    },
   };
 
-  return emailContent[language] ?? emailContent.en;
+  return emailContent[language];
 };

--- a/packages/email-templates/src/translations/certificateExpirationWarning.ts
+++ b/packages/email-templates/src/translations/certificateExpirationWarning.ts
@@ -47,7 +47,15 @@ export const getCertificateExpirationWarningEmailTranslations = (
       ],
       buttonText: "OTEVŘÍT KURZ",
     },
+    es: {
+      heading: "El certificado caduca pronto",
+      paragraphs: [
+        `Tu certificado del curso ${courseName} caduca el ${expiresAt}.`,
+        "Después de la caducidad, el progreso del curso se restablecerá. Completa el curso de nuevo para recibir un certificado nuevo.",
+      ],
+      buttonText: "ABRIR CURSO",
+    },
   };
 
-  return emailContent[language] ?? emailContent.en;
+  return emailContent[language];
 };

--- a/packages/email-templates/src/translations/certificateExpired.ts
+++ b/packages/email-templates/src/translations/certificateExpired.ts
@@ -61,7 +61,17 @@ export const getCertificateExpiredEmailTranslations = (
       ],
       buttonText: "OTEVŘÍT KURZ",
     },
+    es: {
+      heading: isManualReset ? "Certificado restablecido" : "Certificado caducado",
+      paragraphs: [
+        isManualReset
+          ? `Un administrador ha restablecido tu certificado del curso ${courseName}.`
+          : `Tu certificado del curso ${courseName} ha caducado.`,
+        "El certificado se ha archivado y el progreso del curso se ha restablecido. Completa el curso de nuevo para recibir un certificado nuevo.",
+      ],
+      buttonText: "ABRIR CURSO",
+    },
   };
 
-  return emailContent[language] ?? emailContent.en;
+  return emailContent[language];
 };

--- a/packages/email-templates/src/translations/courseDueDateReminder.ts
+++ b/packages/email-templates/src/translations/courseDueDateReminder.ts
@@ -11,9 +11,10 @@ const getDaysLabel = (language: SupportedLanguages, daysBeforeDueDate: number) =
       de: "bald",
       lt: "netrukus",
       cs: "brzy",
+      es: "pronto",
     };
 
-    return labels[language] ?? labels.en;
+    return labels[language];
   }
 
   if (normalizedDaysBeforeDueDate === 1) {
@@ -23,9 +24,10 @@ const getDaysLabel = (language: SupportedLanguages, daysBeforeDueDate: number) =
       de: "morgen",
       lt: "rytoj",
       cs: "zítra",
+      es: "mañana",
     };
 
-    return labels[language] ?? labels.en;
+    return labels[language];
   }
 
   if (normalizedDaysBeforeDueDate === 0) {
@@ -35,9 +37,10 @@ const getDaysLabel = (language: SupportedLanguages, daysBeforeDueDate: number) =
       de: "heute",
       lt: "šiandien",
       cs: "dnes",
+      es: "hoy",
     };
 
-    return labels[language] ?? labels.en;
+    return labels[language];
   }
 
   const labels: Record<SupportedLanguages, string> = {
@@ -46,9 +49,10 @@ const getDaysLabel = (language: SupportedLanguages, daysBeforeDueDate: number) =
     de: `in ${daysBeforeDueDate} Tagen`,
     lt: `po ${daysBeforeDueDate} dienų`,
     cs: `za ${daysBeforeDueDate} dní`,
+    es: `en ${normalizedDaysBeforeDueDate} días`,
   };
 
-  return labels[language] ?? labels.en;
+  return labels[language];
 };
 
 export const getCourseDueDateReminderEmailTranslations = (
@@ -85,7 +89,12 @@ export const getCourseDueDateReminderEmailTranslations = (
       paragraphs: [`Termín dokončení kurzu "${courseName}" vyprší ${daysLabel}.`],
       buttonText: "OTEVŘÍT KURZ",
     },
+    es: {
+      heading: "Se acerca la fecha límite del curso",
+      paragraphs: [`La fecha límite para completar el curso "${courseName}" es ${daysLabel}.`],
+      buttonText: "ABRIR CURSO",
+    },
   };
 
-  return emailContent[language] ?? emailContent.en;
+  return emailContent[language];
 };

--- a/packages/email-templates/src/translations/createPasswordReminder.ts
+++ b/packages/email-templates/src/translations/createPasswordReminder.ts
@@ -43,7 +43,15 @@ export const getCreatePasswordReminderEmailTranslations = (language: SupportedLa
       ],
       buttonText: "VYTVOŘIT HESLO",
     },
+    es: {
+      heading: "Recordatorio",
+      paragraphs: [
+        "Este es un recordatorio amistoso de que tu cuenta aún no está completamente configurada. 🔒",
+        "Para completar la configuración de tu cuenta, crea tu contraseña haciendo clic en el botón de abajo. Si ya has creado tu contraseña, ignora este recordatorio.",
+      ],
+      buttonText: "CREAR CONTRASEÑA",
+    },
   };
 
-  return emailContent[language] ?? emailContent.en;
+  return emailContent[language];
 };

--- a/packages/email-templates/src/translations/finishedCourse.ts
+++ b/packages/email-templates/src/translations/finishedCourse.ts
@@ -41,7 +41,12 @@ export const getFinishedCourseEmailTranslations = (
       ],
       buttonText: "ZOBRAZIT POKROK",
     },
+    es: {
+      heading: "Usuario completó el curso",
+      paragraphs: ["¡Hola! 🧑‍💻", `${userName} completó ${courseName}. Revisa su progreso.`],
+      buttonText: "VER PROGRESO",
+    },
   };
 
-  return emailContent[language] ?? emailContent.en;
+  return emailContent[language];
 };

--- a/packages/email-templates/src/translations/liveTrainingEmail.ts
+++ b/packages/email-templates/src/translations/liveTrainingEmail.ts
@@ -7,7 +7,8 @@ export const getLiveTrainingEmailButtonText = (language: SupportedLanguages) => 
     de: "Live-Schulung öffnen",
     lt: "Atidaryti tiesioginius mokymus",
     cs: "Otevřít živé školení",
+    es: "Abrir formación en vivo",
   };
 
-  return translations[language] ?? translations.en;
+  return translations[language];
 };

--- a/packages/email-templates/src/translations/magicLink.ts
+++ b/packages/email-templates/src/translations/magicLink.ts
@@ -38,7 +38,14 @@ export const getMagicLinkEmailTranslations = (language: SupportedLanguages) => {
       ],
       buttonText: "OTEVŘÍT PŘIHLAŠOVACÍ ODKAZ",
     },
+    es: {
+      heading: "Enlace de inicio de sesión",
+      paragraphs: [
+        "Has recibido un enlace de inicio de sesión para tu cuenta. Haz clic en el botón de abajo para abrirlo.",
+      ],
+      buttonText: "ABRIR ENLACE DE INICIO DE SESIÓN",
+    },
   };
 
-  return emailContent[language] ?? emailContent.en;
+  return emailContent[language];
 };

--- a/packages/email-templates/src/translations/newUser.ts
+++ b/packages/email-templates/src/translations/newUser.ts
@@ -31,7 +31,12 @@ export const getNewUserEmailTranslations = (language: SupportedLanguages, userNa
       paragraphs: ["Ahoj! 🧑‍💻", `${userName} se připojil(a). Zkontroluj profil a přiřaď kurzy.`],
       buttonText: "OTEVŘÍT PROFIL",
     },
+    es: {
+      heading: "Nuevo perfil de usuario",
+      paragraphs: ["¡Hola! 🧑‍💻", `${userName} se ha unido. Revisa el perfil y asigna cursos.`],
+      buttonText: "ABRIR PERFIL",
+    },
   };
 
-  return emailContent[language] ?? emailContent.en;
+  return emailContent[language];
 };

--- a/packages/email-templates/src/translations/overdueCourses.ts
+++ b/packages/email-templates/src/translations/overdueCourses.ts
@@ -85,9 +85,18 @@ export const getOverdueCoursesEmailTranslations = (
       dueDateLabel: "Termín",
       studentsLabel: "Studenti",
     },
+    es: {
+      heading: "Estudiantes con cursos vencidos",
+      intro: "Algunos estudiantes no completaron sus cursos a tiempo:",
+      buttonText: "VER CURSOS",
+      courseLabel: "Curso",
+      groupLabel: "Grupo",
+      dueDateLabel: "Fecha límite",
+      studentsLabel: "Estudiantes",
+    },
   };
 
-  const selectedLabels = labels[language] ?? labels.en;
+  const selectedLabels = labels[language];
 
   return {
     heading: selectedLabels.heading,

--- a/packages/email-templates/src/translations/passwordRecovery.ts
+++ b/packages/email-templates/src/translations/passwordRecovery.ts
@@ -46,7 +46,15 @@ export const getPasswordRecoveryEmailTranslations = (
       ],
       buttonText: "RESETOVAT HESLO",
     },
+    es: {
+      heading: "Recuperación de contraseña",
+      paragraphs: [
+        `Hola ${name}, has solicitado restablecer tu contraseña 🔑`,
+        "Puedes restablecer tu contraseña usando el botón de abajo.",
+      ],
+      buttonText: "RESTABLECER CONTRASEÑA",
+    },
   };
 
-  return emailContent[language] ?? emailContent.en;
+  return emailContent[language];
 };

--- a/packages/email-templates/src/translations/userAssignedToCourse.ts
+++ b/packages/email-templates/src/translations/userAssignedToCourse.ts
@@ -21,6 +21,9 @@ export const getUserAssignedToCourseEmailTranslations = (
   const czMandatoryCourseParagraph = formatedCourseDueDate
     ? `Tento kurz je povinný a musí být dokončen do ${formatedCourseDueDate}.`
     : undefined;
+  const esMandatoryCourseParagraph = formatedCourseDueDate
+    ? `Este curso es obligatorio y debe completarse antes del ${formatedCourseDueDate}.`
+    : undefined;
 
   const emailContent: Record<SupportedLanguages, EmailContent> = {
     en: {
@@ -68,7 +71,16 @@ export const getUserAssignedToCourseEmailTranslations = (
       ].filter(Boolean) as string[],
       buttonText: "MOJE KURZY",
     },
+    es: {
+      heading: "Nuevo curso disponible",
+      paragraphs: [
+        "Te has inscrito 🎓",
+        `Ahora tienes acceso a ${courseName}. Está disponible en tu cuenta.`,
+        esMandatoryCourseParagraph,
+      ].filter(Boolean) as string[],
+      buttonText: "MIS CURSOS",
+    },
   };
 
-  return emailContent[language] ?? emailContent.en;
+  return emailContent[language];
 };

--- a/packages/email-templates/src/translations/userFinishedChapter.ts
+++ b/packages/email-templates/src/translations/userFinishedChapter.ts
@@ -47,7 +47,15 @@ export const getUserFinishedChapterEmailTranslations = (
       ],
       buttonText: "DALŠÍ KAPITOLA",
     },
+    es: {
+      heading: "Capítulo completado",
+      paragraphs: [
+        "Progreso actualizado 🧩",
+        `Has terminado ${chapterName} en ${courseName}. Los siguientes materiales están listos.`,
+      ],
+      buttonText: "SIGUIENTE CAPÍTULO",
+    },
   };
 
-  return emailContent[language] ?? emailContent.en;
+  return emailContent[language];
 };

--- a/packages/email-templates/src/translations/userFinishedCourse.ts
+++ b/packages/email-templates/src/translations/userFinishedCourse.ts
@@ -47,7 +47,15 @@ export const getUserFinishedCourseEmailTranslations = (
       ],
       buttonText: hasCertificate ? "STÁHNOUT CERTIFIKÁT" : "POKRAČOVAT VE STUDIU",
     },
+    es: {
+      heading: "Curso completado",
+      paragraphs: [
+        "¡Enhorabuena! 🏁",
+        `Has completado ${courseName}. ${hasCertificate ? "Tu certificado está listo para descargar; revisa también los siguientes pasos recomendados." : ""}`,
+      ],
+      buttonText: hasCertificate ? "DESCARGAR CERTIFICADO" : "CONTINUAR APRENDIENDO",
+    },
   };
 
-  return emailContent[language] ?? emailContent.en;
+  return emailContent[language];
 };

--- a/packages/email-templates/src/translations/userFirstLogin.ts
+++ b/packages/email-templates/src/translations/userFirstLogin.ts
@@ -43,7 +43,15 @@ export const getUserFirstLoginEmailTranslations = (language: SupportedLanguages,
       ],
       buttonText: "MOJE KURZY",
     },
+    es: {
+      heading: "Bienvenido",
+      paragraphs: [
+        "Nos alegra tenerte aquí 🙂",
+        `Tu primer inicio de sesión se ha completado correctamente. ${name}, revisa tus cursos asignados.`,
+      ],
+      buttonText: "MIS CURSOS",
+    },
   };
 
-  return emailContent[language] ?? emailContent.en;
+  return emailContent[language];
 };

--- a/packages/email-templates/src/translations/userInvite.ts
+++ b/packages/email-templates/src/translations/userInvite.ts
@@ -46,7 +46,15 @@ export const getUserInviteEmailTranslations = (
       ],
       buttonText: "PŘIPOJIT SE NYNÍ",
     },
+    es: {
+      heading: "Estás invitado",
+      paragraphs: [
+        "Hola 👋",
+        `${invitedByUserName} te ha invitado a la plataforma de e-learning. Haz clic en el botón de abajo para empezar a mejorar tus habilidades.`,
+      ],
+      buttonText: "UNIRSE AHORA",
+    },
   };
 
-  return emailContent[language] ?? emailContent.en;
+  return emailContent[language];
 };

--- a/packages/email-templates/src/translations/userLongInactivity.ts
+++ b/packages/email-templates/src/translations/userLongInactivity.ts
@@ -11,6 +11,7 @@ export const getUserLongInactivityEmailTranslations = (
     de: courseName ? `in ${courseName}` : "auf der Plattform",
     lt: courseName ? `kurse ${courseName}` : "platformoje",
     cs: courseName ? `v kurzu ${courseName}` : "na platformě",
+    es: courseName ? `en ${courseName}` : "en la plataforma",
   };
 
   const emailContent: Record<SupportedLanguages, EmailContent> = {
@@ -54,7 +55,15 @@ export const getUserLongInactivityEmailTranslations = (
       ],
       buttonText: "POKRAČOVAT V KURZU",
     },
+    es: {
+      heading: "Es hora de retomar tu curso",
+      paragraphs: [
+        "Continúa aprendiendo 📚",
+        `Han pasado 30 días desde tu última actividad ${activityContext.es}. Retomarlo ahora te ayudará a terminar a tiempo.`,
+      ],
+      buttonText: "RETOMAR CURSO",
+    },
   };
 
-  return emailContent[language] ?? emailContent.en;
+  return emailContent[language];
 };

--- a/packages/email-templates/src/translations/userShortInactivity.ts
+++ b/packages/email-templates/src/translations/userShortInactivity.ts
@@ -11,6 +11,7 @@ export const getUserShortInactivityEmailTranslations = (
     de: courseName ? `im Kurs ${courseName}` : "auf der Plattform",
     lt: courseName ? `kurse ${courseName}` : "platformoje",
     cs: courseName ? `v kurzu ${courseName}` : "na platformě",
+    es: courseName ? `en ${courseName}` : "en la plataforma",
   };
 
   const emailContent: Record<SupportedLanguages, EmailContent> = {
@@ -54,7 +55,15 @@ export const getUserShortInactivityEmailTranslations = (
       ],
       buttonText: courseName ? "POKRAČOVAT V KURZU" : "OTEVŘÍT PLATFORMU",
     },
+    es: {
+      heading: "Recordatorio",
+      paragraphs: [
+        "Retoma tu aprendizaje 🔔",
+        `Han pasado 14 días desde tu última actividad ${activityContext.es}. Continúa para mantener tu progreso.`,
+      ],
+      buttonText: courseName ? "CONTINUAR CURSO" : "ABRIR PLATAFORMA",
+    },
   };
 
-  return emailContent[language] ?? emailContent.en;
+  return emailContent[language];
 };

--- a/packages/email-templates/src/translations/welcome.ts
+++ b/packages/email-templates/src/translations/welcome.ts
@@ -43,7 +43,15 @@ export const getWelcomeEmailTranslations = (language: SupportedLanguages) => {
       ],
       buttonText: "PROHLÉDNOUT KURZY",
     },
+    es: {
+      heading: "Bienvenido",
+      paragraphs: [
+        "Nos alegra tenerte aquí 🙂",
+        "Tu cuenta se ha creado correctamente. Revisa los cursos disponibles.",
+      ],
+      buttonText: "VER CURSOS",
+    },
   };
 
-  return emailContent[language] ?? emailContent.en;
+  return emailContent[language];
 };

--- a/packages/prompts/src/generated-prompts.ts
+++ b/packages/prompts/src/generated-prompts.ts
@@ -1,5 +1,5 @@
 /* AUTO-GENERATED FILE - DO NOT EDIT BY HAND */
-/* Generated At: 6/25/2026, 11:21:05 AM */
+/* Generated At: 6/30/2026, 4:22:47 PM */
 
 export const promptTemplates = {
   judgePrompt: {

--- a/packages/shared/src/constants/languages.ts
+++ b/packages/shared/src/constants/languages.ts
@@ -4,6 +4,7 @@ export const SUPPORTED_LANGUAGES = {
   DE: "de",
   LT: "lt",
   CS: "cs",
+  ES: "es",
 } as const;
 
 export type SupportedLanguages = (typeof SUPPORTED_LANGUAGES)[keyof typeof SUPPORTED_LANGUAGES];

--- a/packages/shared/src/utils/certificate.ts
+++ b/packages/shared/src/utils/certificate.ts
@@ -1,4 +1,4 @@
-import { SupportedLanguages } from "../constants/languages";
+import type { SupportedLanguages } from "../constants/languages";
 
 export interface CertificateRenderTheme {
   titleColor: string;
@@ -111,7 +111,20 @@ const certificateTranslations = {
     expiryDate: "Platí do",
     signature: "Podpis",
   },
-} as const;
+  es: {
+    certificate: "CERTIFICADO",
+    courseCompletion: "DE FINALIZACIÓN DEL CURSO",
+    certifyThat: "SE CERTIFICA QUE",
+    successfulCompletion: {
+      [CERTIFICATE_KIND.COURSE]: "ha completado correctamente el curso",
+      [CERTIFICATE_KIND.LEARNING_PATH]: "ha completado correctamente la ruta de desarrollo",
+    },
+    confirmation: "confirmando así su participación en todo el programa formativo.",
+    date: "Fecha",
+    expiryDate: "Caduca",
+    signature: "Firma",
+  },
+};
 
 export function buildCertificateMarkup(options: BuildCertificateMarkupOptions): string {
   const {


### PR DESCRIPTION
## Issue(s)
- #1698 

## Overview
Adds Spanish language support across the platform.

This includes:
- Spanish as a supported shared language and web i18n locale
- Spanish UI translations and language selector option with flag asset
- Spanish API/email/template translations for notifications and exported labels
- Spanish date/price locale handling
- certificate rendering/copy support across all supported languages
- certificate language selector styling and certificate dialog sizing updates
- generated API/schema updates for the new supported language

## Business Value
Spanish-speaking users can use the LMS interface, receive platform emails, and view certificates in their preferred language. This expands localization coverage and keeps certificate availability consistent across every supported language.

