### PR TITLE
chore: include live training details in calendar activity logs

### DIFF
--- a/apps/api/src/activity-logs/handlers/__tests__/live-training-activity.handler.spec.ts
+++ b/apps/api/src/activity-logs/handlers/__tests__/live-training-activity.handler.spec.ts
@@ -1,0 +1,97 @@
+import { Test } from "@nestjs/testing";
+
+import { ActivityLogsService } from "src/activity-logs/activity-logs.service";
+import { LiveTrainingActivityHandler } from "src/activity-logs/handlers/live-training-activity.handler";
+import { ACTIVITY_LOG_ACTION_TYPES, ACTIVITY_LOG_RESOURCE_TYPES } from "src/activity-logs/types";
+import { UpdateLiveTrainingEvent } from "src/events";
+import { LiveTrainingService } from "src/live-training/live-training.service";
+
+describe("LiveTrainingActivityHandler", () => {
+  let handler: LiveTrainingActivityHandler;
+  let recordActivity: jest.Mock;
+
+  const actor = {
+    userId: "00000000-0000-0000-0000-000000000001",
+    email: "admin@example.com",
+    roleSlugs: ["admin"],
+    permissions: [],
+    tenantId: "00000000-0000-0000-0000-000000000010",
+  };
+
+  const liveTrainingId = "00000000-0000-0000-0000-000000000101";
+
+  beforeEach(async () => {
+    recordActivity = jest.fn();
+    const module = await Test.createTestingModule({
+      providers: [
+        LiveTrainingActivityHandler,
+        {
+          provide: ActivityLogsService,
+          useValue: { recordActivity },
+        },
+        {
+          provide: LiveTrainingService,
+          useValue: {},
+        },
+      ],
+    }).compile();
+
+    handler = module.get(LiveTrainingActivityHandler);
+  });
+
+  it("records update context together with changed fields", async () => {
+    const event = new UpdateLiveTrainingEvent({
+      liveTrainingId,
+      actor,
+      previousLiveTrainingData: {
+        id: liveTrainingId,
+        title: "Customer service training",
+        location: "Room 1",
+        description: null,
+        status: "scheduled",
+        deliveryType: "offline",
+        visibilityScope: "linked_courses",
+        startsAt: "2026-08-01T10:00:00.000Z",
+        endsAt: "2026-08-01T11:00:00.000Z",
+        allDay: false,
+        timezone: "UTC",
+        maxParticipants: 10,
+        authorId: actor.userId,
+        hostIds: [],
+        linkedCourseIds: [],
+        settings: {},
+      },
+      updatedLiveTrainingData: {
+        id: liveTrainingId,
+        title: "Customer service training",
+        location: "Room 2",
+        description: null,
+        status: "scheduled",
+        deliveryType: "offline",
+        visibilityScope: "linked_courses",
+        startsAt: "2026-08-01T10:00:00.000Z",
+        endsAt: "2026-08-01T11:00:00.000Z",
+        allDay: false,
+        timezone: "UTC",
+        maxParticipants: 10,
+        authorId: actor.userId,
+        hostIds: [],
+        linkedCourseIds: [],
+        settings: {},
+      },
+    });
+
+    await handler.handle(event);
+
+    expect(recordActivity).toHaveBeenCalledWith({
+      actor,
+      operation: ACTIVITY_LOG_ACTION_TYPES.UPDATE,
+      resourceType: ACTIVITY_LOG_RESOURCE_TYPES.LIVE_TRAINING,
+      resourceId: liveTrainingId,
+      changedFields: ["location"],
+      before: { location: "Room 1" },
+      after: { location: "Room 2" },
+      context: { title: "Customer service training" },
+    });
+  });
+});

--- a/apps/api/src/activity-logs/handlers/live-training-activity.handler.ts
+++ b/apps/api/src/activity-logs/handlers/live-training-activity.handler.ts
@@ -92,10 +92,14 @@ export class LiveTrainingActivityHandler implements IEventHandler<LiveTrainingEv
 
   private async handleUpdate(event: UpdateLiveTrainingEvent) {
     const { liveTrainingUpdateData } = event;
+    const context = {
+      ...(liveTrainingUpdateData.context ?? {}),
+      title: liveTrainingUpdateData.updatedLiveTrainingData?.title ?? "",
+    };
     const metadata = buildActivityLogMetadata({
       previous: liveTrainingUpdateData.previousLiveTrainingData,
       updated: liveTrainingUpdateData.updatedLiveTrainingData,
-      context: liveTrainingUpdateData.context ?? null,
+      context,
     });
 
     await this.activityLogsService.recordActivity({

--- a/apps/web/app/api/queries/calendar/useCalendarEvents.test.ts
+++ b/apps/web/app/api/queries/calendar/useCalendarEvents.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getEvents: vi.fn(),
+}));
+
+vi.mock("~/api/api-client", () => ({
+  ApiClient: {
+    api: {
+      calendarControllerGetEvents: mocks.getEvents,
+    },
+  },
+}));
+
+import { calendarEventsQueryOptions } from "./useCalendarEvents";
+
+describe("calendarEventsQueryOptions", () => {
+  beforeEach(() => {
+    mocks.getEvents.mockReset();
+  });
+
+  it("does not request events before a visible date range exists", async () => {
+    const options = calendarEventsQueryOptions({ language: "en" });
+    const queryFn = options.queryFn;
+
+    if (typeof queryFn !== "function") throw new Error("Expected calendar query function");
+
+    const events = await queryFn({} as never);
+
+    expect(events).toEqual([]);
+    expect(mocks.getEvents).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/queries/calendar/useCalendarEvents.ts
+++ b/apps/web/app/api/queries/calendar/useCalendarEvents.ts
@@ -25,6 +25,8 @@ export const calendarEventsQueryOptions = (
   queryOptions({
     queryKey: [...CALENDAR_EVENTS_QUERY_KEY, params],
     queryFn: async () => {
+      if (!params.start || !params.end) return [];
+
       const response = await ApiClient.api.calendarControllerGetEvents({
         start: params.start,
         end: params.end,

--- a/apps/web/app/api/utils/invalidateLiveTrainingData.ts
+++ b/apps/web/app/api/utils/invalidateLiveTrainingData.ts
@@ -7,6 +7,22 @@ import { LIVE_TRAINING_SESSION_QUERY_KEY } from "~/api/queries/live-training/use
 import { LIVE_TRAINING_SESSIONS_QUERY_KEY } from "~/api/queries/live-training/useLiveTrainingSessions";
 import { queryClient } from "~/api/queryClient";
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const hasCalendarEventsRange = (queryKey: readonly unknown[]) => {
+  const params = queryKey[1];
+
+  if (!isRecord(params)) return false;
+
+  return (
+    typeof params.start === "string" &&
+    params.start.length > 0 &&
+    typeof params.end === "string" &&
+    params.end.length > 0
+  );
+};
+
 type InvalidateLiveTrainingDataOptions = {
   includeCalendar?: boolean;
   includeCoursesAndLessons?: boolean;
@@ -40,7 +56,11 @@ export async function invalidateLiveTrainingData({
       queryClient.invalidateQueries({ queryKey: CALENDAR_EVENT_DETAILS_QUERY_KEY }),
     );
     refetches.push(
-      queryClient.refetchQueries({ queryKey: CALENDAR_EVENTS_QUERY_KEY }),
+      queryClient.refetchQueries({
+        queryKey: CALENDAR_EVENTS_QUERY_KEY,
+        type: "active",
+        predicate: (query) => hasCalendarEventsRange(query.queryKey),
+      }),
       queryClient.refetchQueries({ queryKey: CALENDAR_EVENT_DETAILS_QUERY_KEY }),
     );
   }


### PR DESCRIPTION
<!--
 1. Make sure you have correct branch name i.e. `ab_prefix_123_task_name`, where `123` is a issue ID, and `ab` is an author
 2. Make sure you have meaningful title related to task with correct prefix: feat/fix/chore/style/docs/refactor
 3. Reference multiple issues in one PR by listing them in the issues section
 4. Make sure all necessary sections are filled, remove obsolete sections
 5. Do a self review first
 6. Check if your PR includes only code related to your task
 7. `Notes` is used for additional info but also to notify if any action is required
-->

## Issue(s)
[1811](https://github.com/Selleo/mentingo/issues/1811)
[1812](https://github.com/Selleo/mentingo/issues/1812)

## Overview

  Prevent calendar event queries from running without a valid visible date range, and restrict Live Training calendar refetches to active queries with complete ranges.

  Add Live Training update context to activity logs using the updated training title, with backend regression coverage for update metadata.

  ## Business Value

  Opening or updating Live Training no longer triggers invalid calendar requests or unnecessary errors. Activity logs now retain enough context to identify which Live Training was updated, improving
  auditability for administrators.