### PR TITLE
chore: improve global search with base language matching

### DIFF
--- a/apps/api/src/global-search/__tests__/global-search.controller.e2e-spec.ts
+++ b/apps/api/src/global-search/__tests__/global-search.controller.e2e-spec.ts
@@ -1,0 +1,318 @@
+import { faker } from "@faker-js/faker";
+import { ENTITY_TYPES, LESSON_TYPES, SUPPORTED_LANGUAGES, SYSTEM_ROLE_SLUGS } from "@repo/shared";
+import request from "supertest";
+
+import { buildJsonbField, buildJsonbFieldWithMultipleEntries } from "src/common/helpers/sqlHelpers";
+import { RESOURCE_RELATIONSHIP_TYPES } from "src/file/file.constants";
+import {
+  SEARCH_DOCUMENT_TYPES,
+  SEARCH_DOCUMENT_WEIGHTS,
+  SEARCH_ENTITY_TYPES,
+} from "src/global-search/global-search.constants";
+import { SearchIndexService } from "src/global-search/search-index.service";
+import { DB, DB_ADMIN } from "src/storage/db/db.providers";
+import { lessons, news, resourceEntity, resources } from "src/storage/schema";
+
+import { createE2ETest } from "../../../test/create-e2e-test";
+import { createCategoryFactory } from "../../../test/factory/category.factory";
+import { createChapterFactory } from "../../../test/factory/chapter.factory";
+import { createCourseFactory } from "../../../test/factory/course.factory";
+import { createQAFactory } from "../../../test/factory/qa.factory";
+import { createSettingsFactory } from "../../../test/factory/settings.factory";
+import { createUserFactory } from "../../../test/factory/user.factory";
+import { cookieFor, truncateAllTables, truncateTables } from "../../../test/helpers/test-helpers";
+
+import type { INestApplication } from "@nestjs/common";
+import type { SupportedLanguages } from "@repo/shared";
+import type { DatabasePg, UUIDType } from "src/common";
+import type { GlobalSearchResponse } from "src/global-search/schemas/global-search.schema";
+
+describe("GlobalSearchController (e2e)", () => {
+  let app: INestApplication;
+  let db: DatabasePg;
+  let baseDb: DatabasePg;
+  let searchIndexService: SearchIndexService;
+  let userFactory: ReturnType<typeof createUserFactory>;
+  let settingsFactory: ReturnType<typeof createSettingsFactory>;
+  let qaFactory: ReturnType<typeof createQAFactory>;
+  let categoryFactory: ReturnType<typeof createCategoryFactory>;
+  let courseFactory: ReturnType<typeof createCourseFactory>;
+  let chapterFactory: ReturnType<typeof createChapterFactory>;
+
+  const password = "Password123!";
+
+  const createAdminCookie = async () => {
+    const admin = await userFactory.withCredentials({ password }).withAdminSettings(db).create({
+      role: SYSTEM_ROLE_SLUGS.ADMIN,
+    });
+
+    return cookieFor(admin, app);
+  };
+
+  const createStudentCookie = async () => {
+    const student = await userFactory.withCredentials({ password }).withUserSettings(db).create({
+      role: SYSTEM_ROLE_SLUGS.STUDENT,
+    });
+
+    return cookieFor(student, app);
+  };
+
+  const indexQA = async (
+    qaId: UUIDType,
+    documents: Array<{ language: SupportedLanguages; content: string }>,
+  ) => {
+    await searchIndexService.replaceEntityDocuments({
+      entityType: SEARCH_ENTITY_TYPES.QA,
+      entityId: qaId,
+      documents: documents.map((document) => ({
+        documentType: SEARCH_DOCUMENT_TYPES.TITLE,
+        language: document.language,
+        content: document.content,
+        weight: SEARCH_DOCUMENT_WEIGHTS.A,
+      })),
+    });
+  };
+
+  const search = async (
+    cookie: string | string[],
+    searchQuery: string,
+    language: SupportedLanguages,
+  ): Promise<GlobalSearchResponse> => {
+    const searchRequest = request(app.getHttpServer())
+      .get("/api/global-search")
+      .query({ searchQuery, language });
+
+    if (Array.isArray(cookie)) {
+      searchRequest.set("Cookie", cookie);
+    } else {
+      searchRequest.set("Cookie", cookie);
+    }
+
+    const response = await searchRequest.expect(200);
+
+    return response.body.data;
+  };
+
+  beforeAll(async () => {
+    const { app: testApp } = await createE2ETest();
+    app = testApp;
+    db = app.get(DB);
+    baseDb = app.get(DB_ADMIN);
+    searchIndexService = app.get(SearchIndexService);
+
+    userFactory = createUserFactory(db);
+    settingsFactory = createSettingsFactory(db);
+    qaFactory = createQAFactory(db);
+    categoryFactory = createCategoryFactory(db);
+    courseFactory = createCourseFactory(db);
+    chapterFactory = createChapterFactory(db);
+  });
+
+  afterAll(async () => {
+    await truncateAllTables(baseDb, db);
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    await truncateTables(baseDb, [
+      "search_documents",
+      "resource_entity",
+      "resources",
+      "lessons",
+      "chapters",
+      "courses",
+      "news",
+      "questions_and_answers",
+      "categories",
+      "settings",
+      "credentials",
+      "user_onboarding",
+      "users",
+    ]);
+    await settingsFactory.create({ userId: null });
+  });
+
+  it("uses requested-language search documents when they exist and match", async () => {
+    const cookie = await createAdminCookie();
+    const qa = await qaFactory.create({
+      title: "Requested language QA",
+      description: "Answer",
+      baseLanguage: SUPPORTED_LANGUAGES.EN,
+      availableLocales: [SUPPORTED_LANGUAGES.EN, SUPPORTED_LANGUAGES.PL],
+    });
+    await indexQA(qa.id, [
+      { language: SUPPORTED_LANGUAGES.EN, content: "english-only-topic" },
+      { language: SUPPORTED_LANGUAGES.PL, content: "polish-only-topic" },
+    ]);
+
+    const results = await search(cookie, "polish", SUPPORTED_LANGUAGES.PL);
+
+    expect(results.qa).toEqual([expect.objectContaining({ id: qa.id })]);
+  });
+
+  it("searches non-requested language documents when requested-language documents are absent", async () => {
+    const cookie = await createAdminCookie();
+    const qa = await qaFactory.create({
+      title: "Base language QA",
+      description: "Answer",
+      baseLanguage: SUPPORTED_LANGUAGES.EN,
+      availableLocales: [SUPPORTED_LANGUAGES.EN],
+    });
+    await indexQA(qa.id, [{ language: SUPPORTED_LANGUAGES.EN, content: "basefallback-topic" }]);
+
+    const results = await search(cookie, "basefallback", SUPPORTED_LANGUAGES.PL);
+
+    expect(results.qa).toEqual([expect.objectContaining({ id: qa.id })]);
+  });
+
+  it("searches all indexed languages even when requested-language documents exist", async () => {
+    const cookie = await createAdminCookie();
+    const qa = await qaFactory.create({
+      title: "All language QA",
+      description: "Answer",
+      baseLanguage: SUPPORTED_LANGUAGES.EN,
+      availableLocales: [SUPPORTED_LANGUAGES.EN, SUPPORTED_LANGUAGES.PL],
+    });
+    await indexQA(qa.id, [
+      { language: SUPPORTED_LANGUAGES.EN, content: "hiddenbase-topic" },
+      { language: SUPPORTED_LANGUAGES.PL, content: "visible-polish-topic" },
+    ]);
+
+    const results = await search(cookie, "visible-polish", SUPPORTED_LANGUAGES.EN);
+
+    expect(results.qa).toEqual([expect.objectContaining({ id: qa.id })]);
+  });
+
+  it("returns entities that match through different indexed languages in one search", async () => {
+    const cookie = await createAdminCookie();
+    const englishQa = await qaFactory.create({
+      title: "English indexed QA",
+      description: "Answer",
+      baseLanguage: SUPPORTED_LANGUAGES.EN,
+      availableLocales: [SUPPORTED_LANGUAGES.EN],
+    });
+    const polishQa = await qaFactory.create({
+      title: "Polish indexed QA",
+      description: "Answer",
+      baseLanguage: SUPPORTED_LANGUAGES.PL,
+      availableLocales: [SUPPORTED_LANGUAGES.PL],
+    });
+    await indexQA(englishQa.id, [
+      { language: SUPPORTED_LANGUAGES.EN, content: "sharedmultilingual-topic" },
+    ]);
+    await indexQA(polishQa.id, [
+      { language: SUPPORTED_LANGUAGES.PL, content: "sharedmultilingual-topic" },
+    ]);
+
+    const results = await search(cookie, "sharedmultilingual", SUPPORTED_LANGUAGES.EN);
+
+    expect(results.qa).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: englishQa.id }),
+        expect.objectContaining({ id: polishQa.id }),
+      ]),
+    );
+  });
+
+  it("shows public content when any matched language is available", async () => {
+    const cookie = await createStudentCookie();
+    const author = await userFactory.create();
+    const [newsItem] = await db
+      .insert(news)
+      .values({
+        title: buildJsonbFieldWithMultipleEntries({
+          [SUPPORTED_LANGUAGES.PL]: "Public Polish news",
+        }),
+        summary: buildJsonbField(SUPPORTED_LANGUAGES.PL, "Summary"),
+        content: buildJsonbField(SUPPORTED_LANGUAGES.PL, "Content"),
+        status: "published",
+        isPublic: true,
+        archived: false,
+        baseLanguage: SUPPORTED_LANGUAGES.PL,
+        availableLocales: [SUPPORTED_LANGUAGES.PL],
+        publishedAt: new Date().toISOString(),
+        authorId: author.id,
+      })
+      .returning();
+    await searchIndexService.replaceEntityDocuments({
+      entityType: SEARCH_ENTITY_TYPES.NEWS,
+      entityId: newsItem.id,
+      documents: [
+        {
+          documentType: SEARCH_DOCUMENT_TYPES.TITLE,
+          language: SUPPORTED_LANGUAGES.PL,
+          content: "publicpolish-topic",
+          weight: SEARCH_DOCUMENT_WEIGHTS.A,
+        },
+      ],
+    });
+
+    const results = await search(cookie, "publicpolish", SUPPORTED_LANGUAGES.EN);
+
+    expect(results.news).toEqual([expect.objectContaining({ id: newsItem.id })]);
+  });
+
+  it("uses the matched non-requested language when resolving lesson attachment matches", async () => {
+    const cookie = await createAdminCookie();
+    const author = await userFactory.create();
+    const category = await categoryFactory.create();
+    const course = await courseFactory.create({
+      authorId: author.id,
+      categoryId: category.id,
+      title: "Attachment fallback course",
+      description: "Course description",
+      thumbnailS3Key: null,
+      baseLanguage: SUPPORTED_LANGUAGES.EN,
+      availableLocales: [SUPPORTED_LANGUAGES.EN],
+    });
+    const chapter = await chapterFactory.create({
+      authorId: author.id,
+      courseId: course.id,
+      title: "Attachment fallback chapter",
+      displayOrder: 1,
+      lessonCount: 1,
+    });
+    const [lesson] = await db
+      .insert(lessons)
+      .values({
+        chapterId: chapter.id,
+        type: LESSON_TYPES.CONTENT,
+        title: buildJsonbFieldWithMultipleEntries({
+          [SUPPORTED_LANGUAGES.EN]: "Attachment fallback lesson",
+        }),
+        description: buildJsonbField(SUPPORTED_LANGUAGES.EN, "Lesson description"),
+        displayOrder: 1,
+      })
+      .returning();
+    const attachmentSearchToken = `resourceguide${faker.string.alphanumeric(8).toLowerCase()}`;
+    const originalFilename = attachmentSearchToken;
+    const [resource] = await db
+      .insert(resources)
+      .values({
+        title: buildJsonbField(SUPPORTED_LANGUAGES.EN, "Resource title"),
+        description: buildJsonbField(SUPPORTED_LANGUAGES.EN, "Resource description"),
+        reference: `uploads/${originalFilename}`,
+        contentType: "application/pdf",
+        metadata: { originalFilename },
+        uploadedBy: author.id,
+      })
+      .returning();
+
+    await db.insert(resourceEntity).values({
+      resourceId: resource.id,
+      entityId: lesson.id,
+      entityType: ENTITY_TYPES.LESSON,
+      relationshipType: RESOURCE_RELATIONSHIP_TYPES.ATTACHMENT,
+    });
+    await searchIndexService.refreshLesson(lesson.id);
+
+    const results = await search(cookie, attachmentSearchToken, SUPPORTED_LANGUAGES.PL);
+
+    expect(results.lessons).toEqual([
+      expect.objectContaining({
+        id: lesson.id,
+        matchedAttachmentFileName: originalFilename,
+      }),
+    ]);
+  });
+});

--- a/apps/api/src/global-search/global-search.repository.ts
+++ b/apps/api/src/global-search/global-search.repository.ts
@@ -32,7 +32,12 @@ import {
 } from "./global-search.constants";
 import { GLOBAL_SEARCH_LESSON_ACCESS } from "./global-search.types";
 
-import type { GlobalSearchLessonAccess, MatchRow, SearchEntityType } from "./global-search.types";
+import type {
+  GlobalSearchLessonAccess,
+  MatchRow,
+  SearchDocumentSqlExpression,
+  SearchEntityType,
+} from "./global-search.types";
 import type { SupportedLanguages } from "@repo/shared";
 import type { UUIDType } from "src/common";
 
@@ -53,13 +58,13 @@ export class GlobalSearchRepository {
     return this.db
       .select({
         entityId: searchDocuments.entityId,
+        languages: sql<SupportedLanguages[]>`ARRAY_AGG(DISTINCT ${searchDocuments.language})`,
         rank: sql<number>`MAX(ts_rank(${searchDocuments.searchVector}, ${tsQuery}))`,
       })
       .from(searchDocuments)
       .where(
         and(
           eq(searchDocuments.entityType, entityType),
-          eq(searchDocuments.language, language),
           sql`${searchDocuments.searchVector} @@ ${tsQuery}`,
         ),
       )
@@ -176,27 +181,17 @@ export class GlobalSearchRepository {
     const ids = this.matchIds(matches);
     if (ids.length === 0) return [];
 
-    const tsQuery = this.buildTsQuery(searchQuery, language);
     const accessCondition = this.getLessonAccessCondition(options);
+    const matchedAttachmentFileNameByLessonId = await this.getLessonMatchedAttachmentFileNames(
+      matches,
+      searchQuery,
+    );
 
     const rows = await this.db
       .select({
         id: lessons.id,
         title: this.localizationService.getLocalizedSqlField(lessons.title, language, courses),
         courseId: courses.id,
-        matchedAttachmentFileName: sql<string | null>`
-          (
-            SELECT ${searchDocuments.metadata}->>'fileName'
-            FROM ${searchDocuments}
-            WHERE ${searchDocuments.entityType} = ${SEARCH_ENTITY_TYPES.LESSON}
-              AND ${searchDocuments.entityId} = ${lessons.id}
-              AND ${searchDocuments.language} = ${language}
-              AND ${searchDocuments.documentType} LIKE ${`${SEARCH_DOCUMENT_TYPES.RESOURCE}:%`}
-              AND ${searchDocuments.searchVector} @@ ${tsQuery}
-            ORDER BY ts_rank(${searchDocuments.searchVector}, ${tsQuery}) DESC
-            LIMIT 1
-          )
-        `,
       })
       .from(lessons)
       .innerJoin(chapters, eq(chapters.id, lessons.chapterId))
@@ -205,12 +200,19 @@ export class GlobalSearchRepository {
       .where(and(inArray(lessons.id, ids), accessCondition))
       .groupBy(lessons.id, courses.id, courses.baseLanguage);
 
-    return this.sortByMatches(rows, matches);
+    return this.sortByMatches(
+      rows.map((row) => ({
+        ...row,
+        matchedAttachmentFileName: matchedAttachmentFileNameByLessonId.get(row.id) ?? null,
+      })),
+      matches,
+    );
   }
 
   async getNews(matches: MatchRow[], language: SupportedLanguages, isAdminLike: boolean) {
     const ids = this.matchIds(matches);
     if (ids.length === 0) return [];
+    const matchedLanguages = this.getMatchedLanguagesExpression(matches, news.id);
 
     const rows = await this.db
       .select({
@@ -223,7 +225,7 @@ export class GlobalSearchRepository {
           inArray(news.id, ids),
           ne(news.archived, true),
           isNotNull(news.publishedAt),
-          isAdminLike ? undefined : sql`${language} = ANY(${news.availableLocales})`,
+          isAdminLike ? undefined : sql`${matchedLanguages} && ${news.availableLocales}`,
         ),
       );
 
@@ -233,6 +235,7 @@ export class GlobalSearchRepository {
   async getArticles(matches: MatchRow[], language: SupportedLanguages, isAdminLike: boolean) {
     const ids = this.matchIds(matches);
     if (ids.length === 0) return [];
+    const matchedLanguages = this.getMatchedLanguagesExpression(matches, articles.id);
 
     const rows = await this.db
       .select({
@@ -246,8 +249,8 @@ export class GlobalSearchRepository {
           inArray(articles.id, ids),
           ne(articles.archived, true),
           isNotNull(articles.publishedAt),
-          isAdminLike ? undefined : sql`${language} = ANY(${articles.availableLocales})`,
-          isAdminLike ? undefined : sql`${language} = ANY(${articleSections.availableLocales})`,
+          isAdminLike ? undefined : sql`${matchedLanguages} && ${articles.availableLocales}`,
+          isAdminLike ? undefined : sql`${matchedLanguages} && ${articleSections.availableLocales}`,
         ),
       );
 
@@ -338,9 +341,29 @@ export class GlobalSearchRepository {
   }
 
   private buildTsQuery(searchQuery: string, language: SupportedLanguages) {
-    return sql`to_tsquery(${getSearchLanguageConfig(
-      language,
-    )}::regconfig, ${normalizeSearchTerm(searchQuery)})`;
+    return sql`to_tsquery(${getSearchLanguageConfig(language)}::regconfig, ${normalizeSearchTerm(
+      searchQuery,
+    )})`;
+  }
+
+  private getMatchedLanguagesExpression(
+    matches: MatchRow[],
+    idExpression: SearchDocumentSqlExpression<UUIDType>,
+  ) {
+    return sql<SupportedLanguages[]>`
+      CASE ${idExpression}
+        ${sql.join(
+          matches.map(
+            (match) =>
+              sql`WHEN ${match.entityId} THEN ARRAY[${sql.join(
+                match.languages.map((language) => sql`${language}`),
+                sql`, `,
+              )}]::text[]`,
+          ),
+          sql` `,
+        )}
+      END
+    `;
   }
 
   private getLessonAccessCondition(options: {
@@ -355,6 +378,52 @@ export class GlobalSearchRepository {
     return and(
       eq(studentCourses.studentId, options.userId),
       eq(studentCourses.status, COURSE_ENROLLMENT.ENROLLED),
+    );
+  }
+
+  private async getLessonMatchedAttachmentFileNames(matches: MatchRow[], searchQuery: string) {
+    const tsQuery = this.buildTsQuery(searchQuery, matches[0].languages[0]);
+    const matchConditions = this.getMatchDocumentConditions(matches);
+    const rank = sql<number>`ts_rank(${searchDocuments.searchVector}, ${tsQuery})`;
+
+    const rows = await this.db
+      .select({
+        entityId: searchDocuments.entityId,
+        metadata: searchDocuments.metadata,
+        rank,
+      })
+      .from(searchDocuments)
+      .where(
+        and(
+          eq(searchDocuments.entityType, SEARCH_ENTITY_TYPES.LESSON),
+          or(...matchConditions),
+          sql`${searchDocuments.documentType} LIKE ${`${SEARCH_DOCUMENT_TYPES.RESOURCE}:%`}`,
+          sql`${searchDocuments.searchVector} @@ ${tsQuery}`,
+        ),
+      )
+      .orderBy(searchDocuments.entityId, desc(rank));
+
+    const fileNameByLessonId = new Map<UUIDType, string | null>();
+
+    for (const row of rows) {
+      if (!fileNameByLessonId.has(row.entityId)) {
+        fileNameByLessonId.set(row.entityId, this.getSearchDocumentFileName(row.metadata));
+      }
+    }
+
+    return fileNameByLessonId;
+  }
+
+  private getSearchDocumentFileName(metadata: Record<string, unknown>) {
+    return typeof metadata.fileName === "string" ? metadata.fileName : null;
+  }
+
+  private getMatchDocumentConditions(matches: MatchRow[]) {
+    return matches.map((match) =>
+      and(
+        eq(searchDocuments.entityId, match.entityId),
+        inArray(searchDocuments.language, match.languages),
+      ),
     );
   }
 

--- a/apps/api/src/global-search/global-search.types.ts
+++ b/apps/api/src/global-search/global-search.types.ts
@@ -69,6 +69,7 @@ export type LocalizedRecord = unknown;
 
 export type MatchRow = {
   entityId: UUIDType;
+  languages: SupportedLanguages[];
   rank: number;
 };
 

--- a/apps/api/src/seed/bulk-users-seed.ts
+++ b/apps/api/src/seed/bulk-users-seed.ts
@@ -36,6 +36,7 @@ import {
   createNiceCourses,
   ensureSeedTenant,
   getTenantEmailSuffix,
+  refreshSeedSearchDocuments,
   seedSystemRolesForTenant,
   seedUserRoleGrantSql,
 } from "./seed-helpers";
@@ -367,6 +368,7 @@ export async function seedBulkUsers(options: {
         const creatorIds = createdContentCreators.map((cc) => cc.id);
         const createdCourses = await createNiceCourses(creatorIds, db, niceCourses, tenantId);
         console.log(`✨ Created ${createdCourses.length} courses`);
+        await refreshSeedSearchDocuments(db, tenantId);
 
         if (enrollStudents && createdStudents.length > 0) {
           const studentIds = createdStudents.map((s) => s.id);

--- a/apps/api/src/seed/seed-helpers.ts
+++ b/apps/api/src/seed/seed-helpers.ts
@@ -12,20 +12,26 @@ import { and, eq, sql } from "drizzle-orm/sql";
 import { buildJsonbField } from "src/common/helpers/sqlHelpers";
 import { EnvRepository } from "src/env/repositories/env.repository";
 import { EnvService } from "src/env/services/env.service";
+import { SearchIndexRepository } from "src/global-search/search-index.repository";
+import { SearchIndexService } from "src/global-search/search-index.service";
 import { LESSON_TYPES } from "src/lesson/lesson.type";
 import { QUESTION_TYPE } from "src/questions/schema/question.types";
 import {
   aiMentorLessons,
+  articles,
   categories,
   chapters,
   courses,
+  learningPaths,
   lessons,
+  news,
   permissionRoleRuleSets,
   permissionRoles,
   permissionRuleSetPermissions,
   permissionRuleSets,
   permissionUserRoles,
   questionAnswerOptions,
+  questionsAndAnswers,
   questions,
   tenants,
 } from "src/storage/schema";
@@ -290,6 +296,50 @@ export async function seedTruncateAllTables(db: DatabasePg): Promise<void> {
     }
 
     await tx.execute(sql`SET CONSTRAINTS ALL IMMEDIATE`);
+  });
+}
+
+export async function refreshSeedSearchDocuments(db: DatabasePg, tenantId: UUIDType) {
+  await db.transaction(async (trx) => {
+    await trx.execute(sql`SELECT set_config('app.tenant_id', ${tenantId}, true)`);
+
+    const searchIndexService = new SearchIndexService(new SearchIndexRepository(trx));
+
+    const [courseRows, lessonRows, learningPathRows, newsRows, articleRows, questionAnswerRows] =
+      await Promise.all([
+        trx.select({ id: courses.id }).from(courses).where(eq(courses.tenantId, tenantId)),
+        trx.select({ id: lessons.id }).from(lessons).where(eq(lessons.tenantId, tenantId)),
+        trx
+          .select({ id: learningPaths.id })
+          .from(learningPaths)
+          .where(eq(learningPaths.tenantId, tenantId)),
+        trx.select({ id: news.id }).from(news).where(eq(news.tenantId, tenantId)),
+        trx.select({ id: articles.id }).from(articles).where(eq(articles.tenantId, tenantId)),
+        trx
+          .select({ id: questionsAndAnswers.id })
+          .from(questionsAndAnswers)
+          .where(eq(questionsAndAnswers.tenantId, tenantId)),
+      ]);
+
+    await Promise.all([
+      ...courseRows.map((course) => searchIndexService.refreshCourse(course.id, trx)),
+      searchIndexService.refreshLessons(
+        lessonRows.map((lesson) => lesson.id),
+        trx,
+      ),
+      ...learningPathRows.map((learningPath) =>
+        searchIndexService.refreshLearningPath(learningPath.id, trx),
+      ),
+      ...newsRows.map((newsRow) => searchIndexService.refreshNews(newsRow.id, trx)),
+      ...articleRows.map((article) => searchIndexService.refreshArticle(article.id, trx)),
+      ...questionAnswerRows.map((questionAnswer) =>
+        searchIndexService.refreshQA(questionAnswer.id, trx),
+      ),
+    ]);
+
+    console.log(
+      `🔎 Refreshed search documents for tenant ${tenantId}: ${courseRows.length} courses, ${lessonRows.length} lessons, ${learningPathRows.length} learning paths, ${newsRows.length} news, ${articleRows.length} articles, ${questionAnswerRows.length} Q&A entries`,
+    );
   });
 }
 

--- a/apps/api/src/seed/seed.ts
+++ b/apps/api/src/seed/seed.ts
@@ -41,6 +41,7 @@ import {
   createNiceCourses,
   ensureSeedTenant,
   getTenantEmailSuffix,
+  refreshSeedSearchDocuments,
   seedSystemRolesForTenant,
   seedTruncateAllTables,
   seedUserRoleGrantSql,
@@ -411,6 +412,7 @@ async function seed() {
       console.log("✨✨✨Created nice courses✨✨✨");
       await createNiceCourses([createdAdmin.id], db, e2eCourses, tenantId);
       console.log("🧪 Created e2e courses");
+      await refreshSeedSearchDocuments(db, tenantId);
 
       console.log("Selected random courses for student from createdCourses");
       await createStudentCourses(createdCourses, createdStudentIds, tenantId);

--- a/docs/specs/global-search-business-spec.md
+++ b/docs/specs/global-search-business-spec.md
@@ -1,0 +1,53 @@
+# Global Search Business Spec
+
+## Business Overview
+
+Global Search helps Mentingo users find learning and administration content quickly from the main navigation. Instead of browsing through separate areas, users can open the search dialog, type a term, and jump directly to matching courses, lessons, learning paths, users, groups, categories, news, articles, or Q&A entries.
+
+For HR and L&D teams, this reduces navigation friction in large tenant workspaces where content libraries, learner records, and operational objects grow over time. It is especially useful for multilingual organizations because indexed learning and knowledge content can be found through any translated language that matches the user's search term, even when the interface is set to a different language.
+
+The main workflow is direct: a user opens search from the navigation or keyboard shortcut, enters at least three characters, reviews grouped results, and selects the item they need.
+
+## Who Uses It
+
+- Learners search for assigned courses, available courses, learning paths, and lesson content so they can resume training faster.
+- Content creators search across courses, lessons, articles, news, and Q&A to manage training materials without manually navigating each module.
+- HR admins and L&D managers search for users, groups, categories, and learning content to support day-to-day administration.
+- Multilingual teams find translated or base-language content from one search box, even when the user's interface language differs from the language of the matching content.
+
+## Feature Functions
+
+- Search across major learning, knowledge, and administration areas from one navigation dialog.
+- Group results by type so users can scan courses, lessons, people, groups, and knowledge content separately.
+- Respect the signed-in user's permissions so each user only sees result categories they are allowed to access.
+- Search every indexed language for learning and knowledge content so multilingual materials remain discoverable.
+- Show matched lesson attachment filenames when the search term matches an attached resource.
+- Support keyboard opening, navigation, and selection for faster repeated use.
+
+## End-User Value
+
+Global Search saves time for learners and administrators by turning Mentingo into a searchable workspace instead of a collection of separate menus. It helps large organizations keep content discoverable as course catalogs, knowledge-base content, groups, and users expand.
+
+The language-aware behavior improves multilingual delivery: users can search from their current interface without losing access to content whose searchable text exists in another language.
+
+## How It Works
+
+Users open the search dialog from the navigation, enter a term, and Mentingo requests matching results for the current interface language. Results are grouped by content type, and selecting a result takes the user to the relevant course, lesson, article, user, or administration area.
+
+For indexed learning and knowledge content, Mentingo searches all language-specific documents attached to each item. The displayed title and category still use the user's selected interface language where those fields are localized, but a result can be found because its Polish, English, or other indexed text matched the query.
+
+Search visibility remains permission-aware. For example, users without user-management permissions do not receive user results, and course/lesson results follow the existing course access distinctions.
+
+## Key Technical Context
+
+- The frontend search dialog lives under `apps/web/app/components/Navigation/GlobalSearch` and sends the current UI language through `useGlobalSearch`.
+- The backend endpoint is `GET /api/global-search`, implemented by `GlobalSearchController`, `GlobalSearchService`, and `GlobalSearchRepository`.
+- Indexed search documents live in the `search_documents` table and are refreshed by `SearchIndexService`.
+- Indexed content matching is language-inclusive: `search_documents` rows from every stored language can match, and the repository tracks which languages matched each result.
+- Permissions are enforced by the global-search endpoint and service-level result category checks.
+
+## Test Evidence
+
+- API E2E coverage verifies requested-language search, non-requested-language search, matching another indexed language even when requested-language documents exist, and returning multiple entities that match through different indexed languages in one request.
+- API E2E coverage verifies that lesson attachment filename matches still resolve when the match comes from a non-requested-language document.
+- Existing frontend behavior is inferred from the global search dialog and query hook; no new frontend E2E coverage was added because the API contract did not change.


### PR DESCRIPTION
## Issue(s)

- #1688 

## Overview

Improves global search so indexed content can be found across all stored languages, not only the currently requested interface language.

- Searches all language-specific search documents for an entity and tracks which languages matched.
- Keeps public news and article visibility aligned with the language that matched the search document.
- Resolves matched lesson attachment filenames from the matched document language.
- Refreshes search documents after seed content is created in regular and bulk seed flows.
- Adds API E2E coverage for multilingual matching and attachment filename matching.
- Updates the global search business spec with the multilingual discovery behavior.

## Business Value

Users in multilingual workspaces can find training and knowledge content even when the matching text exists in a different language than their current interface language. This reduces search friction for learners, content creators, HR admins, and L&D managers working across translated course, news, article, and Q&A content.

Seeded environments also get refreshed search indexes after content creation, which makes demo and test data more reliable when validating search behavior.

## Screenshots / Video


https://github.com/user-attachments/assets/d0796dd0-2381-4ead-a408-e10cecfe17c3

