### PR TITLE
fix: correct fill-in-the-blank behavior when quiz feedback is hidden

### DIFF
--- a/apps/api/src/lesson/__tests__/lesson.controller.e2e-spec.ts
+++ b/apps/api/src/lesson/__tests__/lesson.controller.e2e-spec.ts
@@ -799,7 +799,7 @@ describe("LessonController (e2e) - quiz feedback redaction", () => {
       }
     });
 
-    it("should show full quiz feedback for admin regardless of quizFeedbackEnabled", async () => {
+    it("should redact quiz feedback for admin when quizFeedbackEnabled is false", async () => {
       const category = await categoryFactory.create();
       const contentCreator = await userFactory.create({ role: SYSTEM_ROLE_SLUGS.CONTENT_CREATOR });
       const admin = await userFactory
@@ -821,6 +821,78 @@ describe("LessonController (e2e) - quiz feedback redaction", () => {
       const chapter = await chapterFactory.create({ courseId: course.id });
 
       const { lesson } = await createQuizLesson(course.id, chapter.id, contentCreator.id);
+      await enableStudentMode(admin.id, course.id);
+
+      const questionsAnswers = await buildQuizAnswers(lesson.id);
+      await resetQuizAttemptState(admin.id, lesson.id);
+
+      await request(app.getHttpServer())
+        .post("/api/lesson/evaluation-quiz")
+        .set("Cookie", cookies)
+        .send({
+          lessonId: lesson.id,
+          language: "en",
+          questionsAnswers,
+        })
+        .expect(201);
+
+      const response = await request(app.getHttpServer())
+        .get(`/api/lesson/${lesson.id}?language=en`)
+        .set("Cookie", cookies)
+        .expect(200);
+
+      expect(response.body.data.isQuizFeedbackRedacted).toBe(true);
+      expect(response.body.data.quizDetails).toBeDefined();
+      expect(response.body.data.thresholdScore).toBe(70);
+
+      if (response.body.data.quizDetails.questions) {
+        for (const question of response.body.data.quizDetails.questions) {
+          expect(question.passQuestion === false || question.passQuestion === null).toBe(true);
+          if (question.options && question.options.length > 0) {
+            for (const option of question.options as Array<{ isCorrect: boolean | null }>) {
+              expect(option.isCorrect === false || option.isCorrect === null).toBe(true);
+            }
+          }
+        }
+      }
+    });
+
+    it("should show full quiz feedback for admin when quizFeedbackEnabled is true", async () => {
+      const category = await categoryFactory.create();
+      const contentCreator = await userFactory.create({ role: SYSTEM_ROLE_SLUGS.CONTENT_CREATOR });
+      const admin = await userFactory
+        .withCredentials({ password })
+        .withAdminSettings(db)
+        .withAdminRole()
+        .create();
+      const cookies = await cookieFor(admin, app);
+
+      const course = await courseFactory.create({
+        authorId: contentCreator.id,
+        categoryId: category.id,
+        status: "published",
+        settings: {
+          lessonSequenceEnabled: false,
+          quizFeedbackEnabled: true,
+        },
+      });
+      const chapter = await chapterFactory.create({ courseId: course.id });
+
+      const { lesson } = await createQuizLesson(course.id, chapter.id, contentCreator.id);
+      await enableStudentMode(admin.id, course.id);
+
+      const questionsAnswers = await buildQuizAnswers(lesson.id);
+      await resetQuizAttemptState(admin.id, lesson.id);
+
+      await request(app.getHttpServer())
+        .post("/api/lesson/evaluation-quiz")
+        .set("Cookie", cookies)
+        .send({
+          lessonId: lesson.id,
+          language: "en",
+          questionsAnswers,
+        })
+        .expect(201);
 
       const response = await request(app.getHttpServer())
         .get(`/api/lesson/${lesson.id}?language=en`)
@@ -830,6 +902,67 @@ describe("LessonController (e2e) - quiz feedback redaction", () => {
       expect(response.body.data.isQuizFeedbackRedacted).toBe(false);
       expect(response.body.data.quizDetails).toBeDefined();
       expect(response.body.data.thresholdScore).toBe(70);
+      expect(
+        response.body.data.quizDetails.questions.some(
+          (question: { options?: Array<{ isCorrect: boolean | null }> }) =>
+            question.options?.some((option) => option.isCorrect === true),
+        ),
+      ).toBe(true);
+    });
+
+    it("should redact quiz feedback for the course author when quizFeedbackEnabled is false", async () => {
+      const category = await categoryFactory.create();
+      const author = await userFactory
+        .withCredentials({ password })
+        .withContentCreatorSettings(db)
+        .create();
+      const cookies = await cookieFor(author, app);
+
+      const course = await courseFactory.create({
+        authorId: author.id,
+        categoryId: category.id,
+        status: "published",
+        settings: {
+          lessonSequenceEnabled: false,
+          quizFeedbackEnabled: false,
+        },
+      });
+      const chapter = await chapterFactory.create({ courseId: course.id, authorId: author.id });
+
+      const { lesson } = await createQuizLesson(course.id, chapter.id, author.id);
+      await enableStudentMode(author.id, course.id);
+
+      const questionsAnswers = await buildQuizAnswers(lesson.id);
+      await resetQuizAttemptState(author.id, lesson.id);
+
+      await request(app.getHttpServer())
+        .post("/api/lesson/evaluation-quiz")
+        .set("Cookie", cookies)
+        .send({
+          lessonId: lesson.id,
+          language: "en",
+          questionsAnswers,
+        })
+        .expect(201);
+
+      const response = await request(app.getHttpServer())
+        .get(`/api/lesson/${lesson.id}?language=en`)
+        .set("Cookie", cookies)
+        .expect(200);
+
+      expect(response.body.data.isQuizFeedbackRedacted).toBe(true);
+      expect(response.body.data.quizDetails).toBeDefined();
+
+      if (response.body.data.quizDetails.questions) {
+        for (const question of response.body.data.quizDetails.questions) {
+          expect(question.passQuestion === false || question.passQuestion === null).toBe(true);
+          if (question.options && question.options.length > 0) {
+            for (const option of question.options as Array<{ isCorrect: boolean | null }>) {
+              expect(option.isCorrect === false || option.isCorrect === null).toBe(true);
+            }
+          }
+        }
+      }
     });
   });
 

--- a/apps/api/src/lesson/services/lesson.service.ts
+++ b/apps/api/src/lesson/services/lesson.service.ts
@@ -223,7 +223,7 @@ export class LessonService {
       basicInfo?.languageAnswered ?? actualLanguage,
     );
 
-    const isQuizFeedbackRedacted = isStudent && !lesson.quizFeedbackEnabled;
+    const isQuizFeedbackRedacted = !lesson.quizFeedbackEnabled;
 
     const questionListWithUrls: QuestionBody[] = await Promise.all(
       questionList.map(async (question) => {

--- a/apps/web/app/api/mutations/useRetakeQuiz.ts
+++ b/apps/web/app/api/mutations/useRetakeQuiz.ts
@@ -8,7 +8,7 @@ import { getTranslatedApiErrorMessage } from "../utils/getTranslatedApiErrorMess
 
 type RetakeQuizProps = {
   lessonId: string;
-  handleOnSuccess: () => void;
+  handleOnSuccess: () => Promise<void> | void;
 };
 
 export function useRetakeQuiz({ lessonId, handleOnSuccess }: RetakeQuizProps) {
@@ -20,8 +20,8 @@ export function useRetakeQuiz({ lessonId, handleOnSuccess }: RetakeQuizProps) {
       const response = await ApiClient.api.lessonControllerDeleteStudentQuizAnswers({ lessonId });
       return response.data;
     },
-    onSuccess: () => {
-      handleOnSuccess();
+    onSuccess: async () => {
+      await handleOnSuccess();
     },
     onError: (error) => {
       toast({

--- a/apps/web/app/modules/Courses/Lesson/Question/FillInTheBlanks/FillInTheBlanks.tsx
+++ b/apps/web/app/modules/Courses/Lesson/Question/FillInTheBlanks/FillInTheBlanks.tsx
@@ -4,6 +4,8 @@ import Viewer from "~/components/RichText/Viever";
 import { Card } from "~/components/ui/card";
 import { useQuizContext } from "~/modules/Courses/components/QuizContextProvider";
 
+import { LEARNING_HANDLES } from "../../../../../../e2e/data/learning/handles";
+
 import { getCorrectSentence } from "./correctSentence";
 import { FillInTheTextBlanks } from "./FillInTheTextBlanks";
 import { TextBlank } from "./TextBlank";
@@ -58,7 +60,7 @@ export const FillInTheBlanks = ({ question, isCompleted }: FillInTheBlanksProps)
         }}
       />
       {showCorrectSentence && (
-        <div>
+        <div data-testid={LEARNING_HANDLES.FILL_IN_THE_BLANKS_CORRECT_SENTENCE}>
           <span className="body-base-md text-error-700">
             {t("studentLessonView.other.correctSentence")}
           </span>

--- a/apps/web/app/modules/Courses/Lesson/Question/FillInTheBlanks/dnd/FillInTheBlanksDnd.tsx
+++ b/apps/web/app/modules/Courses/Lesson/Question/FillInTheBlanks/dnd/FillInTheBlanksDnd.tsx
@@ -22,6 +22,7 @@ import Viewer from "~/components/RichText/Viever";
 import { useQuizContext } from "~/modules/Courses/components/QuizContextProvider";
 import { getBlankAnswerIds, getBlankCount } from "~/utils/blankAnswerMarkers";
 
+import { LEARNING_HANDLES } from "../../../../../../../e2e/data/learning/handles";
 import { getCorrectSentence } from "../correctSentence";
 
 import { DndBlank } from "./DndBlank";
@@ -445,7 +446,10 @@ export const FillInTheBlanksDnd: FC<FillInTheBlanksDndProps> = ({ question, isCo
         />
         <WordBank words={renderedWordBankWords} />
         {showCorrectSentence && (
-          <div className="mt-4">
+          <div
+            className="mt-4"
+            data-testid={LEARNING_HANDLES.FILL_IN_THE_BLANKS_DND_CORRECT_SENTENCE}
+          >
             <span className="body-base-md text-error-700">
               {t("studentLessonView.other.correctSentence")}
             </span>

--- a/apps/web/app/modules/Courses/Lesson/Quiz.tsx
+++ b/apps/web/app/modules/Courses/Lesson/Quiz.tsx
@@ -86,9 +86,9 @@ export const Quiz = ({ lesson, userId }: QuizProps) => {
 
   const retakeQuiz = useRetakeQuiz({
     lessonId: lesson.id,
-    handleOnSuccess: () => {
+    handleOnSuccess: async () => {
       setIsRetakingQuiz(true);
-      queryClient.invalidateQueries({ queryKey: ["lesson", lesson.id] });
+      await queryClient.invalidateQueries(lessonQueryOptions(lesson.id, language, userId));
       methods.reset(getEmptyQuizAnswers(questions ?? []));
     },
   });

--- a/apps/web/e2e/data/learning/handles.ts
+++ b/apps/web/e2e/data/learning/handles.ts
@@ -9,6 +9,8 @@ export const LEARNING_HANDLES = {
   QUIZ_PASSING_THRESHOLD: "learning-quiz-passing-threshold",
   QUIZ_SUBMIT_BUTTON: "learning-quiz-submit-button",
   QUIZ_RETAKE_BUTTON: "learning-quiz-retake-button",
+  FILL_IN_THE_BLANKS_CORRECT_SENTENCE: "learning-fill-in-the-blanks-correct-sentence",
+  FILL_IN_THE_BLANKS_DND_CORRECT_SENTENCE: "learning-fill-in-the-blanks-dnd-correct-sentence",
   AI_MENTOR_TASK_DESCRIPTION: "learning-ai-mentor-task-description",
   AI_MENTOR_MESSAGES: "learning-ai-mentor-messages",
   AI_MENTOR_MESSAGE: "learning-ai-mentor-message",

--- a/apps/web/e2e/specs/learning/learning-test-helpers.ts
+++ b/apps/web/e2e/specs/learning/learning-test-helpers.ts
@@ -425,3 +425,39 @@ export const createAllRenderedQuestionTypesQuizCourse = async (
       return { quizLesson, textBlankAnswer, dndBlankAnswer, dndBlankAnswerId };
     },
   });
+
+export const createTextGapFillQuizCourse = async (
+  input: Omit<
+    CreatePublishedLearningCourseInput<{
+      quizLesson: CurriculumCourseLessonRecord;
+      textBlankAnswer: string;
+      wrongTextBlankAnswer: string;
+    }>,
+    "buildLessons"
+  >,
+) =>
+  createPublishedLearningCourse({
+    ...input,
+    categoryTitle: (prefix) => `Learning Text Gap Fill Category ${prefix}`,
+    buildLessons: async ({ courseId, chapterId, curriculumFactory, prefix }) => {
+      const textBlankAnswer = `${prefix}-correct-gap`;
+      const wrongTextBlankAnswer = `${prefix}-wrong-gap`;
+      const quizLesson = await curriculumFactory.createQuizLesson(courseId, {
+        chapterId,
+        title: `${prefix}-quiz-lesson`,
+        displayOrder: 1,
+        thresholdScore: 0,
+        questions: [
+          {
+            type: "fill_in_the_blanks_text",
+            title: `${prefix}-fill-text`,
+            description: "Type the [word] answer.",
+            displayOrder: 1,
+            options: [{ optionText: textBlankAnswer, displayOrder: 1, isCorrect: true }],
+          },
+        ],
+      });
+
+      return { quizLesson, textBlankAnswer, wrongTextBlankAnswer };
+    },
+  });

--- a/apps/web/e2e/specs/learning/quiz-feedback.spec.ts
+++ b/apps/web/e2e/specs/learning/quiz-feedback.spec.ts
@@ -1,0 +1,165 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { LEARNING_HANDLES } from "../../data/learning/handles";
+import { expect, test } from "../../fixtures/test.fixture";
+import { openCourseOverviewFlow } from "../../flows/learning/open-course-overview.flow";
+import { retakeQuizFlow } from "../../flows/learning/retake-quiz.flow";
+import { startLearningFlow } from "../../flows/learning/start-learning.flow";
+import { submitQuizFlow } from "../../flows/learning/submit-quiz.flow";
+
+import { createTextGapFillQuizCourse } from "./learning-test-helpers";
+
+test("student sees the correct answer for an incorrect text gap fill when quiz feedback is enabled", async ({
+  cleanup,
+  factories,
+  withWorkerPage,
+}) => {
+  const enrollmentFactory = factories.createEnrollmentFactory();
+
+  let quizWasSubmitted = false;
+
+  const { courseId, lessons } = await createTextGapFillQuizCourse({
+    cleanup,
+    factories,
+    prefix: `learning-quiz-feedback-gap-${Date.now()}`,
+    shouldKeepCourseAfterTest: () => quizWasSubmitted,
+    withWorkerPage,
+  });
+  const { quizLesson, textBlankAnswer, wrongTextBlankAnswer } = lessons;
+
+  await withWorkerPage(
+    USER_ROLE.student,
+    async ({ page }) => {
+      await enrollmentFactory.selfEnroll(courseId);
+
+      await openCourseOverviewFlow(page, courseId);
+      await startLearningFlow(page);
+
+      await expect(page).toHaveURL(new RegExp(`/course/.+/lesson/${quizLesson.id}$`));
+      await expect(page.getByTestId(LEARNING_HANDLES.QUIZ_FORM)).toBeVisible();
+
+      await page.getByTestId("text-blank-1").fill(wrongTextBlankAnswer);
+      await submitQuizFlow(page);
+      quizWasSubmitted = true;
+
+      await expect(page.getByTestId(LEARNING_HANDLES.QUIZ_SUBMIT_BUTTON)).toBeDisabled();
+      await expect(
+        page.getByTestId(LEARNING_HANDLES.FILL_IN_THE_BLANKS_CORRECT_SENTENCE),
+      ).toContainText(textBlankAnswer);
+    },
+    { root: true },
+  );
+});
+
+test("student does not see text gap fill feedback after retaking a quiz when feedback is disabled", async ({
+  apiClient,
+  cleanup,
+  factories,
+  withWorkerPage,
+}) => {
+  const enrollmentFactory = factories.createEnrollmentFactory();
+
+  let quizWasSubmitted = false;
+
+  const { courseId, lessons } = await createTextGapFillQuizCourse({
+    cleanup,
+    factories,
+    prefix: `learning-quiz-feedback-disabled-${Date.now()}`,
+    settings: { quizFeedbackEnabled: false },
+    shouldKeepCourseAfterTest: () => quizWasSubmitted,
+    withWorkerPage,
+  });
+  const { quizLesson, wrongTextBlankAnswer } = lessons;
+
+  await withWorkerPage(
+    USER_ROLE.student,
+    async ({ page }) => {
+      await enrollmentFactory.selfEnroll(courseId);
+      const studentId = await enrollmentFactory.getCurrentUserId();
+
+      await openCourseOverviewFlow(page, courseId);
+      await startLearningFlow(page);
+
+      await expect(page).toHaveURL(new RegExp(`/course/.+/lesson/${quizLesson.id}$`));
+      await expect(page.getByTestId(LEARNING_HANDLES.QUIZ_FORM)).toBeVisible();
+
+      await page.getByTestId("text-blank-1").fill(wrongTextBlankAnswer);
+      await submitQuizFlow(page);
+      quizWasSubmitted = true;
+
+      await expect(page.getByTestId(LEARNING_HANDLES.QUIZ_SUBMIT_BUTTON)).toBeDisabled();
+      await expect(
+        page.getByTestId(LEARNING_HANDLES.FILL_IN_THE_BLANKS_CORRECT_SENTENCE),
+      ).toBeHidden();
+
+      await retakeQuizFlow(page);
+
+      await expect(page.getByTestId("text-blank-1")).toBeEditable();
+      await page.getByTestId("text-blank-1").fill(`${wrongTextBlankAnswer}-retake`);
+      await submitQuizFlow(page);
+
+      await expect(page.getByTestId(LEARNING_HANDLES.QUIZ_SUBMIT_BUTTON)).toBeDisabled();
+      await expect(
+        page.getByTestId(LEARNING_HANDLES.FILL_IN_THE_BLANKS_CORRECT_SENTENCE),
+      ).toBeHidden();
+
+      await expect
+        .poll(
+          async () => {
+            const response = await apiClient.api.lessonControllerGetLessonById(quizLesson.id, {
+              language: "en",
+              studentId,
+            });
+
+            return response.data.data.isQuizFeedbackRedacted;
+          },
+          { timeout: 15_000 },
+        )
+        .toBe(true);
+    },
+    { root: true },
+  );
+});
+
+test("admin does not see text gap fill feedback in learning mode when feedback is disabled", async ({
+  cleanup,
+  factories,
+  withWorkerPage,
+}) => {
+  let quizWasSubmitted = false;
+
+  const { courseId, lessons } = await createTextGapFillQuizCourse({
+    cleanup,
+    factories,
+    prefix: `learning-quiz-feedback-admin-disabled-${Date.now()}`,
+    settings: { quizFeedbackEnabled: false },
+    shouldKeepCourseAfterTest: () => quizWasSubmitted,
+    withWorkerPage,
+  });
+  const { quizLesson, wrongTextBlankAnswer } = lessons;
+
+  await withWorkerPage(
+    USER_ROLE.admin,
+    async ({ page }) => {
+      const courseFactory = factories.createCourseFactory();
+
+      await courseFactory.setStudentMode(courseId, true);
+
+      await openCourseOverviewFlow(page, courseId);
+      await startLearningFlow(page);
+
+      await expect(page).toHaveURL(new RegExp(`/course/.+/lesson/${quizLesson.id}$`));
+      await expect(page.getByTestId(LEARNING_HANDLES.QUIZ_FORM)).toBeVisible();
+
+      await page.getByTestId("text-blank-1").fill(wrongTextBlankAnswer);
+      await submitQuizFlow(page);
+      quizWasSubmitted = true;
+
+      await expect(page.getByTestId(LEARNING_HANDLES.QUIZ_SUBMIT_BUTTON)).toBeDisabled();
+      await expect(
+        page.getByTestId(LEARNING_HANDLES.FILL_IN_THE_BLANKS_CORRECT_SENTENCE),
+      ).toBeHidden();
+    },
+    { root: true },
+  );
+});

--- a/docs/specs/quiz-assessment-engine-business-spec.md
+++ b/docs/specs/quiz-assessment-engine-business-spec.md
@@ -24,6 +24,7 @@ The core workflow starts in curriculum authoring, where a creator adds a quiz le
 - Require learners to answer every quiz question before submission.
 - Score learner submissions and store question results.
 - Show feedback after submission, including correct-answer context for failed gap-filling questions when feedback is enabled.
+- Hide answer-level feedback after submission, retakes, and privileged lesson views when course quiz feedback is disabled.
 - Mark the lesson complete only when the learner passes the quiz.
 - Let learners retake eligible quizzes and show why retake is unavailable when attempts or cooldown rules block it.
 
@@ -37,7 +38,7 @@ A course author adds a quiz lesson in the curriculum builder, gives it a title, 
 
 A learner opens the quiz lesson, answers every rendered question, and submits the form. Mentingo validates that no expected question is missing, evaluates the answers, calculates the percentage score, and compares the result with the passing threshold. Passing submissions complete the lesson and can unlock course progression; failed submissions keep progression rules in place.
 
-After submission, learners can review which answers were accepted when quiz feedback is enabled for the course. Fill-in-the-blanks questions show the correct completed sentence for failed answers, so learners can understand the intended wording instead of seeing only the words they chose.
+After submission, learners can review which answers were accepted when quiz feedback is enabled for the course. Fill-in-the-blanks questions show the correct completed sentence for failed answers, so learners can understand the intended wording instead of seeing only the words they chose. When course feedback is disabled, Mentingo still records the score and submitted answer but keeps answer-level correction details hidden, including after a learner starts and submits a retake or when an admin opens the lesson view.
 
 When a learner retakes a quiz, Mentingo first checks the attempt limit and cooldown. If retake is allowed, previous answers are cleared and a new attempt begins. If not, the retake button remains disabled and the interface explains the remaining limit or cooldown.
 
@@ -52,4 +53,4 @@ When a learner retakes a quiz, Mentingo first checks the attempt limit and coold
 
 ## Test Evidence
 
-Frontend E2E coverage verifies quiz authoring for choice, text, fill-in-the-blanks, and photo questions; confirms unavailable question types in the builder; verifies learner submission with every rendered question type; covers quiz retake, final-quiz retake after certificate completion, and blocked progression after failing a required quiz. Unit coverage verifies the fallback correct-sentence rendering for completed fill-in-the-blanks questions. Source evidence covers backend validation for missing answers, duplicate completed submissions, threshold scoring, answer storage, retake attempts, cooldown checks, and quiz completion events.
+Frontend E2E coverage verifies quiz authoring for choice, text, fill-in-the-blanks, and photo questions; confirms unavailable question types in the builder; verifies learner submission with every rendered question type; covers quiz retake, final-quiz retake after certificate completion, blocked progression after failing a required quiz, visible text gap-fill correction when feedback is enabled, and hidden gap-fill correction after retake when feedback is disabled. Unit coverage verifies the fallback correct-sentence rendering for completed fill-in-the-blanks questions. Backend E2E coverage verifies feedback redaction for learners, admins, and course authors when the course setting disables feedback. Source evidence covers backend validation for missing answers, duplicate completed submissions, threshold scoring, answer storage, retake attempts, cooldown checks, feedback redaction, and quiz completion events.


### PR DESCRIPTION
## Issue(s)
- #1705

## Overview
Fixes quiz feedback handling for gap-fill questions and redaction:

- Shows correct-sentence feedback for incorrect text gap-fill answers when quiz feedback is enabled.
- Keeps text/DND gap-fill correct-sentence feedback hidden when quiz feedback is disabled.
- Applies quiz feedback redaction to privileged lesson views too, so admins and course authors do not bypass disabled feedback.
- Invalidates the exact lesson query after retake so the learner view refreshes with the correct feedback state.
- Adds focused backend and frontend E2E coverage for the regression.
- Updates the quiz assessment business spec.

## Business Value
Learners get useful correction context when quiz feedback is intentionally enabled, especially for text gap-fill questions where the correct answer was previously missing.

When feedback is disabled, Mentingo now enforces that decision consistently across learners, retakes, admins, and course authors. This keeps assessment feedback controlled by course configuration and avoids accidentally exposing answers through privileged views.

## Screenshots / Video

https://github.com/user-attachments/assets/a59e5954-8134-4321-9894-335c0035d4bf


