### PR TITLE
fix: preserve shared course status when the source course is updated

### DIFF
--- a/apps/api/src/courses/__tests__/master-course.e2e-spec.ts
+++ b/apps/api/src/courses/__tests__/master-course.e2e-spec.ts
@@ -672,6 +672,54 @@ describe("Master course export and sync (e2e)", () => {
     });
   });
 
+  it("preserves the target course status when source updates are synced", async () => {
+    const { sourceCourseId, targetCourseId } = await setupAndExport();
+    const updatedTitle = "Updated Master Source Course";
+
+    await runAsTenant(targetTenantId, () =>
+      db.update(courses).set({ status: "published" }).where(eq(courses.id, targetCourseId)),
+    );
+    await runAsTenant(sourceTenantId, () =>
+      db
+        .update(courses)
+        .set({
+          title: buildJsonbFieldWithMultipleEntries({
+            en: updatedTitle,
+            pl: "Kurs zrodlowy master",
+          }),
+        })
+        .where(eq(courses.id, sourceCourseId)),
+    );
+
+    const [exportLink] = await baseDb
+      .select({ id: masterCourseExports.id })
+      .from(masterCourseExports)
+      .where(eq(masterCourseExports.sourceCourseId, sourceCourseId))
+      .limit(1);
+
+    expect(exportLink).toBeDefined();
+    await masterCourseService.processSyncJob({
+      exportId: exportLink.id,
+      sourceCourseId,
+      sourceTenantId,
+      targetTenantId,
+      triggerEventType: "UpdateCourseEvent",
+    });
+
+    const syncedTargetCourse = await runAsTenant(targetTenantId, async () => {
+      const [targetCourse] = await db
+        .select({ title: courses.title, status: courses.status })
+        .from(courses)
+        .where(eq(courses.id, targetCourseId))
+        .limit(1);
+
+      return targetCourse;
+    });
+
+    expect(syncedTargetCourse?.title.en).toBe(updatedTitle);
+    expect(syncedTargetCourse?.status).toBe("published");
+  });
+
   it("syncs bulk source category changes to exported courses and creates missing target category", async () => {
     const { sourceCourseId, sourceCookie, targetCourseId } = await setupAndExport();
     const categoryTitle = `Bulk synced category ${faker.string.nanoid(8)}`;

--- a/apps/api/src/courses/master-course.service.ts
+++ b/apps/api/src/courses/master-course.service.ts
@@ -800,7 +800,6 @@ export class MasterCourseService {
         "thumbnailS3Key",
         course.thumbnailS3Key,
       ),
-      status: "draft",
       hasCertificate: course.hasCertificate,
       priceInCents: 0,
       currency: course.currency,

--- a/docs/specs/course-sharing-business-spec.md
+++ b/docs/specs/course-sharing-business-spec.md
@@ -1,0 +1,47 @@
+# Course Sharing Business Spec
+
+## Business Overview
+
+Course sharing lets a managing organization distribute one centrally maintained course to other organizations without rebuilding or manually updating the training in every tenant. HR and L&D teams can keep one authoritative curriculum while each recipient organization controls when its local copy is published and who is enrolled.
+
+The managing-tenant administrator selects recipient organizations from the course editor and shares the course. Mentingo creates a read-only draft copy in each selected organization, then automatically synchronizes later content changes from the source. Recipient administrators can publish the shared course and manage enrollment without gaining access to alter centrally owned content.
+
+## Who Uses It
+
+- Managing-tenant administrators share centrally maintained onboarding, compliance, or skills courses with selected customer or subsidiary organizations.
+- Recipient-organization administrators publish the shared course when it is ready for their learners and manage local enrollment while relying on the source organization for content updates.
+- Learners receive the current centrally managed course content according to the publication and enrollment decisions of their own organization.
+
+## Feature Functions
+
+- Share one course with selected recipient organizations.
+- Create each newly shared course as a draft so the recipient can decide when to launch it.
+- Synchronize later course, chapter, lesson, category, resource, quiz, AI Mentor, and supported SCORM content changes from the source.
+- Preserve the recipient course's publication status when source content is synchronized.
+- Let recipient administrators publish shared courses and manage participants while keeping shared content read-only.
+- Show source and recipient copies as shared courses and prevent an exported copy from becoming a new sharing source.
+- Process exports and subsequent synchronization asynchronously so cross-tenant copying is retryable and does not block the source edit request.
+
+## End-User Value
+
+Central course ownership reduces duplicated authoring and makes training updates consistent across organizations. Recipient teams retain operational control over rollout and enrollment, so a central content change cannot unexpectedly withdraw an already published course from learners. Read-only content and tenant-scoped copies also make ownership and access boundaries clear.
+
+## How It Works
+
+A managing-tenant administrator opens a course's sharing area, selects one or more organizations, and starts sharing. Mentingo creates a separate draft course for each recipient and copies the supported curriculum and resources in the background. The source becomes the centrally managed master, while recipient copies display a shared-course notice and restrict editing to the local controls that remain available, including status and enrollment.
+
+When the source course or its curriculum changes, Mentingo queues synchronization for every active sharing link. The recipient copy receives the latest centrally managed content but keeps its existing draft or published status. A later sync therefore updates what learners see without making a locally published course unavailable.
+
+## Key Technical Context
+
+- The source workflow is exposed in the admin course editor's Sharing tab and is limited in the UI to managing-tenant administrators outside support mode.
+- API export endpoints require `course.export` and the managing-tenant administrator guard; cross-tenant work runs through explicit tenant contexts.
+- `apps/api/src/courses/master-course.service.ts` creates recipient courses as drafts and synchronizes existing recipient courses without owning their status.
+- Source update events enqueue durable BullMQ synchronization jobs through the master-course handler and worker.
+- `apps/web/app/modules/Admin/EditCourse/EditCourse.tsx` limits exported copies to the Status and Enrolled tabs, matching the product boundary between central content ownership and local rollout control.
+
+## Test Evidence
+
+API E2E coverage verifies managing-tenant authorization, recipient selection, initial draft creation, read-only exported content, localized course/category copying, repeated sharing behavior, resource and video handling, category synchronization, and source deletion propagation. Regression coverage also verifies that after a recipient publishes its shared copy, a later source update synchronizes content without changing that published status.
+
+There is no dedicated Playwright E2E flow for tenant-to-tenant course sharing; the UI workflow and local controls are evidenced by the course editor implementation and translations rather than browser-level coverage.


### PR DESCRIPTION
## Issue(s)

- #1743 

## Overview

Preserves the recipient tenant's course status when updates from a shared master course are synchronized.

Newly shared courses are still created as drafts, but subsequent content syncs no longer overwrite a recipient course's existing `draft`, `published`, or `private` status. The change includes an API E2E regression test and a business specification for tenant-to-tenant course sharing.

## Business Value

Recipient organizations retain control over when centrally managed training is available to their learners. Publishing a shared course is no longer undone by a later source-content update, preventing unexpected course withdrawal while still delivering the latest curriculum.

## Screenshots / Video

https://github.com/user-attachments/assets/1f61c42a-e995-488e-a42c-223854bfc491