### PR TITLE
chore: add an option to automatically translate AI mentor instructions and completion conditions using AI

### DIFF
--- a/apps/api/src/chapter/repositories/adminChapter.repository.ts
+++ b/apps/api/src/chapter/repositories/adminChapter.repository.ts
@@ -190,11 +190,11 @@ export class AdminChapterRepository {
           SELECT json_build_object(
             'id', ${aiMentorLessons.id},
             'lessonId', ${aiMentorLessons.lessonId},
-            'aiMentorInstructions', ${this.localizationService.getLocalizedSqlField(
+            'aiMentorInstructions', ${this.localizationService.getFieldByLanguage(
               aiMentorLessons.aiMentorInstructions,
               language,
             )},
-            'completionConditions', ${this.localizationService.getLocalizedSqlField(
+            'completionConditions', ${this.localizationService.getFieldByLanguage(
               aiMentorLessons.completionConditions,
               language,
             )},

--- a/apps/api/src/courses/course.service.ts
+++ b/apps/api/src/courses/course.service.ts
@@ -97,6 +97,7 @@ import {
   coursesSummaryStats,
   groups,
   groupUsers,
+  aiMentorLessons,
   lessonLearningTime,
   lessons,
   questionAnswerOptions,
@@ -5020,6 +5021,24 @@ export class CourseService {
           idColumn: lessons.id,
         };
 
+        if (lesson.type === LESSON_TYPES.AI_MENTOR) {
+          yield {
+            id: lesson.id,
+            hasValue: Boolean(lesson.aiMentor?.aiMentorInstructions?.length),
+            baseValue: baseLesson?.aiMentor?.aiMentorInstructions,
+            field: aiMentorLessons.aiMentorInstructions,
+            idColumn: aiMentorLessons.lessonId,
+          };
+
+          yield {
+            id: lesson.id,
+            hasValue: Boolean(lesson.aiMentor?.completionConditions?.length),
+            baseValue: baseLesson?.aiMentor?.completionConditions,
+            field: aiMentorLessons.completionConditions,
+            idColumn: aiMentorLessons.lessonId,
+          };
+        }
+
         if (lesson.type !== LESSON_TYPES.QUIZ || !lesson.questions?.length) continue;
 
         const baseQuestionMap = new Map(
@@ -5399,6 +5418,21 @@ export class CourseService {
             questionTitle: base?.questionTitle,
             questionDescription: base?.questionDescription,
             questionOptions: base?.questionOptions,
+          },
+        };
+      }
+
+      if (entry.field.table === aiMentorLessons) {
+        const base = lessonById.get(entry.id as UUIDType);
+        if (base) getOrCreateLessonGroup(base.chapterId, base.lessonId).fields.push(entry);
+        return {
+          data: entry,
+          metadata,
+          context: {
+            courseTitle,
+            chapterTitle: base ? chapterById.get(base.chapterId)?.chapterTitle : undefined,
+            lessonTitle: base?.lessonTitle,
+            lessonDescription: base?.lessonDescription,
           },
         };
       }

--- a/apps/api/src/lesson/__tests__/lesson.controller.e2e-spec.ts
+++ b/apps/api/src/lesson/__tests__/lesson.controller.e2e-spec.ts
@@ -11,6 +11,8 @@ import {
 import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import request from "supertest";
 
+import { AiRepository } from "src/ai/repositories/ai.repository";
+import { THREAD_STATUS } from "src/ai/utils/ai.type";
 import { buildJsonbField } from "src/common/helpers/sqlHelpers";
 import { LEARNING_MODE_REQUIRED_ERROR_KEY } from "src/common/utils/lessonLearningAccess";
 import { RESOURCE_RELATIONSHIP_TYPES } from "src/file/file.constants";
@@ -20,6 +22,7 @@ import { LESSON_TYPES, type LessonTypes } from "src/lesson/lesson.type";
 import { QUESTION_TYPE } from "src/questions/schema/question.types";
 import { DB, DB_ADMIN } from "src/storage/db/db.providers";
 import {
+  aiMentorLessons,
   lessons,
   chapters,
   quizAttempts,
@@ -49,6 +52,7 @@ describe("LessonController (e2e) - quiz feedback redaction", () => {
   let app: INestApplication;
   let db: DatabasePg;
   let baseDb: DatabasePg;
+  let aiRepository: AiRepository;
   let categoryFactory: ReturnType<typeof createCategoryFactory>;
   let userFactory: ReturnType<typeof createUserFactory>;
   let courseFactory: ReturnType<typeof createCourseFactory>;
@@ -88,6 +92,7 @@ describe("LessonController (e2e) - quiz feedback redaction", () => {
     app = testApp;
     db = app.get(DB);
     baseDb = app.get(DB_ADMIN);
+    aiRepository = app.get(AiRepository);
     userFactory = createUserFactory(db);
     settingsFactory = createSettingsFactory(db);
     categoryFactory = createCategoryFactory(db);
@@ -354,7 +359,7 @@ describe("LessonController (e2e) - quiz feedback redaction", () => {
 
       const lessonId = createResponse.body.data.id;
 
-      return { adminCookies, courseId: course.id, lessonId };
+      return { admin, adminCookies, courseId: course.id, lessonId };
     };
 
     const getAiMentorFromCourse = async (
@@ -417,20 +422,31 @@ describe("LessonController (e2e) - quiz feedback redaction", () => {
       });
     });
 
-    it("falls back to base-language AI mentor scenario fields", async () => {
-      const { adminCookies, courseId, lessonId } = await createAiMentorLessonSetup([
+    it("falls back to base-language AI mentor scenario fields on the learner endpoint", async () => {
+      const { admin, adminCookies, lessonId } = await createAiMentorLessonSetup([
         SUPPORTED_LANGUAGES.EN,
         SUPPORTED_LANGUAGES.DE,
       ]);
 
-      const aiMentor = await getAiMentorFromCourse(
-        courseId,
-        lessonId,
-        SUPPORTED_LANGUAGES.DE,
-        adminCookies,
-      );
+      const [aiMentorLesson] = await db
+        .select({ id: aiMentorLessons.id })
+        .from(aiMentorLessons)
+        .where(eq(aiMentorLessons.lessonId, lessonId));
 
-      expect(aiMentor).toMatchObject({
+      await aiRepository.createThread({
+        userId: admin.id,
+        aiMentorLessonId: aiMentorLesson.id,
+        status: THREAD_STATUS.ACTIVE,
+        userLanguage: SUPPORTED_LANGUAGES.DE,
+      });
+
+      const response = await request(app.getHttpServer())
+        .get(`/api/lesson/${lessonId}`)
+        .query({ language: SUPPORTED_LANGUAGES.DE })
+        .set("Cookie", adminCookies)
+        .expect(200);
+
+      expect(response.body.data).toMatchObject({
         aiMentorInstructions: "<p>Lead the learner through an English scenario.</p>",
         completionConditions: "<p>The learner handles objections in English.</p>",
       });

--- a/apps/api/src/lesson/repositories/lesson.repository.ts
+++ b/apps/api/src/lesson/repositories/lesson.repository.ts
@@ -173,6 +173,14 @@ export class LessonRepository {
             ELSE NULL
           END
         `,
+        aiMentorInstructions: this.localizationService.getLocalizedSqlField(
+          aiMentorLessons.aiMentorInstructions,
+          language,
+        ),
+        completionConditions: this.localizationService.getLocalizedSqlField(
+          aiMentorLessons.completionConditions,
+          language,
+        ),
         isExternal: sql<boolean>`${lessons.isExternal}`,
         liveTrainingId: sql<UUIDType | null>`
           (


### PR DESCRIPTION
## Issue
[1703](https://github.com/Selleo/mentingo/issues/1703)

## Overview 
Makes instructions and conditions translation generation possible for ai mentor lesson.

## Business Value
Makes AI mentor coherent with rest of project as well bringing less friction to adding support to multiple languages

## Video
[Screencast From 2026-07-07 15-05-52.webm](https://github.com/user-attachments/assets/619d6e37-5efb-4e2f-a349-c3dd8c65e8b7)
