### PR TITLE
fix: ensure reliable article editing access for content creators

### DIFF
--- a/apps/api/src/articles/__tests__/articles.controller.e2e-spec.ts
+++ b/apps/api/src/articles/__tests__/articles.controller.e2e-spec.ts
@@ -233,6 +233,39 @@ describe("ArticlesController (e2e)", () => {
 
       await request(app.getHttpServer()).get(`/api/articles/${article.id}?language=pl`).expect(404);
     });
+
+    it("allows a content creator to read published articles created by another user", async () => {
+      const contentCreator = await createContentCreator();
+      const author = await userFactory.create();
+      const section = await sectionFactory.create({ title: "Published access" });
+      const article = await articleFactory.create({
+        articleSectionId: section.id,
+        authorId: author.id,
+        title: "Published article",
+        isPublic: true,
+      });
+      const cookie = await cookieFor(contentCreator, app);
+
+      const articleResponse = await request(app.getHttpServer())
+        .get(`/api/articles/${article.id}?language=en`)
+        .set("Cookie", cookie)
+        .expect(200);
+
+      expect(articleResponse.body.data.id).toBe(article.id);
+
+      const tocResponse = await request(app.getHttpServer())
+        .get("/api/articles/toc?language=en")
+        .set("Cookie", cookie)
+        .expect(200);
+
+      expect(tocResponse.body.data.sections).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            articles: expect.arrayContaining([expect.objectContaining({ id: article.id })]),
+          }),
+        ]),
+      );
+    });
   });
 
   describe("GET /api/articles/drafts", () => {

--- a/apps/api/src/articles/__tests__/articles.controller.e2e-spec.ts
+++ b/apps/api/src/articles/__tests__/articles.controller.e2e-spec.ts
@@ -266,6 +266,26 @@ describe("ArticlesController (e2e)", () => {
         ]),
       );
     });
+
+    it("allows an admin to open a published article in draft mode for editing", async () => {
+      const admin = await createAdmin();
+      const section = await sectionFactory.create({ title: "Published edit" });
+      const article = await articleFactory.create({
+        articleSectionId: section.id,
+        authorId: admin.id,
+        title: "Published article",
+        status: "published",
+        isPublic: true,
+      });
+
+      const response = await request(app.getHttpServer())
+        .get(`/api/articles/${article.id}?language=en&isDraftMode=true`)
+        .set("Cookie", await cookieFor(admin, app))
+        .expect(200);
+
+      expect(response.body.data.id).toBe(article.id);
+      expect(response.body.data.title).toBe("Published article");
+    });
   });
 
   describe("GET /api/articles/drafts", () => {

--- a/apps/api/src/articles/repositories/articles.repository.ts
+++ b/apps/api/src/articles/repositories/articles.repository.ts
@@ -401,6 +401,7 @@ export class ArticlesRepository {
     language: SupportedLanguages,
     options?: {
       isDraftMode?: boolean;
+      includeUnpublished?: boolean;
       excludedId?: UUIDType;
       authorId?: UUIDType;
       canManageArticles?: boolean;
@@ -408,11 +409,17 @@ export class ArticlesRepository {
     },
   ): SQL<unknown>[] {
     const canManageArticles = options?.canManageArticles ?? false;
+    let publicationConditions: SQL<unknown>[] = [];
+
+    if (!options?.includeUnpublished) {
+      publicationConditions = options?.isDraftMode
+        ? [isNull(articles.publishedAt)]
+        : [not(isNull(articles.publishedAt))];
+    }
+
     const conditions = [
       ne(articles.archived, true),
-      ...(options?.isDraftMode
-        ? [isNull(articles.publishedAt)]
-        : [not(isNull(articles.publishedAt))]),
+      ...publicationConditions,
       ...(options?.isPublicOnly ? [eq(articles.isPublic, true)] : []),
       ...(options?.authorId ? [eq(articles.authorId, options.authorId)] : []),
       ...(!canManageArticles ? [sql`${language} = ANY(${articles.availableLocales})`] : []),

--- a/apps/api/src/articles/services/articles.service.ts
+++ b/apps/api/src/articles/services/articles.service.ts
@@ -443,7 +443,7 @@ export class ArticlesService {
   }
 
   async getDraftArticles(requestedLanguage: SupportedLanguages, currentUser: CurrentUserType) {
-    const { authorId } = this.getArticleScope(currentUser);
+    const { authorId } = this.getArticleScope(currentUser, true);
     return this.articlesRepository.getDraftArticles(requestedLanguage, authorId);
   }
 
@@ -547,7 +547,7 @@ export class ArticlesService {
 
     const accessConditions = this.articlesRepository.getVisibleArticleConditions(
       requestedLanguage,
-      { ...this.getArticleScope(currentUser), isDraftMode },
+      { ...this.getArticleScope(currentUser, isDraftMode), isDraftMode },
     );
 
     const [existingArticle] = await this.articlesRepository.getArticleWithAccess(
@@ -671,7 +671,7 @@ export class ArticlesService {
   ): Promise<GetArticleTocResponse> {
     await this.checkContentReadAccess(currentUser, PERMISSIONS.ARTICLE_READ_PUBLIC);
 
-    const articleScope = this.getArticleScope(currentUser);
+    const articleScope = this.getArticleScope(currentUser, isDraftMode);
     const conditions = this.articlesRepository.getVisibleArticleConditions(requestedLanguage, {
       ...articleScope,
       isDraftMode,
@@ -700,7 +700,7 @@ export class ArticlesService {
     const adjacentArticleConditions = this.articlesRepository.getVisibleArticleConditions(
       language,
       {
-        ...this.getArticleScope(currentUser),
+        ...this.getArticleScope(currentUser, isDraftMode),
         isDraftMode,
         excludedId: currentArticleId,
       },
@@ -1332,13 +1332,13 @@ export class ArticlesService {
     }
   }
 
-  private getArticleScope(currentUser?: CurrentUserType) {
+  private getArticleScope(currentUser?: CurrentUserType, isDraftMode = false) {
     const canManageAll = hasPermission(currentUser?.permissions, PERMISSIONS.ARTICLE_MANAGE);
     const canManageOwn = hasPermission(currentUser?.permissions, PERMISSIONS.ARTICLE_MANAGE_OWN);
 
     return {
       canManageArticles: canManageAll || canManageOwn,
-      authorId: canManageOwn && !canManageAll ? currentUser?.userId : undefined,
+      authorId: isDraftMode && canManageOwn && !canManageAll ? currentUser?.userId : undefined,
       isPublicOnly: !currentUser,
     };
   }

--- a/apps/api/src/articles/services/articles.service.ts
+++ b/apps/api/src/articles/services/articles.service.ts
@@ -547,7 +547,11 @@ export class ArticlesService {
 
     const accessConditions = this.articlesRepository.getVisibleArticleConditions(
       requestedLanguage,
-      { ...this.getArticleScope(currentUser, isDraftMode), isDraftMode },
+      {
+        ...this.getArticleScope(currentUser, isDraftMode),
+        isDraftMode,
+        includeUnpublished: isDraftMode,
+      },
     );
 
     const [existingArticle] = await this.articlesRepository.getArticleWithAccess(

--- a/apps/web/app/modules/Articles/ArticleForm.page.tsx
+++ b/apps/web/app/modules/Articles/ArticleForm.page.tsx
@@ -242,16 +242,17 @@ function ArticleFormPage() {
 
   const persistedLocales = existingArticle?.availableLocales ?? [];
   const hasFormChanges =
-    availableLocales.some(
-      (language) => hasDirtyTranslation(language) || !persistedLocales.includes(language),
-    ) || Boolean(formState.dirtyFields.isPublic);
+    formState.isDirty || availableLocales.some((language) => !persistedLocales.includes(language));
 
   const saveArticle = async (values: ArticleFormValues) => {
     if (!articleId || items.length || !hasFormChanges) return;
 
-    const translations = availableLocales
-      .filter((language) => hasDirtyTranslation(language) || !persistedLocales.includes(language))
-      .map((language) => ({ language, ...values.translations[language] }));
+    const dirtyLanguages = availableLocales.filter(
+      (language) => hasDirtyTranslation(language) || !persistedLocales.includes(language),
+    );
+    const translations = (dirtyLanguages.length ? dirtyLanguages : [activeLanguage]).map(
+      (language) => ({ language, ...values.translations[language] }),
+    );
     const covers: Partial<Record<`cover.${SupportedLanguages}`, File>> = {};
     translations.forEach(({ language, cover }) => {
       if (cover) covers[`cover.${language}`] = cover;


### PR DESCRIPTION
## Issue(s)
[1838](https://github.com/Selleo/mentingo/issues/1838)

## Overview
Content Creators with `article.manage_own` can now read published articles created by other users.

The own-author restriction is applied only to draft and management views. Published article detail fetching, the article TOC, and adjacent-article navigation no longer incorrectly filter results by the current user’s author ID.

## Business Value
Content Creators can access the published CMS content they are allowed to read, while their own-content restriction remains intact for drafts and editing workflows.

## Validation
- Articles API E2E: 21/21 passed
- API unit tests: 411/411 passed
- Web unit tests: 280 passed, 12 skipped
- Typecheck, ESLint, and Prettier passed