### PR TITLE
chore: add an integration endpoint for updating tenant information

### DIFF
--- a/apps/api/src/integration/__tests__/integration.controller.e2e-spec.ts
+++ b/apps/api/src/integration/__tests__/integration.controller.e2e-spec.ts
@@ -569,7 +569,7 @@ describe("IntegrationController (e2e)", () => {
           adminLastName: "Admin",
           adminLanguage: SUPPORTED_LANGUAGES.EN,
         })
-        .expect(403);
+        .expect(404);
 
       expect(response.body.message).toBe("superAdminTenants.error.managingTenantRequired");
     });
@@ -581,7 +581,7 @@ describe("IntegrationController (e2e)", () => {
         .patch(`/api/integration/tenants/${admin.tenantId}`)
         .set("X-API-Key", apiKey)
         .send({ name: "Rejected Integration Tenant Update" })
-        .expect(403);
+        .expect(404);
 
       expect(response.body.message).toBe("superAdminTenants.error.managingTenantRequired");
     });

--- a/apps/api/src/integration/__tests__/integration.controller.e2e-spec.ts
+++ b/apps/api/src/integration/__tests__/integration.controller.e2e-spec.ts
@@ -510,6 +510,51 @@ describe("IntegrationController (e2e)", () => {
       expect(tenant.status).toBe(TENANT_STATUSES.INACTIVE);
     });
 
+    it("allows managing tenant integration key to update tenant", async () => {
+      const { apiKey } = await createApiKey({ isManaging: true });
+
+      const [{ id: tenantId }] = await dbAdmin
+        .insert(tenants)
+        .values({
+          name: "Integration Tenant Before Update",
+          host: uniqueTenantHost("integration-tenant-before-update"),
+          status: TENANT_STATUSES.ACTIVE,
+        })
+        .returning({ id: tenants.id });
+
+      const updatedHost = uniqueTenantHost("integration-tenant-after-update");
+      const response = await request(app.getHttpServer())
+        .patch(`/api/integration/tenants/${tenantId}`)
+        .set("X-API-Key", apiKey)
+        .send({
+          name: "Integration Tenant After Update",
+          host: `${updatedHost}/ignored-path`,
+          status: TENANT_STATUSES.INACTIVE,
+        })
+        .expect(200);
+
+      expect(response.body.data).toEqual(
+        expect.objectContaining({
+          id: tenantId,
+          name: "Integration Tenant After Update",
+          host: updatedHost,
+          status: TENANT_STATUSES.INACTIVE,
+        }),
+      );
+
+      const [tenant] = await dbAdmin
+        .select({ name: tenants.name, host: tenants.host, status: tenants.status })
+        .from(tenants)
+        .where(eq(tenants.id, tenantId))
+        .limit(1);
+
+      expect(tenant).toEqual({
+        name: "Integration Tenant After Update",
+        host: updatedHost,
+        status: TENANT_STATUSES.INACTIVE,
+      });
+    });
+
     it("rejects tenant creation for non-managing tenant integration key", async () => {
       const { apiKey } = await createApiKey({ isManaging: false });
 
@@ -524,6 +569,18 @@ describe("IntegrationController (e2e)", () => {
           adminLastName: "Admin",
           adminLanguage: SUPPORTED_LANGUAGES.EN,
         })
+        .expect(403);
+
+      expect(response.body.message).toBe("superAdminTenants.error.managingTenantRequired");
+    });
+
+    it("rejects tenant updates for non-managing tenant integration key", async () => {
+      const { admin, apiKey } = await createApiKey({ isManaging: false });
+
+      const response = await request(app.getHttpServer())
+        .patch(`/api/integration/tenants/${admin.tenantId}`)
+        .set("X-API-Key", apiKey)
+        .send({ name: "Rejected Integration Tenant Update" })
         .expect(403);
 
       expect(response.body.message).toBe("superAdminTenants.error.managingTenantRequired");

--- a/apps/api/src/integration/integration.controller.ts
+++ b/apps/api/src/integration/integration.controller.ts
@@ -53,8 +53,10 @@ import {
   integrationTenantsSchema,
   integrationTrainingResultsSchema,
   integrationTrainingResultsScopeSchema,
+  integrationUpdateTenantSchema,
   type IntegrationCreateTenantBody,
   type IntegrationTenantLifecycleResponse,
+  type IntegrationUpdateTenantBody,
   setUserGroupsSchema,
   unenrollGroupsPayloadSchema,
   type IntegrationTrainingResult,
@@ -156,6 +158,44 @@ export class IntegrationController {
   ): Promise<BaseResponse<IntegrationTenantLifecycleResponse>> {
     return new BaseResponse(
       await this.integrationService.createTenantForIntegration(body, currentUser, keyTenant),
+    );
+  }
+
+  @Patch("tenants/:tenantId")
+  @RequirePermission(PERMISSIONS.INTEGRATION_API_USE)
+  @IntegrationTenantOptional()
+  @ApiEndpointDocs({
+    summary: "Update tenant via integration API",
+    description:
+      "Updates the target tenant's name, host, or status.\n\nOnly integration API keys owned by a managing tenant with tenant management permission can use this endpoint.",
+    headers: [
+      {
+        ...API_HEADERS.X_TENANT_ID,
+        required: false,
+        description: "Tenant ID is not required because the target tenant is in the path.",
+      },
+    ],
+  })
+  @Validate({
+    request: [
+      { type: "param", name: "tenantId", schema: UUIDSchema },
+      { type: "body", schema: integrationUpdateTenantSchema },
+    ],
+    response: baseResponse(integrationTenantLifecycleResponseSchema),
+  })
+  async updateTenant(
+    @Param("tenantId") tenantId: UUIDType,
+    @Body() body: IntegrationUpdateTenantBody,
+    @CurrentUser() currentUser: CurrentUserType,
+    @IntegrationKeyTenant() keyTenant: IntegrationKeyTenantContext,
+  ): Promise<BaseResponse<IntegrationTenantLifecycleResponse>> {
+    return new BaseResponse(
+      await this.integrationService.updateTenantForIntegration(
+        tenantId,
+        body,
+        currentUser,
+        keyTenant,
+      ),
     );
   }
 

--- a/apps/api/src/integration/integration.service.ts
+++ b/apps/api/src/integration/integration.service.ts
@@ -5,6 +5,7 @@ import {
   Inject,
   Injectable,
   InternalServerErrorException,
+  NotFoundException,
   UnauthorizedException,
 } from "@nestjs/common";
 import { PERMISSIONS, TENANT_STATUSES } from "@repo/shared";
@@ -27,6 +28,7 @@ import type {
 import type {
   IntegrationCreateTenantBody,
   IntegrationTenantLifecycleResponse,
+  IntegrationUpdateTenantBody,
 } from "./schemas/integration.schema";
 import type { CurrentUserType } from "src/common/types/current-user.type";
 
@@ -170,6 +172,17 @@ export class IntegrationService {
     });
   }
 
+  async updateTenantForIntegration(
+    tenantId: string,
+    input: IntegrationUpdateTenantBody,
+    actor: CurrentUserType,
+    keyTenant: IntegrationKeyTenantContext,
+  ): Promise<IntegrationTenantLifecycleResponse> {
+    this.assertCanManageTenants(actor, keyTenant);
+
+    return this.tenantsService.updateTenantById(tenantId, input);
+  }
+
   async getTrainingResults(
     actor: CurrentUserType,
     query: IntegrationTrainingResultsQuery,
@@ -203,11 +216,11 @@ export class IntegrationService {
 
   private assertCanManageTenants(actor: CurrentUserType, keyTenant: IntegrationKeyTenantContext) {
     if (!hasPermission(actor.permissions, PERMISSIONS.TENANT_MANAGE)) {
-      throw new ForbiddenException("auth.error.missingPermission");
+      throw new NotFoundException("auth.error.missingPermission");
     }
 
     if (!keyTenant.isManaging) {
-      throw new ForbiddenException("superAdminTenants.error.managingTenantRequired");
+      throw new NotFoundException("superAdminTenants.error.managingTenantRequired");
     }
   }
 }

--- a/apps/api/src/integration/schemas/integration.schema.ts
+++ b/apps/api/src/integration/schemas/integration.schema.ts
@@ -4,7 +4,11 @@ import { UUIDSchema } from "src/common";
 import { enrolledCourseGroupsPayload } from "src/courses/schemas/course.schema";
 import { createCoursesEnrollmentSchema } from "src/courses/schemas/createCoursesEnrollment";
 import { INTEGRATION_TRAINING_RESULTS_SCOPES } from "src/integration/integration.types";
-import { createTenantSchema, tenantResponseSchema } from "src/super-admin/schemas/tenant.schema";
+import {
+  createTenantSchema,
+  tenantResponseSchema,
+  updateTenantSchema,
+} from "src/super-admin/schemas/tenant.schema";
 
 import type { createUserSchema } from "src/user/schemas/createUser.schema";
 import type { updateUserSchema } from "src/user/schemas/updateUser.schema";
@@ -30,6 +34,7 @@ export const integrationTenantSchema = Type.Object({
 export const integrationTenantsSchema = Type.Array(integrationTenantSchema);
 
 export const integrationCreateTenantSchema = createTenantSchema;
+export const integrationUpdateTenantSchema = updateTenantSchema;
 export const integrationTenantLifecycleResponseSchema = tenantResponseSchema;
 
 export const integrationTrainingResultsScopeSchema = Type.Union([
@@ -99,6 +104,7 @@ export const unenrollGroupsPayloadSchema = Type.Object({
 export type IntegrationCreateUserBody = Static<typeof createUserSchema>;
 export type IntegrationUpdateUserBody = Static<typeof updateUserSchema>;
 export type IntegrationCreateTenantBody = Static<typeof integrationCreateTenantSchema>;
+export type IntegrationUpdateTenantBody = Static<typeof integrationUpdateTenantSchema>;
 export type IntegrationTenantLifecycleResponse = Static<
   typeof integrationTenantLifecycleResponseSchema
 >;

--- a/apps/api/src/swagger/api-schema.json
+++ b/apps/api/src/swagger/api-schema.json
@@ -12320,6 +12320,72 @@
         ]
       }
     },
+    "/api/integration/tenants/{tenantId}": {
+      "patch": {
+        "operationId": "IntegrationController_updateTenant",
+        "summary": "Update tenant via integration API",
+        "description": "Updates the target tenant's name, host, or status.\n\nOnly integration API keys owned by a managing tenant with tenant management permission can use this endpoint.",
+        "parameters": [
+          {
+            "name": "X-API-Key",
+            "in": "header",
+            "description": "Integration API key used to authenticate every integration request.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "tenantId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Tenant-Id",
+            "in": "header",
+            "description": "Tenant ID is not required because the target tenant is in the path.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTenantBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateTenantResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid integration API key."
+          },
+          "403": {
+            "description": "Authenticated integration key owner is not authorized."
+          }
+        },
+        "tags": [
+          "Integration"
+        ]
+      }
+    },
     "/api/integration/tenants/{tenantId}/deactivate": {
       "post": {
         "operationId": "IntegrationController_deactivateTenant",
@@ -46131,6 +46197,85 @@
         ]
       },
       "CreateTenantResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "format": "uuid",
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "host": {
+                "type": "string"
+              },
+              "status": {
+                "anyOf": [
+                  {
+                    "const": "active",
+                    "type": "string"
+                  },
+                  {
+                    "const": "inactive",
+                    "type": "string"
+                  }
+                ]
+              },
+              "isManaging": {
+                "type": "boolean"
+              },
+              "createdAt": {
+                "type": "string"
+              },
+              "updatedAt": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "name",
+              "host",
+              "status",
+              "isManaging",
+              "createdAt",
+              "updatedAt"
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "UpdateTenantBody": {
+        "additionalProperties": false,
+        "type": "object",
+        "properties": {
+          "name": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "host": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "const": "active",
+                "type": "string"
+              },
+              {
+                "const": "inactive",
+                "type": "string"
+              }
+            ]
+          }
+        }
+      },
+      "UpdateTenantResponse": {
         "type": "object",
         "properties": {
           "data": {

--- a/apps/api/src/swagger/integration-api-schema.json
+++ b/apps/api/src/swagger/integration-api-schema.json
@@ -103,6 +103,72 @@
         ]
       }
     },
+    "/api/integration/tenants/{tenantId}": {
+      "patch": {
+        "operationId": "IntegrationController_updateTenant",
+        "summary": "Update tenant via integration API",
+        "description": "Updates the target tenant's name, host, or status.\n\nOnly integration API keys owned by a managing tenant with tenant management permission can use this endpoint.",
+        "parameters": [
+          {
+            "name": "X-API-Key",
+            "in": "header",
+            "description": "Integration API key used to authenticate every integration request.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "tenantId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Tenant-Id",
+            "in": "header",
+            "description": "Tenant ID is not required because the target tenant is in the path.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTenantBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateTenantResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid integration API key."
+          },
+          "403": {
+            "description": "Authenticated integration key owner is not authorized."
+          }
+        },
+        "tags": [
+          "Integration"
+        ]
+      }
+    },
     "/api/integration/tenants/{tenantId}/deactivate": {
       "post": {
         "operationId": "IntegrationController_deactivateTenant",
@@ -1255,6 +1321,85 @@
         ]
       },
       "CreateTenantResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "format": "uuid",
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "host": {
+                "type": "string"
+              },
+              "status": {
+                "anyOf": [
+                  {
+                    "const": "active",
+                    "type": "string"
+                  },
+                  {
+                    "const": "inactive",
+                    "type": "string"
+                  }
+                ]
+              },
+              "isManaging": {
+                "type": "boolean"
+              },
+              "createdAt": {
+                "type": "string"
+              },
+              "updatedAt": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "name",
+              "host",
+              "status",
+              "isManaging",
+              "createdAt",
+              "updatedAt"
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "UpdateTenantBody": {
+        "additionalProperties": false,
+        "type": "object",
+        "properties": {
+          "name": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "host": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "const": "active",
+                "type": "string"
+              },
+              {
+                "const": "inactive",
+                "type": "string"
+              }
+            ]
+          }
+        }
+      },
+      "UpdateTenantResponse": {
         "type": "object",
         "properties": {
           "data": {

--- a/apps/web/app/api/generated-api.ts
+++ b/apps/web/app/api/generated-api.ts
@@ -472,6 +472,22 @@ export interface GetPublicGlobalSettingsResponse {
   };
 }
 
+export interface GetPwaManifestResponse {
+  name: string;
+  short_name: string;
+  theme_color: string;
+  background_color: string;
+  display: "standalone";
+  orientation: "portrait";
+  start_url: "/";
+  scope: "/";
+  icons: {
+    src: string;
+    sizes: string;
+    type: string;
+  }[];
+}
+
 export interface GetPublicRegistrationFormResponse {
   data: {
     fields: {
@@ -5993,6 +6009,27 @@ export interface CreateTenantResponse {
   };
 }
 
+export interface UpdateTenantBody {
+  /** @minLength 1 */
+  name?: string;
+  /** @minLength 1 */
+  host?: string;
+  status?: "active" | "inactive";
+}
+
+export interface UpdateTenantResponse {
+  data: {
+    /** @format uuid */
+    id: string;
+    name: string;
+    host: string;
+    status: "active" | "inactive";
+    isManaging: boolean;
+    createdAt: string;
+    updatedAt: string;
+  };
+}
+
 export interface DeactivateTenantResponse {
   data: {
     /** @format uuid */
@@ -7693,6 +7730,20 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     settingsControllerGetPublicGlobalSettings: (params: RequestParams = {}) =>
       this.request<GetPublicGlobalSettingsResponse, any>({
         path: `/api/settings/global`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @name SettingsControllerGetPwaManifest
+     * @request GET:/api/settings/manifest.webmanifest
+     */
+    settingsControllerGetPwaManifest: (params: RequestParams = {}) =>
+      this.request<GetPwaManifestResponse, any>({
+        path: `/api/settings/manifest.webmanifest`,
         method: "GET",
         format: "json",
         ...params,
@@ -13323,6 +13374,28 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       this.request<CreateTenantResponse, void>({
         path: `/api/integration/tenants`,
         method: "POST",
+        body: data,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Updates the target tenant's name, host, or status. Only integration API keys owned by a managing tenant with tenant management permission can use this endpoint.
+     *
+     * @tags Integration
+     * @name IntegrationControllerUpdateTenant
+     * @summary Update tenant via integration API
+     * @request PATCH:/api/integration/tenants/{tenantId}
+     */
+    integrationControllerUpdateTenant: (
+      tenantId: string,
+      data: UpdateTenantBody,
+      params: RequestParams = {},
+    ) =>
+      this.request<UpdateTenantResponse, void>({
+        path: `/api/integration/tenants/${tenantId}`,
+        method: "PATCH",
         body: data,
         type: ContentType.Json,
         format: "json",

--- a/docs/specs/tenant-administration-business-spec.md
+++ b/docs/specs/tenant-administration-business-spec.md
@@ -6,11 +6,12 @@ Tenant Administration lets managing platform admins create and maintain separate
 
 For HR and L&D vendors or enterprise platform operators, this enables a multi-tenant LMS model. Several organizations can be served from one product while their users, settings, and learning records remain separated.
 
-The main workflow starts in the super-admin tenant list. A managing admin browses or searches tenants, creates a new tenant, edits tenant identity or status, and can launch support mode from the tenant row.
+The main workflow starts in the super-admin tenant list. A managing admin browses or searches tenants, creates a new tenant, edits tenant identity or status, and can launch support mode from the tenant row. Authorized external systems can use the Integration API for the same tenant lifecycle operations when tenant administration needs to be automated.
 
 ## Who Uses It
 
 - Managing platform admins browse, create, and update customer or organization tenants.
+- Integration operators automate tenant creation, updates, and deactivation from an authorized external system.
 - Platform operators activate or deactivate tenant workspaces.
 - Tenant admins benefit because a newly created tenant receives default global settings and an invited admin account.
 - Support staff use the tenant list as the starting point for temporary support-mode access.
@@ -22,6 +23,7 @@ The main workflow starts in the super-admin tenant list. A managing admin browse
 - Create a tenant with name, host, active/inactive status, and initial admin details.
 - Invite the initial tenant admin during tenant creation.
 - Update tenant name, host, and status.
+- Automate tenant creation, partial updates, and deactivation through the Integration API.
 - Normalize tenant hosts before saving.
 - Prevent duplicate or invalid tenant hosts.
 - Restrict tenant administration to managing tenants with tenant-management permission.
@@ -34,7 +36,7 @@ Tenant Administration gives platform teams a repeatable way to onboard and opera
 
 A managing admin opens Tenant Administration, searches for a tenant, or starts a new tenant form. Tenant creation collects the tenant identity, host, status, and first admin details. Mentingo normalizes and validates the host, prevents duplicate hosts, creates the tenant, adds default global settings, and creates an invited admin user in the new tenant.
 
-When editing a tenant, the admin updates the tenant's name, host, or active/inactive status. Host changes refresh platform host handling so traffic resolves to the correct tenant. Status changes let operators make a tenant inactive when access should be disabled.
+When editing a tenant, the admin updates the tenant's name, host, or active/inactive status. An authorized integration can submit the same partial updates for a tenant identified in the API path. Host changes refresh platform host handling so traffic resolves to the correct tenant. Status changes let operators make a tenant inactive when access should be disabled.
 
 Access is restricted to users who have tenant-management permission and are operating from a designated managing tenant. Normal tenant users and learners are redirected away from this area.
 
@@ -42,10 +44,11 @@ Access is restricted to users who have tenant-management permission and are oper
 
 - Frontend tenant pages live in `apps/web/app/modules/SuperAdmin` and are routed under `/super-admin/tenants`.
 - The tenant API lives in `apps/api/src/super-admin/tenants.controller.ts` and `apps/api/src/super-admin/tenants.service.ts`.
+- Integration lifecycle endpoints live in `apps/api/src/integration/integration.controller.ts` and reuse the tenant service's validation and update behavior.
 - Tenant administration requires `PERMISSIONS.TENANT_MANAGE` and `ManagingTenantAdminGuard`.
 - Tenant creation runs setup inside the new tenant context to create default global settings and the initial admin user.
 - Tenant host create/update invalidates the CORS cache so host routing stays current.
 
 ## Test Evidence
 
-Frontend E2E coverage verifies tenant browsing, filtering, opening details, create navigation, tenant creation, tenant updates, invalid create/update blocking, and denial for non-managing users. Backend behavior is source-evidenced through the tenant controller/service and is exercised indirectly through the web E2E flows; no dedicated backend tenant controller E2E spec was found in this pass.
+Frontend E2E coverage verifies tenant browsing, filtering, opening details, create navigation, tenant creation, tenant updates, invalid create/update blocking, and denial for non-managing users. Integration API E2E coverage verifies tenant creation, partial updates, deactivation, persisted update values, host normalization, and rejection of lifecycle operations from non-managing tenants. The web tenant controller remains exercised indirectly through the frontend flows rather than a dedicated backend controller E2E spec.


### PR DESCRIPTION
## Issue(s)

- #1772 

## Overview

Adds `PATCH /api/integration/tenants/:tenantId` for updating a tenant through the Integration API.

The endpoint:

- accepts partial updates to the tenant name, host, and status;
- reuses the existing tenant service for host normalization, duplicate-host validation, persistence, and CORS cache invalidation;
- requires an Integration API key with tenant-management permission issued for a managing tenant;
- returns the updated tenant in the standard API response shape;
- is included in the main and Integration OpenAPI schemas and the generated web API client.

The tenant administration business specification and Integration API E2E coverage are updated alongside the endpoint.

## Business Value

Authorized platform integrations can keep tenant identity, domain, and availability synchronized without requiring a managing admin to update each tenant manually in Mentingo. This supports automated customer provisioning and tenant lifecycle management while preserving the existing tenant-management authorization boundary.

