### PR TITLE
fix: stabilize course statistics queries

### DIFF
--- a/apps/api/src/courses/__tests__/course.controller.e2e-spec.ts
+++ b/apps/api/src/courses/__tests__/course.controller.e2e-spec.ts
@@ -237,6 +237,9 @@ describe("CourseController (e2e)", () => {
         courseId: course.id,
         totalSeconds: 120,
       });
+      const group = await groupFactory.withMembers([student.id]).create({
+        name: "Learning time group",
+      });
 
       const partialFullName = `${student.firstName} ${student.lastName.slice(0, 1)}`;
 
@@ -285,6 +288,7 @@ describe("CourseController (e2e)", () => {
           expect(body.data.users).toEqual([
             expect.objectContaining({
               id: student.id,
+              groups: [{ id: group.id, name: group.name }],
             }),
           ]);
         });

--- a/apps/api/src/courses/course.service.ts
+++ b/apps/api/src/courses/course.service.ts
@@ -28,6 +28,7 @@ import {
   countDistinct,
   desc,
   eq,
+  exists,
   gte,
   getTableColumns,
   ilike,
@@ -3931,13 +3932,25 @@ export class CourseService {
       return { averageScoresPerQuiz: [] };
     }
 
+    const activeEnrollment = this.db
+      .select({ studentId: studentCourses.studentId })
+      .from(studentCourses)
+      .innerJoin(users, eq(users.id, studentCourses.studentId))
+      .where(
+        and(
+          eq(studentCourses.studentId, studentLessonProgress.studentId),
+          eq(studentCourses.courseId, chapters.courseId),
+          eq(studentCourses.status, COURSE_ENROLLMENT.ENROLLED),
+          isNull(users.deletedAt),
+        ),
+      );
+
     const conditions = [
       eq(chapters.courseId, courseId),
       eq(lessons.type, LESSON_TYPES.QUIZ),
       isNotNull(studentLessonProgress.completedAt),
       isNotNull(studentLessonProgress.quizScore),
-      eq(studentCourses.status, COURSE_ENROLLMENT.ENROLLED),
-      isNull(users.deletedAt),
+      exists(activeEnrollment),
     ];
 
     if (groupStudentIds.length) {
@@ -3960,14 +3973,6 @@ export class CourseService {
       .innerJoin(courses, eq(courses.id, chapters.courseId))
       .innerJoin(lessons, eq(lessons.chapterId, chapters.id))
       .innerJoin(studentLessonProgress, eq(studentLessonProgress.lessonId, lessons.id))
-      .innerJoin(
-        studentCourses,
-        and(
-          eq(studentCourses.studentId, studentLessonProgress.studentId),
-          eq(studentCourses.courseId, chapters.courseId),
-        ),
-      )
-      .innerJoin(users, eq(users.id, studentCourses.studentId))
       .where(and(...conditions))
       .groupBy(
         lessons.id,

--- a/apps/api/src/learning-time/learning-time.repository.ts
+++ b/apps/api/src/learning-time/learning-time.repository.ts
@@ -163,10 +163,19 @@ export class LearningTimeRepository {
         studentAvatarKey: users.avatarReference,
         totalSeconds: sql<number>`SUM(${lessonLearningTime.totalSeconds})::INTEGER`,
         groups: sql<Array<{ id: string; name: string }>>`(
-          SELECT json_agg(json_build_object('id', g.id, 'name', g.name))
-          FROM ${groups} g
-          JOIN ${groupUsers} gu ON gu.group_id = g.id
-          WHERE gu.user_id = ${users.id}
+          SELECT json_agg(
+            json_build_object(
+              'id', ${groups.id},
+              'name', ${this.localizationService.getLocalizedSqlField(
+                groups.name,
+                undefined,
+                groups,
+              )}
+            )
+          )
+          FROM ${groups}
+          JOIN ${groupUsers} ON ${groupUsers.groupId} = ${groups.id}
+          WHERE ${groupUsers.userId} = ${users.id}
         )`,
       })
       .from(lessonLearningTime)

--- a/docs/specs/learning-time-tracking-business-spec.md
+++ b/docs/specs/learning-time-tracking-business-spec.md
@@ -22,6 +22,7 @@ The learner does not operate this feature directly. When a learner studies a les
 - Flush remaining active time when the learner leaves a lesson or disconnects.
 - Accumulate learning time across multiple study sessions for the same learner and lesson.
 - Show per-student total learning time for a course.
+- Show each learner's group names as display-ready text in the learning-time table.
 - Filter and sort course learning-time statistics by learner, group, search, and total time.
 - Exclude course authoring and course-management users from learner-time tracking.
 
@@ -35,7 +36,7 @@ Group filtering also helps teams compare training engagement across cohorts, dep
 
 When a learner opens a lesson, Mentingo starts a learning-time session over the shared realtime connection. While the learner is active and the browser tab remains visible, the page sends periodic heartbeats. If the learner becomes idle, closes the page, disconnects, or leaves the lesson, Mentingo stops counting inactive time and saves any remaining active time.
 
-Saved time is accumulated per learner and lesson. Course statistics then summarize that data into average learning time and per-student learning-time reports.
+Saved time is accumulated per learner and lesson. Course statistics then summarize that data into average learning time and per-student learning-time reports. Group labels in those reports use each group's configured base-language name so managers see readable labels rather than translation data.
 
 Users with course authoring or course-management permissions are excluded from tracking so preview, editing, or administrative activity does not inflate learner engagement metrics.
 
@@ -50,6 +51,6 @@ Users with course authoring or course-management permissions are excluded from t
 ## Test Evidence
 
 - API E2E coverage verifies learning-time queue processing, accumulation from multiple jobs, and parallel handling for different users.
-- Course controller E2E coverage verifies learning-time statistics exclude deleted students.
+- Course controller E2E coverage verifies learning-time statistics return readable group names and exclude deleted students.
 - Web E2E coverage verifies that the course statistics learning-time table appears in the admin course-statistics workflow.
 - I did not find dedicated frontend E2E coverage for realtime heartbeat timing.


### PR DESCRIPTION
## Issue(s)
[#1843](https://github.com/Selleo/mentingo/issues/1843)

## Overview
- Replaces the average quiz score enrollment join with an `EXISTS` semi-join, preventing repeated enrollment scans under tenant RLS.
- Resolves localized group names to strings in learning-time statistics so response validation matches the API contract.
- Adds regression coverage for learning-time group names and updates the learning-time business specification.

## Business Value
Course managers can load quiz and learning-time statistics reliably for larger learner cohorts. The optimized query avoids database work that grew toward O(n²), while the response fix prevents valid learning-time reports from failing with HTTP 400 when learners belong to localized groups.