### PR TITLE
chore: protect private courses from being deleted

### DIFF
--- a/apps/api/src/courses/__tests__/course.controller.e2e-spec.ts
+++ b/apps/api/src/courses/__tests__/course.controller.e2e-spec.ts
@@ -5,6 +5,7 @@ import {
   COURSE_ENROLLMENT,
   COURSE_FEATURE,
   COURSE_FEATURE_ERROR_TRANSLATION_KEY,
+  COURSE_STATUSES,
   COURSE_TYPE,
   ENTITY_TYPES,
   PERMISSIONS,
@@ -1693,6 +1694,138 @@ describe("CourseController (e2e)", () => {
         .expect(400);
 
       expect(response.body.message).toBe("adminCoursesView.toast.noCoursesSelected");
+    });
+  });
+
+  describe("DELETE /api/course/deleteCourse/:id", () => {
+    it("deletes a draft course", async () => {
+      const admin = await userFactory
+        .withCredentials({ password })
+        .withAdminSettings(db)
+        .withAdminRole()
+        .create();
+      const cookies = await cookieFor(admin, app);
+      const category = await categoryFactory.create();
+      const course = await courseFactory.create({
+        authorId: admin.id,
+        categoryId: category.id,
+        status: COURSE_STATUSES.DRAFT,
+        thumbnailS3Key: null,
+      });
+
+      await request(app.getHttpServer())
+        .delete(`/api/course/deleteCourse/${course.id}`)
+        .set("Cookie", cookies)
+        .expect(200);
+
+      const deletedCourse = await db.select().from(courses).where(eq(courses.id, course.id));
+
+      expect(deletedCourse).toHaveLength(0);
+    });
+
+    it.each([COURSE_STATUSES.PUBLISHED, COURSE_STATUSES.PRIVATE])(
+      "rejects deleting a %s course",
+      async (status) => {
+        const admin = await userFactory
+          .withCredentials({ password })
+          .withAdminSettings(db)
+          .withAdminRole()
+          .create();
+        const cookies = await cookieFor(admin, app);
+        const category = await categoryFactory.create();
+        const course = await courseFactory.create({
+          authorId: admin.id,
+          categoryId: category.id,
+          status,
+          thumbnailS3Key: null,
+        });
+
+        const response = await request(app.getHttpServer())
+          .delete(`/api/course/deleteCourse/${course.id}`)
+          .set("Cookie", cookies)
+          .expect(403);
+
+        expect(response.body.message).toBe("adminCoursesView.toast.deleteProtectedCourseFailed");
+
+        const [existingCourse] = await db.select().from(courses).where(eq(courses.id, course.id));
+
+        expect(existingCourse.id).toBe(course.id);
+      },
+    );
+  });
+
+  describe("DELETE /api/course/deleteManyCourses", () => {
+    it("deletes draft courses", async () => {
+      const admin = await userFactory
+        .withCredentials({ password })
+        .withAdminSettings(db)
+        .withAdminRole()
+        .create();
+      const cookies = await cookieFor(admin, app);
+      const category = await categoryFactory.create();
+      const draftCourses = await Promise.all([
+        courseFactory.create({
+          authorId: admin.id,
+          categoryId: category.id,
+          status: COURSE_STATUSES.DRAFT,
+          thumbnailS3Key: null,
+        }),
+        courseFactory.create({
+          authorId: admin.id,
+          categoryId: category.id,
+          status: COURSE_STATUSES.DRAFT,
+          thumbnailS3Key: null,
+        }),
+      ]);
+      const courseIds = draftCourses.map((course) => course.id);
+
+      await request(app.getHttpServer())
+        .delete("/api/course/deleteManyCourses")
+        .send({ ids: courseIds })
+        .set("Cookie", cookies)
+        .expect(200);
+
+      const deletedCourses = await db.select().from(courses).where(inArray(courses.id, courseIds));
+
+      expect(deletedCourses).toHaveLength(0);
+    });
+
+    it("rejects deleting a selection that includes a private course", async () => {
+      const admin = await userFactory
+        .withCredentials({ password })
+        .withAdminSettings(db)
+        .withAdminRole()
+        .create();
+      const cookies = await cookieFor(admin, app);
+      const category = await categoryFactory.create();
+      const draftCourse = await courseFactory.create({
+        authorId: admin.id,
+        categoryId: category.id,
+        status: COURSE_STATUSES.DRAFT,
+        thumbnailS3Key: null,
+      });
+      const privateCourse = await courseFactory.create({
+        authorId: admin.id,
+        categoryId: category.id,
+        status: COURSE_STATUSES.PRIVATE,
+        thumbnailS3Key: null,
+      });
+      const courseIds = [draftCourse.id, privateCourse.id];
+
+      const response = await request(app.getHttpServer())
+        .delete("/api/course/deleteManyCourses")
+        .send({ ids: courseIds })
+        .set("Cookie", cookies)
+        .expect(403);
+
+      expect(response.body.message).toBe("adminCoursesView.toast.deleteProtectedCourseFailed");
+
+      const remainingCourses = await db
+        .select()
+        .from(courses)
+        .where(inArray(courses.id, courseIds));
+
+      expect(remainingCourses).toHaveLength(2);
     });
   });
 

--- a/apps/api/src/courses/course.constants.ts
+++ b/apps/api/src/courses/course.constants.ts
@@ -1,1 +1,8 @@
+import { COURSE_STATUSES, type CourseStatus } from "@repo/shared";
+
 export const COURSE_BULK_STATUS_UPDATE_BATCH_SIZE = 25;
+
+export const PROTECTED_COURSE_DELETE_STATUSES: CourseStatus[] = [
+  COURSE_STATUSES.PUBLISHED,
+  COURSE_STATUSES.PRIVATE,
+];

--- a/apps/api/src/courses/course.service.ts
+++ b/apps/api/src/courses/course.service.ts
@@ -12,8 +12,8 @@ import {
 import { OverdueCoursesEmail } from "@repo/email-templates";
 import {
   COURSE_FEATURE,
-  COURSE_TYPE,
   COURSE_ENROLLMENT,
+  COURSE_TYPE,
   ENTITY_TYPES,
   PERMISSIONS,
   type LocalizedText,
@@ -129,7 +129,10 @@ import { COURSE_DUE_DATE_REMINDER_DAYS } from "./constants/course-due-date-remin
 import { DURATION_DEFAULTS } from "./constants/duration-defaults";
 import { CourseFeaturePolicyService } from "./course-feature-policy.service";
 import { CourseSlugService } from "./course-slug.service";
-import { COURSE_BULK_STATUS_UPDATE_BATCH_SIZE } from "./course.constants";
+import {
+  COURSE_BULK_STATUS_UPDATE_BATCH_SIZE,
+  PROTECTED_COURSE_DELETE_STATUSES,
+} from "./course.constants";
 import { GroupCourseDueDateCalendarService } from "./group-course-due-date-calendar.service";
 import { MasterCourseService } from "./master-course.service";
 import {
@@ -3221,8 +3224,8 @@ export class CourseService {
       throw new ForbiddenException("You don't have permission to delete this course");
     }
 
-    if (course.status === "published") {
-      throw new ForbiddenException("adminCoursesView.toast.deletePublishedCourseFailed");
+    if (PROTECTED_COURSE_DELETE_STATUSES.includes(course.status)) {
+      throw new ForbiddenException("adminCoursesView.toast.deleteProtectedCourseFailed");
     }
 
     const { enabled: isLumaConfigured } = await this.envService.getLumaConfigured();
@@ -3267,8 +3270,8 @@ export class CourseService {
 
     const course = await this.db.select().from(courses).where(inArray(courses.id, ids));
 
-    if (course.some((course) => course.status === "published")) {
-      throw new ForbiddenException("adminCoursesView.toast.deletePublishedCourseFailed");
+    if (course.some((course) => PROTECTED_COURSE_DELETE_STATUSES.includes(course.status))) {
+      throw new ForbiddenException("adminCoursesView.toast.deleteProtectedCourseFailed");
     }
 
     return this.db.transaction(async (trx) => {

--- a/apps/api/src/storage/schema/index.ts
+++ b/apps/api/src/storage/schema/index.ts
@@ -67,6 +67,7 @@ import {
 } from "./utils";
 
 import type {
+  CourseStatus,
   CourseType,
   CourseOriginType,
   FormType,
@@ -303,7 +304,7 @@ export const courses = pgTable(
     title: jsonb("title").$type<LocalizedText>().default({}).notNull(),
     description: jsonb("description").$type<LocalizedText>().default({}).notNull(),
     thumbnailS3Key: varchar("thumbnail_s3_key", { length: 500 }),
-    status: coursesStatusEnum("status").notNull().default("draft"),
+    status: coursesStatusEnum("status").$type<CourseStatus>().notNull().default("draft"),
     hasCertificate: boolean("has_certificate").notNull().default(false),
     priceInCents: integer("price_in_cents").notNull().default(0),
     currency: varchar("currency").notNull().default("usd"),

--- a/apps/web/app/locales/cs/translation.json
+++ b/apps/web/app/locales/cs/translation.json
@@ -1243,7 +1243,7 @@
     "toast": {
       "deleteCourseSuccessfully": "Kurz byl úspěšně smazán",
       "deleteCourseFailed": "Kurz se nepodařilo smazat",
-      "deletePublishedCourseFailed": "Publikovaný kurz nelze smazat. Nejprve nastavte její stav na Koncept.",
+      "deleteProtectedCourseFailed": "Publikovaný ani soukromý kurz nelze smazat. Nejprve nastavte jeho stav na Koncept.",
       "bulkCategoryUpdateSuccessfully": "Kategorie kurzů byly úspěšně aktualizovány",
       "bulkCategoryUpdateFailed": "Nepodařilo se aktualizovat kategorie kurzů",
       "bulkCategoryUpdateForbidden": "Nemáte oprávnění aktualizovat jeden nebo více vybraných kurzů.",

--- a/apps/web/app/locales/de/translation.json
+++ b/apps/web/app/locales/de/translation.json
@@ -1237,7 +1237,7 @@
     "toast": {
       "deleteCourseSuccessfully": "Kurs erfolgreich gelöscht",
       "deleteCourseFailed": "Der Kurs konnte nicht gelöscht werden",
-      "deletePublishedCourseFailed": "Ein veröffentlichter Kurs kann nicht gelöscht werden. Bitte setzen Sie den Status zunächst auf „Entwurf“.",
+      "deleteProtectedCourseFailed": "Ein veröffentlichter oder privater Kurs kann nicht gelöscht werden. Bitte setzen Sie den Status zunächst auf „Entwurf“.",
       "bulkCategoryUpdateSuccessfully": "Kurskategorien wurden erfolgreich aktualisiert",
       "bulkCategoryUpdateFailed": "Kurskategorien konnten nicht aktualisiert werden",
       "bulkCategoryUpdateForbidden": "Sie haben keine Berechtigung, einen oder mehrere ausgewählte Kurse zu aktualisieren.",

--- a/apps/web/app/locales/en/translation.json
+++ b/apps/web/app/locales/en/translation.json
@@ -1238,7 +1238,7 @@
     "toast": {
       "deleteCourseSuccessfully": "Course deleted successfully",
       "deleteCourseFailed": "Failed to delete course",
-      "deletePublishedCourseFailed": "Cannot delete a published course. Please set its status to Draft first.",
+      "deleteProtectedCourseFailed": "Cannot delete a published or private course. Please set its status to Draft first.",
       "bulkCategoryUpdateSuccessfully": "Course categories updated successfully",
       "bulkCategoryUpdateFailed": "Failed to update course categories",
       "bulkCategoryUpdateForbidden": "You do not have permission to update one or more selected courses.",

--- a/apps/web/app/locales/es/translation.json
+++ b/apps/web/app/locales/es/translation.json
@@ -1238,7 +1238,7 @@
     "toast": {
       "deleteCourseSuccessfully": "Curso eliminado exitosamente",
       "deleteCourseFailed": "No se pudo eliminar el curso",
-      "deletePublishedCourseFailed": "No se puede eliminar un curso publicado. Primero establezca su estado en Borrador.",
+      "deleteProtectedCourseFailed": "No se puede eliminar un curso publicado o privado. Primero establezca su estado en Borrador.",
       "bulkCategoryUpdateSuccessfully": "Categorías de cursos actualizadas exitosamente",
       "bulkCategoryUpdateFailed": "No se pudieron actualizar las categorías del curso",
       "bulkCategoryUpdateForbidden": "No tienes permiso para actualizar uno o más cursos seleccionados.",

--- a/apps/web/app/locales/lt/translation.json
+++ b/apps/web/app/locales/lt/translation.json
@@ -1243,7 +1243,7 @@
     "toast": {
       "deleteCourseSuccessfully": "Kursas sėkmingai ištrintas",
       "deleteCourseFailed": "Nepavyko ištrinti kurso",
-      "deletePublishedCourseFailed": "Negalima ištrinti paskelbto kurso. Pirmiausia nustatykite jo būseną į juodraštį.",
+      "deleteProtectedCourseFailed": "Negalima ištrinti paskelbto ar privataus kurso. Pirmiausia nustatykite jo būseną į juodraštį.",
       "bulkCategoryUpdateSuccessfully": "Kursų kategorijos sėkmingai atnaujintos",
       "bulkCategoryUpdateFailed": "Nepavyko atnaujinti kursų kategorijų",
       "bulkCategoryUpdateForbidden": "Neturite teisės atnaujinti vieno ar daugiau pasirinktų kursų.",

--- a/apps/web/app/locales/pl/translation.json
+++ b/apps/web/app/locales/pl/translation.json
@@ -1457,7 +1457,7 @@
     "toast": {
       "deleteCourseSuccessfully": "Kurs został usunięty pomyślnie",
       "deleteCourseFailed": "Nie udało się usunąć kursu",
-      "deletePublishedCourseFailed": "Nie można usunąć opublikowanego kursu. Najpierw zmień jego status na Wersja Robocza.",
+      "deleteProtectedCourseFailed": "Nie można usunąć opublikowanego ani prywatnego kursu. Najpierw zmień jego status na Wersja Robocza.",
       "bulkCategoryUpdateSuccessfully": "Kategorie kursów zostały zaktualizowane",
       "bulkCategoryUpdateFailed": "Nie udało się zaktualizować kategorii kursów",
       "bulkCategoryUpdateForbidden": "Nie masz uprawnień do aktualizacji co najmniej jednego z wybranych kursów.",

--- a/apps/web/e2e/factories/course.factory.ts
+++ b/apps/web/e2e/factories/course.factory.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from "node:crypto";
 
+import { COURSE_STATUSES, type CourseStatus } from "@repo/shared";
+
 import { TEST_DATA } from "../data/test-data/entity-name.data";
 
 import type { FixtureApiClient } from "../utils/api-client";
@@ -19,6 +21,10 @@ export type CourseFactoryCreateInput = Partial<CreateCourseBody> & {
 export type CourseFactoryUpdateInput = UpdateCourseBody;
 
 const createCourseTitle = () => `${TEST_DATA.course.titlePrefix} ${randomUUID().slice(0, 8)}`;
+const PROTECTED_COURSE_DELETE_STATUSES: CourseStatus[] = [
+  COURSE_STATUSES.PUBLISHED,
+  COURSE_STATUSES.PRIVATE,
+];
 
 export class CourseFactory {
   constructor(private readonly apiClient: FixtureApiClient) {}
@@ -127,6 +133,8 @@ export class CourseFactory {
     const existingCourse = await this.safeGetById(id);
     if (!existingCourse) return;
 
+    await this.prepareCourseForDeletion(existingCourse);
+
     await this.apiClient.api.courseControllerDeleteCourse(id);
   }
 
@@ -140,7 +148,20 @@ export class CourseFactory {
 
     if (existingIds.length === 0) return;
 
+    await Promise.all(
+      existingCourses.map((course) => course && this.prepareCourseForDeletion(course)),
+    );
+
     await this.apiClient.api.courseControllerDeleteManyCourses({ ids: existingIds });
+  }
+
+  private async prepareCourseForDeletion(course: CourseFactoryRecord) {
+    if (!PROTECTED_COURSE_DELETE_STATUSES.includes(course.status)) return;
+
+    await this.update(course.id, {
+      status: COURSE_STATUSES.DRAFT,
+      language: course.baseLanguage,
+    });
   }
 
   private async safeGetById(id: string): Promise<CourseFactoryRecord | null> {

--- a/docs/specs/course-authoring-management-business-spec.md
+++ b/docs/specs/course-authoring-management-business-spec.md
@@ -25,14 +25,14 @@ For HR and L&D teams, this is the control center for the learning catalog. It ke
 - Add, edit, delete, and generate course language variants.
 - Manage course enrollment for users and groups from the course edit area.
 - Transfer course ownership to another eligible user.
-- Delete draft courses individually or in bulk.
+- Delete draft courses individually or in bulk while protecting private and published courses.
 - Export supported courses as SCORM packages or master-course exports when permissions and configuration allow it.
 
 ## End-User Value
 
 The feature gives L&D teams governance over the training library. Teams can prepare courses before learners see them, publish only when content is ready, keep accountability through ownership, and maintain multilingual versions for different learner populations.
 
-Operational controls reduce mistakes. Permissions distinguish full course management from own-course editing, published courses are protected from draft-delete flows, and optional capabilities such as pricing, certificates, SCORM, and master exports appear only when the course and tenant support them.
+Operational controls reduce mistakes. Permissions distinguish full course management from own-course editing, private and published courses are protected from draft-delete flows, and optional capabilities such as pricing, certificates, SCORM, and master exports appear only when the course and tenant support them.
 
 ## How It Works
 
@@ -40,7 +40,7 @@ Administrators start in the admin course list and open a course edit screen or c
 
 The edit experience adapts to course type, tenant configuration, integrations, available languages, and permissions. For example, pricing depends on Stripe configuration, AI/Luma-related tools depend on their configuration, SCORM courses hide unsupported admin features, and managing-tenant exports are shown only to eligible users.
 
-Course mutations are permission-gated. Full course administrators can manage courses according to their permissions, while content creators rely on own-course update permissions for courses they own. In the admin course list, permitted users can select multiple courses and use the bulk-edit menu to change their category, change their status, or delete draft courses in one governed workflow. Language operations respect supported-language and base-language rules.
+Course mutations are permission-gated. Full course administrators can manage courses according to their permissions, while content creators rely on own-course update permissions for courses they own. In the admin course list, permitted users can select multiple courses and use the bulk-edit menu to change their category, change their status, or delete draft courses in one governed workflow. Private and published courses must be moved back to draft before deletion is allowed. Language operations respect supported-language and base-language rules.
 
 ## Key Technical Context
 
@@ -53,4 +53,5 @@ Course mutations are permission-gated. Full course administrators can manage cou
 ## Test Evidence
 
 - Web E2E coverage verifies course creation, invalid create-form validation, course list browsing/filtering, opening the create page, updating settings, updating status, bulk category updates, bulk status updates, deleting draft courses, bulk deleting draft courses, transferring ownership, student-mode preview, course pricing, course language variants, SCORM course creation/import behavior, unsupported SCORM feature hiding, and SCORM export flows.
+- API E2E coverage verifies draft course deletion and rejects deletion of private or published courses for single-course deletion and protected bulk selections.
 - Source-level API evidence covers permission checks and service paths for course creation, updates, bulk category updates, bulk status updates, settings, language management, enrollment, deletion, ownership transfer, and export operations.


### PR DESCRIPTION
## Issue(s)
- #1707 

## Overview

Protect private courses from being deleted, matching the existing protection for published courses.

This PR:
- blocks single-course deletion when the course status is `published` or `private`;
- blocks bulk deletion when any selected course is `published` or `private`;
- keeps draft course deletion working for single and bulk delete flows;
- centralizes protected delete statuses in course constants;
- types the course status schema field as `CourseStatus`;
- updates localized delete error copy and the course authoring business spec.

## Business Value

Private courses are often used to prepare or restrict access to training content before wider release. Preventing deletion of private courses reduces the risk of losing managed catalog content that is already part of a controlled publishing workflow.

Admins can still delete draft courses, but they must explicitly move private or published courses back to Draft before deletion. This keeps destructive actions intentional and consistent with course lifecycle governance.

## Screenshots / Video

https://github.com/user-attachments/assets/faaf2574-b7cc-4bde-b839-f6f4cbec5048

