### PR TITLE
chore: limit content creators to viewing statistics for their own courses

### DIFF
--- a/apps/api/src/courses/__tests__/course.controller.e2e-spec.ts
+++ b/apps/api/src/courses/__tests__/course.controller.e2e-spec.ts
@@ -344,6 +344,76 @@ describe("CourseController (e2e)", () => {
     });
   });
 
+  describe("course statistics access", () => {
+    it("allows a content creator to view statistics for their own course", async () => {
+      const contentCreator = await userFactory
+        .withCredentials({ password })
+        .withContentCreatorSettings(db)
+        .create({ role: SYSTEM_ROLE_SLUGS.CONTENT_CREATOR });
+      const category = await categoryFactory.create();
+      const course = await courseFactory.create({
+        authorId: contentCreator.id,
+        categoryId: category.id,
+        status: "published",
+      });
+
+      await request(app.getHttpServer())
+        .get(`/api/course/${course.id}/statistics/average-quiz-score`)
+        .query({ language: SUPPORTED_LANGUAGES.EN })
+        .set("Cookie", await cookieFor(contentCreator, app))
+        .expect(200);
+    });
+
+    it("denies a content creator statistics for another author's course", async () => {
+      const contentCreator = await userFactory
+        .withCredentials({ password })
+        .withContentCreatorSettings(db)
+        .create({ role: SYSTEM_ROLE_SLUGS.CONTENT_CREATOR });
+      const otherAuthor = await userFactory
+        .withCredentials({ password })
+        .withContentCreatorSettings(db)
+        .create({ role: SYSTEM_ROLE_SLUGS.CONTENT_CREATOR });
+      const category = await categoryFactory.create();
+      const course = await courseFactory.create({
+        authorId: otherAuthor.id,
+        categoryId: category.id,
+        status: "published",
+      });
+
+      await request(app.getHttpServer())
+        .get(`/api/course/${course.id}/statistics/average-quiz-score`)
+        .query({ language: SUPPORTED_LANGUAGES.EN })
+        .set("Cookie", await cookieFor(contentCreator, app))
+        .expect(403)
+        .expect(({ body }) => {
+          expect(body.message).toBe("adminCourseView.errors.statisticsAccessForbidden");
+        });
+    });
+
+    it("allows a user with any-course update permission to view another author's statistics", async () => {
+      const admin = await userFactory
+        .withCredentials({ password })
+        .withAdminSettings(db)
+        .create({ role: SYSTEM_ROLE_SLUGS.ADMIN });
+      const otherAuthor = await userFactory
+        .withCredentials({ password })
+        .withContentCreatorSettings(db)
+        .create({ role: SYSTEM_ROLE_SLUGS.CONTENT_CREATOR });
+      const category = await categoryFactory.create();
+      const course = await courseFactory.create({
+        authorId: otherAuthor.id,
+        categoryId: category.id,
+        status: "published",
+      });
+
+      await request(app.getHttpServer())
+        .get(`/api/course/${course.id}/statistics/average-quiz-score`)
+        .query({ language: SUPPORTED_LANGUAGES.EN })
+        .set("Cookie", await cookieFor(admin, app))
+        .expect(200);
+    });
+  });
+
   describe("GET /api/course/:courseId/statistics/average-quiz-score", () => {
     const createAverageQuizScoreFixture = async () => {
       const admin = await userFactory

--- a/apps/api/src/courses/course.controller.ts
+++ b/apps/api/src/courses/course.controller.ts
@@ -891,7 +891,9 @@ export class CourseController {
   async getCourseStatistics(
     @Param("courseId") courseId: UUIDType,
     @Query("groupId") groupId: UUIDType,
+    @CurrentUser() currentUser: CurrentUserType,
   ): Promise<BaseResponse<CourseStatisticsResponse>> {
+    await this.courseService.assertCanViewCourseStatistics(courseId, currentUser);
     const query = { groupId };
 
     const data = await this.courseService.getCourseStatistics(courseId, query);
@@ -921,7 +923,9 @@ export class CourseController {
     @Query("page") page: number,
     @Query("perPage") perPage: number,
     @Query("sort") sort: LearningTimeStatisticsSortOptions,
+    @CurrentUser() currentUser: CurrentUserType,
   ) {
+    await this.courseService.assertCanViewCourseStatistics(courseId, currentUser);
     const query = { userId, groupId, page, perPage, sort, searchQuery };
     const data = await this.learningTimeService.getLearningTimeStatistics(courseId, query);
 
@@ -940,7 +944,9 @@ export class CourseController {
   async getCourseLearningStatisticsFilterOptions(
     @Param("courseId") courseId: UUIDType,
     @Query("language") language: SupportedLanguages | undefined,
+    @CurrentUser() currentUser: CurrentUserType,
   ) {
+    await this.courseService.assertCanViewCourseStatistics(courseId, currentUser);
     const data = await this.learningTimeService.getFilterOptions(courseId, language);
 
     return new BaseResponse(data);
@@ -960,7 +966,9 @@ export class CourseController {
     @Param("courseId") courseId: UUIDType,
     @Query("groupId") groupId: UUIDType,
     @Query("language") language: SupportedLanguages,
+    @CurrentUser() currentUser: CurrentUserType,
   ) {
+    await this.courseService.assertCanViewCourseStatistics(courseId, currentUser);
     const query = { groupId };
 
     const averageQuizScores = await this.courseService.getAverageQuizScoreForCourse(
@@ -998,7 +1006,9 @@ export class CourseController {
     @Query("groupId") groupId: UUIDType,
     @Query("sort") sort: SortCourseStudentProgressionOptions,
     @Query("language") language: SupportedLanguages,
+    @CurrentUser() currentUser: CurrentUserType,
   ): Promise<PaginatedResponse<AllStudentCourseProgressionResponse>> {
+    await this.courseService.assertCanViewCourseStatistics(courseId, currentUser);
     const query = {
       courseId,
       page,
@@ -1042,7 +1052,9 @@ export class CourseController {
     @Query("search") searchQuery: string,
     @Query("sort") sort: SortCourseStudentQuizResultsOptions,
     @Query("language") language: SupportedLanguages,
+    @CurrentUser() currentUser: CurrentUserType,
   ): Promise<PaginatedResponse<AllStudentQuizResultsResponse>> {
+    await this.courseService.assertCanViewCourseStatistics(courseId, currentUser);
     const query = {
       courseId,
       page,
@@ -1087,7 +1099,9 @@ export class CourseController {
     @Query("search") searchQuery: string,
     @Query("sort") sort: SortCourseStudentAiMentorResultsOptions,
     @Query("language") language: SupportedLanguages,
+    @CurrentUser() currentUser: CurrentUserType,
   ): Promise<PaginatedResponse<AllStudentAiMentorResultsResponse>> {
+    await this.courseService.assertCanViewCourseStatistics(courseId, currentUser);
     const query = {
       courseId,
       page,

--- a/apps/api/src/courses/course.service.ts
+++ b/apps/api/src/courses/course.service.ts
@@ -3869,6 +3869,22 @@ export class CourseService {
     return { ...courseStats, averageSeconds: courseLearningTime.averageSeconds };
   }
 
+  async assertCanViewCourseStatistics(
+    courseId: UUIDType,
+    currentUser: CurrentUserType,
+  ): Promise<void> {
+    const [course] = await this.db
+      .select({ authorId: courses.authorId })
+      .from(courses)
+      .where(eq(courses.id, courseId));
+
+    if (!course) throw new NotFoundException("adminCourseView.errors.notFound.course");
+
+    if (!canUpdateCourseByAuthor(currentUser, course.authorId)) {
+      throw new ForbiddenException("adminCourseView.errors.statisticsAccessForbidden");
+    }
+  }
+
   async getAverageQuizScoreForCourse(
     courseId: UUIDType,
     query: CourseStatisticsQueryBody,

--- a/apps/web/app/common/permissions/permission.utils.test.ts
+++ b/apps/web/app/common/permissions/permission.utils.test.ts
@@ -1,0 +1,44 @@
+import { PERMISSIONS } from "@repo/shared";
+import { describe, expect, it } from "vitest";
+
+import { canManageCourseByAuthor } from "./permission.utils";
+
+describe("canManageCourseByAuthor", () => {
+  it("allows any-course managers regardless of author", () => {
+    expect(
+      canManageCourseByAuthor({
+        permissions: [PERMISSIONS.COURSE_UPDATE],
+        courseAuthorId: "author-id",
+        currentUserId: "other-user-id",
+      }),
+    ).toBe(true);
+  });
+
+  it("allows own-course managers only for their course", () => {
+    expect(
+      canManageCourseByAuthor({
+        permissions: [PERMISSIONS.COURSE_UPDATE_OWN],
+        courseAuthorId: "author-id",
+        currentUserId: "author-id",
+      }),
+    ).toBe(true);
+
+    expect(
+      canManageCourseByAuthor({
+        permissions: [PERMISSIONS.COURSE_UPDATE_OWN],
+        courseAuthorId: "author-id",
+        currentUserId: "other-user-id",
+      }),
+    ).toBe(false);
+  });
+
+  it("denies users without course-management permissions", () => {
+    expect(
+      canManageCourseByAuthor({
+        permissions: [PERMISSIONS.COURSE_STATISTICS],
+        courseAuthorId: "author-id",
+        currentUserId: "author-id",
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/app/common/permissions/permission.utils.ts
+++ b/apps/web/app/common/permissions/permission.utils.ts
@@ -1,8 +1,25 @@
-export {
+import {
+  PERMISSIONS,
   hasAllPermissions,
   hasAnyPermission,
   hasPermission,
   matchesRequirement,
-  type PermissionKey,
-  type PermissionRequirement,
 } from "@repo/shared";
+
+import type { PermissionKey } from "@repo/shared";
+
+export { hasAllPermissions, hasAnyPermission, hasPermission, matchesRequirement };
+export type { PermissionKey, PermissionRequirement } from "@repo/shared";
+
+export const canManageCourseByAuthor = ({
+  permissions,
+  courseAuthorId,
+  currentUserId,
+}: {
+  permissions: PermissionKey[];
+  courseAuthorId?: string;
+  currentUserId?: string;
+}): boolean =>
+  hasPermission(permissions, PERMISSIONS.COURSE_UPDATE) ||
+  (hasPermission(permissions, PERMISSIONS.COURSE_UPDATE_OWN) &&
+    Boolean(courseAuthorId && currentUserId === courseAuthorId));

--- a/apps/web/app/locales/cs/translation.json
+++ b/apps/web/app/locales/cs/translation.json
@@ -1922,6 +1922,7 @@
         "chapter": "Kapitola nenalezena.",
         "lesson": "Lekce nenalezena."
       },
+      "statisticsAccessForbidden": "Nemáte oprávnění zobrazit statistiky tohoto kurzu.",
       "create": {
         "courseFailed": "Kurz se nepodařilo vytvořit.",
         "stripeProductFailed": "Platební produkt kurzu se nepodařilo vytvořit."

--- a/apps/web/app/locales/de/translation.json
+++ b/apps/web/app/locales/de/translation.json
@@ -1923,6 +1923,7 @@
         "chapter": "Kapitel nicht gefunden.",
         "lesson": "Lektion nicht gefunden."
       },
+      "statisticsAccessForbidden": "Sie haben keine Berechtigung, die Statistiken für diesen Kurs anzuzeigen.",
       "create": {
         "courseFailed": "Kurs konnte nicht erstellt werden.",
         "stripeProductFailed": "Zahlungsprodukt für den Kurs konnte nicht erstellt werden."

--- a/apps/web/app/locales/en/translation.json
+++ b/apps/web/app/locales/en/translation.json
@@ -1985,6 +1985,7 @@
         "chapter": "Chapter not found.",
         "lesson": "Lesson not found."
       },
+      "statisticsAccessForbidden": "You do not have permission to view statistics for this course.",
       "create": {
         "courseFailed": "Failed to create course.",
         "stripeProductFailed": "Failed to create course payment product."

--- a/apps/web/app/locales/es/translation.json
+++ b/apps/web/app/locales/es/translation.json
@@ -1973,6 +1973,7 @@
         "chapter": "Capítulo no encontrado.",
         "lesson": "Lección no encontrada."
       },
+      "statisticsAccessForbidden": "No tienes permiso para ver las estadísticas de este curso.",
       "create": {
         "courseFailed": "No se pudo crear el curso.",
         "stripeProductFailed": "No se pudo crear el producto de pago del curso."

--- a/apps/web/app/locales/lt/translation.json
+++ b/apps/web/app/locales/lt/translation.json
@@ -1922,6 +1922,7 @@
         "chapter": "Skyrius nerastas.",
         "lesson": "Pamoka nerasta."
       },
+      "statisticsAccessForbidden": "Neturite teisės peržiūrėti šio kurso statistikos.",
       "create": {
         "courseFailed": "Nepavyko sukurti kurso.",
         "stripeProductFailed": "Nepavyko sukurti kurso mokėjimo produkto."

--- a/apps/web/app/locales/pl/translation.json
+++ b/apps/web/app/locales/pl/translation.json
@@ -2205,6 +2205,7 @@
         "chapter": "Nie znaleziono rozdziału.",
         "lesson": "Nie znaleziono lekcji."
       },
+      "statisticsAccessForbidden": "Nie masz uprawnień do wyświetlania statystyk tego kursu.",
       "create": {
         "courseFailed": "Nie udało się utworzyć kursu.",
         "stripeProductFailed": "Nie udało się utworzyć produktu płatności dla kursu."

--- a/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/CourseAdminStatistics.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/CourseAdminStatistics.tsx
@@ -1,5 +1,4 @@
 import { TabsList } from "@radix-ui/react-tabs";
-import { PERMISSIONS } from "@repo/shared";
 import { useEffect, useMemo, useState, useTransition } from "react";
 import { useTranslation } from "react-i18next";
 import { match } from "ts-pattern";
@@ -19,7 +18,6 @@ import {
 } from "~/components/ui/select";
 import { Tabs, TabsContent, TabsTrigger } from "~/components/ui/tabs";
 import { TooltipProvider } from "~/components/ui/tooltip";
-import { usePermissions } from "~/hooks/usePermissions";
 import { LessonType } from "~/modules/Admin/EditCourse/EditCourse.types";
 import {
   SearchFilter,
@@ -54,6 +52,7 @@ import type { CourseStudentsQuizResultsQueryParams } from "~/api/queries/admin/u
 
 interface CourseAdminStatisticsProps {
   course?: GetCourseResponse["data"];
+  canManageCourse: boolean;
 }
 
 export const formatLearningTime = (totalSeconds: number) => {
@@ -70,14 +69,10 @@ export const formatLearningTime = (totalSeconds: number) => {
   return `${seconds}s`;
 };
 
-export function CourseAdminStatistics({ course }: CourseAdminStatisticsProps) {
+export function CourseAdminStatistics({ course, canManageCourse }: CourseAdminStatisticsProps) {
   const { t } = useTranslation();
   const language = useLanguageStore((state) => state.language);
   const courseId = course?.id || "";
-
-  const { hasAccess: canManageCourses } = usePermissions({
-    required: [PERMISSIONS.COURSE_UPDATE, PERMISSIONS.COURSE_UPDATE_OWN],
-  });
 
   const [groupId, setGroupId] = useState<string | undefined>(undefined);
 
@@ -128,18 +123,18 @@ export function CourseAdminStatistics({ course }: CourseAdminStatisticsProps) {
 
   const { data: learningTimeFilterOptions } = useCourseStatisticsFilter({
     id: courseId,
-    enabled: canManageCourses,
+    enabled: canManageCourse,
     language,
   });
 
   const { data: courseStatistics } = useCourseStatistics({
     id: courseId,
-    enabled: canManageCourses,
+    enabled: canManageCourse,
     query: courseStatisticsParams,
   });
   const { data: averageQuizScores } = useCourseAverageScorePerQuiz({
     id: courseId,
-    enabled: canManageCourses,
+    enabled: canManageCourse,
     query: { ...courseStatisticsParams, language },
   });
   const { data: aiConfigured } = useAIConfigured();
@@ -148,7 +143,7 @@ export function CourseAdminStatistics({ course }: CourseAdminStatisticsProps) {
 
   const { data: aiMentorResultsPreview } = useCourseStudentsAiMentorResults({
     id: courseId,
-    enabled: canManageCourses && Boolean(courseId),
+    enabled: canManageCourse && Boolean(courseId),
     query: {
       page: 1,
       perPage: 1,

--- a/apps/web/app/modules/Courses/CourseView/CourseView.page.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseView.page.tsx
@@ -8,7 +8,7 @@ import { match } from "ts-pattern";
 import { courseLookupQueryOptions, useCourse, useCurrentUser } from "~/api/queries";
 import { useGlobalSettings } from "~/api/queries/useGlobalSettings";
 import { queryClient } from "~/api/queryClient";
-import { hasPermission } from "~/common/permissions/permission.utils";
+import { canManageCourseByAuthor, hasPermission } from "~/common/permissions/permission.utils";
 import { PageWrapper } from "~/components/PageWrapper";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
 import { ContentAccessGuard } from "~/Guards/AccessGuard";
@@ -128,6 +128,11 @@ export default function CourseViewPage() {
     required: PERMISSIONS.COURSE_STATISTICS,
   });
   const { data: currentUser } = useCurrentUser();
+  const canManageCourse = canManageCourseByAuthor({
+    permissions: currentUser?.permissions ?? [],
+    courseAuthorId: course?.authorId,
+    currentUserId: currentUser?.id,
+  });
 
   const courseViewTabs = useMemo(
     () => [
@@ -178,7 +183,7 @@ export default function CourseViewPage() {
         value: "statistics",
         queryValue: COURSE_VIEW_TAB_QUERY_VALUES.STATISTICS,
         title: t("studentCourseView.tabs.statistics"),
-        content: <CourseAdminStatistics course={course} />,
+        content: <CourseAdminStatistics course={course} canManageCourse={canManageCourse} />,
         isForAdminLike: true,
         isForUnregistered: false,
         isForEnrolled: false,
@@ -189,6 +194,7 @@ export default function CourseViewPage() {
       course,
       currentUser?.id,
       currentUser?.permissions,
+      canManageCourse,
       globalSettings?.courseDiscussionsEnabled,
     ],
   );
@@ -218,7 +224,8 @@ export default function CourseViewPage() {
   ];
 
   const canView = (isForAdminLike: boolean, isForUnregistered: boolean, isForEnrolled: boolean) => {
-    const hideForAdmin = isForAdminLike && (!canViewCourseStatistics || !currentUser);
+    const hideForAdmin =
+      isForAdminLike && (!canViewCourseStatistics || !currentUser || !canManageCourse);
     const hideWhenUnregistered = !isForUnregistered && !currentUser;
     const hideWhenNotEnrolled = isForEnrolled && !course.enrolled;
 

--- a/docs/specs/course-authoring-management-business-spec.md
+++ b/docs/specs/course-authoring-management-business-spec.md
@@ -29,12 +29,15 @@ For HR and L&D teams, this is the control center for the learning catalog. It ke
 - Delete draft courses individually or in bulk while protecting private and published courses.
 - Share eligible master courses with managed tenants while preserving course content, cover-image quality, trailers, and future source updates.
 - Export supported courses as SCORM packages when permissions and configuration allow it.
+- Review learner progress, learning time, quiz outcomes, and AI Mentor results for courses the user manages.
 
 ## End-User Value
 
 The feature gives L&D teams governance over the training library. Teams can prepare courses before learners see them, publish only when content is ready, keep accountability through ownership, and maintain multilingual versions for different learner populations.
 
 Operational controls reduce mistakes. Permissions distinguish full course management from own-course editing, private and published courses are protected from draft-delete flows, and optional capabilities such as pricing, certificates, SCORM, and master exports appear only when the course and tenant support them.
+
+Course reporting follows the same ownership model. Content creators can review outcomes for their own courses, while users with broader course-management responsibility can review the courses they oversee. This keeps learner reporting useful without exposing another creator's operational data.
 
 ## How It Works
 
@@ -48,6 +51,8 @@ When a managing-tenant administrator shares a master course, Mentingo creates a 
 
 Course mutations are permission-gated. Full course administrators can manage courses according to their permissions, while content creators rely on own-course update permissions for courses they own. In the admin course list, permitted users can select multiple courses and use the bulk-edit menu to change their category, change their status, or delete draft courses in one governed workflow. Private and published courses must be moved back to draft before deletion is allowed. Language operations respect supported-language and base-language rules.
 
+From a course view, an eligible administrator opens the Statistics tab to review course-level completion, learner progress, learning time, quiz results, and—when available—AI Mentor outcomes. Published courses may still be viewed by users who do not manage them, but the Statistics tab and its data are limited to the course owner or users with any-course management responsibility. The API rechecks this boundary for every statistics request so direct links cannot bypass the UI.
+
 ## Key Technical Context
 
 - Admin course pages live under `apps/web/app/modules/Admin/Courses`, `apps/web/app/modules/Admin/AddCourse`, and `apps/web/app/modules/Admin/EditCourse`.
@@ -55,13 +60,15 @@ Course mutations are permission-gated. Full course administrators can manage cou
 - Chapter editing is provided by the curriculum area and `apps/api/src/chapter`; chapter deletion removes its related learner chapter-progress data in the same database operation.
 - Course create, update, bulk category update, bulk status update, settings, language, deletion, SCORM export, master export, enrollment, and ownership endpoints live in `apps/api/src/courses/course.controller.ts`.
 - Master-course sharing and synchronization run as queued work in `apps/api/src/courses/master-course.service.ts`; copied storage references are tenant- and target-course-prefixed, and every discovered image variant is checked independently so retries repair partial copies and preserve future image sizes.
-- Key permissions include `PERMISSIONS.COURSE_CREATE`, `PERMISSIONS.COURSE_READ_MANAGEABLE`, `PERMISSIONS.COURSE_UPDATE`, `PERMISSIONS.COURSE_UPDATE_OWN`, `PERMISSIONS.COURSE_DELETE`, `PERMISSIONS.COURSE_ENROLLMENT`, and `PERMISSIONS.COURSE_EXPORT`.
+- Key permissions include `PERMISSIONS.COURSE_CREATE`, `PERMISSIONS.COURSE_READ_MANAGEABLE`, `PERMISSIONS.COURSE_UPDATE`, `PERMISSIONS.COURSE_UPDATE_OWN`, `PERMISSIONS.COURSE_STATISTICS`, `PERMISSIONS.COURSE_DELETE`, `PERMISSIONS.COURSE_ENROLLMENT`, and `PERMISSIONS.COURSE_EXPORT`.
+- Course statistics require both the statistics capability and resource-level manageability: `COURSE_UPDATE` allows any course, while `COURSE_UPDATE_OWN` requires the requester to match `courses.authorId`.
 - The edit UI adapts to course type, enabled integrations, available locales, Stripe configuration, AI/Luma configuration, and managing-tenant status.
 
 ## Test Evidence
 
 - Web E2E coverage verifies course creation, invalid create-form validation, course list browsing/filtering, opening the create page, updating settings, updating status, bulk category updates, bulk status updates, deleting draft courses, bulk deleting draft courses, transferring ownership, student-mode preview, course pricing, course language variants, SCORM course creation/import behavior, unsupported SCORM feature hiding, and SCORM export flows.
 - API E2E coverage verifies draft course deletion and rejects deletion of private or published courses for single-course deletion and protected bulk selections.
+- API E2E coverage verifies that content creators can access their own course statistics, cannot access another author's statistics, and that any-course administrators retain access.
 - Curriculum web E2E coverage verifies an administrator can create, update, reorder, and delete a chapter; chapter API E2E coverage verifies deletion also clears the chapter's learner progress.
 - Master-course API E2E coverage verifies eligible tenant selection, queued export and synchronization, read-only target copies, category and lesson updates, tenant-owned resource copying, Bunny/S3 video handling, and complete course-cover variant copying when the target already has only part of the image set.
 - Source-level API evidence covers permission checks and service paths for course creation, updates, bulk category updates, bulk status updates, settings, language management, enrollment, deletion, ownership transfer, and export operations.


### PR DESCRIPTION
<!--
 1. Make sure you have correct branch name i.e. `ab_prefix_123_task_name`, where `123` is a issue ID, and `ab` is an author
 2. Make sure you have meaningful title related to task with correct prefix: feat/fix/chore/style/docs/refactor
 3. Reference multiple issues in one PR by listing them in the issues section
 4. Make sure all necessary sections are filled, remove obsolete sections
 5. Do a self review first
 6. Check if your PR includes only code related to your task
 7. `Notes` is used for additional info but also to notify if any action is required
-->

## Issue(s)
[1810](https://github.com/Selleo/mentingo/issues/1810)

  ## Overview

  Added resource-level authorization for course statistics. Content creators can access statistics only for courses they own, while users with broad course-management permissions retain access to all
  courses.

  The frontend now hides the Statistics tab and disables statistics queries for unmanaged courses. Added localized authorization messages, tests, and updated the course business specification.

  ## Business Value

  Prevents content creators from viewing learner performance data belonging to courses they cannot manage, preserving course ownership boundaries and reporting privacy.