### PR TITLE
fix: block sharing with inactive organizations and allow organization deletion

### DIFF
--- a/apps/api/src/courses/__tests__/master-course.e2e-spec.ts
+++ b/apps/api/src/courses/__tests__/master-course.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Readable } from "stream";
 
 import { faker } from "@faker-js/faker";
-import { LESSON_TYPES, SYSTEM_ROLE_SLUGS } from "@repo/shared";
+import { LESSON_TYPES, SYSTEM_ROLE_SLUGS, TENANT_STATUSES } from "@repo/shared";
 import { and, asc, eq, inArray } from "drizzle-orm";
 import request from "supertest";
 
@@ -210,7 +210,11 @@ describe("Master course export and sync (e2e)", () => {
       targetTenantId = existingTargetTenant.id;
       await baseDb
         .update(tenants)
-        .set({ isManaging: false, name: "Target Tenant" })
+        .set({
+          isManaging: false,
+          name: "Target Tenant",
+          status: TENANT_STATUSES.ACTIVE,
+        })
         .where(eq(tenants.id, targetTenantId));
     } else {
       const [createdTargetTenant] = await baseDb
@@ -539,6 +543,41 @@ describe("Master course export and sync (e2e)", () => {
     expect(response.body.data.summary.totalTenants).toBe(candidateTenants.length);
     expect(response.body.data.summary.exportedCount).toBe(1);
     expect(response.body.data.summary.remainingCount).toBe(candidateTenants.length - 1);
+  });
+
+  it("excludes inactive tenants from course sharing candidates and export", async () => {
+    const { sourceCourseId, sourceCookie } = await setupAndExport();
+
+    await baseDb
+      .update(tenants)
+      .set({ status: TENANT_STATUSES.INACTIVE })
+      .where(eq(tenants.id, targetTenantId));
+
+    try {
+      const response = await withTenantHost(
+        request(app.getHttpServer())
+          .get(`/api/course/master/${sourceCourseId}/export-candidates`)
+          .set("Cookie", sourceCookie),
+        SOURCE_HOST,
+      ).expect(200);
+
+      expect(
+        response.body.data.tenants.some((tenant: { id: string }) => tenant.id === targetTenantId),
+      ).toBe(false);
+
+      await withTenantHost(
+        request(app.getHttpServer())
+          .post(`/api/course/master/${sourceCourseId}/export`)
+          .set("Cookie", sourceCookie)
+          .send({ targetTenantIds: [targetTenantId] }),
+        SOURCE_HOST,
+      ).expect(400);
+    } finally {
+      await baseDb
+        .update(tenants)
+        .set({ status: TENANT_STATUSES.ACTIVE })
+        .where(eq(tenants.id, targetTenantId));
+    }
   });
 
   it("exports source course to target tenant and keeps exported copy readonly", async () => {

--- a/apps/api/src/courses/master-course.repository.ts
+++ b/apps/api/src/courses/master-course.repository.ts
@@ -5,6 +5,7 @@ import {
   MASTER_COURSE_EXPORT_SYNC_STATUSES,
   PERMISSIONS,
   SCORM_PACKAGE_ENTITY_TYPE,
+  TENANT_STATUSES,
   type MasterCourseEntityType,
   type SupportedLanguages,
 } from "@repo/shared";
@@ -193,7 +194,7 @@ export class MasterCourseRepository {
           eq(masterCourseExports.targetTenantId, tenants.id),
         ),
       )
-      .where(ne(tenants.id, sourceTenantId))
+      .where(and(ne(tenants.id, sourceTenantId), eq(tenants.status, TENANT_STATUSES.ACTIVE)))
       .orderBy(asc(tenants.name));
   }
 

--- a/apps/api/src/integration/__tests__/integration.controller.e2e-spec.ts
+++ b/apps/api/src/integration/__tests__/integration.controller.e2e-spec.ts
@@ -555,6 +555,43 @@ describe("IntegrationController (e2e)", () => {
       });
     });
 
+    it("allows managing tenant integration key to delete another tenant", async () => {
+      const { apiKey } = await createApiKey({ isManaging: true });
+
+      const [{ id: tenantId }] = await dbAdmin
+        .insert(tenants)
+        .values({
+          name: "Integration Deleted Tenant",
+          host: uniqueTenantHost("integration-deleted-tenant"),
+          status: TENANT_STATUSES.INACTIVE,
+        })
+        .returning({ id: tenants.id });
+
+      await request(app.getHttpServer())
+        .delete(`/api/integration/tenants/${tenantId}`)
+        .set("X-API-Key", apiKey)
+        .expect(204);
+
+      const [deletedTenant] = await dbAdmin
+        .select({ id: tenants.id })
+        .from(tenants)
+        .where(eq(tenants.id, tenantId))
+        .limit(1);
+
+      expect(deletedTenant).toBeUndefined();
+    });
+
+    it("rejects deleting the integration key's managing tenant", async () => {
+      const { admin, apiKey } = await createApiKey({ isManaging: true });
+
+      const response = await request(app.getHttpServer())
+        .delete(`/api/integration/tenants/${admin.tenantId}`)
+        .set("X-API-Key", apiKey)
+        .expect(400);
+
+      expect(response.body.message).toBe("superAdminTenants.error.currentTenantDeleteNotAllowed");
+    });
+
     it("rejects tenant creation for non-managing tenant integration key", async () => {
       const { apiKey } = await createApiKey({ isManaging: false });
 
@@ -581,6 +618,25 @@ describe("IntegrationController (e2e)", () => {
         .patch(`/api/integration/tenants/${admin.tenantId}`)
         .set("X-API-Key", apiKey)
         .send({ name: "Rejected Integration Tenant Update" })
+        .expect(404);
+
+      expect(response.body.message).toBe("superAdminTenants.error.managingTenantRequired");
+    });
+
+    it("rejects tenant deletion for non-managing tenant integration key", async () => {
+      const { apiKey } = await createApiKey({ isManaging: false });
+
+      const [{ id: tenantId }] = await dbAdmin
+        .insert(tenants)
+        .values({
+          name: "Rejected Integration Tenant Deletion",
+          host: uniqueTenantHost("rejected-integration-tenant-deletion"),
+        })
+        .returning({ id: tenants.id });
+
+      const response = await request(app.getHttpServer())
+        .delete(`/api/integration/tenants/${tenantId}`)
+        .set("X-API-Key", apiKey)
         .expect(404);
 
       expect(response.body.message).toBe("superAdminTenants.error.managingTenantRequired");

--- a/apps/api/src/integration/integration.controller.ts
+++ b/apps/api/src/integration/integration.controller.ts
@@ -3,6 +3,8 @@ import {
   Controller,
   Delete,
   Get,
+  HttpCode,
+  HttpStatus,
   Param,
   Patch,
   Post,
@@ -230,6 +232,33 @@ export class IntegrationController {
         keyTenant,
       ),
     );
+  }
+
+  @Delete("tenants/:tenantId")
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @RequirePermission(PERMISSIONS.INTEGRATION_API_USE)
+  @IntegrationTenantOptional()
+  @ApiEndpointDocs({
+    summary: "Delete tenant via integration API",
+    description:
+      "Permanently deletes the target tenant and its tenant-owned data.\n\nOnly integration API keys owned by a managing tenant with tenant management permission can use this endpoint. The managing tenant cannot delete itself.",
+    headers: [
+      {
+        ...API_HEADERS.X_TENANT_ID,
+        required: false,
+        description: "Tenant ID is not required because the target tenant is in the path.",
+      },
+    ],
+  })
+  @Validate({
+    request: [{ type: "param", name: "tenantId", schema: UUIDSchema }],
+  })
+  async deleteTenant(
+    @Param("tenantId") tenantId: UUIDType,
+    @CurrentUser() currentUser: CurrentUserType,
+    @IntegrationKeyTenant() keyTenant: IntegrationKeyTenantContext,
+  ): Promise<void> {
+    await this.integrationService.deleteTenantForIntegration(tenantId, currentUser, keyTenant);
   }
 
   @Get("users")

--- a/apps/api/src/integration/integration.service.ts
+++ b/apps/api/src/integration/integration.service.ts
@@ -172,6 +172,16 @@ export class IntegrationService {
     });
   }
 
+  async deleteTenantForIntegration(
+    tenantId: string,
+    actor: CurrentUserType,
+    keyTenant: IntegrationKeyTenantContext,
+  ): Promise<void> {
+    this.assertCanManageTenants(actor, keyTenant);
+
+    await this.tenantsService.deleteTenantById(tenantId, keyTenant.tenantId);
+  }
+
   async updateTenantForIntegration(
     tenantId: string,
     input: IntegrationUpdateTenantBody,

--- a/apps/api/src/learning-path/__tests__/learning-path-export.e2e-spec.ts
+++ b/apps/api/src/learning-path/__tests__/learning-path-export.e2e-spec.ts
@@ -3,6 +3,7 @@ import {
   COURSE_ORIGIN_TYPES,
   MASTER_COURSE_EXPORT_SYNC_STATUSES,
   SYSTEM_ROLE_SLUGS,
+  TENANT_STATUSES,
 } from "@repo/shared";
 import { and, eq, inArray } from "drizzle-orm";
 import request from "supertest";
@@ -115,7 +116,11 @@ describe("LearningPathExportController (e2e)", () => {
       targetTenantId = existingTargetTenant.id;
       await baseDb
         .update(tenants)
-        .set({ isManaging: false, name: "Target Tenant" })
+        .set({
+          isManaging: false,
+          name: "Target Tenant",
+          status: TENANT_STATUSES.ACTIVE,
+        })
         .where(eq(tenants.id, targetTenantId));
     } else {
       const [createdTargetTenant] = await baseDb
@@ -357,6 +362,43 @@ describe("LearningPathExportController (e2e)", () => {
       expect(targetCourseResponse.body.data.id).toBe(courseId);
       expect(targetCourseResponse.body.data.originType).toBe("exported");
       expect(targetCourseResponse.body.data.sourceTenantId).toBe(sourceTenantId);
+    }
+  });
+
+  it("excludes inactive tenants from learning path sharing candidates and export", async () => {
+    const { learningPathId, sourceCookie } = await setupSourcePath();
+
+    await baseDb
+      .update(tenants)
+      .set({ status: TENANT_STATUSES.INACTIVE })
+      .where(eq(tenants.id, targetTenantId));
+
+    try {
+      const candidatesResponse = await withTenantHost(
+        request(app.getHttpServer())
+          .get(`/api/learning-path/master/${learningPathId}/export-candidates`)
+          .set("Cookie", sourceCookie),
+        SOURCE_HOST,
+      ).expect(200);
+
+      expect(
+        candidatesResponse.body.data.tenants.some(
+          (tenant: { id: string }) => tenant.id === targetTenantId,
+        ),
+      ).toBe(false);
+
+      await withTenantHost(
+        request(app.getHttpServer())
+          .post(`/api/learning-path/master/${learningPathId}/export`)
+          .set("Cookie", sourceCookie)
+          .send({ targetTenantIds: [targetTenantId] }),
+        SOURCE_HOST,
+      ).expect(400);
+    } finally {
+      await baseDb
+        .update(tenants)
+        .set({ status: TENANT_STATUSES.ACTIVE })
+        .where(eq(tenants.id, targetTenantId));
     }
   });
 

--- a/apps/api/src/learning-path/learning-path.repository.ts
+++ b/apps/api/src/learning-path/learning-path.repository.ts
@@ -7,6 +7,7 @@ import {
   LEARNING_PATH_ENROLLMENT_TYPES,
   LEARNING_PATH_CERTIFICATE_STATUSES,
   SUPPORTED_LANGUAGES,
+  TENANT_STATUSES,
   type LearningPathEnrollmentType,
   type LearningPathProgressStatus,
   type LearningPathEntityType,
@@ -866,7 +867,7 @@ export class LearningPathRepository {
           eq(learningPathExports.targetTenantId, tenants.id),
         ),
       )
-      .where(ne(tenants.id, sourceTenantId))
+      .where(and(ne(tenants.id, sourceTenantId), eq(tenants.status, TENANT_STATUSES.ACTIVE)))
       .orderBy(asc(tenants.name));
   }
 

--- a/apps/api/src/swagger/api-schema.json
+++ b/apps/api/src/swagger/api-schema.json
@@ -12944,6 +12944,54 @@
         "tags": [
           "Integration"
         ]
+      },
+      "delete": {
+        "operationId": "IntegrationController_deleteTenant",
+        "summary": "Delete tenant via integration API",
+        "description": "Permanently deletes the target tenant and its tenant-owned data.\n\nOnly integration API keys owned by a managing tenant with tenant management permission can use this endpoint. The managing tenant cannot delete itself.",
+        "parameters": [
+          {
+            "name": "X-API-Key",
+            "in": "header",
+            "description": "Integration API key used to authenticate every integration request.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "tenantId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Tenant-Id",
+            "in": "header",
+            "description": "Tenant ID is not required because the target tenant is in the path.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "401": {
+            "description": "Missing or invalid integration API key."
+          },
+          "403": {
+            "description": "Authenticated integration key owner is not authorized."
+          }
+        },
+        "tags": [
+          "Integration"
+        ]
       }
     },
     "/api/integration/tenants/{tenantId}/deactivate": {

--- a/apps/api/src/swagger/integration-api-schema.json
+++ b/apps/api/src/swagger/integration-api-schema.json
@@ -167,6 +167,54 @@
         "tags": [
           "Integration"
         ]
+      },
+      "delete": {
+        "operationId": "IntegrationController_deleteTenant",
+        "summary": "Delete tenant via integration API",
+        "description": "Permanently deletes the target tenant and its tenant-owned data.\n\nOnly integration API keys owned by a managing tenant with tenant management permission can use this endpoint. The managing tenant cannot delete itself.",
+        "parameters": [
+          {
+            "name": "X-API-Key",
+            "in": "header",
+            "description": "Integration API key used to authenticate every integration request.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "tenantId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Tenant-Id",
+            "in": "header",
+            "description": "Tenant ID is not required because the target tenant is in the path.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "401": {
+            "description": "Missing or invalid integration API key."
+          },
+          "403": {
+            "description": "Authenticated integration key owner is not authorized."
+          }
+        },
+        "tags": [
+          "Integration"
+        ]
       }
     },
     "/api/integration/tenants/{tenantId}/deactivate": {

--- a/apps/web/app/api/generated-api.ts
+++ b/apps/web/app/api/generated-api.ts
@@ -15312,6 +15312,21 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
+     * @description Permanently deletes the target tenant and its tenant-owned data. Only integration API keys owned by a managing tenant with tenant management permission can use this endpoint. The managing tenant cannot delete itself.
+     *
+     * @tags Integration
+     * @name IntegrationControllerDeleteTenant
+     * @summary Delete tenant via integration API
+     * @request DELETE:/api/integration/tenants/{tenantId}
+     */
+    integrationControllerDeleteTenant: (tenantId: string, params: RequestParams = {}) =>
+      this.request<void, void>({
+        path: `/api/integration/tenants/${tenantId}`,
+        method: "DELETE",
+        ...params,
+      }),
+
+    /**
      * @description Marks the target tenant as inactive. Only integration API keys owned by a managing tenant with tenant management permission can use this endpoint.
      *
      * @tags Integration

--- a/docs/specs/course-sharing-business-spec.md
+++ b/docs/specs/course-sharing-business-spec.md
@@ -20,6 +20,7 @@ The managing-tenant administrator selects recipient organizations from the cours
 - Preserve the recipient course's publication status when source content is synchronized.
 - Let recipient administrators publish shared courses and manage participants while keeping shared content read-only.
 - Show source and recipient copies as shared courses and prevent an exported copy from becoming a new sharing source.
+- Offer only active organizations as sharing destinations and reject exports to inactive organizations.
 - Process exports and subsequent synchronization asynchronously so cross-tenant copying is retryable and does not block the source edit request.
 
 ## End-User Value
@@ -28,7 +29,7 @@ Central course ownership reduces duplicated authoring and makes training updates
 
 ## How It Works
 
-A managing-tenant administrator opens a course's sharing area, selects one or more organizations, and starts sharing. Mentingo creates a separate draft course for each recipient and copies the supported curriculum and resources in the background. The source becomes the centrally managed master, while recipient copies display a shared-course notice and restrict editing to the local controls that remain available, including status and enrollment.
+A managing-tenant administrator opens a course's sharing area, selects one or more active organizations, and starts sharing. Inactive organizations are omitted from the selector and cannot be supplied directly through the API. Mentingo creates a separate draft course for each recipient and copies the supported curriculum and resources in the background. The source becomes the centrally managed master, while recipient copies display a shared-course notice and restrict editing to the local controls that remain available, including status and enrollment.
 
 When the source course or its curriculum changes, Mentingo queues synchronization for every active sharing link. The recipient copy receives the latest centrally managed content but keeps its existing draft or published status. A later sync therefore updates what learners see without making a locally published course unavailable.
 
@@ -42,6 +43,6 @@ When the source course or its curriculum changes, Mentingo queues synchronizatio
 
 ## Test Evidence
 
-API E2E coverage verifies managing-tenant authorization, recipient selection, initial draft creation, read-only exported content, localized course/category copying, repeated sharing behavior, resource and video handling, category synchronization, and source deletion propagation. Regression coverage also verifies that after a recipient publishes its shared copy, a later source update synchronizes content without changing that published status.
+API E2E coverage verifies managing-tenant authorization, active-recipient selection, rejection of inactive recipients, initial draft creation, read-only exported content, localized course/category copying, repeated sharing behavior, resource and video handling, category synchronization, and source deletion propagation. Regression coverage also verifies that after a recipient publishes its shared copy, a later source update synchronizes content without changing that published status.
 
 There is no dedicated Playwright E2E flow for tenant-to-tenant course sharing; the UI workflow and local controls are evidenced by the course editor implementation and translations rather than browser-level coverage.

--- a/docs/specs/learning-paths-business-spec.md
+++ b/docs/specs/learning-paths-business-spec.md
@@ -25,7 +25,7 @@ Learners open the development paths page, browse available paths, enroll when el
 - Enroll individual learners or groups into a path.
 - Let eligible learners self-enroll in available paths.
 - Track path progress and issue certificates when path certification is enabled.
-- Export learning paths and linked courses to other tenants where permitted.
+- Export learning paths and linked courses to active recipient organizations where permitted.
 
 ## End-User Value
 
@@ -37,7 +37,7 @@ Group enrollment, sequence rules, certificates, and export support larger organi
 
 When learning paths are enabled, learners with access can open `/development-paths` and see path cards in their selected language. If they are eligible, they can enroll and start working through the path's courses.
 
-Administrators and content creators with learning-path authoring access use the learning-path management experience to define localized title and description, status, thumbnail, certificate settings, course order, and sequencing. They can enroll selected learners or groups. When the path's courses, enrollment, order, or sequence setting changes, Mentingo synchronizes the course access each enrolled learner should have.
+Administrators and content creators with learning-path authoring access use the learning-path management experience to define localized title and description, status, thumbnail, certificate settings, course order, and sequencing. They can enroll selected learners or groups. Managing-tenant administrators can share a path only with active recipient organizations; inactive organizations are omitted from the selector and rejected by the export API. When the path's courses, enrollment, order, or sequence setting changes, Mentingo synchronizes the course access each enrolled learner should have.
 
 In sequence mode, learners receive access to the next course only after prior course requirements are met. When all required courses are completed and certificates are enabled, Mentingo can create a learning-path certificate that learners can view, download, or share.
 
@@ -53,5 +53,5 @@ In sequence mode, learners receive access to the next course only after prior co
 
 ## Test Evidence
 
-- API E2E coverage verifies the feature gate, create/read/update/delete, localization, own-path permissions, course add/remove/reorder, sequence synchronization, direct and group enrollment/unenrollment, export behavior, course access retention/removal rules, duplicate sync handling, future group members, and learning-path certificate rendering/share flows.
+- API E2E coverage verifies the feature gate, create/read/update/delete, localization, own-path permissions, course add/remove/reorder, sequence synchronization, direct and group enrollment/unenrollment, active-recipient export behavior, rejection of inactive recipients, course access retention/removal rules, duplicate sync handling, future group members, and learning-path certificate rendering/share flows.
 - I did not find a dedicated Playwright learning-path spec under `apps/web/e2e/specs`; frontend behavior is supported by source evidence and strong backend workflow coverage.

--- a/docs/specs/tenant-administration-business-spec.md
+++ b/docs/specs/tenant-administration-business-spec.md
@@ -6,12 +6,12 @@ Tenant Administration lets managing platform admins create and maintain separate
 
 For HR and L&D vendors or enterprise platform operators, this enables a multi-tenant LMS model. Several organizations can be served from one product while their users, settings, and learning records remain separated.
 
-The main workflow starts in the super-admin tenant list. A managing admin browses or searches tenants, reviews each organization's latest recorded activity and recent activity volume, creates a new tenant, edits tenant identity or status, launches support mode, or permanently removes an organization that is no longer required. Authorized external systems can use the Integration API for tenant creation, update, and deactivation when administration needs to be automated.
+The main workflow starts in the super-admin tenant list. A managing admin browses or searches tenants, reviews each organization's latest recorded activity and recent activity volume, creates a new tenant, edits tenant identity or status, launches support mode, or permanently removes an organization that is no longer required. Authorized external systems can use the Integration API for tenant creation, update, deactivation, and permanent deletion when administration needs to be automated.
 
 ## Who Uses It
 
 - Managing platform admins browse customer tenants, use recent activity signals to identify organizations that may need attention, and permanently remove obsolete organizations when retention is no longer required.
-- Integration operators automate tenant creation, updates, and deactivation from an authorized external system.
+- Integration operators automate tenant creation, updates, deactivation, and permanent deletion from an authorized external system.
 - Platform operators activate or deactivate tenant workspaces.
 - Tenant admins benefit because a newly created tenant receives default global settings and an invited admin account.
 - Support staff use the tenant list as the starting point for temporary support-mode access.
@@ -25,7 +25,7 @@ The main workflow starts in the super-admin tenant list. A managing admin browse
 - Create an organization with its host, status, default settings, and invited initial admin.
 - Update organization identity, host, and active/inactive status.
 - Permanently delete another organization after confirming an irreversible warning.
-- Automate organization creation, partial updates, and deactivation through the Integration API.
+- Automate organization creation, partial updates, deactivation, and permanent deletion through the Integration API.
 - Normalize organization hosts and prevent duplicate or invalid hosts.
 - Restrict administration to authorized users in the managing organization and prevent them from deleting their current organization.
 
@@ -41,7 +41,7 @@ From the same page, the admin searches for a tenant or starts a new tenant form.
 
 Row-level Edit and Delete actions are grouped in a compact actions menu. When an organization must be removed rather than disabled, the admin chooses Delete from that menu. Mentingo presents an explicit warning that the organization and its tenant-owned users, learning records, activity, and settings will be permanently removed. The admin must confirm before deletion proceeds. The current managing organization cannot be deleted, preventing an admin from removing the workspace that authorizes tenant administration.
 
-When editing a tenant, the admin updates the tenant's name, host, or active/inactive status. An authorized integration can submit the same partial updates for a tenant identified in the API path. Host changes refresh platform host handling so traffic resolves to the correct tenant. Status changes let operators make a tenant inactive when access should be disabled.
+When editing a tenant, the admin updates the tenant's name, host, or active/inactive status. An authorized integration can submit the same partial updates for a tenant identified in the API path or permanently delete a tenant that is no longer required. Integration deletion uses the same safeguards as the administrative UI: only a managing organization can perform it, and it cannot delete itself. Host changes refresh platform host handling so traffic resolves to the correct tenant. Status changes let operators make a tenant inactive when access should be disabled.
 
 Access is restricted to users who have tenant-management permission and are operating from a designated managing tenant. Normal tenant users and learners are redirected away from this area.
 
@@ -49,7 +49,7 @@ Access is restricted to users who have tenant-management permission and are oper
 
 - Frontend tenant pages live in `apps/web/app/modules/SuperAdmin` and are routed under `/super-admin/tenants`.
 - The tenant API lives in `apps/api/src/super-admin/tenants.controller.ts` and `apps/api/src/super-admin/tenants.service.ts`.
-- Integration lifecycle endpoints live in `apps/api/src/integration/integration.controller.ts` and reuse the tenant service's validation and update behavior.
+- Integration lifecycle endpoints live in `apps/api/src/integration/integration.controller.ts` and reuse the tenant service's validation, update, and deletion safeguards.
 - Tenant administration requires `PERMISSIONS.TENANT_MANAGE` and `ManagingTenantAdminGuard`.
 - Hard deletion uses the tenant foreign-key cascade to remove tenant-scoped relational records atomically; the API independently rejects attempts to delete the current managing tenant.
 - Activity summaries use tenant-scoped audit records and display historical actor emails without exposing role snapshots. The five-action preview is loaded in one additional batched query for the visible organization page rather than one query per row.
@@ -60,4 +60,4 @@ Access is restricted to users who have tenant-management permission and are oper
 
 ## Test Evidence
 
-Frontend coverage verifies protocol-free host display with truncation and a full-value tooltip; activity-summary, five-action hover preview, trend, and active-user reach rendering; activity sort requests; status filtering; the hard-delete confirmation flow; protection of the current organization; tenant browsing; opening details; creation; updates; and denial for non-managing users. Backend E2E coverage verifies role-free latest actor snapshots, the newest-five activity limit, rolling current and previous 14-day activity summaries, distinct active-user reach, activity sorting, active/inactive filtering with matching totals, cascading tenant deletion, and rejection of current-tenant deletion. Integration API E2E coverage verifies tenant creation, partial updates, deactivation, persisted update values, host normalization, and rejection of lifecycle operations from non-managing tenants.
+Frontend coverage verifies protocol-free host display with truncation and a full-value tooltip; activity-summary, five-action hover preview, trend, and active-user reach rendering; activity sort requests; status filtering; the hard-delete confirmation flow; protection of the current organization; tenant browsing; opening details; creation; updates; and denial for non-managing users. Backend E2E coverage verifies role-free latest actor snapshots, the newest-five activity limit, rolling current and previous 14-day activity summaries, distinct active-user reach, activity sorting, active/inactive filtering with matching totals, cascading tenant deletion, and rejection of current-tenant deletion. Integration API E2E coverage verifies tenant creation, partial updates, deactivation, permanent deletion, persisted update values, host normalization, current-managing-tenant protection, and rejection of lifecycle operations from non-managing tenants.


### PR DESCRIPTION
## Issue(s)
[#1841](https://github.com/Selleo/mentingo/issues/1841)

## Overview

- Excludes inactive tenants from course and development-path sharing candidates.
- Rejects forged sharing requests targeting inactive tenants at the API boundary.
- Adds a permanent tenant deletion endpoint to the Integration API with managing-tenant authorization and self-deletion protection.
- Regenerates API contracts and adds backend E2E coverage for the new behavior.

## Business Value

Prevents content from being shared with inactive organizations and enables authorized integrations to complete the tenant lifecycle safely without manual platform administration.
