### PR TITLE
chore: improve activity logs for article language changes

### DIFF
--- a/apps/api/src/activity-logs/handlers/articles-activity.handler.ts
+++ b/apps/api/src/activity-logs/handlers/articles-activity.handler.ts
@@ -7,6 +7,7 @@ import { CreateSectionLanguageEvent } from "src/events/articles/create-section-l
 import { CreateArticleSectionEvent } from "src/events/articles/create-section.event";
 import { DeleteArticleLanguageEvent } from "src/events/articles/delete-article-language.event";
 import { DeleteArticleEvent } from "src/events/articles/delete-articles.event";
+import { DeleteSectionLanguageEvent } from "src/events/articles/delete-section-language.event";
 import { DeleteArticleSectionEvent } from "src/events/articles/delete-section.event";
 import { UpdateArticleEvent } from "src/events/articles/update-articles.event";
 import { UpdateArticleSectionEvent } from "src/events/articles/update-section.event";
@@ -24,7 +25,8 @@ type ArticleEventType =
   | DeleteArticleSectionEvent
   | CreateArticleLanguageEvent
   | DeleteArticleLanguageEvent
-  | CreateSectionLanguageEvent;
+  | CreateSectionLanguageEvent
+  | DeleteSectionLanguageEvent;
 
 const ArticleActivityEvents = [
   CreateArticleEvent,
@@ -36,6 +38,7 @@ const ArticleActivityEvents = [
   CreateArticleLanguageEvent,
   DeleteArticleLanguageEvent,
   CreateSectionLanguageEvent,
+  DeleteSectionLanguageEvent,
 ] as const;
 
 @Injectable()
@@ -53,6 +56,8 @@ export class ArticlesActivityHandler implements IEventHandler<ArticleEventType> 
     if (event instanceof DeleteArticleEvent) return await this.handleDeleteArticle(event);
     if (event instanceof CreateSectionLanguageEvent)
       return await this.handleCreateSectionLanguageEvent(event);
+    if (event instanceof DeleteSectionLanguageEvent)
+      return await this.handleDeleteSectionLanguageEvent(event);
     if (event instanceof CreateArticleSectionEvent)
       return await this.handleCreateArticleSection(event);
     if (event instanceof UpdateArticleSectionEvent)
@@ -198,6 +203,22 @@ export class ArticlesActivityHandler implements IEventHandler<ArticleEventType> 
       before: null,
       after: metadata.after,
       context: metadata.context ?? null,
+    });
+  }
+
+  private async handleDeleteSectionLanguageEvent(event: DeleteSectionLanguageEvent) {
+    const { articleSectionUpdateData } = event;
+
+    await this.activityLogsService.recordActivity({
+      actor: articleSectionUpdateData.actor,
+      operation: ACTIVITY_LOG_ACTION_TYPES.DELETE,
+      resourceType: ACTIVITY_LOG_RESOURCE_TYPES.ARTICLE_SECTION,
+      resourceId: articleSectionUpdateData.articleSectionId,
+      context: this.buildLanguageContext(
+        articleSectionUpdateData.language,
+        undefined,
+        articleSectionUpdateData.action,
+      ),
     });
   }
 

--- a/apps/api/src/activity-logs/handlers/articles-activity.handler.ts
+++ b/apps/api/src/activity-logs/handlers/articles-activity.handler.ts
@@ -1,6 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import { EventsHandler, type IEventHandler } from "@nestjs/cqrs";
 
+import { CreateArticleLanguageEvent } from "src/events/articles/create-article-language.event";
 import { CreateArticleEvent } from "src/events/articles/create-articles.event";
 import { CreateArticleSectionEvent } from "src/events/articles/create-section.event";
 import { DeleteArticleEvent } from "src/events/articles/delete-articles.event";
@@ -18,7 +19,8 @@ type ArticleEventType =
   | DeleteArticleEvent
   | CreateArticleSectionEvent
   | UpdateArticleSectionEvent
-  | DeleteArticleSectionEvent;
+  | DeleteArticleSectionEvent
+  | CreateArticleLanguageEvent;
 
 const ArticleActivityEvents = [
   CreateArticleEvent,
@@ -27,6 +29,7 @@ const ArticleActivityEvents = [
   CreateArticleSectionEvent,
   UpdateArticleSectionEvent,
   DeleteArticleSectionEvent,
+  CreateArticleLanguageEvent,
 ] as const;
 
 @Injectable()
@@ -36,6 +39,8 @@ export class ArticlesActivityHandler implements IEventHandler<ArticleEventType> 
 
   async handle(event: ArticleEventType) {
     if (event instanceof CreateArticleEvent) return await this.handleCreateArticle(event);
+    if (event instanceof CreateArticleLanguageEvent)
+      return await this.handleCreateArticleLanguage(event);
     if (event instanceof UpdateArticleEvent) return await this.handleUpdateArticle(event);
     if (event instanceof DeleteArticleEvent) return await this.handleDeleteArticle(event);
     if (event instanceof CreateArticleSectionEvent)
@@ -203,5 +208,29 @@ export class ArticlesActivityHandler implements IEventHandler<ArticleEventType> 
     if (title) context.title = title;
 
     return Object.keys(context).length ? context : null;
+  }
+
+  private async handleCreateArticleLanguage(event: CreateArticleLanguageEvent) {
+    const { articleUpdateData } = event;
+
+    const metadata = buildActivityLogMetadata({
+      previous: articleUpdateData.previousArticleData,
+      updated: articleUpdateData.updatedArticleData,
+      context: this.buildLanguageContext(
+        articleUpdateData.language,
+        articleUpdateData.updatedArticleData,
+        articleUpdateData.action,
+      ),
+    });
+
+    await this.activityLogsService.recordActivity({
+      actor: articleUpdateData.actor,
+      operation: ACTIVITY_LOG_ACTION_TYPES.UPDATE,
+      resourceType: ACTIVITY_LOG_RESOURCE_TYPES.ARTICLE,
+      resourceId: articleUpdateData.articleId,
+      changedFields: metadata.changedFields,
+      after: metadata.after,
+      context: metadata.context ?? null,
+    });
   }
 }

--- a/apps/api/src/activity-logs/handlers/articles-activity.handler.ts
+++ b/apps/api/src/activity-logs/handlers/articles-activity.handler.ts
@@ -247,7 +247,7 @@ export class ArticlesActivityHandler implements IEventHandler<ArticleEventType> 
       updated: null,
       context: this.buildLanguageContext(
         articleUpdateData.language,
-        articleUpdateData.updatedArticleData,
+        undefined,
         articleUpdateData.action,
       ),
     });
@@ -258,7 +258,7 @@ export class ArticlesActivityHandler implements IEventHandler<ArticleEventType> 
       resourceType: ACTIVITY_LOG_RESOURCE_TYPES.ARTICLE,
       resourceId: articleUpdateData.articleId,
       changedFields: metadata.changedFields,
-      before: metadata.before,
+      before: null,
       context: metadata.context ?? null,
     });
   }

--- a/apps/api/src/activity-logs/handlers/articles-activity.handler.ts
+++ b/apps/api/src/activity-logs/handlers/articles-activity.handler.ts
@@ -4,6 +4,7 @@ import { EventsHandler, type IEventHandler } from "@nestjs/cqrs";
 import { CreateArticleLanguageEvent } from "src/events/articles/create-article-language.event";
 import { CreateArticleEvent } from "src/events/articles/create-articles.event";
 import { CreateArticleSectionEvent } from "src/events/articles/create-section.event";
+import { DeleteArticleLanguageEvent } from "src/events/articles/delete-article-language.event";
 import { DeleteArticleEvent } from "src/events/articles/delete-articles.event";
 import { DeleteArticleSectionEvent } from "src/events/articles/delete-section.event";
 import { UpdateArticleEvent } from "src/events/articles/update-articles.event";
@@ -20,7 +21,8 @@ type ArticleEventType =
   | CreateArticleSectionEvent
   | UpdateArticleSectionEvent
   | DeleteArticleSectionEvent
-  | CreateArticleLanguageEvent;
+  | CreateArticleLanguageEvent
+  | DeleteArticleLanguageEvent;
 
 const ArticleActivityEvents = [
   CreateArticleEvent,
@@ -30,6 +32,7 @@ const ArticleActivityEvents = [
   UpdateArticleSectionEvent,
   DeleteArticleSectionEvent,
   CreateArticleLanguageEvent,
+  DeleteArticleLanguageEvent,
 ] as const;
 
 @Injectable()
@@ -39,6 +42,8 @@ export class ArticlesActivityHandler implements IEventHandler<ArticleEventType> 
 
   async handle(event: ArticleEventType) {
     if (event instanceof CreateArticleEvent) return await this.handleCreateArticle(event);
+    if (event instanceof DeleteArticleLanguageEvent)
+      return await this.handleDeleteArticleLanguage(event);
     if (event instanceof CreateArticleLanguageEvent)
       return await this.handleCreateArticleLanguage(event);
     if (event instanceof UpdateArticleEvent) return await this.handleUpdateArticle(event);
@@ -225,11 +230,35 @@ export class ArticlesActivityHandler implements IEventHandler<ArticleEventType> 
 
     await this.activityLogsService.recordActivity({
       actor: articleUpdateData.actor,
-      operation: ACTIVITY_LOG_ACTION_TYPES.UPDATE,
+      operation: ACTIVITY_LOG_ACTION_TYPES.CREATE,
       resourceType: ACTIVITY_LOG_RESOURCE_TYPES.ARTICLE,
       resourceId: articleUpdateData.articleId,
       changedFields: metadata.changedFields,
       after: metadata.after,
+      context: metadata.context ?? null,
+    });
+  }
+
+  private async handleDeleteArticleLanguage(event: DeleteArticleLanguageEvent) {
+    const { articleUpdateData } = event;
+
+    const metadata = buildActivityLogMetadata({
+      previous: articleUpdateData.previousArticleData,
+      updated: null,
+      context: this.buildLanguageContext(
+        articleUpdateData.language,
+        articleUpdateData.updatedArticleData,
+        articleUpdateData.action,
+      ),
+    });
+
+    await this.activityLogsService.recordActivity({
+      actor: articleUpdateData.actor,
+      operation: ACTIVITY_LOG_ACTION_TYPES.DELETE,
+      resourceType: ACTIVITY_LOG_RESOURCE_TYPES.ARTICLE,
+      resourceId: articleUpdateData.articleId,
+      changedFields: metadata.changedFields,
+      before: metadata.before,
       context: metadata.context ?? null,
     });
   }

--- a/apps/api/src/activity-logs/handlers/articles-activity.handler.ts
+++ b/apps/api/src/activity-logs/handlers/articles-activity.handler.ts
@@ -3,6 +3,7 @@ import { EventsHandler, type IEventHandler } from "@nestjs/cqrs";
 
 import { CreateArticleLanguageEvent } from "src/events/articles/create-article-language.event";
 import { CreateArticleEvent } from "src/events/articles/create-articles.event";
+import { CreateSectionLanguageEvent } from "src/events/articles/create-section-language.event";
 import { CreateArticleSectionEvent } from "src/events/articles/create-section.event";
 import { DeleteArticleLanguageEvent } from "src/events/articles/delete-article-language.event";
 import { DeleteArticleEvent } from "src/events/articles/delete-articles.event";
@@ -22,7 +23,8 @@ type ArticleEventType =
   | UpdateArticleSectionEvent
   | DeleteArticleSectionEvent
   | CreateArticleLanguageEvent
-  | DeleteArticleLanguageEvent;
+  | DeleteArticleLanguageEvent
+  | CreateSectionLanguageEvent;
 
 const ArticleActivityEvents = [
   CreateArticleEvent,
@@ -33,6 +35,7 @@ const ArticleActivityEvents = [
   DeleteArticleSectionEvent,
   CreateArticleLanguageEvent,
   DeleteArticleLanguageEvent,
+  CreateSectionLanguageEvent,
 ] as const;
 
 @Injectable()
@@ -48,6 +51,8 @@ export class ArticlesActivityHandler implements IEventHandler<ArticleEventType> 
       return await this.handleCreateArticleLanguage(event);
     if (event instanceof UpdateArticleEvent) return await this.handleUpdateArticle(event);
     if (event instanceof DeleteArticleEvent) return await this.handleDeleteArticle(event);
+    if (event instanceof CreateSectionLanguageEvent)
+      return await this.handleCreateSectionLanguageEvent(event);
     if (event instanceof CreateArticleSectionEvent)
       return await this.handleCreateArticleSection(event);
     if (event instanceof UpdateArticleSectionEvent)
@@ -166,6 +171,31 @@ export class ArticlesActivityHandler implements IEventHandler<ArticleEventType> 
       resourceId: articleSectionUpdateData.articleSectionId,
       changedFields: metadata.changedFields,
       before: metadata.before,
+      after: metadata.after,
+      context: metadata.context ?? null,
+    });
+  }
+
+  private async handleCreateSectionLanguageEvent(event: CreateSectionLanguageEvent) {
+    const { articleSectionUpdateData } = event;
+
+    const metadata = buildActivityLogMetadata({
+      previous: null,
+      updated: articleSectionUpdateData.updatedArticleSectionData,
+      schema: "create",
+      context: this.buildLanguageContext(
+        articleSectionUpdateData.language,
+        articleSectionUpdateData.updatedArticleSectionData,
+        articleSectionUpdateData.action,
+      ),
+    });
+
+    await this.activityLogsService.recordActivity({
+      actor: articleSectionUpdateData.actor,
+      operation: ACTIVITY_LOG_ACTION_TYPES.CREATE,
+      resourceType: ACTIVITY_LOG_RESOURCE_TYPES.ARTICLE_SECTION,
+      resourceId: articleSectionUpdateData.articleSectionId,
+      before: null,
       after: metadata.after,
       context: metadata.context ?? null,
     });

--- a/apps/api/src/articles/services/articles.service.ts
+++ b/apps/api/src/articles/services/articles.service.ts
@@ -1070,7 +1070,20 @@ export class ArticlesService {
     previousSnapshot: ArticleSectionActivityLogSnapshot | null,
     updatedSnapshot: ArticleSectionActivityLogSnapshot | null,
   ) {
-    return isEqual(previousSnapshot, updatedSnapshot);
+    return isEqual(
+      this.getComparableSectionSnapshot(previousSnapshot),
+      this.getComparableSectionSnapshot(updatedSnapshot),
+    );
+  }
+
+  private getComparableSectionSnapshot(snapshot: ArticleSectionActivityLogSnapshot | null) {
+    if (!snapshot) return null;
+
+    return {
+      title: snapshot.title ?? null,
+      baseLanguage: snapshot.baseLanguage ?? null,
+      availableLocales: snapshot.availableLocales ?? [],
+    };
   }
 
   private extractTitleByLanguage(titleField: unknown, language: SupportedLanguages) {

--- a/apps/api/src/articles/services/articles.service.ts
+++ b/apps/api/src/articles/services/articles.service.ts
@@ -433,7 +433,6 @@ export class ArticlesService {
           articleId,
           actor: currentUser,
           previousArticleData: previousSnapshot,
-          updatedArticleData: updatedSnapshot,
           language,
           action: "remove_language",
         }),

--- a/apps/api/src/articles/services/articles.service.ts
+++ b/apps/api/src/articles/services/articles.service.ts
@@ -17,6 +17,7 @@ import { annotateVideoAutoplayAndBlockIndexesInContent } from "src/common/utils/
 import { injectResourcesIntoContent } from "src/common/utils/injectResourcesIntoContent";
 import {
   CreateArticleEvent,
+  CreateArticleLanguageEvent,
   CreateArticleSectionEvent,
   DeleteArticleEvent,
   DeleteArticleSectionEvent,
@@ -688,7 +689,7 @@ export class ArticlesService {
 
     if (!this.areArticleSnapshotsEqual(previousSnapshot, updatedSnapshot)) {
       await this.outboxPublisher.publish(
-        new UpdateArticleEvent({
+        new CreateArticleLanguageEvent({
           articleId,
           actor: currentUser,
           previousArticleData: previousSnapshot,

--- a/apps/api/src/articles/services/articles.service.ts
+++ b/apps/api/src/articles/services/articles.service.ts
@@ -23,6 +23,7 @@ import {
   DeleteArticleEvent,
   DeleteArticleLanguageEvent,
   DeleteArticleSectionEvent,
+  DeleteSectionLanguageEvent,
   UpdateArticleEvent,
   UpdateArticleSectionEvent,
 } from "src/events";
@@ -244,10 +245,9 @@ export class ArticlesService {
 
     if (!this.areSectionSnapshotsEqual(previousSnapshot, updatedSnapshot)) {
       await this.outboxPublisher.publish(
-        new UpdateArticleSectionEvent({
+        new DeleteSectionLanguageEvent({
           articleSectionId: sectionId,
           actor: currentUser,
-          previousArticleSectionData: previousSnapshot,
           updatedArticleSectionData: updatedSnapshot,
           language,
           action: "remove_language",

--- a/apps/api/src/articles/services/articles.service.ts
+++ b/apps/api/src/articles/services/articles.service.ts
@@ -20,6 +20,7 @@ import {
   CreateArticleLanguageEvent,
   CreateArticleSectionEvent,
   DeleteArticleEvent,
+  DeleteArticleLanguageEvent,
   DeleteArticleSectionEvent,
   UpdateArticleEvent,
   UpdateArticleSectionEvent,
@@ -428,7 +429,7 @@ export class ArticlesService {
 
     if (!this.areArticleSnapshotsEqual(previousSnapshot, updatedSnapshot)) {
       await this.outboxPublisher.publish(
-        new UpdateArticleEvent({
+        new DeleteArticleLanguageEvent({
           articleId,
           actor: currentUser,
           previousArticleData: previousSnapshot,

--- a/apps/api/src/articles/services/articles.service.ts
+++ b/apps/api/src/articles/services/articles.service.ts
@@ -19,6 +19,7 @@ import {
   CreateArticleEvent,
   CreateArticleLanguageEvent,
   CreateArticleSectionEvent,
+  CreateSectionLanguageEvent,
   DeleteArticleEvent,
   DeleteArticleLanguageEvent,
   DeleteArticleSectionEvent,
@@ -197,7 +198,7 @@ export class ArticlesService {
 
     if (!this.areSectionSnapshotsEqual(previousSnapshot, updatedSnapshot)) {
       await this.outboxPublisher.publish(
-        new UpdateArticleSectionEvent({
+        new CreateSectionLanguageEvent({
           articleSectionId: sectionId,
           actor: currentUser,
           previousArticleSectionData: previousSnapshot,

--- a/apps/api/src/events/articles/create-article-language.event.ts
+++ b/apps/api/src/events/articles/create-article-language.event.ts
@@ -1,0 +1,17 @@
+import type { SupportedLanguages } from "@repo/shared";
+import type { ArticleActivityLogSnapshot } from "src/activity-logs/types";
+import type { UUIDType } from "src/common";
+import type { ActorUserType } from "src/common/types/actor-user.type";
+
+type LanguageCreateData = {
+  articleId: UUIDType;
+  actor: ActorUserType;
+  previousArticleData: ArticleActivityLogSnapshot;
+  updatedArticleData: ArticleActivityLogSnapshot;
+  language?: SupportedLanguages;
+  action?: "add_language";
+};
+
+export class CreateArticleLanguageEvent {
+  constructor(public readonly articleUpdateData: LanguageCreateData) {}
+}

--- a/apps/api/src/events/articles/create-section-language.event.ts
+++ b/apps/api/src/events/articles/create-section-language.event.ts
@@ -1,0 +1,17 @@
+import type { SupportedLanguages } from "@repo/shared";
+import type { ArticleSectionActivityLogSnapshot } from "src/activity-logs/types";
+import type { UUIDType } from "src/common";
+import type { ActorUserType } from "src/common/types/actor-user.type";
+
+type CreateSectionLanguageData = {
+  articleSectionId: UUIDType;
+  actor: ActorUserType;
+  previousArticleSectionData: ArticleSectionActivityLogSnapshot;
+  updatedArticleSectionData: ArticleSectionActivityLogSnapshot;
+  language?: SupportedLanguages;
+  action?: "add_language";
+};
+
+export class CreateSectionLanguageEvent {
+  constructor(public readonly articleSectionUpdateData: CreateSectionLanguageData) {}
+}

--- a/apps/api/src/events/articles/delete-article-language.event.ts
+++ b/apps/api/src/events/articles/delete-article-language.event.ts
@@ -7,7 +7,6 @@ type DeleteLanguageData = {
   articleId: UUIDType;
   actor: ActorUserType;
   previousArticleData: ArticleActivityLogSnapshot;
-  updatedArticleData: ArticleActivityLogSnapshot;
   language?: SupportedLanguages;
   action?: "remove_language";
 };

--- a/apps/api/src/events/articles/delete-article-language.event.ts
+++ b/apps/api/src/events/articles/delete-article-language.event.ts
@@ -3,15 +3,15 @@ import type { ArticleActivityLogSnapshot } from "src/activity-logs/types";
 import type { UUIDType } from "src/common";
 import type { ActorUserType } from "src/common/types/actor-user.type";
 
-type UpdateLanguageData = {
+type DeleteLanguageData = {
   articleId: UUIDType;
   actor: ActorUserType;
   previousArticleData: ArticleActivityLogSnapshot;
   updatedArticleData: ArticleActivityLogSnapshot;
   language?: SupportedLanguages;
-  action?: "update";
+  action?: "remove_language";
 };
 
-export class CreateArticleLanguageEvent {
-  constructor(public readonly articleUpdateData: UpdateLanguageData) {}
+export class DeleteArticleLanguageEvent {
+  constructor(public readonly articleUpdateData: DeleteLanguageData) {}
 }

--- a/apps/api/src/events/articles/delete-section-language.event.ts
+++ b/apps/api/src/events/articles/delete-section-language.event.ts
@@ -1,0 +1,16 @@
+import type { SupportedLanguages } from "@repo/shared";
+import type { ArticleSectionActivityLogSnapshot } from "src/activity-logs/types";
+import type { UUIDType } from "src/common";
+import type { ActorUserType } from "src/common/types/actor-user.type";
+
+type DeleteSectionLanguageData = {
+  articleSectionId: UUIDType;
+  actor: ActorUserType;
+  updatedArticleSectionData: ArticleSectionActivityLogSnapshot;
+  language?: SupportedLanguages;
+  action?: "remove_language";
+};
+
+export class DeleteSectionLanguageEvent {
+  constructor(public readonly articleSectionUpdateData: DeleteSectionLanguageData) {}
+}

--- a/apps/api/src/events/articles/update-article-language-event.ts
+++ b/apps/api/src/events/articles/update-article-language-event.ts
@@ -1,0 +1,17 @@
+import type { SupportedLanguages } from "@repo/shared";
+import type { ArticleActivityLogSnapshot } from "src/activity-logs/types";
+import type { UUIDType } from "src/common";
+import type { ActorUserType } from "src/common/types/actor-user.type";
+
+type UpdateLanguageData = {
+  articleId: UUIDType;
+  actor: ActorUserType;
+  previousArticleData: ArticleActivityLogSnapshot;
+  updatedArticleData: ArticleActivityLogSnapshot;
+  language?: SupportedLanguages;
+  action?: "update";
+};
+
+export class CreateArticleLanguageEvent {
+  constructor(public readonly articleUpdateData: UpdateLanguageData) {}
+}

--- a/apps/api/src/events/index.ts
+++ b/apps/api/src/events/index.ts
@@ -67,6 +67,7 @@ export * from "./articles/create-articles.event";
 export * from "./articles/create-article-language.event";
 export * from "./articles/delete-article-language.event";
 export * from "./articles/create-section-language.event";
+export * from "./articles/delete-section-language.event";
 export * from "./articles/update-articles.event";
 export * from "./articles/delete-articles.event";
 export * from "./articles/create-section.event";

--- a/apps/api/src/events/index.ts
+++ b/apps/api/src/events/index.ts
@@ -65,6 +65,7 @@ export * from "./qa/update-qa.event";
 export * from "./qa/delete-qa.event";
 export * from "./articles/create-articles.event";
 export * from "./articles/create-article-language.event";
+export * from "./articles/delete-article-language.event";
 export * from "./articles/update-articles.event";
 export * from "./articles/delete-articles.event";
 export * from "./articles/create-section.event";

--- a/apps/api/src/events/index.ts
+++ b/apps/api/src/events/index.ts
@@ -66,6 +66,7 @@ export * from "./qa/delete-qa.event";
 export * from "./articles/create-articles.event";
 export * from "./articles/create-article-language.event";
 export * from "./articles/delete-article-language.event";
+export * from "./articles/create-section-language.event";
 export * from "./articles/update-articles.event";
 export * from "./articles/delete-articles.event";
 export * from "./articles/create-section.event";

--- a/apps/api/src/events/index.ts
+++ b/apps/api/src/events/index.ts
@@ -64,6 +64,7 @@ export * from "./qa/create-qa.event";
 export * from "./qa/update-qa.event";
 export * from "./qa/delete-qa.event";
 export * from "./articles/create-articles.event";
+export * from "./articles/create-article-language.event";
 export * from "./articles/update-articles.event";
 export * from "./articles/delete-articles.event";
 export * from "./articles/create-section.event";


### PR DESCRIPTION

## Issue(s)
[1152](https://github.com/Selleo/mentingo/issues/1152)

## Overview 
Added specific actions (Delete and Add) in activity logs when article language or article section language is created or deleted. Before those operations were logged as simply Update event which wasn't that informative. Log information were also adjusted, removed unnecessary before state when creating.
## Business Value 

Adding specific action on Delete and Create action makes it easier for admin to track changes of what happened to the articles.

