### PR TITLE
fix: video playback access for unregistered users

### DIFF
--- a/apps/api/src/file/__tests__/thumbnail.service.spec.ts
+++ b/apps/api/src/file/__tests__/thumbnail.service.spec.ts
@@ -7,18 +7,23 @@ describe("ThumbnailService", () => {
   const bunnyVideoId = "22222222-2222-2222-2222-222222222222";
 
   const createService = () => {
-    const where = jest.fn().mockResolvedValue([
+    const resourceWhere = jest.fn().mockResolvedValue([
       {
         id: resourceId,
         reference: `bunny-${bunnyVideoId}`,
         tenantId: "33333333-3333-3333-3333-333333333333",
+      },
+    ]);
+    const resourceLinksWhere = jest.fn().mockResolvedValue([
+      {
         entityType: "unknown",
         entityId: "44444444-4444-4444-4444-444444444444",
       },
     ]);
-    const innerJoin = jest.fn(() => ({ where }));
-    const from = jest.fn(() => ({ innerJoin }));
-    const select = jest.fn(() => ({ from }));
+    const select = jest
+      .fn()
+      .mockReturnValueOnce({ from: jest.fn(() => ({ where: resourceWhere })) })
+      .mockReturnValueOnce({ from: jest.fn(() => ({ where: resourceLinksWhere })) });
     const bunnyStreamService = {
       getThumbnailUrl: jest.fn().mockResolvedValue("https://bunny.example/thumbnail.jpg"),
     };

--- a/apps/api/src/file/thumbnail.service.ts
+++ b/apps/api/src/file/thumbnail.service.ts
@@ -75,18 +75,13 @@ export class ThumbnailService {
     if (!resourceId) throw new BadRequestException("Invalid sourceUrl");
 
     const [resource] = await this.db
-      .select({
-        ...getTableColumns(resources),
-        entityType: resourceEntity.entityType,
-        entityId: resourceEntity.entityId,
-      })
+      .select({ ...getTableColumns(resources) })
       .from(resources)
-      .innerJoin(resourceEntity, eq(resourceEntity.resourceId, resources.id))
       .where(eq(resources.id, resourceId));
 
     if (!resource) throw new BadRequestException("common.toast.notFound");
 
-    await this.validateThumbnailAccess(resource, currentUser);
+    await this.validateThumbnailAccessForResource(resource.id, currentUser);
 
     if (resource.reference.startsWith("bunny-")) {
       const videoId = resource.reference.replace("bunny-", "");
@@ -150,6 +145,34 @@ export class ThumbnailService {
       default:
         return;
     }
+  }
+
+  private async validateThumbnailAccessForResource(
+    resourceId: UUIDType,
+    currentUser: CurrentUserType | null,
+  ) {
+    const resourceLinks = await this.db
+      .select({
+        entityType: resourceEntity.entityType,
+        entityId: resourceEntity.entityId,
+      })
+      .from(resourceEntity)
+      .where(eq(resourceEntity.resourceId, resourceId));
+
+    if (!resourceLinks.length) throw new BadRequestException("common.toast.notFound");
+
+    let accessError: unknown;
+
+    for (const resourceLink of resourceLinks) {
+      try {
+        await this.validateThumbnailAccess(resourceLink, currentUser);
+        return;
+      } catch (error) {
+        accessError = error;
+      }
+    }
+
+    throw accessError;
   }
 
   private async getGlobalSettingsFlags() {
@@ -277,7 +300,7 @@ export class ThumbnailService {
         studentCourses,
         and(
           eq(studentCourses.courseId, chapters.courseId),
-          eq(studentCourses.studentId, currentUserId ?? ""),
+          currentUserId ? eq(studentCourses.studentId, currentUserId) : sql`FALSE`,
         ),
       )
       .where(eq(lessons.id, resourceEntityId));

--- a/apps/api/src/lesson/__tests__/lesson.controller.e2e-spec.ts
+++ b/apps/api/src/lesson/__tests__/lesson.controller.e2e-spec.ts
@@ -61,12 +61,12 @@ describe("LessonController (e2e) - quiz feedback redaction", () => {
       getFileUrl: jest.fn().mockResolvedValue("http://example.com/file"),
       isBunnyConfigured: jest.fn().mockResolvedValue(false),
       getResourcesForEntity: jest.fn().mockResolvedValue([]),
-      getFileDeliveryWithPreview: jest.fn().mockResolvedValue({
+      getFileDeliveryWithPreview: jest.fn().mockImplementation(async () => ({
         type: FILE_DELIVERY_TYPE.STREAM,
         stream: Readable.from(["public video"]),
         contentType: "video/mp4",
         contentLength: "public video".length,
-      }),
+      })),
     };
 
     const mockCacheManager = {
@@ -221,6 +221,49 @@ describe("LessonController (e2e) - quiz feedback redaction", () => {
         entityType: ENTITY_TYPES.LESSON,
         relationshipType: RESOURCE_RELATIONSHIP_TYPES.ATTACHMENT,
       });
+
+      const response = await request(app.getHttpServer())
+        .get(`/api/lesson/lesson-resource/${resource.id}`)
+        .expect(200);
+
+      expect(response.body.toString()).toBe("public video");
+      expect(response.headers["content-type"]).toContain("video/mp4");
+    });
+
+    it("allows guests to stream reused resources attached to a public content lesson", async () => {
+      await setPublicCourseAccess(true);
+      const privateLesson = await createLessonForPublicAccess({
+        isFreemium: false,
+        lessonType: LESSON_TYPES.CONTENT,
+      });
+      const publicLesson = await createLessonForPublicAccess({
+        isFreemium: true,
+        lessonType: LESSON_TYPES.CONTENT,
+      });
+      const [resource] = await db
+        .insert(resources)
+        .values({
+          id: crypto.randomUUID(),
+          reference: "reused-public-video.mp4",
+          contentType: "video/mp4",
+        })
+        .returning();
+      await db.insert(resourceEntity).values([
+        {
+          id: crypto.randomUUID(),
+          resourceId: resource.id,
+          entityId: privateLesson.id,
+          entityType: ENTITY_TYPES.LESSON,
+          relationshipType: RESOURCE_RELATIONSHIP_TYPES.ATTACHMENT,
+        },
+        {
+          id: crypto.randomUUID(),
+          resourceId: resource.id,
+          entityId: publicLesson.id,
+          entityType: ENTITY_TYPES.LESSON,
+          relationshipType: RESOURCE_RELATIONSHIP_TYPES.ATTACHMENT,
+        },
+      ]);
 
       const response = await request(app.getHttpServer())
         .get(`/api/lesson/lesson-resource/${resource.id}`)

--- a/apps/api/src/lesson/repositories/lesson.repository.ts
+++ b/apps/api/src/lesson/repositories/lesson.repository.ts
@@ -299,6 +299,29 @@ export class LessonRepository {
     return Boolean(lessonAccess);
   }
 
+  async getHasPublicContentResourceAccess(resourceId: UUIDType) {
+    const [resourceAccess] = await this.db
+      .select({ id: resources.id })
+      .from(resources)
+      .innerJoin(resourceEntity, eq(resourceEntity.resourceId, resources.id))
+      .innerJoin(lessons, eq(lessons.id, resourceEntity.entityId))
+      .innerJoin(chapters, eq(chapters.id, lessons.chapterId))
+      .leftJoin(settings, and(isNull(settings.userId), eq(settings.tenantId, chapters.tenantId)))
+      .where(
+        and(
+          eq(resources.id, resourceId),
+          eq(resources.archived, false),
+          eq(resourceEntity.entityType, ENTITY_TYPE.LESSON),
+          eq(lessons.type, LESSON_TYPES.CONTENT),
+          eq(chapters.isFreemium, true),
+          sql`COALESCE((${settings.settings}->>'unregisteredUserCoursesAccessibility')::boolean, false)`,
+        ),
+      )
+      .limit(1);
+
+    return Boolean(resourceAccess);
+  }
+
   async getLessonsByChapterId(chapterId: UUIDType, language: SupportedLanguages) {
     return this.db
       .select({

--- a/apps/api/src/lesson/services/lesson.service.ts
+++ b/apps/api/src/lesson/services/lesson.service.ts
@@ -579,9 +579,8 @@ export class LessonService {
         throw new NotFoundException("common.toast.notFound");
       }
 
-      const hasPublicLessonAccess = await this.lessonRepository.getHasPublicContentLessonAccess(
-        lessonResource.entityId,
-      );
+      const hasPublicLessonAccess =
+        await this.lessonRepository.getHasPublicContentResourceAccess(resourceId);
 
       if (!hasPublicLessonAccess) {
         throw new ForbiddenException("common.toast.lessonAccessDenied");


### PR DESCRIPTION
## Overview

Fixes public video playback for unregistered users by authorizing lesson resources by the requested resource ID instead of relying on a single resource-entity row. This allows reused video resources to stream when any linked lesson is a public freemium content lesson and visitor course access is enabled.

The change also updates internal thumbnail access checks to evaluate all entities linked to a resource and allow the thumbnail when at least one linked entity grants access.

## Business Value

Unregistered learners can reliably watch public course videos in freemium lessons, including videos reused across multiple lessons. This keeps publicly accessible course content playable without weakening access checks for private lessons, quizzes, or disabled visitor access.
