### PR TITLE
fix: ensure course attachments and cover image variants are copied correctly

### DIFF
--- a/apps/api/src/courses/__tests__/master-course.e2e-spec.ts
+++ b/apps/api/src/courses/__tests__/master-course.e2e-spec.ts
@@ -97,6 +97,7 @@ describe("Master course export and sync (e2e)", () => {
     getFileExists: jest.Mock;
     getFileStream: jest.Mock;
     isConfigured: jest.Mock;
+    listFileKeysByPrefix: jest.Mock;
     uploadStreamMultipart: jest.Mock;
   };
   let mockBunnyStreamService: {
@@ -130,6 +131,7 @@ describe("Master course export and sync (e2e)", () => {
         contentType: "video/mp4",
       }),
       isConfigured: jest.fn().mockReturnValue(true),
+      listFileKeysByPrefix: jest.fn().mockResolvedValue([]),
       uploadStreamMultipart: jest.fn().mockResolvedValue(undefined),
     };
     mockBunnyStreamService = {
@@ -251,6 +253,7 @@ describe("Master course export and sync (e2e)", () => {
       if (key.includes("/master-course/")) return false;
       return true;
     });
+    mockS3Service.listFileKeysByPrefix.mockResolvedValue([]);
     mockS3Service.isConfigured.mockReturnValue(true);
     mockBunnyStreamService.isConfigured.mockResolvedValue(false);
     mockBunnyStreamService.getMediaConfigurationSignature.mockResolvedValue("source-target-same");
@@ -807,6 +810,86 @@ describe("Master course export and sync (e2e)", () => {
     expect(links).toHaveLength(1);
   });
 
+  it("copies every missing course cover image variant when the target has a partial copy", async () => {
+    const sourceThumbnailReference = `${sourceTenantId}/course/variants/${faker.string.uuid()}.webp`;
+    const sourceStem = sourceThumbnailReference.replace(/\.webp$/, "");
+    const sourceVariantKeys = ["160w", "512w", "2560w"].map(
+      (quality) => `${sourceStem}-${quality}.webp`,
+    );
+
+    mockS3Service.listFileKeysByPrefix.mockImplementation(async (prefix: string) =>
+      prefix === `${sourceStem}-` ? sourceVariantKeys : [],
+    );
+
+    mockS3Service.getFileExists.mockImplementation(async (key: string) => {
+      if (!key.includes("/master-course/")) return false;
+      return key.endsWith("-512w.webp");
+    });
+
+    const { sourceCourseId, targetCourseId } = await setupAndExport({
+      beforeExport: async ({ sourceCourseId }) => {
+        await runAsTenant(sourceTenantId, async () => {
+          await db
+            .update(courses)
+            .set({ thumbnailS3Key: sourceThumbnailReference })
+            .where(eq(courses.id, sourceCourseId));
+        });
+      },
+    });
+
+    const [targetCourse] = await runAsTenant(targetTenantId, () =>
+      db
+        .select({ thumbnailS3Key: courses.thumbnailS3Key })
+        .from(courses)
+        .where(eq(courses.id, targetCourseId))
+        .limit(1),
+    );
+
+    expect(targetCourse.thumbnailS3Key).toContain(`${targetTenantId}/master-course/`);
+    expect(targetCourse.thumbnailS3Key).toContain(`/${targetCourseId}/variants/`);
+
+    const [exportLink] = await baseDb
+      .select({ id: masterCourseExports.id })
+      .from(masterCourseExports)
+      .where(
+        and(
+          eq(masterCourseExports.sourceTenantId, sourceTenantId),
+          eq(masterCourseExports.sourceCourseId, sourceCourseId),
+          eq(masterCourseExports.targetTenantId, targetTenantId),
+        ),
+      )
+      .limit(1);
+
+    expect(targetCourse.thumbnailS3Key).not.toContain(`/${exportLink.id}/`);
+    expect(mockS3Service.listFileKeysByPrefix).toHaveBeenCalledWith(`${sourceStem}-`);
+
+    const targetStem = targetCourse.thumbnailS3Key!.replace(/\.webp$/, "");
+    const targetVariantKeys = sourceVariantKeys.map(
+      (sourceVariantKey) => `${targetStem}${sourceVariantKey.slice(sourceStem.length)}`,
+    );
+
+    expect(new Set(targetVariantKeys).size).toBe(sourceVariantKeys.length);
+
+    for (const [index, sourceVariantKey] of sourceVariantKeys.entries()) {
+      const targetVariantKey = targetVariantKeys[index];
+
+      if (targetVariantKey.endsWith("-512w.webp")) {
+        expect(mockS3Service.copyFile).not.toHaveBeenCalledWith(
+          sourceVariantKey,
+          targetVariantKey,
+          "image/webp",
+        );
+        continue;
+      }
+
+      expect(mockS3Service.copyFile).toHaveBeenCalledWith(
+        sourceVariantKey,
+        targetVariantKey,
+        "image/webp",
+      );
+    }
+  });
+
   it("copies rich-text S3 resources, rewrites localized content, and reuses target resource rows on sync", async () => {
     const sourceResourceId = faker.string.uuid();
     const sourceReference = `course/${faker.string.uuid()}.png`;
@@ -873,7 +956,9 @@ describe("Master course export and sync (e2e)", () => {
       pl: "Opis obrazu zrodlowego",
     });
     expect(targetResource.reference).not.toBe(sourceReference);
-    expect(targetResource.reference).toContain(`${targetTenantId}/master-course/`);
+    expect(targetResource.reference).toContain(
+      `${targetTenantId}/master-course/${targetCourseId}/`,
+    );
     expect(targetResource.contentType).toBe("image/png");
     expect(targetResource.metadata).toEqual({
       originalFilename: "source-image.png",
@@ -899,7 +984,7 @@ describe("Master course export and sync (e2e)", () => {
     expect(targetLessonDescription.pl).not.toContain(sourceResourceId);
     expect(mockS3Service.copyFile).toHaveBeenCalledWith(
       sourceReference,
-      expect.stringContaining(`${targetTenantId}/master-course/`),
+      expect.stringContaining(`${targetTenantId}/master-course/${targetCourseId}/`),
       "image/png",
     );
 
@@ -1111,10 +1196,10 @@ describe("Master course export and sync (e2e)", () => {
     );
     expect(mockS3Service.uploadStreamMultipart).toHaveBeenCalledWith(
       expect.any(Readable),
-      expect.stringContaining(`${targetTenantId}/master-course/`),
+      expect.stringContaining(`${targetTenantId}/master-course/${targetCourseId}/`),
       "video/mp4",
     );
-    expect(targetLesson.fileS3Key).toContain(`${targetTenantId}/master-course/`);
+    expect(targetLesson.fileS3Key).toContain(`${targetTenantId}/master-course/${targetCourseId}/`);
     expect(targetLesson.fileS3Key).toMatch(/\.mp4$/);
   });
 

--- a/apps/api/src/courses/master-course.service.ts
+++ b/apps/api/src/courses/master-course.service.ts
@@ -41,10 +41,7 @@ import { MasterCourseRepository } from "src/courses/master-course.repository";
 import { MASTER_COURSE_RESOURCE_REFERENCE_KIND } from "src/courses/types/master-course.types";
 import { RESOURCE_RELATIONSHIP_TYPES } from "src/file/file.constants";
 import { IMAGE_VARIANT_CONTENT_TYPE } from "src/file/image-variants/image-variant.constants";
-import {
-  getAllImageVariantKeys,
-  isImageVariantReference,
-} from "src/file/image-variants/image-variant.utils";
+import { isImageVariantReference } from "src/file/image-variants/image-variant.utils";
 import { prefixTenantStorageKey } from "src/file/utils/tenantStorageKey";
 import { rewriteBlankAnswerIds } from "src/questions/fill-in-the-blanks.utils";
 import { QUESTION_TYPE } from "src/questions/schema/question.types";
@@ -244,7 +241,7 @@ export class MasterCourseService {
 
     const resourceCollection = this.buildSourceResourceCollection(sourceSnapshot);
     await this.copySourceResourceReferences(resourceCollection, {
-      exportId: params.targetCourseId,
+      targetCourseId: params.targetCourseId,
       sourceTenantId: params.tenantId,
       sourceTenantOrigin: this.toTenantOrigin(tenantHost),
       targetTenantId: params.tenantId,
@@ -540,9 +537,10 @@ export class MasterCourseService {
     if (!targetTenantHost) throw new NotFoundException("masterCourse.error.targetTenantMissing");
     if (!sourceTenantHost) throw new NotFoundException("masterCourse.error.sourceTenantMissing");
 
+    const targetCourseId = await this.resolveTargetCourseId(exportLink, sourceSnapshot.course.id);
     const resourceCollection = this.buildSourceResourceCollection(sourceSnapshot);
     await this.copySourceResourceReferences(resourceCollection, {
-      exportId: exportLink.id,
+      targetCourseId,
       sourceTenantId: exportLink.sourceTenantId,
       sourceTenantOrigin: this.toTenantOrigin(sourceTenantHost),
       targetTenantId: exportLink.targetTenantId,
@@ -565,14 +563,14 @@ export class MasterCourseService {
 
       const categoryId = await this.syncCategoryFromSource(sourceSnapshot);
 
-      const existingTargetCourse = await this.masterCourseRepository.findCourseByIdInTenant(
-        exportLink.targetCourseId,
-      );
+      const existingTargetCourse =
+        await this.masterCourseRepository.findCourseByIdInTenant(targetCourseId);
 
-      let targetCourseId = existingTargetCourse?.id;
+      let syncedTargetCourseId = existingTargetCourse?.id;
 
-      if (!targetCourseId) {
-        targetCourseId = await this.createTargetCourseFromSource({
+      if (!syncedTargetCourseId) {
+        syncedTargetCourseId = await this.createTargetCourseFromSource({
+          targetCourseId,
           exportLink,
           sourceSnapshot,
           sourceLanguage,
@@ -583,7 +581,7 @@ export class MasterCourseService {
         });
       } else {
         await this.updateTargetCourseFromSource({
-          targetCourseId,
+          targetCourseId: syncedTargetCourseId,
           sourceSnapshot,
           sourceLanguage,
           courseSettings,
@@ -594,11 +592,11 @@ export class MasterCourseService {
         });
       }
 
-      if (!targetCourseId) {
+      if (!syncedTargetCourseId) {
         throw new BadRequestException("masterCourse.error.targetCourseMissing");
       }
 
-      const resolvedTargetCourseId = targetCourseId;
+      const resolvedTargetCourseId = syncedTargetCourseId;
 
       const chapterMap = await this.syncChapters({
         exportId: exportLink.id,
@@ -688,6 +686,7 @@ export class MasterCourseService {
     );
 
     const targetCourseId = await this.masterCourseRepository.createTargetCourse({
+      id: params.targetCourseId,
       title: toJsonbBuildObject(params.sourceSnapshot.course.title),
       description: toJsonbBuildObject(params.sourceSnapshot.course.description),
       thumbnailS3Key: this.getCopiedInternalReference(
@@ -1933,7 +1932,7 @@ export class MasterCourseService {
 
     for (const resourceReference of this.getAllResourceReferences(collection)) {
       const targetReference = await this.resolveTargetResourceReference(resourceReference.source, {
-        exportId: params.exportId,
+        targetCourseId: params.targetCourseId,
         sourceTenantId: params.sourceTenantId,
         sourceTenantOrigin: params.sourceTenantOrigin,
         targetTenantId: params.targetTenantId,
@@ -1962,7 +1961,7 @@ export class MasterCourseService {
     if (!this.isCopyableS3Reference(source.reference)) return source.reference;
 
     const targetReference = this.buildCopiedResourceReference(source.reference, {
-      exportId: params.exportId,
+      targetCourseId: params.targetCourseId,
       targetTenantId: params.targetTenantId,
     });
 
@@ -1992,16 +1991,28 @@ export class MasterCourseService {
   }
 
   private async copyImageVariantReference(sourceReference: string, targetReference: string) {
-    const sourceKeys = getAllImageVariantKeys(sourceReference);
-    const targetKeys = getAllImageVariantKeys(targetReference);
-    const targetHighKey = targetKeys[targetKeys.length - 1];
+    const sourceExtension = path.extname(sourceReference);
+    const sourceStem = sourceExtension
+      ? sourceReference.slice(0, -sourceExtension.length)
+      : sourceReference;
 
-    if (targetHighKey && (await this.s3Service.getFileExists(targetHighKey))) return;
+    const targetExtension = path.extname(targetReference);
+    const targetStem = targetExtension
+      ? targetReference.slice(0, -targetExtension.length)
+      : targetReference;
+
+    const sourcePrefix = `${sourceStem}-`;
+    const sourceKeys = await this.s3Service.listFileKeysByPrefix(sourcePrefix);
 
     await Promise.all(
-      sourceKeys.map(async (sourceKey, index) => {
-        const targetKey = targetKeys[index];
-        if (!targetKey || !(await this.s3Service.getFileExists(sourceKey))) return;
+      sourceKeys.map(async (sourceKey) => {
+        if (!sourceKey.startsWith(sourcePrefix)) return;
+
+        const variantSuffix = sourceKey.slice(sourceStem.length);
+        if (!variantSuffix) return;
+
+        const targetKey = `${targetStem}${variantSuffix}`;
+        if (await this.s3Service.getFileExists(targetKey)) return;
 
         await this.s3Service.copyFile(sourceKey, targetKey, IMAGE_VARIANT_CONTENT_TYPE);
       }),
@@ -2052,7 +2063,7 @@ export class MasterCourseService {
 
     if (this.isCopyableS3Reference(source.reference)) {
       const targetReference = this.buildCopiedResourceReference(source.reference, {
-        exportId: params.exportId,
+        targetCourseId: params.targetCourseId,
         targetTenantId: params.targetTenantId,
       });
 
@@ -2076,7 +2087,7 @@ export class MasterCourseService {
       params.sourceTenantOrigin,
     );
     const targetReference = this.buildCopiedResourceReference(source.reference, {
-      exportId: params.exportId,
+      targetCourseId: params.targetCourseId,
       targetTenantId: params.targetTenantId,
       fallbackExtension: ".mp4",
     });
@@ -2167,11 +2178,31 @@ export class MasterCourseService {
     const extension =
       path.extname(sourceReference.split("?")[0] ?? "") || params.fallbackExtension || "";
     const sourceHash = createHash("sha256").update(sourceReference).digest("hex").slice(0, 32);
+    const targetDirectory = isImageVariantReference(sourceReference)
+      ? `master-course/${params.targetCourseId}/variants`
+      : `master-course/${params.targetCourseId}`;
 
     return prefixTenantStorageKey(
-      `master-course/${params.exportId}/${sourceHash}${extension}`,
+      `${targetDirectory}/${sourceHash}${extension}`,
       params.targetTenantId,
     );
+  }
+
+  private async resolveTargetCourseId(
+    exportLink: MasterCourseExportRecord,
+    sourceCourseId: UUIDType,
+  ): Promise<UUIDType> {
+    if (exportLink.targetCourseId) return exportLink.targetCourseId;
+
+    const mappedTargetCourseId = await this.masterCourseRepository.getMappedTargetEntityId(
+      exportLink.id,
+      MASTER_COURSE_ENTITY_TYPES.COURSE,
+      sourceCourseId,
+    );
+
+    if (mappedTargetCourseId) return mappedTargetCourseId;
+
+    return uuidv5(exportLink.id, exportLink.targetTenantId) as UUIDType;
   }
 
   private getAllResourceReferences(collection: MasterCourseResourceCollection) {

--- a/apps/api/src/courses/types/master-course.types.ts
+++ b/apps/api/src/courses/types/master-course.types.ts
@@ -229,6 +229,7 @@ export type EnsureCourseExportSyncedParams = {
 };
 
 export type CreateTargetCourseFromSourceParams = {
+  targetCourseId: UUIDType;
   exportLink: MasterCourseExportRecord;
   sourceSnapshot: SourceSnapshot;
   sourceLanguage: string;
@@ -341,7 +342,7 @@ export type AddInternalResourceReferenceParams = {
 };
 
 export type CopySourceResourceReferencesParams = {
-  exportId: UUIDType;
+  targetCourseId: UUIDType;
   sourceTenantId: UUIDType;
   sourceTenantOrigin: string;
   targetTenantId: UUIDType;
@@ -359,7 +360,7 @@ export type CopyVideoReferenceParams = Omit<
 >;
 
 export type BuildCopiedResourceReferenceParams = {
-  exportId: UUIDType;
+  targetCourseId: UUIDType;
   targetTenantId: UUIDType;
   fallbackExtension?: string;
 };

--- a/docs/specs/course-authoring-management-business-spec.md
+++ b/docs/specs/course-authoring-management-business-spec.md
@@ -26,7 +26,8 @@ For HR and L&D teams, this is the control center for the learning catalog. It ke
 - Manage course enrollment for users and groups from the course edit area.
 - Transfer course ownership to another eligible user.
 - Delete draft courses individually or in bulk while protecting private and published courses.
-- Export supported courses as SCORM packages or master-course exports when permissions and configuration allow it.
+- Share eligible master courses with managed tenants while preserving course content, cover-image quality, trailers, and future source updates.
+- Export supported courses as SCORM packages when permissions and configuration allow it.
 
 ## End-User Value
 
@@ -40,6 +41,8 @@ Administrators start in the admin course list and open a course edit screen or c
 
 The edit experience adapts to course type, tenant configuration, integrations, available languages, and permissions. For example, pricing depends on Stripe configuration, AI/Luma-related tools depend on their configuration, SCORM courses hide unsupported admin features, and managing-tenant exports are shown only to eligible users.
 
+When a managing-tenant administrator shares a master course, Mentingo creates a read-only copy for each selected target tenant and copies tenant-owned media into that tenant's storage. Course covers retain every generated size, including the highest-quality version, and an incomplete earlier copy is repaired by transferring only the missing variants. Subsequent source changes synchronize to the linked target course.
+
 Course mutations are permission-gated. Full course administrators can manage courses according to their permissions, while content creators rely on own-course update permissions for courses they own. In the admin course list, permitted users can select multiple courses and use the bulk-edit menu to change their category, change their status, or delete draft courses in one governed workflow. Private and published courses must be moved back to draft before deletion is allowed. Language operations respect supported-language and base-language rules.
 
 ## Key Technical Context
@@ -47,6 +50,7 @@ Course mutations are permission-gated. Full course administrators can manage cou
 - Admin course pages live under `apps/web/app/modules/Admin/Courses`, `apps/web/app/modules/Admin/AddCourse`, and `apps/web/app/modules/Admin/EditCourse`.
 - Main routes include `/admin/courses`, `/admin/beta-courses/new/standard`, and `/admin/beta-courses/:id`.
 - Course create, update, bulk category update, bulk status update, settings, language, deletion, SCORM export, master export, enrollment, and ownership endpoints live in `apps/api/src/courses/course.controller.ts`.
+- Master-course sharing and synchronization run as queued work in `apps/api/src/courses/master-course.service.ts`; copied storage references are tenant- and target-course-prefixed, and every discovered image variant is checked independently so retries repair partial copies and preserve future image sizes.
 - Key permissions include `PERMISSIONS.COURSE_CREATE`, `PERMISSIONS.COURSE_READ_MANAGEABLE`, `PERMISSIONS.COURSE_UPDATE`, `PERMISSIONS.COURSE_UPDATE_OWN`, `PERMISSIONS.COURSE_DELETE`, `PERMISSIONS.COURSE_ENROLLMENT`, and `PERMISSIONS.COURSE_EXPORT`.
 - The edit UI adapts to course type, enabled integrations, available locales, Stripe configuration, AI/Luma configuration, and managing-tenant status.
 
@@ -54,4 +58,5 @@ Course mutations are permission-gated. Full course administrators can manage cou
 
 - Web E2E coverage verifies course creation, invalid create-form validation, course list browsing/filtering, opening the create page, updating settings, updating status, bulk category updates, bulk status updates, deleting draft courses, bulk deleting draft courses, transferring ownership, student-mode preview, course pricing, course language variants, SCORM course creation/import behavior, unsupported SCORM feature hiding, and SCORM export flows.
 - API E2E coverage verifies draft course deletion and rejects deletion of private or published courses for single-course deletion and protected bulk selections.
+- Master-course API E2E coverage verifies eligible tenant selection, queued export and synchronization, read-only target copies, category and lesson updates, tenant-owned resource copying, Bunny/S3 video handling, and complete course-cover variant copying when the target already has only part of the image set.
 - Source-level API evidence covers permission checks and service paths for course creation, updates, bulk category updates, bulk status updates, settings, language management, enrollment, deletion, ownership transfer, and export operations.


### PR DESCRIPTION
## Issue(s)

- [#1776](https://github.com/Selleo/mentingo/issues/1776)
- [#1789](https://github.com/Selleo/mentingo/issues/1789)
- [#1782](https://github.com/Selleo/mentingo/issues/1782)

## Overview

Fixes copying course attachments, videos, and cover-image variants when a master course is shared or synchronized with another tenant.

- Stores copied resources under the target course ID instead of the master-course export row ID.
- Creates target image references under a proper `/variants/` path.
- Discovers and copies every concrete source image variant, including future or nonstandard resolutions.
- Preserves each variant suffix so concurrent S3 copies write to distinct target objects.
- Skips variants that already exist in the target while repairing any missing variants during retries or later synchronization.
- Uses a deterministic target course ID before the target course row is created, keeping queued export retries idempotent.
- Extends master-course E2E coverage and updates the course authoring and management business specification.

## Business Value

Managing-tenant administrators can share courses without losing attachments or cover-image quality. Target tenants receive complete, tenant-owned media copies, and course covers render the appropriate resolution instead of an unpredictable variant caused by concurrent copies overwriting one S3 object.

The retry-safe behavior also repairs incomplete transfers without recopying variants that are already present, improving synchronization reliability and avoiding unnecessary storage operations.

