### PR TITLE
fix: ensure imported students are enrolled in courses assigned to their groups

### DIFF
--- a/apps/api/src/activity-logs/handlers/group-activity.handler.ts
+++ b/apps/api/src/activity-logs/handlers/group-activity.handler.ts
@@ -7,7 +7,9 @@ import {
   EnrollGroupToCourseEvent,
   EnrollUserToGroupEvent,
   UpdateGroupEvent,
+  BulkAssignUsersToGroupsEvent,
 } from "src/events";
+import { BULK_ASSIGN_USERS_TO_GROUPS_SOURCES } from "src/group/types/group-membership-assignment.types";
 
 import { ActivityLogsService } from "../activity-logs.service";
 import { ACTIVITY_LOG_ACTION_TYPES, ACTIVITY_LOG_RESOURCE_TYPES } from "../types";
@@ -18,6 +20,7 @@ type GroupEventType =
   | UpdateGroupEvent
   | DeleteGroupEvent
   | EnrollUserToGroupEvent
+  | BulkAssignUsersToGroupsEvent
   | EnrollGroupToCourseEvent;
 
 const GroupActivityEvents = [
@@ -25,6 +28,7 @@ const GroupActivityEvents = [
   UpdateGroupEvent,
   DeleteGroupEvent,
   EnrollUserToGroupEvent,
+  BulkAssignUsersToGroupsEvent,
   EnrollGroupToCourseEvent,
 ] as const;
 
@@ -38,6 +42,8 @@ export class GroupActivityHandler implements IEventHandler<GroupEventType> {
     if (event instanceof UpdateGroupEvent) return await this.handleUpdate(event);
     if (event instanceof DeleteGroupEvent) return await this.handleDelete(event);
     if (event instanceof EnrollUserToGroupEvent) return await this.handleEnrollUser(event);
+    if (event instanceof BulkAssignUsersToGroupsEvent)
+      return await this.handleBulkAssignUsersToGroups(event);
     if (event instanceof EnrollGroupToCourseEvent)
       return await this.handleEnrollGroupToCourse(event);
   }
@@ -96,6 +102,26 @@ export class GroupActivityHandler implements IEventHandler<GroupEventType> {
       resourceType: ACTIVITY_LOG_RESOURCE_TYPES.GROUP,
       resourceId: event.enrollmentData.groupId,
       context: { userId: event.enrollmentData.userId },
+    });
+  }
+
+  private async handleBulkAssignUsersToGroups(event: BulkAssignUsersToGroupsEvent) {
+    const { actor, source, updates, tenantId, requestedCount, updatedCount, skippedCount } =
+      event.bulkAssignUsersToGroupsData;
+
+    if (source !== BULK_ASSIGN_USERS_TO_GROUPS_SOURCES.BULK_EDIT || updatedCount === 0) return;
+
+    await this.activityLogsService.recordActivity({
+      actor,
+      tenantId,
+      operation: ACTIVITY_LOG_ACTION_TYPES.GROUP_ASSIGNMENT,
+      resourceType: ACTIVITY_LOG_RESOURCE_TYPES.GROUP,
+      context: {
+        requestedCount: String(requestedCount),
+        updatedCount: String(updatedCount),
+        skippedCount: String(skippedCount),
+        memberships: JSON.stringify(updates),
+      },
     });
   }
 

--- a/apps/api/src/events/group/bulk-assign-users-to-groups.event.ts
+++ b/apps/api/src/events/group/bulk-assign-users-to-groups.event.ts
@@ -1,0 +1,22 @@
+import type { UUIDType } from "src/common";
+import type { ActorUserType } from "src/common/types/actor-user.type";
+import type {
+  BulkAssignUsersToGroupsSource,
+  UserGroupMembershipUpdate,
+} from "src/group/types/group-membership-assignment.types";
+
+export type BulkAssignUsersToGroupsUpdate = UserGroupMembershipUpdate;
+
+type BulkAssignUsersToGroupsData = {
+  actor: ActorUserType;
+  tenantId: UUIDType;
+  source: BulkAssignUsersToGroupsSource;
+  requestedCount: number;
+  updatedCount: number;
+  skippedCount: number;
+  updates: BulkAssignUsersToGroupsUpdate[];
+};
+
+export class BulkAssignUsersToGroupsEvent {
+  constructor(public readonly bulkAssignUsersToGroupsData: BulkAssignUsersToGroupsData) {}
+}

--- a/apps/api/src/events/index.ts
+++ b/apps/api/src/events/index.ts
@@ -54,6 +54,7 @@ export * from "./group/update-group.event";
 export * from "./group/delete-group.event";
 export * from "./group/enroll-user-to-group.event";
 export * from "./group/enroll-group-to-course.event";
+export * from "./group/bulk-assign-users-to-groups.event";
 export * from "./course/enroll-course.event";
 export * from "./learning-path/learning-path-course-added.event";
 export * from "./learning-path/learning-path-course-sync.event";

--- a/apps/api/src/group/group.module.ts
+++ b/apps/api/src/group/group.module.ts
@@ -3,13 +3,14 @@ import { forwardRef, Module } from "@nestjs/common";
 import { CourseModule } from "src/courses/course.module";
 import { GroupController } from "src/group/group.controller";
 import { GroupService } from "src/group/group.service";
+import { GroupMembershipEnrollmentHandler } from "src/group/handlers/group-membership-enrollment.handler";
 import { LocalizationModule } from "src/localization/localization.module";
 import { PermissionsModule } from "src/permissions/permissions.module";
 
 @Module({
   imports: [forwardRef(() => CourseModule), LocalizationModule, PermissionsModule],
   controllers: [GroupController],
-  providers: [GroupService],
+  providers: [GroupService, GroupMembershipEnrollmentHandler],
   exports: [GroupService],
 })
 export class GroupModule {}

--- a/apps/api/src/group/group.service.ts
+++ b/apps/api/src/group/group.service.ts
@@ -27,6 +27,7 @@ import {
   DeleteGroupEvent,
   EnrollUserToGroupEvent,
   UpdateGroupEvent,
+  BulkAssignUsersToGroupsEvent,
 } from "src/events";
 import { GROUP_ENROLLMENT_EVENT_BATCH_SIZE } from "src/group/group.constants";
 import { GroupSortFields } from "src/group/group.schema";
@@ -40,6 +41,7 @@ import type { SQL } from "drizzle-orm";
 import type { GroupActivityLogSnapshot } from "src/activity-logs/types";
 import type { PaginatedResponse, Pagination, UUIDType } from "src/common";
 import type { CurrentUserType } from "src/common/types/current-user.type";
+import type { BulkAssignUsersToGroupsUpdate } from "src/events";
 import type { GroupSortField, GroupKeywordFilterBody } from "src/group/group.schema";
 import type {
   AllGroupsResponse,
@@ -49,6 +51,10 @@ import type {
   GroupBaseLanguageUpdateBody,
   UpdateGroupBody,
 } from "src/group/group.types";
+import type {
+  ChangeUsersGroupsOptions,
+  UserGroupAssignment,
+} from "src/group/types/group-membership-assignment.types";
 import type { UserGroupAssignmentResult } from "src/group/types/user-group-assignment-result.type";
 import type { UserResponse } from "src/user/schemas/user.schema";
 
@@ -449,6 +455,43 @@ export class GroupService {
     });
   }
 
+  async changeUsersGroups(assignments: UserGroupAssignment[], options: ChangeUsersGroupsOptions) {
+    if (!assignments.length) return;
+
+    const db = options.db ?? this.db;
+
+    await db.transaction(async (trx) => {
+      const changes = await processInBatches(
+        assignments,
+        async ({ userId, groupIds }) => ({
+          userId,
+          ...(await this.replaceUserGroupAssignments(groupIds, userId, trx)),
+        }),
+        { batchSize: GROUP_ENROLLMENT_EVENT_BATCH_SIZE },
+      );
+
+      const changedAssignments = changes.filter(
+        ({ groupIdsToAssign, groupIdsToRemove }) =>
+          groupIdsToAssign.length > 0 || groupIdsToRemove.length > 0,
+      );
+
+      if (!changedAssignments.length) return;
+
+      await this.outboxPublisher.publish(
+        new BulkAssignUsersToGroupsEvent({
+          actor: options.actor,
+          tenantId: options.actor.tenantId,
+          source: options.source,
+          requestedCount: assignments.length,
+          updatedCount: changedAssignments.length,
+          skippedCount: assignments.length - changedAssignments.length,
+          updates: changedAssignments,
+        }),
+        trx,
+      );
+    });
+  }
+
   private async replaceUserGroupAssignments(
     groupIds: UUIDType[],
     userId: UUIDType,
@@ -506,19 +549,6 @@ export class GroupService {
     };
   }
 
-  public async insertUsersGroupAssignmentsBulk(
-    assignments: Array<{ userId: UUIDType; groupIds: UUIDType[] }>,
-    trx: DatabasePg,
-  ) {
-    const groupAssignments = assignments.flatMap(({ userId, groupIds }) =>
-      [...new Set(groupIds)].map((groupId) => ({ userId, groupId })),
-    );
-
-    if (!groupAssignments.length) return;
-
-    await trx.insert(groupUsers).values(groupAssignments).onConflictDoNothing();
-  }
-
   private async syncUserGroupEnrollment(
     userId: UUIDType,
     groupIdsToAssign: UUIDType[],
@@ -554,6 +584,15 @@ export class GroupService {
 
     await Promise.all(
       groupIdsToAssign.map((groupId) => this.enrollUserToCoursesInGroup(groupId, userId, trx)),
+    );
+  }
+
+  async syncUserGroupMembershipEnrollments(updates: BulkAssignUsersToGroupsUpdate[]) {
+    await processInBatches(
+      updates,
+      async ({ userId, groupIdsToAssign, groupIdsToRemove }) =>
+        this.syncUserGroupEnrollment(userId, groupIdsToAssign, groupIdsToRemove, this.db),
+      { batchSize: GROUP_ENROLLMENT_EVENT_BATCH_SIZE },
     );
   }
 

--- a/apps/api/src/group/handlers/group-membership-enrollment.handler.ts
+++ b/apps/api/src/group/handlers/group-membership-enrollment.handler.ts
@@ -1,0 +1,31 @@
+import { Injectable } from "@nestjs/common";
+import { EventsHandler, type IEventHandler } from "@nestjs/cqrs";
+
+import { BulkAssignUsersToGroupsEvent } from "src/events";
+import { GroupService } from "src/group/group.service";
+import { TenantDbRunnerService } from "src/storage/db/tenant-db-runner.service";
+
+@Injectable()
+@EventsHandler(BulkAssignUsersToGroupsEvent)
+export class GroupMembershipEnrollmentHandler
+  implements IEventHandler<BulkAssignUsersToGroupsEvent>
+{
+  constructor(
+    private readonly groupService: GroupService,
+    private readonly tenantRunner: TenantDbRunnerService,
+  ) {}
+
+  async handle(event: BulkAssignUsersToGroupsEvent) {
+    if (event instanceof BulkAssignUsersToGroupsEvent) {
+      return this.handleBulkAssignUsersToGroups(event);
+    }
+  }
+
+  private async handleBulkAssignUsersToGroups(event: BulkAssignUsersToGroupsEvent) {
+    const { tenantId, updates } = event.bulkAssignUsersToGroupsData;
+
+    await this.tenantRunner.runWithTenant(tenantId, async () => {
+      await this.groupService.syncUserGroupMembershipEnrollments(updates);
+    });
+  }
+}

--- a/apps/api/src/group/types/group-membership-assignment.types.ts
+++ b/apps/api/src/group/types/group-membership-assignment.types.ts
@@ -1,0 +1,27 @@
+import type { DatabasePg, UUIDType } from "src/common";
+import type { CurrentUserType } from "src/common/types/current-user.type";
+
+export const BULK_ASSIGN_USERS_TO_GROUPS_SOURCES = {
+  IMPORT: "import",
+  BULK_EDIT: "bulk-edit",
+} as const;
+
+export type BulkAssignUsersToGroupsSource =
+  (typeof BULK_ASSIGN_USERS_TO_GROUPS_SOURCES)[keyof typeof BULK_ASSIGN_USERS_TO_GROUPS_SOURCES];
+
+export type UserGroupAssignment = {
+  userId: UUIDType;
+  groupIds: UUIDType[];
+};
+
+export type UserGroupMembershipUpdate = {
+  userId: UUIDType;
+  groupIdsToAssign: UUIDType[];
+  groupIdsToRemove: UUIDType[];
+};
+
+export type ChangeUsersGroupsOptions = {
+  actor: CurrentUserType;
+  source: BulkAssignUsersToGroupsSource;
+  db?: DatabasePg;
+};

--- a/apps/api/src/learning-path/handlers/learning-path-course-sync.handler.ts
+++ b/apps/api/src/learning-path/handlers/learning-path-course-sync.handler.ts
@@ -1,6 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import { EventsHandler, type IEventHandler } from "@nestjs/cqrs";
 
+import { processInBatches } from "src/common/utils/processInBatches";
 import {
   EnrollUserToGroupEvent,
   LearningPathCourseAddedEvent,
@@ -8,13 +9,16 @@ import {
   LearningPathCourseSyncEvent,
   LessonCompletedEvent,
   UserCourseFinishedEvent,
+  BulkAssignUsersToGroupsEvent,
 } from "src/events";
+import { GROUP_ENROLLMENT_EVENT_BATCH_SIZE } from "src/group/group.constants";
 import { TenantDbRunnerService } from "src/storage/db/tenant-db-runner.service";
 
 import { LearningPathCourseSyncService } from "../services/learning-path-course-sync.service";
 
 type EventType =
   | EnrollUserToGroupEvent
+  | BulkAssignUsersToGroupsEvent
   | LearningPathCourseAddedEvent
   | LearningPathCourseRemovedEvent
   | LearningPathCourseSyncEvent
@@ -23,6 +27,7 @@ type EventType =
 
 const LearningPathCourseEvents = [
   EnrollUserToGroupEvent,
+  BulkAssignUsersToGroupsEvent,
   LearningPathCourseAddedEvent,
   LearningPathCourseRemovedEvent,
   LearningPathCourseSyncEvent,
@@ -41,6 +46,10 @@ export class LearningPathCourseSyncHandler implements IEventHandler<EventType> {
   async handle(event: EventType) {
     if (event instanceof EnrollUserToGroupEvent) {
       return this.handleEnrollUserToGroup(event);
+    }
+
+    if (event instanceof BulkAssignUsersToGroupsEvent) {
+      return this.handleBulkAssignUsersToGroups(event);
     }
 
     if (event instanceof LearningPathCourseAddedEvent) {
@@ -71,6 +80,28 @@ export class LearningPathCourseSyncHandler implements IEventHandler<EventType> {
         userId,
         actor.tenantId,
         actor,
+      );
+    });
+  }
+
+  private async handleBulkAssignUsersToGroups(event: BulkAssignUsersToGroupsEvent) {
+    const { actor, tenantId, updates } = event.bulkAssignUsersToGroupsData;
+
+    const assignments = updates.flatMap(({ userId, groupIdsToAssign }) =>
+      groupIdsToAssign.map((groupId) => ({ groupId, userId })),
+    );
+
+    await this.tenantRunner.runWithTenant(tenantId, async () => {
+      await processInBatches(
+        assignments,
+        ({ groupId, userId }) =>
+          this.syncService.syncLearningPathEnrollmentsForGroupMember(
+            groupId,
+            userId,
+            tenantId,
+            actor,
+          ),
+        { batchSize: GROUP_ENROLLMENT_EVENT_BATCH_SIZE },
       );
     });
   }

--- a/apps/api/src/user/services/user-import.service.ts
+++ b/apps/api/src/user/services/user-import.service.ts
@@ -14,6 +14,7 @@ import { UsersImportInviteEmailsEvent } from "src/events/user/users-import-invit
 import { UsersImportEvent } from "src/events/user/users-import.event";
 import { FileService } from "src/file/file.service";
 import { GroupService } from "src/group/group.service";
+import { BULK_ASSIGN_USERS_TO_GROUPS_SOURCES } from "src/group/types/group-membership-assignment.types";
 import { OutboxPublisher } from "src/outbox/outbox.publisher";
 import { SettingsService } from "src/settings/settings.service";
 import { DB } from "src/storage/db/db.providers";
@@ -352,7 +353,7 @@ export class UserImportService {
   private async createUsersCoreBulk(
     trx: DatabasePg,
     userImportRows: CreateUsersCoreBulkItem[],
-    context: Exclude<CreateUserContext, { flowType: typeof USER_CREATION_FLOW_TYPE.REGISTRATION }>,
+    context: Extract<CreateUserContext, { flowType: typeof USER_CREATION_FLOW_TYPE.ADMIN }>,
   ): Promise<CreateUsersCoreBulkResult[]> {
     if (!userImportRows.length) return [];
 
@@ -390,7 +391,11 @@ export class UserImportService {
     const groupAssignments = this.prepareUserGroupAssignments(createdUserImportRows);
 
     if (groupAssignments.length) {
-      await this.groupService.insertUsersGroupAssignmentsBulk(groupAssignments, trx);
+      await this.groupService.changeUsersGroups(groupAssignments, {
+        actor: context.creator,
+        source: BULK_ASSIGN_USERS_TO_GROUPS_SOURCES.IMPORT,
+        db: trx,
+      });
     }
 
     const tokenByUserId = new Map(createTokenRows.map(({ userId, token }) => [userId, token]));

--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -57,6 +57,7 @@ import { UserPasswordReminderEvent } from "src/events/user/user-password-reminde
 import { FileService } from "src/file/file.service";
 import { IMAGE_QUALITY } from "src/file/image-variants/image-variant.constants";
 import { GroupService } from "src/group/group.service";
+import { BULK_ASSIGN_USERS_TO_GROUPS_SOURCES } from "src/group/types/group-membership-assignment.types";
 import { LocalizationService } from "src/localization/localization.service";
 import { OutboxPublisher } from "src/outbox/outbox.publisher";
 import { SessionRevocationService } from "src/redis";
@@ -953,16 +954,15 @@ export class UserService {
   }
 
   async bulkAssignUsersToGroup(data: BulkAssignUserGroups, actor?: CurrentUserType) {
-    await this.db.transaction(async (trx) => {
-      await Promise.all(
-        data.map((user) =>
-          this.groupService.setUserGroups(user.groups, user.userId, {
-            db: trx,
-            actor,
-          }),
-        ),
-      );
-    });
+    if (!actor) throw new BadRequestException("common.toast.somethingWentWrong");
+
+    await this.groupService.changeUsersGroups(
+      data.map(({ userId, groups }) => ({ userId, groupIds: groups })),
+      {
+        actor,
+        source: BULK_ASSIGN_USERS_TO_GROUPS_SOURCES.BULK_EDIT,
+      },
+    );
   }
 
   public async getAdminsWithSettings() {

--- a/apps/web/app/assets/svgs/index.ts
+++ b/apps/web/app/assets/svgs/index.ts
@@ -27,7 +27,7 @@ export { default as StatusIllustration } from "./status-illustration.svg?react";
 export { default as TrashIcon } from "./trash-icon.svg?react";
 export { default as UploadIllustration } from "./upload-illustration.svg?react";
 export { default as UploadImageIcon } from "./upload-image.svg?react";
-export { default as User } from "./user.svg?react";
+export { Building, User, Users } from "lucide-react";
 export { default as Warning } from "./warning.svg?react";
 export { default as Admin } from "./admin.svg?react";
 export { default as Hat } from "./hat.svg?react";

--- a/apps/web/app/config/navigationConfig.ts
+++ b/apps/web/app/config/navigationConfig.ts
@@ -167,13 +167,13 @@ export const getNavigationConfig = (
         {
           label: t("navigationSideBar.users"),
           path: "admin/users",
-          iconName: "Hat",
+          iconName: "User",
           testId: NAVIGATION_HANDLES.USERS_LINK,
         },
         {
           label: t("navigationSideBar.groups"),
           path: "admin/groups",
-          iconName: "Share",
+          iconName: "Users",
           testId: NAVIGATION_HANDLES.GROUPS_LINK,
         },
         {
@@ -207,7 +207,7 @@ export const getNavigationConfig = (
         {
           label: t("navigationSideBar.tenants", "Tenants"),
           path: "super-admin/tenants",
-          iconName: "Admin",
+          iconName: "Building",
           testId: NAVIGATION_HANDLES.TENANTS_LINK,
         },
       ],

--- a/apps/web/e2e/specs/users/bulk-assign-user-groups.spec.ts
+++ b/apps/web/e2e/specs/users/bulk-assign-user-groups.spec.ts
@@ -16,14 +16,26 @@ test("admin can bulk update groups for selected users", async ({
 }) => {
   await withWorkerPage(USER_ROLE.admin, async ({ page }) => {
     const userFactory = factories.createUserFactory();
+    const categoryFactory = factories.createCategoryFactory();
+    const courseFactory = factories.createCourseFactory();
+    const enrollmentFactory = factories.createEnrollmentFactory();
     const groupFactory = factories.createGroupFactory();
     const prefix = `bulk-groups-${Date.now()}`;
+    const category = await categoryFactory.create(`Bulk groups ${prefix}`);
+    const course = await courseFactory.create({
+      title: `${prefix}-course`,
+      categoryId: category.id,
+    });
     const removableGroup = await groupFactory.create({ name: `${prefix}-remove` });
     const assignedGroup = await groupFactory.create({ name: `${prefix}-assign` });
     const users = await userFactory.createMany(2, (index) => ({
       email: `${prefix}-${index}@example.com`,
     }));
 
+    cleanup.add(async () => {
+      await courseFactory.delete(course.id);
+      await categoryFactory.delete(category.id);
+    });
     cleanup.add(async () => {
       await groupFactory.delete(assignedGroup.id);
     });
@@ -41,6 +53,7 @@ test("admin can bulk update groups for selected users", async ({
         }),
       ),
     );
+    await enrollmentFactory.enrollGroups(course.id, [{ id: assignedGroup.id, isMandatory: false }]);
 
     await openUsersPageFlow(page);
     await filterUsersFlow(page, { keyword: prefix });
@@ -73,6 +86,16 @@ test("admin can bulk update groups for selected users", async ({
             user.groups.some((group) => group.id === assignedGroup.id) &&
             user.groups.every((group) => group.id !== removableGroup.id),
         );
+      })
+      .toBe(true);
+
+    await expect
+      .poll(async () => {
+        const enrolledUsers = await Promise.all(
+          users.map((user) => enrollmentFactory.getUser(course.id, user.id)),
+        );
+
+        return enrolledUsers.every((user) => user?.isEnrolledByGroup === true);
       })
       .toBe(true);
   });

--- a/apps/web/e2e/specs/users/import-users.spec.ts
+++ b/apps/web/e2e/specs/users/import-users.spec.ts
@@ -21,8 +21,16 @@ test("admin can import users from csv and assign existing groups", async ({
 }) => {
   await withWorkerPage(USER_ROLE.admin, async ({ page }) => {
     const userFactory = factories.createUserFactory();
+    const categoryFactory = factories.createCategoryFactory();
+    const courseFactory = factories.createCourseFactory();
+    const enrollmentFactory = factories.createEnrollmentFactory();
     const groupFactory = factories.createGroupFactory();
     const prefix = `import-users-success-${Date.now()}`;
+    const category = await categoryFactory.create(`Import users ${prefix}`);
+    const course = await courseFactory.create({
+      title: `${prefix}-course`,
+      categoryId: category.id,
+    });
     const groupOne = await groupFactory.create({ name: `${prefix}-group-one` });
     const groupTwo = await groupFactory.create({ name: `${prefix}-group-two` });
     const importedStudentEmail = `${prefix}-student@example.com`;
@@ -34,6 +42,10 @@ test("admin can import users from csv and assign existing groups", async ({
       GROUP_TWO: groupTwo.name,
     });
 
+    cleanup.add(async () => {
+      await courseFactory.delete(course.id);
+      await categoryFactory.delete(category.id);
+    });
     cleanup.add(async () => {
       await groupFactory.delete(groupOne.id);
     });
@@ -56,6 +68,8 @@ test("admin can import users from csv and assign existing groups", async ({
       await userFactory.deleteMany(importedUserIds);
     });
     cleanup.add(importFile.cleanup);
+
+    await enrollmentFactory.enrollGroups(course.id, [{ id: groupOne.id, isMandatory: false }]);
 
     await openUsersPageFlow(page);
     await openImportUsersModalFlow(page);
@@ -86,6 +100,18 @@ test("admin can import users from csv and assign existing groups", async ({
           creatorUser.groups.some((group) => group.id === groupOne.id) &&
           creatorUser.groups.some((group) => group.id === groupTwo.id)
         );
+      })
+      .toBe(true);
+
+    await expect
+      .poll(async () => {
+        const importedStudent = await userFactory.getByEmail(importedStudentEmail);
+
+        if (!importedStudent) return false;
+
+        const enrolledUser = await enrollmentFactory.getUser(course.id, importedStudent.id);
+
+        return enrolledUser?.isEnrolledByGroup === true;
       })
       .toBe(true);
 

--- a/docs/specs/user-management-business-spec.md
+++ b/docs/specs/user-management-business-spec.md
@@ -40,7 +40,7 @@ For high-volume work, admins select users and apply bulk role, group, password e
 
 Bulk role changes cannot include the current admin's own account. Deletion is limited to users who look like learner/student accounts and cannot include the actor; Mentingo soft-deletes eligible users, anonymizes their core identity fields, and deflates affected course statistics.
 
-For imports, admins upload a supported spreadsheet file. Mentingo creates new users, assigns known groups from the file, reports imported users, and reports skipped users such as duplicate emails. Malformed files show an error without completing the import.
+For imports, admins upload a supported spreadsheet file. Mentingo creates new users, assigns known groups from the file, and gives learners the courses assigned to those groups. It reports imported users and skipped users such as duplicate emails. Malformed files show an error without completing the import.
 
 ## Key Technical Context
 
@@ -49,6 +49,7 @@ For imports, admins upload a supported spreadsheet file. Mentingo creates new us
 - Password access emails are handled by `UserPasswordEmailService`, which prepares reset or creation links according to whether the selected account already has credentials.
 - Administrative user-management endpoints require `PERMISSIONS.USER_MANAGE`; self-service profile, password, and onboarding endpoints use account-level permissions.
 - User creation creates onboarding/settings records, assigns role slugs, and may create a one-year invitation token for password setup.
+- Import and bulk group changes publish one aggregate membership event after the membership update commits, so group-based course and learning-path access can synchronize reliably without one event per learner/group pair.
 - Role changes revoke active sessions and send a websocket permissions-updated notification.
 
 ## Test Evidence


### PR DESCRIPTION
## Issue(s)

- #1814 
- #1809 

## Overview

- Publish one durable `BulkAssignUsersToGroupsEvent` for imported and bulk-edited group memberships.
- Synchronize group-based course and learning-path enrollment in bounded batches after the membership transaction commits.
- Record one aggregate activity log for dashboard bulk group edits instead of one event per learner/group assignment.
- Update Users, Groups, and Organizations navigation icons to `User`, `Users`, and `Building`.

## Business Value

HR and L&D administrators can import learners into enrolled groups knowing those learners receive the required training. Bulk group changes remain auditable without producing excessive events, and navigation more clearly represents people, groups, and organizations.
