### PR TITLE
chore: improve resending password emails experience

### DIFF
--- a/apps/api/src/swagger/api-schema.json
+++ b/apps/api/src/swagger/api-schema.json
@@ -2200,6 +2200,33 @@
         }
       }
     },
+    "/api/user/bulk/password-email": {
+      "post": {
+        "operationId": "UserController_sendBulkPasswordEmails",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendBulkPasswordEmailsBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SendBulkPasswordEmailsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/user/bulk/password-creation-email": {
       "post": {
         "operationId": "UserController_sendBulkPasswordCreationEmails",
@@ -22412,6 +22439,52 @@
             "required": [
               "sentCount",
               "skippedCount"
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "SendBulkPasswordEmailsBody": {
+        "type": "object",
+        "properties": {
+          "userIds": {
+            "type": "array",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "userIds"
+        ]
+      },
+      "SendBulkPasswordEmailsResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "sentCount": {
+                "type": "number"
+              },
+              "skippedCount": {
+                "type": "number"
+              },
+              "passwordResetSentCount": {
+                "type": "number"
+              },
+              "passwordCreationSentCount": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "sentCount",
+              "skippedCount",
+              "passwordResetSentCount",
+              "passwordCreationSentCount"
             ]
           }
         },

--- a/apps/api/src/user/__tests__/user.controller.e2e-spec.ts
+++ b/apps/api/src/user/__tests__/user.controller.e2e-spec.ts
@@ -627,6 +627,103 @@ describe("UsersController (e2e)", () => {
     });
   });
 
+  describe("POST /user/bulk/password-email", () => {
+    it("sends reset emails to users with credentials and creation emails to users without credentials", async () => {
+      const userWithPassword = await userFactory
+        .withCredentials({ password: testPassword })
+        .withUserSettings(db)
+        .create({
+          email: "bulk-password-email-with-password@example.com",
+          tenantId: testUser.tenantId,
+        });
+      const userWithoutPassword = await userFactory.withUserSettings(db).create({
+        email: "bulk-password-email-without-password@example.com",
+        tenantId: testUser.tenantId,
+      });
+      const archivedUser = await userFactory
+        .withCredentials({ password: testPassword })
+        .withUserSettings(db)
+        .create({
+          email: "bulk-password-email-archived@example.com",
+          archived: true,
+          tenantId: testUser.tenantId,
+        });
+
+      await db.insert(createTokens).values({
+        userId: userWithoutPassword.id,
+        tokenHash: "old-combined-token-hash",
+        expiryDate: new Date(Date.now() + 60_000),
+        reminderCount: 2,
+        tenantId: testUser.tenantId,
+      });
+
+      const response = await request(app.getHttpServer())
+        .post("/api/user/bulk/password-email")
+        .set("Cookie", testCookies)
+        .send({ userIds: [userWithPassword.id, userWithoutPassword.id, archivedUser.id] })
+        .expect(201);
+
+      expect(response.body.data).toEqual({
+        sentCount: 2,
+        skippedCount: 1,
+        passwordResetSentCount: 1,
+        passwordCreationSentCount: 1,
+      });
+
+      const sentEmails = await waitForEmails(2);
+      expect(sentEmails.map(({ to }) => to)).toEqual(
+        expect.arrayContaining([userWithPassword.email, userWithoutPassword.email]),
+      );
+
+      const resetTokenRows = await db
+        .select({ userId: resetTokens.userId })
+        .from(resetTokens)
+        .where(eq(resetTokens.userId, userWithPassword.id));
+
+      expect(resetTokenRows).toHaveLength(1);
+
+      const createTokenRows = await db
+        .select({
+          tokenHash: createTokens.tokenHash,
+          reminderCount: createTokens.reminderCount,
+        })
+        .from(createTokens)
+        .where(eq(createTokens.userId, userWithoutPassword.id));
+
+      expect(createTokenRows).toHaveLength(1);
+      expect(createTokenRows[0]).toEqual(
+        expect.objectContaining({
+          reminderCount: 0,
+        }),
+      );
+      expect(createTokenRows[0]?.tokenHash).not.toBe("old-combined-token-hash");
+    });
+
+    it("returns forbidden for non-admin users", async () => {
+      const regularUser = await userFactory
+        .withCredentials({ password: testPassword })
+        .withUserSettings(db)
+        .create({
+          email: "bulk-password-email-regular@example.com",
+          tenantId: testUser.tenantId,
+        });
+
+      const loginResponse = await request(app.getHttpServer())
+        .post("/api/auth/login")
+        .send({
+          email: regularUser.email,
+          password: testPassword,
+        })
+        .expect(201);
+
+      await request(app.getHttpServer())
+        .post("/api/user/bulk/password-email")
+        .set("Cookie", loginResponse.headers["set-cookie"])
+        .send({ userIds: [regularUser.id] })
+        .expect(403);
+    });
+  });
+
   describe("POST /user/bulk/password-creation-email", () => {
     it("replaces creation tokens and sends emails only to selected active users without credentials", async () => {
       const userWithoutPassword = await userFactory.withUserSettings(db).create({

--- a/apps/api/src/user/schemas/userPasswordEmail.schema.ts
+++ b/apps/api/src/user/schemas/userPasswordEmail.schema.ts
@@ -11,5 +11,13 @@ export const bulkUserPasswordEmailResponseSchema = Type.Object({
   skippedCount: Type.Number(),
 });
 
+export const bulkUserPasswordEmailsResponseSchema = Type.Object({
+  sentCount: Type.Number(),
+  skippedCount: Type.Number(),
+  passwordResetSentCount: Type.Number(),
+  passwordCreationSentCount: Type.Number(),
+});
+
 export type BulkUserPasswordEmailBody = Static<typeof bulkUserPasswordEmailSchema>;
 export type BulkUserPasswordEmailResponse = Static<typeof bulkUserPasswordEmailResponseSchema>;
+export type BulkUserPasswordEmailsResponse = Static<typeof bulkUserPasswordEmailsResponseSchema>;

--- a/apps/api/src/user/services/user-password-email.service.ts
+++ b/apps/api/src/user/services/user-password-email.service.ts
@@ -20,7 +20,10 @@ import { UserPasswordEmailRepository } from "src/user/repositories/user-password
 
 import type { UUIDType } from "src/common";
 import type { CurrentUserType } from "src/common/types/current-user.type";
-import type { BulkUserPasswordEmailResponse } from "src/user/schemas/userPasswordEmail.schema";
+import type {
+  BulkUserPasswordEmailResponse,
+  BulkUserPasswordEmailsResponse,
+} from "src/user/schemas/userPasswordEmail.schema";
 import type {
   PreparedUserPasswordEmail,
   UserCreatePasswordTokenInsert,
@@ -70,6 +73,71 @@ export class UserPasswordEmailService {
         result,
         trx,
       );
+    });
+
+    return result;
+  }
+
+  async sendBulkPasswordEmails(
+    userIds: UUIDType[],
+    currentUser: CurrentUserType,
+  ): Promise<BulkUserPasswordEmailsResponse> {
+    const uniqueUserIds = this.getUniqueUserIds(userIds);
+
+    const recipients = await this.userPasswordEmailRepository.findRecipientsByIds(uniqueUserIds);
+
+    const tenantOrigin = await this.userPasswordEmailRepository.findTenantOrigin(
+      currentUser.tenantId,
+    );
+
+    const resetRecipients = recipients.filter(({ hasCredentials }) => hasCredentials);
+    const creationRecipients = recipients.filter(({ hasCredentials }) => !hasCredentials);
+
+    const preparedResetEmails = this.preparePasswordResetEmails(resetRecipients, tenantOrigin);
+    const preparedCreationEmails = this.preparePasswordCreationEmails(
+      creationRecipients,
+      tenantOrigin,
+    );
+
+    const passwordResetSentCount = preparedResetEmails.emails.length;
+    const passwordCreationSentCount = preparedCreationEmails.emails.length;
+    const sentCount = passwordResetSentCount + passwordCreationSentCount;
+
+    const result = {
+      sentCount,
+      skippedCount: uniqueUserIds.length - sentCount,
+      passwordResetSentCount,
+      passwordCreationSentCount,
+    };
+
+    if (!sentCount) return result;
+
+    await this.db.transaction(async (trx) => {
+      await this.userPasswordEmailRepository.insertResetTokens(preparedResetEmails.tokenRows, trx);
+      await this.userPasswordEmailRepository.replaceCreateTokens(
+        preparedCreationEmails.tokenRows,
+        trx,
+      );
+
+      if (passwordResetSentCount > 0) {
+        await this.publishPasswordEmailsEvent(
+          USER_PASSWORD_EMAIL_TYPES.RESET,
+          currentUser,
+          preparedResetEmails.emails,
+          { sentCount: passwordResetSentCount, skippedCount: 0 },
+          trx,
+        );
+      }
+
+      if (passwordCreationSentCount > 0) {
+        await this.publishPasswordEmailsEvent(
+          USER_PASSWORD_EMAIL_TYPES.CREATION,
+          currentUser,
+          preparedCreationEmails.emails,
+          { sentCount: passwordCreationSentCount, skippedCount: 0 },
+          trx,
+        );
+      }
     });
 
     return result;

--- a/apps/api/src/user/user.controller.ts
+++ b/apps/api/src/user/user.controller.ts
@@ -98,6 +98,8 @@ import {
 import {
   type BulkUserPasswordEmailBody,
   type BulkUserPasswordEmailResponse,
+  type BulkUserPasswordEmailsResponse,
+  bulkUserPasswordEmailsResponseSchema,
   bulkUserPasswordEmailResponseSchema,
   bulkUserPasswordEmailSchema,
 } from "./schemas/userPasswordEmail.schema";
@@ -426,6 +428,24 @@ export class UserController {
     @CurrentUser() currentUser: CurrentUserType,
   ): Promise<BaseResponse<BulkUserPasswordEmailResponse>> {
     const result = await this.userPasswordEmailService.sendBulkPasswordResetEmails(
+      data.userIds,
+      currentUser,
+    );
+
+    return new BaseResponse(result);
+  }
+
+  @Post("bulk/password-email")
+  @RequirePermission(PERMISSIONS.USER_MANAGE)
+  @Validate({
+    request: [{ type: "body", schema: bulkUserPasswordEmailSchema }],
+    response: baseResponse(bulkUserPasswordEmailsResponseSchema),
+  })
+  async sendBulkPasswordEmails(
+    @Body() data: BulkUserPasswordEmailBody,
+    @CurrentUser() currentUser: CurrentUserType,
+  ): Promise<BaseResponse<BulkUserPasswordEmailsResponse>> {
+    const result = await this.userPasswordEmailService.sendBulkPasswordEmails(
       data.userIds,
       currentUser,
     );

--- a/apps/web/app/api/generated-api.ts
+++ b/apps/web/app/api/generated-api.ts
@@ -1470,6 +1470,19 @@ export interface SendBulkPasswordResetEmailsResponse {
   };
 }
 
+export interface SendBulkPasswordEmailsBody {
+  userIds: string[];
+}
+
+export interface SendBulkPasswordEmailsResponse {
+  data: {
+    sentCount: number;
+    skippedCount: number;
+    passwordResetSentCount: number;
+    passwordCreationSentCount: number;
+  };
+}
+
 export interface SendBulkPasswordCreationEmailsBody {
   userIds: string[];
 }
@@ -8696,6 +8709,25 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     ) =>
       this.request<SendBulkPasswordResetEmailsResponse, any>({
         path: `/api/user/bulk/password-reset-email`,
+        method: "POST",
+        body: data,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @name UserControllerSendBulkPasswordEmails
+     * @request POST:/api/user/bulk/password-email
+     */
+    userControllerSendBulkPasswordEmails: (
+      data: SendBulkPasswordEmailsBody,
+      params: RequestParams = {},
+    ) =>
+      this.request<SendBulkPasswordEmailsResponse, any>({
+        path: `/api/user/bulk/password-email`,
         method: "POST",
         body: data,
         type: ContentType.Json,

--- a/apps/web/app/api/mutations/admin/useBulkSendPasswordEmails.ts
+++ b/apps/web/app/api/mutations/admin/useBulkSendPasswordEmails.ts
@@ -1,0 +1,33 @@
+import { useMutation } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+
+import { useToast } from "~/components/ui/use-toast";
+
+import { ApiClient } from "../../api-client";
+
+import type { SendBulkPasswordEmailsBody } from "../../generated-api";
+
+export function useBulkSendPasswordEmails() {
+  const { toast } = useToast();
+  const { t } = useTranslation();
+
+  return useMutation({
+    mutationFn: async (data: SendBulkPasswordEmailsBody) => {
+      const response = await ApiClient.api.userControllerSendBulkPasswordEmails(data);
+
+      return response.data;
+    },
+    onSuccess: ({ data }) => {
+      toast({
+        variant: "default",
+        description: t("changeUserInformationView.toast.passwordEmailsSent", data),
+      });
+    },
+    onError: () => {
+      toast({
+        variant: "destructive",
+        description: t("changeUserInformationView.toast.passwordEmailsError"),
+      });
+    },
+  });
+}

--- a/apps/web/app/locales/cs/translation.json
+++ b/apps/web/app/locales/cs/translation.json
@@ -1045,7 +1045,9 @@
       "passwordResetEmailsSent": "E-maily pro reset hesla odeslány: {{sentCount}}. Přeskočeno: {{skippedCount}}.",
       "passwordResetEmailsError": "Nepodařilo se odeslat e-maily pro reset hesla",
       "passwordCreationEmailsSent": "E-maily pro vytvoření hesla odeslány: {{sentCount}}. Přeskočeno: {{skippedCount}}.",
-      "passwordCreationEmailsError": "Nepodařilo se odeslat e-maily pro vytvoření hesla"
+      "passwordCreationEmailsError": "Nepodařilo se odeslat e-maily pro vytvoření hesla",
+      "passwordEmailsSent": "E-maily k heslu odeslány: {{sentCount}}. Reset: {{passwordResetSentCount}}. Vytvoření: {{passwordCreationSentCount}}. Přeskočeno: {{skippedCount}}.",
+      "passwordEmailsError": "Nepodařilo se odeslat e-maily k heslu"
     },
     "field": {
       "description": "Popis",
@@ -1463,6 +1465,7 @@
     "dropdown": {
       "roles": "Role",
       "groups": "Skupiny",
+      "passwordEmail": "Odeslat e-mail k heslu",
       "passwordReset": "Odeslat e-mail pro reset hesla",
       "passwordCreation": "Znovu odeslat e-mail pro vytvoření hesla",
       "delete": "Vymazat",
@@ -1473,6 +1476,7 @@
         "delete": "Chcete tyto účty smazat?",
         "role": "Upravte role",
         "group": "Upravte skupiny",
+        "passwordEmail": "Odeslat e-mail k heslu",
         "passwordReset": "Odeslat e-mail pro reset hesla",
         "passwordCreation": "Znovu odeslat e-mail pro vytvoření hesla",
         "archive": "Archivovat uživatelské účty",
@@ -1484,6 +1488,7 @@
         "delete": "Vymazat",
         "role": "Uložit",
         "group": "Uložit",
+        "passwordEmail": "Odeslat",
         "passwordReset": "Odeslat",
         "passwordCreation": "Odeslat",
         "archive": "Archiv",
@@ -1496,6 +1501,7 @@
         "confirmationForGroup_other": "Změníte skupinu na {{ group }} pro {{ count }} uživatelů",
         "confirmationForRole_one": "Změníte roli na {{ role }} pro 1 uživatele.",
         "confirmationForRole_other": "Změníte roli na {{ role }} pro {{ count }} uživatelů",
+        "passwordEmail": "Odešlete e-maily k heslu vybraným uživatelům. Uživatelé s existujícím heslem dostanou e-mail pro reset hesla a uživatelé bez hesla dostanou e-mail pro vytvoření hesla.",
         "passwordReset": "Odešlete e-maily pro reset hesla vybraným uživatelům s existujícím heslem. Uživatelé bez hesla budou přeskočeni.",
         "passwordCreation": "Znovu odešlete e-maily pro vytvoření hesla vybraným uživatelům bez hesla. Uživatelé s existujícím heslem budou přeskočeni.",
         "archive": "Opravdu chcete tyto účty archivovat?",
@@ -1570,6 +1576,7 @@
     },
     "button": {
       "createUser": "Vytvořit uživatele",
+      "passwordEmail": "Odeslat e-mail k heslu",
       "passwordResetEmail": "Odeslat e-mail pro reset hesla",
       "passwordCreationEmail": "Znovu odeslat e-mail pro vytvoření hesla"
     },

--- a/apps/web/app/locales/de/translation.json
+++ b/apps/web/app/locales/de/translation.json
@@ -1039,7 +1039,9 @@
       "passwordResetEmailsSent": "Passwort-Zurücksetzen-E-Mails gesendet: {{sentCount}}. Übersprungen: {{skippedCount}}.",
       "passwordResetEmailsError": "Passwort-Zurücksetzen-E-Mails konnten nicht gesendet werden",
       "passwordCreationEmailsSent": "Passwort-Erstellungs-E-Mails gesendet: {{sentCount}}. Übersprungen: {{skippedCount}}.",
-      "passwordCreationEmailsError": "Passwort-Erstellungs-E-Mails konnten nicht gesendet werden"
+      "passwordCreationEmailsError": "Passwort-Erstellungs-E-Mails konnten nicht gesendet werden",
+      "passwordEmailsSent": "Passwort-E-Mails gesendet: {{sentCount}}. Zurücksetzen: {{passwordResetSentCount}}. Erstellung: {{passwordCreationSentCount}}. Übersprungen: {{skippedCount}}.",
+      "passwordEmailsError": "Passwort-E-Mails konnten nicht gesendet werden"
     },
     "field": {
       "description": "Beschreibung",
@@ -1457,6 +1459,7 @@
     "dropdown": {
       "roles": "Rollen",
       "groups": "Gruppen",
+      "passwordEmail": "Passwort-E-Mail senden",
       "passwordReset": "Passwort-Zurücksetzen-E-Mail senden",
       "passwordCreation": "Passwort-Erstellungs-E-Mail erneut senden",
       "delete": "Löschen",
@@ -1467,6 +1470,7 @@
         "delete": "Möchten Sie diese Konten löschen?",
         "role": "Rollen ändern",
         "group": "Gruppen ändern",
+        "passwordEmail": "Passwort-E-Mail senden",
         "passwordReset": "Passwort-Zurücksetzen-E-Mail senden",
         "passwordCreation": "Passwort-Erstellungs-E-Mail erneut senden",
         "archive": "Benutzerkonten archivieren",
@@ -1478,6 +1482,7 @@
         "delete": "Löschen",
         "role": "Speichern",
         "group": "Speichern",
+        "passwordEmail": "Senden",
         "passwordReset": "Senden",
         "passwordCreation": "Senden",
         "archive": "Archiv",
@@ -1490,6 +1495,7 @@
         "confirmationForGroup_other": "Sie ändern die Gruppe für {{ count }} Benutzer in {{ group }}",
         "confirmationForRole_one": "Sie ändern die Rolle für einen Benutzer in {{ role }}.",
         "confirmationForRole_other": "Sie ändern die Rolle für {{ count }} Benutzer in {{ role }}",
+        "passwordEmail": "Senden Sie Passwort-E-Mails an ausgewählte Benutzer. Benutzer mit bestehendem Passwort erhalten eine Passwort-Zurücksetzen-E-Mail, Benutzer ohne Passwort erhalten eine Passwort-Erstellungs-E-Mail.",
         "passwordReset": "Senden Sie Passwort-Zurücksetzen-E-Mails an ausgewählte Benutzer mit bestehendem Passwort. Benutzer ohne Passwort werden übersprungen.",
         "passwordCreation": "Senden Sie Passwort-Erstellungs-E-Mails erneut an ausgewählte Benutzer ohne Passwort. Benutzer mit bestehendem Passwort werden übersprungen.",
         "archive": "Sind Sie sicher, dass Sie diese Konten archivieren möchten?",
@@ -1564,6 +1570,7 @@
     },
     "button": {
       "createUser": "Benutzer erstellen",
+      "passwordEmail": "Passwort-E-Mail senden",
       "passwordResetEmail": "Passwort-Zurücksetzen-E-Mail senden",
       "passwordCreationEmail": "Passwort-Erstellungs-E-Mail erneut senden"
     },

--- a/apps/web/app/locales/en/translation.json
+++ b/apps/web/app/locales/en/translation.json
@@ -1040,7 +1040,9 @@
       "passwordResetEmailsSent": "Password reset emails sent: {{sentCount}}. Skipped: {{skippedCount}}.",
       "passwordResetEmailsError": "Failed to send password reset emails",
       "passwordCreationEmailsSent": "Password creation emails sent: {{sentCount}}. Skipped: {{skippedCount}}.",
-      "passwordCreationEmailsError": "Failed to send password creation emails"
+      "passwordCreationEmailsError": "Failed to send password creation emails",
+      "passwordEmailsSent": "Password emails sent: {{sentCount}}. Reset: {{passwordResetSentCount}}. Creation: {{passwordCreationSentCount}}. Skipped: {{skippedCount}}.",
+      "passwordEmailsError": "Failed to send password emails"
     },
     "field": {
       "description": "Description",
@@ -1518,6 +1520,7 @@
     "dropdown": {
       "roles": "Roles",
       "groups": "Groups",
+      "passwordEmail": "Send password email",
       "passwordReset": "Send password reset email",
       "passwordCreation": "Resend password creation email",
       "delete": "Delete",
@@ -1528,6 +1531,7 @@
         "delete": "Do you want to delete these accounts?",
         "role": "Modify roles",
         "group": "Modify groups",
+        "passwordEmail": "Send password email",
         "passwordReset": "Send password reset email",
         "passwordCreation": "Resend password creation email",
         "archive": "Archive user accounts",
@@ -1539,6 +1543,7 @@
         "delete": "Delete",
         "role": "Save",
         "group": "Save",
+        "passwordEmail": "Send",
         "passwordReset": "Send",
         "passwordCreation": "Send",
         "archive": "Archive",
@@ -1551,6 +1556,7 @@
         "confirmationForGroup_other": "You will change group to {{ group }} for {{ count }} users",
         "confirmationForRole_one": "You will change role to {{ role }} for 1 user.",
         "confirmationForRole_other": "You will change role to {{ role }} for {{ count }} users",
+        "passwordEmail": "Send password emails to selected users. Users with existing passwords will receive password reset emails, and users without passwords will receive password creation emails.",
         "passwordReset": "Send password reset emails to selected users with existing passwords. Users without passwords will be skipped.",
         "passwordCreation": "Resend password creation emails to selected users without passwords. Users with existing passwords will be skipped.",
         "archive": "Are you sure you want to archive these accounts?",
@@ -1625,6 +1631,7 @@
     },
     "button": {
       "createUser": "Create user",
+      "passwordEmail": "Send password email",
       "passwordResetEmail": "Send password reset email",
       "passwordCreationEmail": "Resend password creation email"
     },

--- a/apps/web/app/locales/es/translation.json
+++ b/apps/web/app/locales/es/translation.json
@@ -1040,7 +1040,9 @@
       "passwordResetEmailsSent": "Correos electrónicos de restablecimiento de contraseña enviados: {{sentCount}}. Omitido: {{skippedCount}}.",
       "passwordResetEmailsError": "No se pudieron enviar correos electrónicos para restablecer la contraseña",
       "passwordCreationEmailsSent": "Correos electrónicos de creación de contraseña enviados: {{sentCount}}. Omitido: {{skippedCount}}.",
-      "passwordCreationEmailsError": "No se pudieron enviar correos electrónicos de creación de contraseña"
+      "passwordCreationEmailsError": "No se pudieron enviar correos electrónicos de creación de contraseña",
+      "passwordEmailsSent": "Correos electrónicos de contraseña enviados: {{sentCount}}. Restablecimiento: {{passwordResetSentCount}}. Creación: {{passwordCreationSentCount}}. Omitidos: {{skippedCount}}.",
+      "passwordEmailsError": "No se pudieron enviar correos electrónicos de contraseña"
     },
     "field": {
       "description": "Descripción",
@@ -1518,6 +1520,7 @@
     "dropdown": {
       "roles": "Roles",
       "groups": "Grupos",
+      "passwordEmail": "Enviar correo electrónico de contraseña",
       "passwordReset": "Enviar correo electrónico para restablecer contraseña",
       "passwordCreation": "Reenviar correo electrónico de creación de contraseña",
       "delete": "Eliminar",
@@ -1528,6 +1531,7 @@
         "delete": "¿Quieres eliminar estas cuentas?",
         "role": "Modificar roles",
         "group": "Modificar grupos",
+        "passwordEmail": "Enviar correo electrónico de contraseña",
         "passwordReset": "Enviar correo electrónico para restablecer contraseña",
         "passwordCreation": "Reenviar correo electrónico de creación de contraseña",
         "archive": "Archivar cuentas de usuario",
@@ -1539,6 +1543,7 @@
         "delete": "Eliminar",
         "role": "Guardar",
         "group": "Guardar",
+        "passwordEmail": "Enviar",
         "passwordReset": "Enviar",
         "passwordCreation": "Enviar",
         "archive": "Archivar",
@@ -1551,6 +1556,7 @@
         "confirmationForGroup_other": "Cambiará el grupo a {{ group }} para los usuarios de {{ count }}",
         "confirmationForRole_one": "Cambiará el rol a {{ role }} para 1 usuario.",
         "confirmationForRole_other": "Cambiará el rol a {{ role }} para los usuarios de {{ count }}",
+        "passwordEmail": "Envíe correos electrónicos de contraseña a los usuarios seleccionados. Los usuarios con contraseña existente recibirán correos de restablecimiento y los usuarios sin contraseña recibirán correos de creación de contraseña.",
         "passwordReset": "Envíe correos electrónicos de restablecimiento de contraseña a usuarios seleccionados con contraseñas existentes. Se omitirán los usuarios sin contraseñas.",
         "passwordCreation": "Reenviar correos electrónicos de creación de contraseñas a usuarios seleccionados sin contraseñas. Se omitirán los usuarios con contraseñas existentes.",
         "archive": "¿Está seguro de que desea archivar estas cuentas?",
@@ -1625,6 +1631,7 @@
     },
     "button": {
       "createUser": "Crear usuario",
+      "passwordEmail": "Enviar correo electrónico de contraseña",
       "passwordResetEmail": "Enviar correo electrónico para restablecer contraseña",
       "passwordCreationEmail": "Reenviar correo electrónico de creación de contraseña"
     },

--- a/apps/web/app/locales/lt/translation.json
+++ b/apps/web/app/locales/lt/translation.json
@@ -1045,7 +1045,9 @@
       "passwordResetEmailsSent": "Slaptažodžio atkūrimo el. laiškai išsiųsti: {{sentCount}}. Praleista: {{skippedCount}}.",
       "passwordResetEmailsError": "Nepavyko išsiųsti slaptažodžio atkūrimo el. laiškų",
       "passwordCreationEmailsSent": "Slaptažodžio sukūrimo el. laiškai išsiųsti: {{sentCount}}. Praleista: {{skippedCount}}.",
-      "passwordCreationEmailsError": "Nepavyko išsiųsti slaptažodžio sukūrimo el. laiškų"
+      "passwordCreationEmailsError": "Nepavyko išsiųsti slaptažodžio sukūrimo el. laiškų",
+      "passwordEmailsSent": "Slaptažodžio el. laiškai išsiųsti: {{sentCount}}. Atkūrimas: {{passwordResetSentCount}}. Sukūrimas: {{passwordCreationSentCount}}. Praleista: {{skippedCount}}.",
+      "passwordEmailsError": "Nepavyko išsiųsti slaptažodžio el. laiškų"
     },
     "field": {
       "description": "Aprašymas",
@@ -1463,6 +1465,7 @@
     "dropdown": {
       "roles": "Vaidmenys",
       "groups": "Grupės",
+      "passwordEmail": "Siųsti slaptažodžio el. laišką",
       "passwordReset": "Siųsti slaptažodžio atkūrimo el. laišką",
       "passwordCreation": "Pakartotinai siųsti slaptažodžio sukūrimo el. laišką",
       "delete": "Ištrinti",
@@ -1473,6 +1476,7 @@
         "delete": "Ar norite ištrinti šias paskyras?",
         "role": "Keisti vaidmenis",
         "group": "Keisti grupes",
+        "passwordEmail": "Siųsti slaptažodžio el. laišką",
         "passwordReset": "Siųsti slaptažodžio atkūrimo el. laišką",
         "passwordCreation": "Pakartotinai siųsti slaptažodžio sukūrimo el. laišką",
         "archive": "Archyvuokite vartotojų paskyras",
@@ -1484,6 +1488,7 @@
         "delete": "Ištrinti",
         "role": "Išsaugoti",
         "group": "Išsaugoti",
+        "passwordEmail": "Siųsti",
         "passwordReset": "Siųsti",
         "passwordCreation": "Siųsti",
         "archive": "Archyvas",
@@ -1496,6 +1501,7 @@
         "confirmationForGroup_other": "Jūs pakeisite grupę į {{ group }} {{ count }} naudotojams",
         "confirmationForRole_one": "1 naudotojo vaidmenį pakeisite į {{ role }}.",
         "confirmationForRole_other": "{{ count }} naudotojų vaidmenį pakeisite į {{ role }}",
+        "passwordEmail": "Siųskite slaptažodžio el. laiškus pasirinktiems naudotojams. Naudotojai su esamais slaptažodžiais gaus slaptažodžio atkūrimo el. laiškus, o naudotojai be slaptažodžių gaus slaptažodžio sukūrimo el. laiškus.",
         "passwordReset": "Siųskite slaptažodžio atkūrimo el. laiškus pasirinktiems naudotojams su esamais slaptažodžiais. Naudotojai be slaptažodžių bus praleisti.",
         "passwordCreation": "Pakartotinai siųskite slaptažodžio sukūrimo el. laiškus pasirinktiems naudotojams be slaptažodžių. Naudotojai su esamais slaptažodžiais bus praleisti.",
         "archive": "Ar tikrai norite archyvuoti šias paskyras?",
@@ -1570,6 +1576,7 @@
     },
     "button": {
       "createUser": "Sukurti vartotoją",
+      "passwordEmail": "Siųsti slaptažodžio el. laišką",
       "passwordResetEmail": "Siųsti slaptažodžio atkūrimo el. laišką",
       "passwordCreationEmail": "Pakartotinai siųsti slaptažodžio sukūrimo el. laišką"
     },

--- a/apps/web/app/locales/pl/translation.json
+++ b/apps/web/app/locales/pl/translation.json
@@ -1253,7 +1253,9 @@
       "passwordResetEmailsSent": "Wysłano e-maile resetowania hasła: {{sentCount}}. Pominięto: {{skippedCount}}.",
       "passwordResetEmailsError": "Nie udało się wysłać e-maili resetowania hasła",
       "passwordCreationEmailsSent": "Wysłano e-maile utworzenia hasła: {{sentCount}}. Pominięto: {{skippedCount}}.",
-      "passwordCreationEmailsError": "Nie udało się wysłać e-maili utworzenia hasła"
+      "passwordCreationEmailsError": "Nie udało się wysłać e-maili utworzenia hasła",
+      "passwordEmailsSent": "Wysłano e-maile z hasłem: {{sentCount}}. Resetowanie: {{passwordResetSentCount}}. Utworzenie: {{passwordCreationSentCount}}. Pominięto: {{skippedCount}}.",
+      "passwordEmailsError": "Nie udało się wysłać e-maili z hasłem"
     },
     "field": {
       "description": "Opis",
@@ -1737,6 +1739,7 @@
     "dropdown": {
       "roles": "Role",
       "groups": "Grupy",
+      "passwordEmail": "Wyślij e-mail z hasłem",
       "passwordReset": "Wyślij e-mail resetowania hasła",
       "passwordCreation": "Wyślij ponownie e-mail utworzenia hasła",
       "delete": "Usuń",
@@ -1747,6 +1750,7 @@
         "delete": "Czy chcesz usunąć te konta?",
         "role": "Modyfikuj role",
         "group": "Modyfikuj grupy",
+        "passwordEmail": "Wyślij e-mail z hasłem",
         "passwordReset": "Wyślij e-mail resetowania hasła",
         "passwordCreation": "Wyślij ponownie e-mail utworzenia hasła",
         "archive": "Archiwizuj konta użytkowników",
@@ -1758,6 +1762,7 @@
         "delete": "Usuń",
         "role": "Zapisz",
         "group": "Zapisz",
+        "passwordEmail": "Wyślij",
         "passwordReset": "Wyślij",
         "passwordCreation": "Wyślij",
         "archive": "Archiwizuj",
@@ -1774,6 +1779,7 @@
         "confirmationForRole_few": "Zmienisz rolę na {{ role }} dla {{ count }} użytkowników",
         "confirmationForRole_many": "Zmienisz rolę na {{ role }} dla {{ count }} użytkowników",
         "confirmationForRole_other": "Zmienisz rolę na {{ role }} dla {{ count }} użytkowników",
+        "passwordEmail": "Wyślij e-maile z hasłem do wybranych użytkowników. Użytkownicy z istniejącym hasłem otrzymają e-mail resetowania hasła, a użytkownicy bez hasła otrzymają e-mail utworzenia hasła.",
         "passwordReset": "Wyślij e-maile resetowania hasła do wybranych użytkowników z istniejącymi hasłami. Użytkownicy bez hasła zostaną pominięci.",
         "passwordCreation": "Wyślij ponownie e-maile utworzenia hasła do wybranych użytkowników bez hasła. Użytkownicy z istniejącym hasłem zostaną pominięci.",
         "archive": "Czy na pewno chcesz zarchiwizować te konta?",
@@ -1848,6 +1854,7 @@
     },
     "button": {
       "createUser": "Utwórz użytkownika",
+      "passwordEmail": "Wyślij e-mail z hasłem",
       "passwordResetEmail": "Wyślij e-mail resetowania hasła",
       "passwordCreationEmail": "Wyślij ponownie e-mail utworzenia hasła"
     },

--- a/apps/web/app/modules/Admin/Users/User.page.tsx
+++ b/apps/web/app/modules/Admin/Users/User.page.tsx
@@ -1,14 +1,13 @@
 import { useParams } from "@remix-run/react";
 import { PERMISSIONS, SYSTEM_ROLE_PERMISSIONS } from "@repo/shared";
 import { startCase } from "lodash-es";
-import { KeyRound, Mail, UserCircle2 } from "lucide-react";
+import { KeyRound, UserCircle2 } from "lucide-react";
 import { useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 
 import { useAdminUpdateUser } from "~/api/mutations/admin/useAdminUpdateUser";
-import { useBulkResendPasswordCreationEmails } from "~/api/mutations/admin/useBulkResendPasswordCreationEmails";
-import { useBulkSendPasswordResetEmails } from "~/api/mutations/admin/useBulkSendPasswordResetEmails";
+import { useBulkSendPasswordEmails } from "~/api/mutations/admin/useBulkSendPasswordEmails";
 import { userQueryOptions, useUserById } from "~/api/queries/admin/useUserById";
 import { ENROLLED_USERS_QUERY_KEY } from "~/api/queries/admin/useUsersEnrolled";
 import { queryClient } from "~/api/queryClient";
@@ -51,10 +50,8 @@ const User = () => {
 
   const { data: user, isLoading } = useUserById(id, language);
   const { mutateAsync: updateUser } = useAdminUpdateUser();
-  const { mutateAsync: sendPasswordResetEmail, isPending: isSendingPasswordResetEmail } =
-    useBulkSendPasswordResetEmails();
-  const { mutateAsync: resendPasswordCreationEmail, isPending: isResendingPasswordCreationEmail } =
-    useBulkResendPasswordCreationEmails();
+  const { mutateAsync: sendPasswordEmail, isPending: isSendingPasswordEmail } =
+    useBulkSendPasswordEmails();
 
   const {
     control,
@@ -104,12 +101,8 @@ const User = () => {
     });
   };
 
-  const handleSendPasswordResetEmail = () => {
-    sendPasswordResetEmail({ userIds: [id] });
-  };
-
-  const handleResendPasswordCreationEmail = () => {
-    resendPasswordCreationEmail({ userIds: [id] });
+  const handleSendPasswordEmail = () => {
+    sendPasswordEmail({ userIds: [id] });
   };
 
   const breadcrumbs = [
@@ -153,26 +146,15 @@ const User = () => {
             </TabsList>
             <div className="flex flex-wrap items-center justify-end gap-2">
               <Button
-                data-testid={USER_PAGE_HANDLES.PASSWORD_RESET_EMAIL_BUTTON}
+                data-testid={USER_PAGE_HANDLES.PASSWORD_EMAIL_BUTTON}
                 type="button"
                 variant="outline"
                 className="h-10 gap-2"
-                onClick={handleSendPasswordResetEmail}
-                disabled={isSendingPasswordResetEmail}
+                onClick={handleSendPasswordEmail}
+                disabled={isSendingPasswordEmail}
               >
                 <KeyRound className="size-4 shrink-0" />
-                {t("adminUserView.button.passwordResetEmail")}
-              </Button>
-              <Button
-                data-testid={USER_PAGE_HANDLES.PASSWORD_CREATION_EMAIL_BUTTON}
-                type="button"
-                variant="outline"
-                className="h-10 gap-2"
-                onClick={handleResendPasswordCreationEmail}
-                disabled={isResendingPasswordCreationEmail}
-              >
-                <Mail className="size-4 shrink-0" />
-                {t("adminUserView.button.passwordCreationEmail")}
+                {t("adminUserView.button.passwordEmail")}
               </Button>
             </div>
           </div>

--- a/apps/web/app/modules/Admin/Users/Users.page.tsx
+++ b/apps/web/app/modules/Admin/Users/Users.page.tsx
@@ -14,7 +14,6 @@ import {
   Import,
   KeyRound,
   Mail,
-  MailPlus,
   Plus,
   Shield,
   ShieldUser,
@@ -26,8 +25,7 @@ import { useTranslation } from "react-i18next";
 
 import { useBulkArchiveUsers } from "~/api/mutations/admin/useBulkArchiveUsers";
 import { useBulkDeleteUsers } from "~/api/mutations/admin/useBulkDeleteUsers";
-import { useBulkResendPasswordCreationEmails } from "~/api/mutations/admin/useBulkResendPasswordCreationEmails";
-import { useBulkSendPasswordResetEmails } from "~/api/mutations/admin/useBulkSendPasswordResetEmails";
+import { useBulkSendPasswordEmails } from "~/api/mutations/admin/useBulkSendPasswordEmails";
 import { useBulkUpdateUsersGroups } from "~/api/mutations/admin/useBulkUpdateUsersGroups";
 import { useBulkUpdateUsersRoles } from "~/api/mutations/admin/useBulkUpdateUsersRoles";
 import { useGroupsQuerySuspense } from "~/api/queries/admin/useGroups";
@@ -84,14 +82,7 @@ const MailKey = ({ className }: { className?: string }) => (
   </span>
 );
 
-type ModalTypes =
-  | "group"
-  | "role"
-  | "delete"
-  | "archive"
-  | "passwordReset"
-  | "passwordCreation"
-  | null;
+type ModalTypes = "group" | "role" | "delete" | "archive" | "passwordEmail" | null;
 
 export const meta: MetaFunction = ({ matches }) => setPageTitle(matches, "pages.users");
 
@@ -133,8 +124,7 @@ const Users = () => {
   const { mutateAsync: updateUsersGroups } = useBulkUpdateUsersGroups();
   const { mutateAsync: archiveUsers } = useBulkArchiveUsers();
   const { mutateAsync: updateUsersRoles } = useBulkUpdateUsersRoles();
-  const { mutateAsync: sendPasswordResetEmails } = useBulkSendPasswordResetEmails();
-  const { mutateAsync: resendPasswordCreationEmails } = useBulkResendPasswordCreationEmails();
+  const { mutateAsync: sendPasswordEmails } = useBulkSendPasswordEmails();
 
   const { t } = useTranslation();
 
@@ -178,18 +168,10 @@ const Users = () => {
     {
       iconName: undefined,
       icon: <MailKey className="size-4 shrink-0" />,
-      translationKey: "adminUsersView.dropdown.passwordReset",
-      action: () => setShowEditModal("passwordReset"),
+      translationKey: "adminUsersView.dropdown.passwordEmail",
+      action: () => setShowEditModal("passwordEmail"),
       destructive: false,
-      testId: USERS_PAGE_HANDLES.BULK_EDIT_PASSWORD_RESET_ACTION,
-    },
-    {
-      iconName: undefined,
-      icon: <MailPlus className="size-4 shrink-0" />,
-      translationKey: "adminUsersView.dropdown.passwordCreation",
-      action: () => setShowEditModal("passwordCreation"),
-      destructive: false,
-      testId: USERS_PAGE_HANDLES.BULK_EDIT_PASSWORD_CREATION_ACTION,
+      testId: USERS_PAGE_HANDLES.BULK_EDIT_PASSWORD_EMAIL_ACTION,
     },
     {
       iconName: undefined,
@@ -493,23 +475,14 @@ const Users = () => {
     });
   }, [selectedUsers, selectedValue, table, updateUsersRoles]);
 
-  const handlePasswordResetEmails = useCallback(() => {
-    sendPasswordResetEmails({
+  const handlePasswordEmails = useCallback(() => {
+    sendPasswordEmails({
       userIds: selectedUsers.map(({ userId }) => userId),
     }).then(() => {
       table.resetRowSelection();
       setShowEditModal(null);
     });
-  }, [selectedUsers, sendPasswordResetEmails, table]);
-
-  const handlePasswordCreationEmails = useCallback(() => {
-    resendPasswordCreationEmails({
-      userIds: selectedUsers.map(({ userId }) => userId),
-    }).then(() => {
-      table.resetRowSelection();
-      setShowEditModal(null);
-    });
-  }, [resendPasswordCreationEmails, selectedUsers, table]);
+  }, [selectedUsers, sendPasswordEmails, table]);
 
   const handleRowClick = (userId: string) => {
     navigate(userId);
@@ -520,8 +493,7 @@ const Users = () => {
     group: handleUsersGroups,
     delete: handleDeleteUsers,
     archive: handleArchiveUsers,
-    passwordReset: handlePasswordResetEmails,
-    passwordCreation: handlePasswordCreationEmails,
+    passwordEmail: handlePasswordEmails,
   };
 
   const { totalItems, perPage, page } = userData?.pagination || {};

--- a/apps/web/app/modules/Admin/Users/components/EditModal.tsx
+++ b/apps/web/app/modules/Admin/Users/components/EditModal.tsx
@@ -127,12 +127,7 @@ export const EditModal = ({
     setSelectedGroups(updatedOptions);
   };
 
-  const isConfirmationOnlyAction = [
-    "delete",
-    "archive",
-    "passwordReset",
-    "passwordCreation",
-  ].includes(type);
+  const isConfirmationOnlyAction = ["delete", "archive", "passwordEmail"].includes(type);
 
   const handleSubmit = () =>
     isConfirmationOnlyAction ? onConfirm() : setShowConfirmationModal(true);
@@ -146,8 +141,7 @@ export const EditModal = ({
     switch (type) {
       case "delete":
       case "archive":
-      case "passwordReset":
-      case "passwordCreation":
+      case "passwordEmail":
         return t(`adminUsersView.modal.description.${type}`);
 
       case "group":

--- a/apps/web/e2e/data/users/handles.ts
+++ b/apps/web/e2e/data/users/handles.ts
@@ -8,8 +8,7 @@ export const USERS_PAGE_HANDLES = {
   BULK_EDIT_TRIGGER: "users-page-bulk-edit-trigger",
   BULK_EDIT_ROLE_ACTION: "users-page-bulk-edit-role-action",
   BULK_EDIT_GROUP_ACTION: "users-page-bulk-edit-group-action",
-  BULK_EDIT_PASSWORD_RESET_ACTION: "users-page-bulk-edit-password-reset-action",
-  BULK_EDIT_PASSWORD_CREATION_ACTION: "users-page-bulk-edit-password-creation-action",
+  BULK_EDIT_PASSWORD_EMAIL_ACTION: "users-page-bulk-edit-password-email-action",
   BULK_EDIT_ARCHIVE_ACTION: "users-page-bulk-edit-archive-action",
   BULK_EDIT_DELETE_ACTION: "users-page-bulk-edit-delete-action",
   SEARCH_INPUT: "users-page-search-input",
@@ -63,8 +62,7 @@ export const USER_PAGE_HANDLES = {
   GROUPS_SELECT: "user-page-groups-select",
   groupOption: (groupId: string) => `user-page-group-option-${groupId}`,
   ARCHIVED_CHECKBOX: "user-page-archived-checkbox",
-  PASSWORD_RESET_EMAIL_BUTTON: "user-page-password-reset-email-button",
-  PASSWORD_CREATION_EMAIL_BUTTON: "user-page-password-creation-email-button",
+  PASSWORD_EMAIL_BUTTON: "user-page-password-email-button",
   SAVE_BUTTON: "user-page-save-button",
 } as const;
 

--- a/apps/web/e2e/flows/users/open-bulk-edit-action.flow.ts
+++ b/apps/web/e2e/flows/users/open-bulk-edit-action.flow.ts
@@ -4,11 +4,12 @@ import { USER_BULK_EDIT_MODAL_HANDLES, USERS_PAGE_HANDLES } from "../../data/use
 
 import type { Page } from "@playwright/test";
 
-type BulkEditAction = "role" | "group" | "archive" | "delete";
+type BulkEditAction = "role" | "group" | "passwordEmail" | "archive" | "delete";
 
 const actionHandleMap: Record<BulkEditAction, string> = {
   role: USERS_PAGE_HANDLES.BULK_EDIT_ROLE_ACTION,
   group: USERS_PAGE_HANDLES.BULK_EDIT_GROUP_ACTION,
+  passwordEmail: USERS_PAGE_HANDLES.BULK_EDIT_PASSWORD_EMAIL_ACTION,
   archive: USERS_PAGE_HANDLES.BULK_EDIT_ARCHIVE_ACTION,
   delete: USERS_PAGE_HANDLES.BULK_EDIT_DELETE_ACTION,
 };

--- a/apps/web/e2e/specs/users/users-list.spec.ts
+++ b/apps/web/e2e/specs/users/users-list.spec.ts
@@ -68,9 +68,16 @@ test("admin can browse, filter, sort, paginate, select, and open user details", 
       "checked",
     );
 
+    await page.getByTestId(USERS_PAGE_HANDLES.BULK_EDIT_TRIGGER).click();
+    await expect(
+      page.getByTestId(USERS_PAGE_HANDLES.BULK_EDIT_PASSWORD_EMAIL_ACTION),
+    ).toBeVisible();
+    await page.keyboard.press("Escape");
+
     await openUserDetailsFromListFlow(page, users[10].id);
 
     await expect(page).toHaveURL(new RegExp(`/admin/users/${users[10].id}$`));
     await expect(page.getByTestId(USER_PAGE_HANDLES.PAGE)).toBeVisible();
+    await expect(page.getByTestId(USER_PAGE_HANDLES.PASSWORD_EMAIL_BUTTON)).toBeVisible();
   });
 });

--- a/docs/specs/user-management-business-spec.md
+++ b/docs/specs/user-management-business-spec.md
@@ -2,16 +2,17 @@
 
 ## Business Overview
 
-User Management lets HR and L&D administrators manage people inside a tenant. Admins can browse users, filter and sort the user list, create users, update user details, assign roles and groups, import users from a file, archive accounts, and delete eligible learner accounts.
+User Management lets HR and L&D administrators manage people inside a tenant. Admins can browse users, filter and sort the user list, create users, update user details, assign roles and groups, send password access emails, import users from a file, archive accounts, and delete eligible learner accounts.
 
 For learning operations, this turns organizational structure into platform access. Roles control what a person can do, groups help assign or segment training, and account lifecycle actions help teams keep the tenant clean as people join, move teams, or leave.
 
-The main workflow starts on the admin users page. An administrator finds users through search and filters, opens details for one user or selects many users for bulk action, and Mentingo validates and applies the change while keeping sessions and permissions consistent.
+The main workflow starts on the admin users page. An administrator finds users through search and filters, opens details for one user or selects many users for bulk action, and Mentingo validates and applies the change while keeping sessions, permissions, and account access consistent.
 
 ## Who Uses It
 
 - HR administrators create, import, update, archive, and delete learner accounts.
 - L&D administrators assign roles and groups so people receive the right learning access.
+- HR or platform administrators send the correct password email when learners need account access or password recovery help.
 - Platform administrators inspect user permissions and status for access review.
 - Learners benefit indirectly because their role, group, language, and account status determine their learning experience.
 
@@ -23,6 +24,7 @@ The main workflow starts on the admin users page. An administrator finds users t
 - Update a user's identity fields, status, roles, and groups.
 - Bulk-update roles for selected users.
 - Bulk-update group assignments for selected users.
+- Send one password email action that chooses reset or password-creation delivery for each selected user.
 - Archive users from the details page or through a bulk action.
 - Delete selected student-level users while preventing self-deletion and non-student deletion.
 
@@ -34,7 +36,9 @@ User Management reduces manual administration and supports structured learning d
 
 An admin opens the users page and filters by keyword, role, archived status, or group. The table supports sorting, pagination, row selection, role/group badges, and navigation to a user's details page. The details page lets the admin edit core fields, roles, groups, and archived status, and review effective permissions.
 
-For high-volume work, admins select users and apply bulk role, group, archive, or delete actions. Bulk role changes cannot include the current admin's own account. Deletion is limited to users who look like learner/student accounts and cannot include the actor; Mentingo soft-deletes eligible users, anonymizes their core identity fields, and deflates affected course statistics.
+For high-volume work, admins select users and apply bulk role, group, password email, archive, or delete actions. The password email action checks each selected account and sends a reset email to users who already have a password, or a password-creation email to users who have not set one yet. Archived or unavailable users are skipped and included in the result count.
+
+Bulk role changes cannot include the current admin's own account. Deletion is limited to users who look like learner/student accounts and cannot include the actor; Mentingo soft-deletes eligible users, anonymizes their core identity fields, and deflates affected course statistics.
 
 For imports, admins upload a supported spreadsheet file. Mentingo creates new users, assigns known groups from the file, reports imported users, and reports skipped users such as duplicate emails. Malformed files show an error without completing the import.
 
@@ -42,10 +46,11 @@ For imports, admins upload a supported spreadsheet file. Mentingo creates new us
 
 - Frontend user management lives in `apps/web/app/modules/Admin/Users` and is routed under `/admin/users`.
 - User-management API endpoints are in `apps/api/src/user/user.controller.ts`; lifecycle and bulk rules are in `apps/api/src/user/user.service.ts`.
+- Password access emails are handled by `UserPasswordEmailService`, which prepares reset or creation links according to whether the selected account already has credentials.
 - Administrative user-management endpoints require `PERMISSIONS.USER_MANAGE`; self-service profile, password, and onboarding endpoints use account-level permissions.
 - User creation creates onboarding/settings records, assigns role slugs, and may create a one-year invitation token for password setup.
 - Role changes revoke active sessions and send a websocket permissions-updated notification.
 
 ## Test Evidence
 
-Frontend E2E coverage verifies browsing, filtering, sorting, pagination, opening details, creating users, invalid and duplicate user creation, updating basic fields, updating roles and groups, importing users, bulk role updates, bulk group assignment, bulk archiving, single-user archiving, and guarded bulk deletion. Backend E2E coverage verifies listing users, fetching users, updating user/group data, password status and changes, deletion protections, user details access, bulk group updates, bulk role updates, own-role-change rejection, and non-admin authorization denial.
+Frontend E2E coverage verifies browsing, filtering, sorting, pagination, opening details, the combined password-email controls, creating users, invalid and duplicate user creation, updating basic fields, updating roles and groups, importing users, bulk role updates, bulk group assignment, bulk archiving, single-user archiving, and guarded bulk deletion. Backend E2E coverage verifies listing users, fetching users, updating user/group data, password status and changes, password-email delivery by account credential state, deletion protections, user details access, bulk group updates, bulk role updates, own-role-change rejection, and non-admin authorization denial.


### PR DESCRIPTION
## Issue(s)
- #1702 

## Overview

Merged the separate password reset and password creation email actions into one password email action.

The backend now exposes a combined bulk password email endpoint that decides which email to send per selected user:
- users with existing credentials receive a password reset email,
- users without credentials receive a password creation email,
- archived or otherwise ineligible users are skipped.

The admin user detail page and users bulk actions now use this combined flow. API schemas, generated web client, translations, E2E handles, and the user management business spec were updated accordingly.

## Business Value

Admins no longer need to know whether a user has already set a password before sending the correct access email. This reduces mistakes, simplifies account support, and makes single-user and bulk user management more consistent.

## Screenshots / Video


https://github.com/user-attachments/assets/24b0706b-298b-40ce-914d-de6ecde8e97a

