### PR TITLE
feat: add progress bar showing video progression

### DIFF
--- a/apps/web/app/api/mutations/__tests__/useLessonVideoProgress.test.ts
+++ b/apps/web/app/api/mutations/__tests__/useLessonVideoProgress.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  invalidateQueries: vi.fn(),
+  setQueriesData: vi.fn(),
+  invalidateLearningPathProgressionData: vi.fn(),
+}));
+
+vi.mock("~/api/queryClient", () => ({
+  queryClient: {
+    invalidateQueries: mocks.invalidateQueries,
+    setQueriesData: mocks.setQueriesData,
+  },
+}));
+
+vi.mock("~/api/utils/invalidateLearningPathProgressionData", () => ({
+  invalidateLearningPathProgressionData: mocks.invalidateLearningPathProgressionData,
+}));
+
+import { syncLessonVideoCompletionQueries } from "../useLessonVideoProgress";
+
+describe("syncLessonVideoCompletionQueries", () => {
+  it("does not invalidate the active lesson query while syncing completion state", async () => {
+    await syncLessonVideoCompletionQueries("lesson-id");
+
+    expect(mocks.invalidateQueries).not.toHaveBeenCalledWith({
+      queryKey: ["lesson", "lesson-id"],
+    });
+    expect(mocks.invalidateQueries).toHaveBeenCalledWith({ queryKey: ["lessons"] });
+    expect(mocks.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["lessonProgress", "lesson-id"],
+    });
+    expect(mocks.invalidateLearningPathProgressionData).toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/mutations/useLessonVideoProgress.ts
+++ b/apps/web/app/api/mutations/useLessonVideoProgress.ts
@@ -26,6 +26,7 @@ const markLessonCompletedInCache = (lessonId: string) => {
 
 export const syncLessonVideoCompletionQueries = async (lessonId: string) => {
   await Promise.all([
+    queryClient.invalidateQueries({ queryKey: ["lessons"] }),
     queryClient.invalidateQueries({ queryKey: ["lessonProgress", lessonId] }),
     queryClient.invalidateQueries({ queryKey: ["certificates"] }),
     queryClient.invalidateQueries({ queryKey: ["certificate"] }),

--- a/apps/web/app/components/RichText/Viever.tsx
+++ b/apps/web/app/components/RichText/Viever.tsx
@@ -13,6 +13,7 @@ import {
 import { RICH_TEXT_VIEWER_VARIANT, type RichTextViewerVariant } from "./viewerTypes";
 
 import type { SupportedLanguages } from "@repo/shared";
+import type { VideoCoverageSnapshotChange } from "~/components/VideoPlayer/videoCoverage.types";
 
 type ViewerProps = {
   content: string;
@@ -25,6 +26,7 @@ type ViewerProps = {
     showCoverageMarkers?: boolean;
     lessonId?: string;
     language?: SupportedLanguages;
+    onSnapshotChange?: (change: VideoCoverageSnapshotChange) => void;
   };
 };
 

--- a/apps/web/app/components/RichText/extensions/video.tsx
+++ b/apps/web/app/components/RichText/extensions/video.tsx
@@ -25,6 +25,7 @@ import {
 import type { SupportedLanguages } from "@repo/shared";
 import type { NodeConfig } from "@tiptap/core";
 import type { NodeViewProps } from "@tiptap/react";
+import type { VideoCoverageSnapshotChange } from "~/components/VideoPlayer/videoCoverage.types";
 
 type VideoViewerOptions = {
   onVideoEnded?: (index: number | null) => void;
@@ -33,6 +34,7 @@ type VideoViewerOptions = {
     showCoverageMarkers?: boolean;
     lessonId?: string;
     language?: SupportedLanguages;
+    onSnapshotChange?: (change: VideoCoverageSnapshotChange) => void;
   };
 };
 
@@ -255,6 +257,7 @@ const VideoViewerView = ({ node, extension }: NodeViewProps) => {
           initialIsWatched: attrs.videoIsWatched,
           initialDurationSeconds: attrs.videoDurationSeconds,
           initialBucketSizeSeconds: attrs.videoBucketSizeSeconds,
+          onSnapshotChange: videoCoverageTracking?.onSnapshotChange,
         }}
       />
     </NodeViewWrapper>

--- a/apps/web/app/components/VideoPlayer/__tests__/useVideoCoverageTracker.test.tsx
+++ b/apps/web/app/components/VideoPlayer/__tests__/useVideoCoverageTracker.test.tsx
@@ -200,7 +200,7 @@ describe("useVideoCoverageTracker", () => {
     expect(mutateAsync).not.toHaveBeenCalled();
   });
 
-  it("defers completion query sync until playback stops", async () => {
+  it("syncs completion queries as soon as a flush completes the lesson", async () => {
     const player = new FakeVideoPlayer();
     mutateAsync.mockResolvedValue({
       ...createProgressResponse([[0, 95]]),
@@ -230,14 +230,7 @@ describe("useVideoCoverageTracker", () => {
       await result.current.flush();
     });
 
-    expect(syncLessonCompletionQueries).not.toHaveBeenCalled();
-
-    act(() => {
-      player.setPaused(true);
-      player.emit("pause");
-    });
-
-    await waitFor(() => expect(syncLessonCompletionQueries).toHaveBeenCalledWith("lesson-id"));
+    expect(syncLessonCompletionQueries).toHaveBeenCalledWith("lesson-id");
   });
 
   it("reports snapshot changes for the tracked resource", async () => {
@@ -286,6 +279,46 @@ describe("useVideoCoverageTracker", () => {
         }),
       ),
     );
+  });
+
+  it("keeps live progress when rerendered with equivalent initial watched ranges", async () => {
+    const player = new FakeVideoPlayer();
+
+    const { result, rerender } = renderHook(
+      ({ initialWatchedRanges }: { initialWatchedRanges: VideoCoverageRange[] }) =>
+        useVideoCoverageTracker(player as unknown as VideoJSType, {
+          enabled: true,
+          lessonId: "lesson-id",
+          resourceEntityId: "resource-entity-id",
+          initialCoveragePercent: 0.1,
+          initialWatchedRanges,
+          initialDurationSeconds: 100,
+          initialBucketSizeSeconds: 1,
+        }),
+      {
+        initialProps: {
+          initialWatchedRanges: [[0, 10]],
+        },
+      },
+    );
+
+    act(() => {
+      player.setPaused(false);
+      player.setCurrentTime(10);
+      player.emit("play");
+      now = 15_000;
+      player.setCurrentTime(15);
+      player.emit("timeupdate");
+    });
+
+    await waitFor(() => expect(result.current.snapshot.watchedRanges).toEqual([[0, 15]]));
+
+    rerender({
+      initialWatchedRanges: [[0, 10]],
+    });
+
+    expect(result.current.snapshot.watchedRanges).toEqual([[0, 15]]);
+    expect(result.current.snapshot.coveragePercent).toBe(0.15);
   });
 });
 

--- a/apps/web/app/components/VideoPlayer/__tests__/useVideoCoverageTracker.test.tsx
+++ b/apps/web/app/components/VideoPlayer/__tests__/useVideoCoverageTracker.test.tsx
@@ -239,6 +239,54 @@ describe("useVideoCoverageTracker", () => {
 
     await waitFor(() => expect(syncLessonCompletionQueries).toHaveBeenCalledWith("lesson-id"));
   });
+
+  it("reports snapshot changes for the tracked resource", async () => {
+    const player = new FakeVideoPlayer();
+    const onSnapshotChange = vi.fn();
+
+    renderHook(() =>
+      useVideoCoverageTracker(player as unknown as VideoJSType, {
+        enabled: true,
+        lessonId: "lesson-id",
+        resourceEntityId: "resource-entity-id",
+        initialBucketSizeSeconds: 1,
+        onSnapshotChange,
+      }),
+    );
+
+    await waitFor(() =>
+      expect(onSnapshotChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resourceEntityId: "resource-entity-id",
+          snapshot: expect.objectContaining({
+            coveragePercent: 0,
+            watchedRanges: [],
+          }),
+        }),
+      ),
+    );
+
+    act(() => {
+      player.setPaused(false);
+      player.setCurrentTime(0);
+      player.emit("play");
+      now = 5_000;
+      player.setCurrentTime(4.6);
+      player.emit("timeupdate");
+    });
+
+    await waitFor(() =>
+      expect(onSnapshotChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          resourceEntityId: "resource-entity-id",
+          snapshot: expect.objectContaining({
+            coveragePercent: 0.05,
+            watchedRanges: [[0, 5]],
+          }),
+        }),
+      ),
+    );
+  });
 });
 
 describe("getVideoResumeTimeSeconds", () => {

--- a/apps/web/app/components/VideoPlayer/useVideoCoverageTracker.ts
+++ b/apps/web/app/components/VideoPlayer/useVideoCoverageTracker.ts
@@ -49,6 +49,9 @@ const getInitialSnapshot = ({
   bucketSizeSeconds: initialBucketSizeSeconds ?? DEFAULT_BUCKET_SIZE_SECONDS,
 });
 
+const getVideoCoverageRangesSignature = (ranges: VideoCoverageRange[] | undefined) =>
+  JSON.stringify(mergeVideoCoverageRanges(ranges ?? []));
+
 export const getVideoResumeTimeSeconds = ({
   watchedRanges,
   durationSeconds,
@@ -97,6 +100,7 @@ export const useVideoCoverageTracker = (
     initialWatchedRanges,
     initialBucketSizeSeconds,
   } = options;
+  const initialWatchedRangesSignature = getVideoCoverageRangesSignature(initialWatchedRanges);
   const onSnapshotChange = options.onSnapshotChange;
 
   const enabled = Boolean(
@@ -118,17 +122,7 @@ export const useVideoCoverageTracker = (
   }, [enabled, onSnapshotChange, resourceEntityId, snapshot]);
 
   useEffect(() => {
-    setSnapshot(
-      getInitialSnapshot({
-        ...optionsRef.current,
-        resourceEntityId,
-        initialCoveragePercent,
-        initialDurationSeconds,
-        initialIsWatched,
-        initialWatchedRanges,
-        initialBucketSizeSeconds,
-      }),
-    );
+    setSnapshot(getInitialSnapshot(optionsRef.current));
     pendingRangesRef.current = [];
     activeWatchSecondsDeltaRef.current = 0;
     previousSampleRef.current = null;
@@ -138,7 +132,7 @@ export const useVideoCoverageTracker = (
     initialCoveragePercent,
     initialDurationSeconds,
     initialIsWatched,
-    initialWatchedRanges,
+    initialWatchedRangesSignature,
     initialBucketSizeSeconds,
   ]);
 
@@ -258,7 +252,11 @@ export const useVideoCoverageTracker = (
           pendingLessonCompletionSyncRef.current = true;
         }
 
-        if (shouldSyncCompletionAfterFlush || completionSyncRequestedRef.current) {
+        if (
+          progress.lessonCompleted ||
+          shouldSyncCompletionAfterFlush ||
+          completionSyncRequestedRef.current
+        ) {
           completionSyncRequestedRef.current = false;
           await syncPendingLessonCompletion();
         }

--- a/apps/web/app/components/VideoPlayer/useVideoCoverageTracker.ts
+++ b/apps/web/app/components/VideoPlayer/useVideoCoverageTracker.ts
@@ -97,6 +97,7 @@ export const useVideoCoverageTracker = (
     initialWatchedRanges,
     initialBucketSizeSeconds,
   } = options;
+  const onSnapshotChange = options.onSnapshotChange;
 
   const enabled = Boolean(
     options.enabled && options.lessonId && options.resourceEntityId && player,
@@ -109,6 +110,12 @@ export const useVideoCoverageTracker = (
   useEffect(() => {
     snapshotDurationSecondsRef.current = snapshot.durationSeconds;
   }, [snapshot.durationSeconds]);
+
+  useEffect(() => {
+    if (!enabled || !resourceEntityId) return;
+
+    onSnapshotChange?.({ resourceEntityId, snapshot });
+  }, [enabled, onSnapshotChange, resourceEntityId, snapshot]);
 
   useEffect(() => {
     setSnapshot(

--- a/apps/web/app/components/VideoPlayer/videoCoverage.types.ts
+++ b/apps/web/app/components/VideoPlayer/videoCoverage.types.ts
@@ -2,6 +2,19 @@ import type { SupportedLanguages, VideoCoverageRange } from "@repo/shared";
 
 export type { VideoCoverageRange };
 
+export type VideoCoverageSnapshot = {
+  coveragePercent: number;
+  watchedRanges: VideoCoverageRange[];
+  isWatched: boolean;
+  durationSeconds: number | null;
+  bucketSizeSeconds: number;
+};
+
+export type VideoCoverageSnapshotChange = {
+  resourceEntityId: string;
+  snapshot: VideoCoverageSnapshot;
+};
+
 export type VideoCoverageTrackingOptions = {
   enabled: boolean;
   showCoverageMarkers?: boolean;
@@ -14,12 +27,5 @@ export type VideoCoverageTrackingOptions = {
   initialDurationSeconds?: number | null;
   initialBucketSizeSeconds?: number | null;
   flushIntervalMs?: number;
-};
-
-export type VideoCoverageSnapshot = {
-  coveragePercent: number;
-  watchedRanges: VideoCoverageRange[];
-  isWatched: boolean;
-  durationSeconds: number | null;
-  bucketSizeSeconds: number;
+  onSnapshotChange?: (change: VideoCoverageSnapshotChange) => void;
 };

--- a/apps/web/app/locales/cs/translation.json
+++ b/apps/web/app/locales/cs/translation.json
@@ -2741,6 +2741,10 @@
       "body": "Počkejte prosím chvíli. Jakmile bude připraven, objeví se zde."
     },
     "videoProgress": {
+      "label": "Průběh videa",
+      "completedSummary": "Dokončeno {{completed}} z {{total}}",
+      "overviewAriaLabel": "Průběh videí v lekci",
+      "segmentAriaLabel": "Průběh videa {{index}}: zhlédnuto {{progress}} %",
       "errors": {
         "resourceNotFound": "Postup videa pro tuto lekci se nepodařilo uložit.",
         "unsupportedLessonType": "Postup videa je dostupný pouze pro obsahové lekce.",

--- a/apps/web/app/locales/de/translation.json
+++ b/apps/web/app/locales/de/translation.json
@@ -2735,6 +2735,10 @@
       "body": "Bitte warten Sie einen Moment. Sobald es fertig ist, wird es hier angezeigt."
     },
     "videoProgress": {
+      "label": "Video-Fortschritt",
+      "completedSummary": "{{completed}} von {{total}} abgeschlossen",
+      "overviewAriaLabel": "Video-Fortschritt der Lektion",
+      "segmentAriaLabel": "Fortschritt von Video {{index}}: {{progress}} % angesehen",
       "errors": {
         "resourceNotFound": "Der Videofortschritt konnte für diese Lektion nicht gespeichert werden.",
         "unsupportedLessonType": "Videofortschritt ist nur für Inhaltslektionen verfügbar.",

--- a/apps/web/app/locales/en/translation.json
+++ b/apps/web/app/locales/en/translation.json
@@ -2796,6 +2796,10 @@
       "body": "Please wait a moment. It will appear here once it is ready."
     },
     "videoProgress": {
+      "label": "Video progress",
+      "completedSummary": "{{completed}} of {{total}} completed",
+      "overviewAriaLabel": "Lesson video progress",
+      "segmentAriaLabel": "Video {{index}} progress: {{progress}}% watched",
       "errors": {
         "resourceNotFound": "Video progress could not be saved for this lesson.",
         "unsupportedLessonType": "Video progress is only available for content lessons.",

--- a/apps/web/app/locales/es/translation.json
+++ b/apps/web/app/locales/es/translation.json
@@ -2796,6 +2796,10 @@
       "body": "Espere un momento. Aparecerá aquí una vez que esté listo."
     },
     "videoProgress": {
+      "label": "Progreso del video",
+      "completedSummary": "{{completed}} de {{total}} completados",
+      "overviewAriaLabel": "Progreso de los videos de la lección",
+      "segmentAriaLabel": "Progreso del video {{index}}: {{progress}}% visto",
       "errors": {
         "resourceNotFound": "No se pudo guardar el progreso del video para esta lección.",
         "unsupportedLessonType": "El progreso del video solo está disponible para lecciones de contenido.",

--- a/apps/web/app/locales/lt/translation.json
+++ b/apps/web/app/locales/lt/translation.json
@@ -2741,6 +2741,10 @@
       "body": "Šiek tiek palaukite. Jis pasirodys čia, kai bus paruoštas."
     },
     "videoProgress": {
+      "label": "Vaizdo įrašų eiga",
+      "completedSummary": "Užbaigta {{completed}} iš {{total}}",
+      "overviewAriaLabel": "Pamokos vaizdo įrašų eiga",
+      "segmentAriaLabel": "{{index}} vaizdo įrašo eiga: peržiūrėta {{progress}}%",
       "errors": {
         "resourceNotFound": "Nepavyko išsaugoti šios pamokos vaizdo įrašo pažangos.",
         "unsupportedLessonType": "Vaizdo įrašo pažanga pasiekiama tik turinio pamokoms.",

--- a/apps/web/app/locales/pl/translation.json
+++ b/apps/web/app/locales/pl/translation.json
@@ -3034,6 +3034,10 @@
       "body": "Poczekaj chwilę. Pojawi się tutaj, gdy będzie gotowe."
     },
     "videoProgress": {
+      "label": "Postęp wideo",
+      "completedSummary": "Ukończono {{completed}} z {{total}}",
+      "overviewAriaLabel": "Postęp wideo w lekcji",
+      "segmentAriaLabel": "Postęp wideo {{index}}: obejrzano {{progress}}%",
       "errors": {
         "resourceNotFound": "Nie udało się zapisać postępu wideo dla tej lekcji.",
         "unsupportedLessonType": "Postęp wideo jest dostępny tylko dla lekcji z treścią.",

--- a/apps/web/app/modules/Courses/Lesson/LessonContent.tsx
+++ b/apps/web/app/modules/Courses/Lesson/LessonContent.tsx
@@ -74,7 +74,7 @@ export const LessonContent = ({
       showCoverageMarkers: videoProgressPersistenceEnabled && videoCompletionTrackingEnabled,
       lessonId: lesson.id,
       language,
-      onSnapshotChange: videoProgressStore.publishSnapshot,
+      onSnapshotChange: videoProgressStore.getState().publishSnapshot,
     }),
     [
       language,

--- a/apps/web/app/modules/Courses/Lesson/LessonContent.tsx
+++ b/apps/web/app/modules/Courses/Lesson/LessonContent.tsx
@@ -17,6 +17,8 @@ import { useLanguageStore } from "~/modules/Dashboard/Settings/Language/Language
 import { LEARNING_HANDLES } from "../../../../e2e/data/learning/handles";
 
 import { LessonContentRenderer } from "./LessonContentRenderer";
+import { LessonVideoProgressStrip } from "./LessonVideoProgressStrip";
+import { createLessonVideoProgressStore } from "./LessonVideoProgressStrip.utils";
 import { isNextBlocked, isPreviousBlocked } from "./utils";
 
 import type { GetCourseResponse, GetLessonByIdResponse } from "~/api/generated-api";
@@ -65,14 +67,22 @@ export const LessonContent = ({
   const videoCompletionTrackingEnabled = Boolean(lesson.videoCompletionTrackingEnabled);
   const shouldUseCoverageCompletion =
     videoProgressPersistenceEnabled && videoCompletionTrackingEnabled;
+  const videoProgressStore = useMemo(() => createLessonVideoProgressStore(), []);
   const videoCoverageTracking = useMemo(
     () => ({
       enabled: videoProgressPersistenceEnabled,
       showCoverageMarkers: videoProgressPersistenceEnabled && videoCompletionTrackingEnabled,
       lessonId: lesson.id,
       language,
+      onSnapshotChange: videoProgressStore.publishSnapshot,
     }),
-    [language, lesson.id, videoCompletionTrackingEnabled, videoProgressPersistenceEnabled],
+    [
+      language,
+      lesson.id,
+      videoCompletionTrackingEnabled,
+      videoProgressPersistenceEnabled,
+      videoProgressStore,
+    ],
   );
 
   const currentChapterIndex = course.chapters.findIndex((chapter) =>
@@ -285,6 +295,13 @@ export const LessonContent = ({
               </div>
             )}
           </div>
+
+          <LessonVideoProgressStrip
+            lessonId={lesson.id}
+            description={lesson.description}
+            enabled={shouldUseCoverageCompletion}
+            store={videoProgressStore}
+          />
 
           <LessonContentRenderer
             lesson={lesson}

--- a/apps/web/app/modules/Courses/Lesson/LessonContentRenderer.tsx
+++ b/apps/web/app/modules/Courses/Lesson/LessonContentRenderer.tsx
@@ -12,6 +12,7 @@ import { ScormLesson } from "./ScormLesson/ScormLesson";
 
 import type { SupportedLanguages } from "@repo/shared";
 import type { CurrentUserResponse, GetLessonByIdResponse } from "~/api/generated-api";
+import type { VideoCoverageSnapshotChange } from "~/components/VideoPlayer/videoCoverage.types";
 import type { LessonPreviewUser } from "~/modules/Courses/Lesson/types";
 
 type LessonContentRendererProps = {
@@ -26,6 +27,7 @@ type LessonContentRendererProps = {
     showCoverageMarkers?: boolean;
     lessonId: string;
     language: SupportedLanguages;
+    onSnapshotChange?: (change: VideoCoverageSnapshotChange) => void;
   };
 };
 

--- a/apps/web/app/modules/Courses/Lesson/LessonVideoProgressStrip.tsx
+++ b/apps/web/app/modules/Courses/Lesson/LessonVideoProgressStrip.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useSyncExternalStore } from "react";
+import { useTranslation } from "react-i18next";
+
+import { cn } from "~/lib/utils";
+
+import {
+  getLessonVideoProgressRangeStyle,
+  getLessonVideoProgressSegmentDurationSeconds,
+  getLessonVideoProgressSegmentWatchedRanges,
+  isLessonVideoProgressSegmentComplete,
+  parseLessonVideoProgressSegments,
+} from "./LessonVideoProgressStrip.utils";
+
+import type { LessonVideoProgressStripProps } from "./LessonVideoProgressStrip.types";
+
+export const LessonVideoProgressStrip = ({
+  lessonId,
+  description,
+  enabled,
+  store,
+}: LessonVideoProgressStripProps) => {
+  const { t } = useTranslation();
+  const segments = useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot);
+
+  useEffect(() => {
+    if (!enabled) {
+      store.reset([]);
+      return;
+    }
+
+    store.reset(parseLessonVideoProgressSegments(description));
+  }, [description, enabled, lessonId, store]);
+
+  if (!enabled || segments.length === 0) return null;
+
+  const completedSegmentsCount = segments.filter(isLessonVideoProgressSegmentComplete).length;
+
+  return (
+    <div
+      className="mb-6 flex w-full flex-col gap-2"
+      role="group"
+      aria-label={t("studentLessonView.videoProgress.overviewAriaLabel")}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-sm font-semibold text-neutral-800">
+          {t("studentLessonView.videoProgress.label")}
+        </span>
+        <span className="text-xs font-medium text-neutral-600">
+          {t("studentLessonView.videoProgress.completedSummary", {
+            completed: completedSegmentsCount,
+            total: segments.length,
+          })}
+        </span>
+      </div>
+      <div className="flex min-w-0 flex-1 gap-1">
+        {segments.map((segment, index) => {
+          const isComplete = isLessonVideoProgressSegmentComplete(segment);
+          const durationSeconds = getLessonVideoProgressSegmentDurationSeconds(segment);
+          const progressLabel = Math.round(segment.coveragePercent * 100);
+          const watchedRanges = getLessonVideoProgressSegmentWatchedRanges(
+            segment,
+            durationSeconds,
+          );
+
+          return (
+            <div
+              key={`${segment.id}-${index}`}
+              className={cn(
+                "relative h-1 min-w-0 flex-1 overflow-hidden rounded-sm bg-neutral-200 transition-colors duration-300 ease-out",
+                isComplete && "bg-success-100",
+              )}
+              role="progressbar"
+              aria-label={t("studentLessonView.videoProgress.segmentAriaLabel", {
+                index: index + 1,
+                progress: progressLabel,
+              })}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-valuenow={progressLabel}
+            >
+              {watchedRanges.map(([start, end], rangeIndex) => {
+                return (
+                  <span
+                    key={`${segment.id}-${rangeIndex}`}
+                    className={cn(
+                      "absolute inset-y-0 rounded-sm transition-[background-color,left,width] duration-300 ease-out will-change-[left,width]",
+                      isComplete ? "bg-success-500" : "bg-primary-600",
+                    )}
+                    style={getLessonVideoProgressRangeStyle({ start, end, durationSeconds })}
+                  />
+                );
+              })}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/apps/web/app/modules/Courses/Lesson/LessonVideoProgressStrip.tsx
+++ b/apps/web/app/modules/Courses/Lesson/LessonVideoProgressStrip.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useSyncExternalStore } from "react";
+import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
+import { useStore } from "zustand";
 
 import { cn } from "~/lib/utils";
 
@@ -20,16 +21,17 @@ export const LessonVideoProgressStrip = ({
   store,
 }: LessonVideoProgressStripProps) => {
   const { t } = useTranslation();
-  const segments = useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot);
+  const segments = useStore(store, (state) => state.segments);
+  const resetLessonVideoProgress = useStore(store, (state) => state.reset);
 
   useEffect(() => {
     if (!enabled) {
-      store.reset([]);
+      resetLessonVideoProgress([]);
       return;
     }
 
-    store.reset(parseLessonVideoProgressSegments(description));
-  }, [description, enabled, lessonId, store]);
+    resetLessonVideoProgress(parseLessonVideoProgressSegments(description));
+  }, [description, enabled, lessonId, resetLessonVideoProgress]);
 
   if (!enabled || segments.length === 0) return null;
 

--- a/apps/web/app/modules/Courses/Lesson/LessonVideoProgressStrip.types.ts
+++ b/apps/web/app/modules/Courses/Lesson/LessonVideoProgressStrip.types.ts
@@ -1,0 +1,30 @@
+import type { VideoCoverageRange } from "@repo/shared";
+import type { VideoCoverageSnapshot } from "~/components/VideoPlayer/videoCoverage.types";
+
+export type LessonVideoProgressSnapshotChange = {
+  resourceEntityId: string;
+  snapshot: VideoCoverageSnapshot;
+};
+
+export type LessonVideoProgressSegment = {
+  id: string;
+  resourceEntityId: string | null;
+  coveragePercent: number;
+  isWatched: boolean;
+  watchedRanges: VideoCoverageRange[];
+  durationSeconds: number | null;
+};
+
+export type LessonVideoProgressStripProps = {
+  lessonId: string;
+  description: string | null;
+  enabled: boolean;
+  store: LessonVideoProgressStore;
+};
+
+export type LessonVideoProgressStore = {
+  getSnapshot: () => LessonVideoProgressSegment[];
+  publishSnapshot: (change: LessonVideoProgressSnapshotChange) => void;
+  reset: (segments: LessonVideoProgressSegment[]) => void;
+  subscribe: (listener: () => void) => () => void;
+};

--- a/apps/web/app/modules/Courses/Lesson/LessonVideoProgressStrip.types.ts
+++ b/apps/web/app/modules/Courses/Lesson/LessonVideoProgressStrip.types.ts
@@ -1,4 +1,5 @@
 import type { VideoCoverageRange } from "@repo/shared";
+import type { StoreApi } from "zustand/vanilla";
 import type { VideoCoverageSnapshot } from "~/components/VideoPlayer/videoCoverage.types";
 
 export type LessonVideoProgressSnapshotChange = {
@@ -22,9 +23,10 @@ export type LessonVideoProgressStripProps = {
   store: LessonVideoProgressStore;
 };
 
-export type LessonVideoProgressStore = {
-  getSnapshot: () => LessonVideoProgressSegment[];
+export type LessonVideoProgressStoreState = {
+  segments: LessonVideoProgressSegment[];
   publishSnapshot: (change: LessonVideoProgressSnapshotChange) => void;
   reset: (segments: LessonVideoProgressSegment[]) => void;
-  subscribe: (listener: () => void) => () => void;
 };
+
+export type LessonVideoProgressStore = StoreApi<LessonVideoProgressStoreState>;

--- a/apps/web/app/modules/Courses/Lesson/LessonVideoProgressStrip.utils.ts
+++ b/apps/web/app/modules/Courses/Lesson/LessonVideoProgressStrip.utils.ts
@@ -1,4 +1,6 @@
 import { mergeVideoCoverageRanges, type VideoCoverageRange } from "@repo/shared";
+import { clamp } from "lodash-es";
+import { createStore } from "zustand/vanilla";
 
 import { getVideoEmbedAttrsFromElement } from "~/components/RichText/extensions/utils/video";
 
@@ -6,6 +8,7 @@ import type {
   LessonVideoProgressSegment,
   LessonVideoProgressSnapshotChange,
   LessonVideoProgressStore,
+  LessonVideoProgressStoreState,
 } from "./LessonVideoProgressStrip.types";
 
 export const VIDEO_COMPLETION_COVERAGE_THRESHOLD = 0.9;
@@ -13,7 +16,7 @@ export const VIDEO_COMPLETION_COVERAGE_THRESHOLD = 0.9;
 export const clampVideoProgress = (value: number | null | undefined) => {
   if (typeof value !== "number" || !Number.isFinite(value)) return 0;
 
-  return Math.max(0, Math.min(1, value));
+  return clamp(value, 0, 1);
 };
 
 export const parseLessonVideoProgressSegments = (
@@ -90,8 +93,8 @@ export const getLessonVideoProgressRangeStyle = ({
   end: number;
   durationSeconds: number;
 }) => {
-  const left = Math.max(0, Math.min(100, (start / durationSeconds) * 100));
-  const width = Math.max(0, Math.min(100 - left, ((end - start) / durationSeconds) * 100));
+  const left = clamp((start / durationSeconds) * 100, 0, 100);
+  const width = clamp(((end - start) / durationSeconds) * 100, 0, 100 - left);
 
   return {
     left: `${left}%`,
@@ -100,13 +103,7 @@ export const getLessonVideoProgressRangeStyle = ({
 };
 
 export const createLessonVideoProgressStore = (): LessonVideoProgressStore => {
-  let segments: LessonVideoProgressSegment[] = [];
   const progressChangesByResourceId = new Map<string, LessonVideoProgressSnapshotChange>();
-  const listeners = new Set<() => void>();
-
-  const emit = () => {
-    listeners.forEach((listener) => listener());
-  };
 
   const applyStoredProgressChanges = (nextSegments: LessonVideoProgressSegment[]) => {
     return Array.from(progressChangesByResourceId.values()).reduce(
@@ -116,23 +113,16 @@ export const createLessonVideoProgressStore = (): LessonVideoProgressStore => {
     );
   };
 
-  return {
-    getSnapshot: () => segments,
+  return createStore<LessonVideoProgressStoreState>((set) => ({
+    segments: [],
     publishSnapshot: (change) => {
       progressChangesByResourceId.set(change.resourceEntityId, change);
-      segments = applyLessonVideoProgressSnapshotChange(segments, change);
-      emit();
+      set((state) => ({
+        segments: applyLessonVideoProgressSnapshotChange(state.segments, change),
+      }));
     },
     reset: (nextSegments) => {
-      segments = applyStoredProgressChanges(nextSegments);
-      emit();
+      set({ segments: applyStoredProgressChanges(nextSegments) });
     },
-    subscribe: (listener) => {
-      listeners.add(listener);
-
-      return () => {
-        listeners.delete(listener);
-      };
-    },
-  };
+  }));
 };

--- a/apps/web/app/modules/Courses/Lesson/LessonVideoProgressStrip.utils.ts
+++ b/apps/web/app/modules/Courses/Lesson/LessonVideoProgressStrip.utils.ts
@@ -1,0 +1,138 @@
+import { mergeVideoCoverageRanges, type VideoCoverageRange } from "@repo/shared";
+
+import { getVideoEmbedAttrsFromElement } from "~/components/RichText/extensions/utils/video";
+
+import type {
+  LessonVideoProgressSegment,
+  LessonVideoProgressSnapshotChange,
+  LessonVideoProgressStore,
+} from "./LessonVideoProgressStrip.types";
+
+export const VIDEO_COMPLETION_COVERAGE_THRESHOLD = 0.9;
+
+export const clampVideoProgress = (value: number | null | undefined) => {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 0;
+
+  return Math.max(0, Math.min(1, value));
+};
+
+export const parseLessonVideoProgressSegments = (
+  description: string | null,
+): LessonVideoProgressSegment[] => {
+  if (!description || typeof DOMParser === "undefined") return [];
+
+  const doc = new DOMParser().parseFromString(description, "text/html");
+
+  return Array.from(doc.querySelectorAll<HTMLElement>('[data-node-type="video"]'))
+    .map((element, index): LessonVideoProgressSegment | null => {
+      const attrs = getVideoEmbedAttrsFromElement(element);
+
+      if (!attrs) return null;
+
+      return {
+        id: attrs.resourceEntityId ?? attrs.src ?? `video-${index}`,
+        resourceEntityId: attrs.resourceEntityId,
+        coveragePercent: clampVideoProgress(attrs.videoCoveragePercent),
+        isWatched: attrs.videoIsWatched,
+        watchedRanges: mergeVideoCoverageRanges(attrs.videoWatchedRanges),
+        durationSeconds: attrs.videoDurationSeconds,
+      };
+    })
+    .filter((segment): segment is LessonVideoProgressSegment => Boolean(segment));
+};
+
+export const applyLessonVideoProgressSnapshotChange = (
+  segments: LessonVideoProgressSegment[],
+  progressChange: LessonVideoProgressSnapshotChange,
+) =>
+  segments.map((segment) => {
+    if (segment.resourceEntityId !== progressChange.resourceEntityId) return segment;
+
+    return {
+      ...segment,
+      coveragePercent: clampVideoProgress(progressChange.snapshot.coveragePercent),
+      isWatched: progressChange.snapshot.isWatched,
+      watchedRanges: mergeVideoCoverageRanges(progressChange.snapshot.watchedRanges),
+      durationSeconds: progressChange.snapshot.durationSeconds,
+    };
+  });
+
+export const isLessonVideoProgressSegmentComplete = (segment: LessonVideoProgressSegment) =>
+  segment.isWatched || segment.coveragePercent >= VIDEO_COMPLETION_COVERAGE_THRESHOLD;
+
+export const getFallbackDurationSeconds = (watchedRanges: VideoCoverageRange[]) => {
+  const maxEnd = watchedRanges.reduce((duration, [, end]) => Math.max(duration, end), 0);
+
+  return maxEnd > 0 ? maxEnd : 1;
+};
+
+export const getLessonVideoProgressSegmentDurationSeconds = (
+  segment: LessonVideoProgressSegment,
+) =>
+  segment.durationSeconds && segment.durationSeconds > 0
+    ? segment.durationSeconds
+    : getFallbackDurationSeconds(segment.watchedRanges);
+
+export const getLessonVideoProgressSegmentWatchedRanges = (
+  segment: LessonVideoProgressSegment,
+  durationSeconds: number,
+) =>
+  isLessonVideoProgressSegmentComplete(segment) && segment.watchedRanges.length === 0
+    ? ([[0, durationSeconds]] satisfies VideoCoverageRange[])
+    : segment.watchedRanges;
+
+export const getLessonVideoProgressRangeStyle = ({
+  start,
+  end,
+  durationSeconds,
+}: {
+  start: number;
+  end: number;
+  durationSeconds: number;
+}) => {
+  const left = Math.max(0, Math.min(100, (start / durationSeconds) * 100));
+  const width = Math.max(0, Math.min(100 - left, ((end - start) / durationSeconds) * 100));
+
+  return {
+    left: `${left}%`,
+    width: `${width}%`,
+  };
+};
+
+export const createLessonVideoProgressStore = (): LessonVideoProgressStore => {
+  let segments: LessonVideoProgressSegment[] = [];
+  const progressChangesByResourceId = new Map<string, LessonVideoProgressSnapshotChange>();
+  const listeners = new Set<() => void>();
+
+  const emit = () => {
+    listeners.forEach((listener) => listener());
+  };
+
+  const applyStoredProgressChanges = (nextSegments: LessonVideoProgressSegment[]) => {
+    return Array.from(progressChangesByResourceId.values()).reduce(
+      (currentSegments, progressChange) =>
+        applyLessonVideoProgressSnapshotChange(currentSegments, progressChange),
+      nextSegments,
+    );
+  };
+
+  return {
+    getSnapshot: () => segments,
+    publishSnapshot: (change) => {
+      progressChangesByResourceId.set(change.resourceEntityId, change);
+      segments = applyLessonVideoProgressSnapshotChange(segments, change);
+      emit();
+    },
+    reset: (nextSegments) => {
+      segments = applyStoredProgressChanges(nextSegments);
+      emit();
+    },
+    subscribe: (listener) => {
+      listeners.add(listener);
+
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+};

--- a/apps/web/app/modules/Courses/Lesson/__tests__/LessonVideoProgressStrip.test.tsx
+++ b/apps/web/app/modules/Courses/Lesson/__tests__/LessonVideoProgressStrip.test.tsx
@@ -102,7 +102,7 @@ describe("LessonVideoProgressStrip", () => {
     await waitFor(() => expect(screen.getAllByRole("progressbar")).toHaveLength(3));
 
     act(() => {
-      store.publishSnapshot({
+      store.getState().publishSnapshot({
         resourceEntityId: "resource-one",
         snapshot: {
           coveragePercent: 0.95,
@@ -126,7 +126,7 @@ describe("LessonVideoProgressStrip", () => {
   it("keeps a video update that arrives before the strip parses lesson content", async () => {
     const store = createLessonVideoProgressStore();
 
-    store.publishSnapshot({
+    store.getState().publishSnapshot({
       resourceEntityId: "resource-one",
       snapshot: {
         coveragePercent: 0.95,

--- a/apps/web/app/modules/Courses/Lesson/__tests__/LessonVideoProgressStrip.test.tsx
+++ b/apps/web/app/modules/Courses/Lesson/__tests__/LessonVideoProgressStrip.test.tsx
@@ -1,0 +1,153 @@
+import { act, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { renderWith } from "~/utils/testUtils";
+
+import { LessonVideoProgressStrip } from "../LessonVideoProgressStrip";
+import {
+  createLessonVideoProgressStore,
+  parseLessonVideoProgressSegments,
+} from "../LessonVideoProgressStrip.utils";
+
+const lessonDescription = `
+  <div>
+    <div
+      data-node-type="video"
+      data-source-type="internal"
+      data-src="/api/lesson/lesson-resource/11111111-1111-1111-1111-111111111111"
+      data-resource-entity-id="resource-one"
+      data-video-coverage-percent="0.3"
+      data-video-watched-ranges="[[0,10],[20,30]]"
+      data-video-duration-seconds="100"
+    ></div>
+    <div
+      data-node-type="video"
+      data-source-type="internal"
+      data-src="/api/lesson/lesson-resource/22222222-2222-2222-2222-222222222222"
+      data-resource-entity-id="resource-two"
+      data-video-coverage-percent="0.9"
+      data-video-watched-ranges="[[0,90]]"
+      data-video-duration-seconds="100"
+    ></div>
+    <div
+      data-node-type="video"
+      data-source-type="external"
+      data-src="https://vimeo.com/123"
+    ></div>
+  </div>
+`;
+
+describe("LessonVideoProgressStrip", () => {
+  it("parses one segment per video node with watched range metadata", () => {
+    expect(parseLessonVideoProgressSegments(lessonDescription)).toMatchObject([
+      {
+        resourceEntityId: "resource-one",
+        coveragePercent: 0.3,
+        watchedRanges: [
+          [0, 10],
+          [20, 30],
+        ],
+        durationSeconds: 100,
+      },
+      {
+        resourceEntityId: "resource-two",
+        coveragePercent: 0.9,
+        watchedRanges: [[0, 90]],
+        durationSeconds: 100,
+      },
+      {
+        resourceEntityId: null,
+        coveragePercent: 0,
+        watchedRanges: [],
+      },
+    ]);
+  });
+
+  it("renders tracked chunks and marks 90 percent progress as completed", async () => {
+    const store = createLessonVideoProgressStore();
+    const { container } = renderWith().render(
+      <LessonVideoProgressStrip
+        lessonId="lesson-id"
+        description={lessonDescription}
+        enabled
+        store={store}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getAllByRole("progressbar")).toHaveLength(3));
+
+    const progressBars = screen.getAllByRole("progressbar");
+
+    expect(screen.getByText("Video progress")).toBeInTheDocument();
+    expect(screen.getByText("1 of 3 completed")).toBeInTheDocument();
+    expect(progressBars[0]).toHaveAttribute("aria-valuenow", "30");
+    expect(progressBars[0].querySelectorAll(".bg-primary-600")).toHaveLength(2);
+    expect(progressBars[1]).toHaveAttribute("aria-valuenow", "90");
+    expect(progressBars[1].querySelector(".bg-success-500")).toBeInTheDocument();
+    expect(progressBars[2]).toHaveAttribute("aria-valuenow", "0");
+    expect(container.querySelectorAll(".bg-success-500")).toHaveLength(1);
+  });
+
+  it("updates a segment when a video tracker reports a new snapshot", async () => {
+    const store = createLessonVideoProgressStore();
+    renderWith().render(
+      <LessonVideoProgressStrip
+        lessonId="lesson-id"
+        description={lessonDescription}
+        enabled
+        store={store}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getAllByRole("progressbar")).toHaveLength(3));
+
+    act(() => {
+      store.publishSnapshot({
+        resourceEntityId: "resource-one",
+        snapshot: {
+          coveragePercent: 0.95,
+          watchedRanges: [[0, 95]],
+          isWatched: true,
+          durationSeconds: 100,
+          bucketSizeSeconds: 1,
+        },
+      });
+    });
+
+    await waitFor(() =>
+      expect(screen.getAllByRole("progressbar")[0]).toHaveAttribute("aria-valuenow", "95"),
+    );
+
+    expect(
+      screen.getAllByRole("progressbar")[0].querySelector(".bg-success-500"),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps a video update that arrives before the strip parses lesson content", async () => {
+    const store = createLessonVideoProgressStore();
+
+    store.publishSnapshot({
+      resourceEntityId: "resource-one",
+      snapshot: {
+        coveragePercent: 0.95,
+        watchedRanges: [[0, 95]],
+        isWatched: true,
+        durationSeconds: 100,
+        bucketSizeSeconds: 1,
+      },
+    });
+
+    renderWith().render(
+      <LessonVideoProgressStrip
+        lessonId="lesson-id"
+        description={lessonDescription}
+        enabled
+        store={store}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getAllByRole("progressbar")[0]).toHaveAttribute("aria-valuenow", "95"),
+    );
+  });
+});

--- a/docs/specs/lesson-delivery-learning-mode-business-spec.md
+++ b/docs/specs/lesson-delivery-learning-mode-business-spec.md
@@ -20,6 +20,7 @@ The main workflow starts when a learner opens a course and chooses to start or c
 - Start or continue a course from the course overview.
 - Render content, quiz, AI mentor, embed, SCORM, and live training lessons.
 - Control lesson videos with focused keyboard shortcuts for play, seeking, volume, mute, restart, and fullscreen.
+- Show watched and missed chunks across lesson videos when video completion tracking is enabled.
 - Navigate to previous and next lessons from the learner lesson page.
 - Enforce lesson sequencing when ordered completion is enabled.
 - Keep later lessons locked after unmet requirements, such as a failed required quiz.
@@ -39,7 +40,7 @@ The lesson page loads the selected course and lesson in the active content langu
 
 Each lesson type has its own completion behavior. Content and embed lessons can complete when opened or when required video content finishes. Quiz lessons depend on quiz submission and passing rules. AI mentor, SCORM, and live training lessons use their own lesson-specific state. When sequence mode is enabled, Mentingo blocks access to later lessons until earlier lessons are complete.
 
-For content videos, opening the video focuses the player so learners can use familiar playback shortcuts while the player is active, without those shortcuts taking over the rest of the lesson page.
+For content videos, opening the video focuses the player so learners can use familiar playback shortcuts while the player is active, without those shortcuts taking over the rest of the lesson page. When video completion tracking is enabled, the lesson also shows a segmented progress strip with one part per video, helping learners spot which parts they have watched and which parts they still missed. A video segment turns green after the learner has watched enough of that video to satisfy the completion threshold.
 
 While the learner studies, the page also runs the learning-time tracker. Completion events update lesson, chapter, and course progress and can trigger downstream completion behavior such as certificates or reporting updates.
 
@@ -48,7 +49,8 @@ While the learner studies, the page also runs the learning-time tracker. Complet
 - Learner lesson UI lives in `apps/web/app/modules/Courses/Lesson`.
 - The route is `/course/:courseId/lesson/:lessonId`.
 - Lesson rendering is centralized in `LessonContentRenderer`.
-- Rich-text lesson videos use the shared `VideoPlayer` component for playback controls and focused keyboard shortcuts.
+- Rich-text lesson videos use the shared `VideoPlayer` component for playback controls, focused keyboard shortcuts, and watched-range tracking.
+- Video completion tracking stores watched ranges per lesson video and treats 90% watched coverage as completed.
 - Lesson access and progress updates use `PERMISSIONS.LEARNING_PROGRESS_UPDATE` and `PERMISSIONS.LEARNING_MODE_USE`.
 - Progress updates are handled through `apps/api/src/studentLessonProgress`.
 - Learning-time tracking uses `apps/web/app/hooks/useLearningTimeTracker.ts` and `apps/api/src/learning-time`.
@@ -56,4 +58,5 @@ While the learner studies, the page also runs the learning-time tracker. Complet
 ## Test Evidence
 
 - Web E2E coverage verifies starting learning, continuing to the next content lesson, opening lessons out of order when sequence is disabled, blocking skipped lessons when sequence is enabled, keeping the next lesson locked after a failed required quiz, submitting and retaking quizzes, completing embed lessons, accessing AI mentor entry points, and SCORM launch/resume/completion behavior.
+- Web unit coverage verifies the segmented lesson video progress strip, watched chunk rendering, 90% green completion state, and live updates from the video tracker.
 - API E2E coverage verifies quiz feedback visibility rules, lesson completion restrictions for authors/admins outside learning mode, admin/content-creator learning-mode behavior, quiz submission rules, quiz lesson deletion with submitted answers, and learning-time queue processing.


### PR DESCRIPTION
## Issue(s)
- #1739 

## Overview
Adds a lesson-level segmented video progress strip for content lessons with video completion tracking enabled.

The strip renders one segment per video in the lesson, shows watched chunks inside each segment, updates live while learners watch videos, and marks a segment as completed when the video reaches the 90% watched threshold. It also includes translated labels and accessible progressbar metadata.

## Business Value
Learners can quickly see which lesson videos they have completed and which parts they missed. This reduces confusion around video-based lesson completion and makes it easier to return to unfinished video chunks without replaying already watched content.

## Screenshots / Video

https://github.com/user-attachments/assets/dd614b56-6b38-47f1-954c-b1daa09590a9